### PR TITLE
Provide ATLAS for SciPy and NumPy

### DIFF
--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -1,46 +1,61 @@
 <tool_dependency>
-    <package name="atlas" version="3.10.1">
+    <package name="atlas" version="3.10.2">
         <install version="1.0">
-            <actions>
-                <!-- first action is always downloading -->
-                <!--<action type="download_by_url" target_filename="ATLAS.tar.bz2">http://downloads.sourceforge.net/project/math-atlas/Stable/3.10.1/atlas3.10.1.tar.bz2</action>-->
-                <action type="download_file">http://downloads.sourceforge.net/project/math-atlas/Stable/3.10.1/atlas3.10.1.tar.bz2</action>
-                <action type="shell_command">tar -jxvf atlas3.10.1.tar.bz2</action>
-                <action type="download_file">http://www.netlib.org/lapack/lapack-3.4.2.tgz</action>
-
-                <action type="shell_command">
-                # try to disable cpu throttling
-                if hash cpufreq-selector 2>/dev/null; then
-                    cpufreq-selector -g performance
-                elif hash cpupower 2>/dev/null; then
-                    cpupower frequency-set -g performance
-                else
-                    echo 'Please deactivate CPU throttling by your own, or install cpufreq-selector'
-                    exit
-                fi
-                </action>
-                <action type="shell_command">
-                    cd ATLAS &amp;&amp;
-                    pwd > $INSTALL_DIR/pwd.txt &amp;&amp;
-                    ls -l > $INSTALL_DIR/ls.txt &amp;&amp;
-                    ls -l CONFIG/src/ > $INSTALL_DIR/ls2.txt &amp;&amp;
-
-                    mkdir build &amp;&amp;
-                    cd build &amp;&amp;
-                    mkdir $INSTALL_DIR/atlas/ &amp;&amp;
-                    ../configure -Fa alg -fPIC --prefix=$INSTALL_DIR/atlas/ --with-netlib-lapack-tarfile=../../lapack-3.4.2.tgz &amp;&amp;
-                    make &amp;&amp; make install
-                </action>
-
-                <action type="set_environment">
-                    <environment_variable name="ATLAS_LIB_DIR" action="set_to">$INSTALL_DIR/atlas/lib</environment_variable>
-                    <environment_variable name="ATLAS_INCLUDE_DIR" action="set_to">$INSTALL_DIR/atlas/include</environment_variable>
-                </action>
-            </actions>
+            <actions_group>
+                <actions architecture="x86_64" os="linux">
+                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/atlas/atlas-3.10.2-Linux-x86_64.tar.gz</action>
+                    <action type="move_directory_files">
+                        <source_directory>.</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable action="set_to" name="ATLAS_LIB_DIR">$INSTALL_DIR/lib</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_INCLUDE_DIR">$INSTALL_DIR/include</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_BLAS_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_LAPACK_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    </action>
+                </actions>
+                <actions architecture="x86_64" os="darwin">
+                    <!-- NOOP: On OS X we will use Apple's vecLib -->
+                </actions>
+                <actions>
+                    <action type="download_file">http://downloads.sourceforge.net/project/math-atlas/Stable/3.10.2/atlas3.10.2.tar.bz2</action>
+                    <action type="download_file">http://www.netlib.org/lapack/lapack-3.5.0.tgz</action>
+                    <action type="download_file">https://depot.galaxyproject.org/patch/atlas/static_full_blas_lapack.diff</action>
+                    <action type="download_file">https://depot.galaxyproject.org/patch/atlas/shared_libraries.diff</action>
+                    <action type="download_file">https://depot.galaxyproject.org/patch/atlas/cpu-throttling-check.diff</action>
+                    <action type="shell_command">tar -jxvf atlas3.10.2.tar.bz2</action>
+                    <!-- a 64-bit architecture is assumed for compilation -->
+                    <action type="shell_command">
+                        cd ATLAS &amp;&amp;
+                        mkdir ATLAS/build &amp;&amp;
+                        patch -p1 &lt;/host/static_full_blas_lapack.diff &amp;&amp;
+                        patch -p1 &lt;/host/shared_libraries.diff &amp;&amp;
+                        patch -p1 &lt;/host/cpu-throttling-check.diff &amp;&amp;
+                        cd build &amp;&amp;
+                        ../configure --prefix="$INSTALL_DIR" -D c -DWALL -b 64 -Fa alg '-fPIC' --with-netlib-lapack-tarfile=../../lapack-3.5.0.tgz -v 2 -t 0 -Si cputhrchk 0 &amp;&amp;
+                        make &amp;&amp;
+                        make install
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable action="set_to" name="ATLAS_LIB_DIR">$INSTALL_DIR/lib</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_INCLUDE_DIR">$INSTALL_DIR/include</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_BLAS_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_LAPACK_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
+                        <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    </action>
+                </actions>
+            </actions_group>
         </install>
-        <readme>ATLAS_LIB_DIR and ATLAS_INCLUDE_DIR (including libatlas.a) will be exported for later use.
-        During ATLAS library compilation, ATLAS performs code efficiency checks. These checks can only provide optimal results, if "frequency scaling" is disabled on the CPU, and no other load-intense processes are running.
-        Ideally, you should compile on an empty cluster node with CPU frequency scaling disabled (see "cpufreq-selector" or "cpufreq-set").
+        <readme>Compiling ATLAS requires a C and Fortran compiler (typically gcc and gfortran). The base ATLAS installation path can be is exported as ATLAS_ROOT_PATH, libraries as ATLAS_LIB_DIR, and headers as ATLAS_INCLUDE_DIR.
+        This ATLAS build includes patches from the Debian ATLAS packages which enable additional features:
+            1. Shared versions of the standard ATLAS libraries are built in addition to the static versions
+            2. Full BLAS and LAPACK libraries are built, which can be found in the ATLAS_BLAS_LIB_DIR and ATLAS_LAPACK_LIB_DIR directories
+        This package also includes a bundled libgfortran and export LD_LIBRARY_PATH=$ATLAS_LIB_DIR so that any dependent packages which link to ATLAS will be able to resolve all necessary libraries at runtime.
+        On Mac OS X, this package is a dummy package - BLAS and LAPACK libraries are already provided in Apple's vecLib.
         </readme>
     </package>
 </tool_dependency>

--- a/packages/package_numpy_1_7/tool_dependencies.xml
+++ b/packages/package_numpy_1_7/tool_dependencies.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0"?>
 <tool_dependency>
+        <package name="atlas" version="3.10.2">
+            <repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+        </package>
         <package name="numpy" version="1.7.1">
             <install version="1.0">
                 <actions>
                     <action type="download_by_url">https://pypi.python.org/packages/source/n/numpy/numpy-1.7.1.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_atlas_3_10" owner="iuc">
+                            <package name="atlas" version="3.10.2" />
+                        </repository>
+                    </action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; 
+                        export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
                     </action>
                     <action type="set_environment">

--- a/packages/package_numpy_1_8/tool_dependencies.xml
+++ b/packages/package_numpy_1_8/tool_dependencies.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0"?>
 <tool_dependency>
+        <package name="atlas" version="3.10.2">
+            <repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+        </package>
         <package name="numpy" version="1.8.1">
             <install version="1.0">
                 <actions>
                     <action type="download_by_url">https://pypi.python.org/packages/source/n/numpy/numpy-1.8.1.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_atlas_3_10" owner="iuc">
+                            <package name="atlas" version="3.10.2" />
+                        </repository>
+                    </action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                        export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
                     </action>
                     <action type="set_environment">
@@ -14,7 +23,7 @@
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                         <environment_variable action="set_to" name="PYTHONPATH_NUMPY">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="set_to" name="PATH_NUMPY">$INSTALL_DIR/bin</environment_variable>
-                        </action>
+                    </action>
                 </actions>
             </install>
             <readme>Compiling numpy requires a C and Fortran compiler (typically gcc and gfortran). The PYTHONPATH for numpy can be accessed through PYTHONPATH_NUMPY and the binaries with PATH_NUMPY.</readme>

--- a/packages/package_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_numpy_1_9/tool_dependencies.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0"?>
 <tool_dependency>
+        <package name="atlas" version="3.10.2">
+            <repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+        </package>
         <package name="numpy" version="1.9">
             <install version="1.0">
                 <actions>
                     <action type="download_by_url">https://pypi.python.org/packages/source/n/numpy/numpy-1.9.0.tar.gz#md5=510cee1c6a131e0a9eb759aa2cc62609</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_atlas_3_10" owner="iuc">
+                            <package name="atlas" version="3.10.2" />
+                        </repository>
+                    </action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; 
+                        export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
                     </action>
                     <action type="set_environment">
@@ -14,7 +23,7 @@
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                         <environment_variable action="set_to" name="PYTHONPATH_NUMPY">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="set_to" name="PATH_NUMPY">$INSTALL_DIR/bin</environment_variable>
-                        </action>
+                    </action>
                 </actions>
             </install>
             <readme>Compiling numpy requires a C and Fortran compiler (typically gcc and gfortran). The PYTHONPATH for numpy can be accessed through PYTHONPATH_NUMPY and the binaries with PATH_NUMPY.</readme>

--- a/packages/package_scipy_0_12/tool_dependencies.xml
+++ b/packages/package_scipy_0_12/tool_dependencies.xml
@@ -1,5 +1,8 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0"?>
 <tool_dependency>
+        <package name="atlas" version="3.10.2">
+            <repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+        </package>
         <package name="numpy" version="1.7.1">
             <repository name="package_numpy_1_7" owner="iuc" prior_installation_required="True" />
         </package>
@@ -8,6 +11,9 @@
                 <actions>
                     <action type="download_by_url">http://downloads.sourceforge.net/project/scipy/scipy/0.12.0/scipy-0.12.0.tar.gz</action>
                     <action type="set_environment_for_install">
+                        <repository name="package_atlas_3_10" owner="iuc">
+                            <package name="atlas" version="3.10.2" />
+                        </repository>
                         <repository name="package_numpy_1_7" owner="iuc">
                             <package name="numpy" version="1.7.1" />
                         </repository>
@@ -15,8 +21,7 @@
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
-                        export PATH=$PATH:$PATH_NUMPY &amp;&amp;
-                        export PYTHONPATH=$PYTHONPATH:$PYTHONPATH_NUMPY &amp;&amp;
+                        export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
                     </action>
                     <action type="set_environment">

--- a/packages/package_scipy_0_14/tool_dependencies.xml
+++ b/packages/package_scipy_0_14/tool_dependencies.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool_dependency>
+        <package name="atlas" version="3.10.2">
+            <repository name="package_atlas_3_10" owner="iuc" prior_installation_required="True" />
+        </package>
         <package name="numpy" version="1.9">
             <repository name="package_numpy_1_9" owner="iuc" prior_installation_required="True" />
         </package>
@@ -8,6 +11,9 @@
                 <actions>
                     <action type="download_by_url">https://pypi.python.org/packages/source/s/scipy/scipy-0.14.0.tar.gz#md5=d7c7f4ccf8b07b08d6fe49d5cd51f85d</action>
                     <action type="set_environment_for_install">
+                        <repository name="package_atlas_3_10" owner="iuc">
+                            <package name="atlas" version="3.10.2" />
+                        </repository>
                         <repository name="package_numpy_1_9" owner="iuc">
                             <package name="numpy" version="1.9" />
                         </repository>
@@ -15,8 +21,7 @@
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; 
-                        export PATH=$PATH:$PATH_NUMPY &amp;&amp; 
-                        export PYTHONPATH=$PYTHONPATH:$PYTHONPATH_NUMPY &amp;&amp; 
+                        export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
                     </action>
                     <action type="set_environment">


### PR DESCRIPTION
# ATLAS changes

* Update the ATLAS stable version in to 3.10.2
* Provide a binary build for Linux x86_64
* Prevent OS X from attempting to build ATLAS - BLAS and LAPACK are already provided by Apple's bundled vecLib, and these are the preferred versions for SciPy, for which ATLAS is being built.
* Update the build instructions to bypass the CPU throttling check, as is done for Debian.
* Build shared libraries as well as full BLAS and LAPACK libraries.

# NumPy/SciPy changes

* Depend on `package_atlas_3_10`

# ATLAS binary package

The ATLAS build script follows (the binary package was built in a Debian Squeeze docker container):

```
#!/bin/bash

version=3.10.2
urls="
http://downloads.sourceforge.net/project/math-atlas/Stable/${version}/atlas${version}.tar.bz2
http://www.netlib.org/lapack/lapack-3.5.0.tgz
"

# The libgfortran muckery is because the filesystem layout looks like this, on
# squeeze:
#
# /usr/lib/gcc/x86_64-linux-gnu/4.4.5/libgfortran.so -> ../../../x86_64-linux-gnu/libgfortran.so.3
# /usr/lib/x86_64-linux-gnu/libgfortran.so.3 -> libgfortran.so.3.0.0
# /usr/lib/x86_64-linux-gnu/libgfortran.so.3.0.0 (real file)
#
# The assumption is made that the symlinks point to the most specific (e.g.
# libgfortran.so.3.0.0) version of the library. I am not aware of any linuxes
# that do not follow this convention. Regardless, this is the case on squeeze.

mkdir /build &&
    cd /build &&

    ( for url in $urls; do
        wget "$url" || false || exit
    done ) &&

    tar jxf atlas${version}.tar.bz2 &&
    cd ATLAS &&
    patch -p1 </host/static_full_blas_lapack.diff &&
    patch -p1 </host/shared_libraries.diff &&
    patch -p1 </host/cpu-throttling-check.diff &&
    mkdir build &&
    cd build &&
    ../configure \
        --prefix="/build/dest" \
        -D c -DWALL \
        -b 64 \
        -Fa alg '-fPIC' \
        -Ss f77lib "-L$(gcc -print-search-dirs|grep ^install:|awk '{print $2}') -lgfortran -lgcc_s -lpthread"  \
        --with-netlib-lapack-tarfile=/build/lapack-3.5.0.tgz \
        -A 14 \
        -V 384 \
        -v 2 \
        -t 0 \
        -Ss ADdir ../../archdefs/amd64 \
        -Si cputhrchk 0 &&
    make &&
    make install &&
    libgfortran=$(readlink -f $(gcc -print-search-dirs|grep ^install:|awk '{print $2}')/libgfortran.so) &&
    basename_libgfortran=$(basename $libgfortran) &&
    libgfortran_version=${basename_libgfortran#"libgfortran.so."} &&
    cp $libgfortran /build/dest/lib &&
    ln -s $(basename $libgfortran) /build/dest/lib/libgfortran.so.${libgfortran_version:0:1} &&
    ln -s libgfortran.so.${libgfortran_version:0:1} /build/dest/lib/libgfortran.so &&
    tar zcf /host/atlas-${version}-Linux-x86_64.tar.gz -C /build/dest .
```

The patches are located at https://depot.galaxyproject.org/patch/atlas/