### PR TITLE
Add a CONTRIBUTING file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+This document describes how to contribute to this repository. Pull
+requests containing bug fixes, updates, and extensions to the existing
+tools and tool suites in this repository will be considered for
+inclusion.
+
+## How to Contribute
+
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Make sure you have git [installed](https://help.github.com/articles/set-up-git)
+* Fork the repository on [GitHub](https://github.com/galaxyproject/tools-iuc/fork)
+* Make the desired modifications - consider using a [feature branch](https://github.com/Kunena/Kunena-Forum/wiki/Create-a-new-branch-with-git-and-manage-branches).
+* Make sure you have added the necessary tests for your changes and they pass.
+* Open a [pull request](https://help.github.com/articles/using-pull-requests)
+  with these changes.


### PR DESCRIPTION
Describes how to fork, pull request, etc.... Github will display a link to this information in certain contexts and even if it didn't it can be very useful to potential developers.

Lots of TODO left here - what to contribute, what not to contribute, mention how to write tests, update test-data, decide if linting is required and provide links - but since I am not on the IUC I shouldn't be writing policy I just wanted to make sure all the most relevant Galaxy repositories have CONTRIBUTING files before we submit our GSOC application.