### PR TITLE
differences in OSX/UNIX sed

### DIFF
--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -20,7 +20,7 @@
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepanding means that the new install perl binary will be used after the pipe -->
                 <action type="shell_command">export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
-                <action type="shell_command">sed -i 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
+                <action type="shell_command">sed -i -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
 
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>


### PR DESCRIPTION
On OSX, I am getting error when editing my Makefile in tool_dependencies.xml (sed -i 's/O2/O2 -fPIC/' Makefile doesn't work, sed -i -e 's/O2/O2 -fPIC/' Makefile works). When installing this package on OSX, I am getting very similar error. Maybe this small edit will help. 
http://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed