### PR TITLE
Add data_manager for Bowtie1 indices. Thanks to James Johnson!

### DIFF
--- a/data_managers/data_manager_bowtie_index_builder/README
+++ b/data_managers/data_manager_bowtie_index_builder/README
@@ -1,0 +1,2 @@
+Builds a bowtie version 1 index from a fasta reference from the tool_data_table_conf all_fasta reference. 
+It adds an entry to the tool_data_table_conf bowtie_indexes or bowtie_indexes_color reference.

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_color_space_index_builder.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_color_space_index_builder.xml
@@ -1,0 +1,32 @@
+<tool id="bowtie_color_space_index_builder_data_manager" name="Bowtie Color index" tool_type="manage_data" version="0.0.2">
+    <description>builder</description>
+    <requirements>
+        <requirement type="package" version="0.12.7">bowtie</requirement>
+    </requirements>
+    <command interpreter="python">
+        bowtie_index_builder.py
+            "${out_file}"
+            --fasta_filename "${all_fasta_source.fields.path}"
+            --fasta_dbkey "${all_fasta_source.fields.dbkey}"
+            --fasta_description "${all_fasta_source.fields.name}"
+            --data_table_name "bowtie_indexes_color"
+            --color_space
+    </command>
+    <inputs>
+        <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
+            <options from_data_table="all_fasta"/>
+        </param>
+        <param type="text" name="sequence_name" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
+        <param type="text" name="sequence_id" value="" label="ID for sequence" help="Leave blank to use all_fasta id" />
+    </inputs>
+    <outputs>
+        <data name="out_file" format="data_manager_json"/>
+    </outputs>
+    <help>
+
+.. class:: infomark
+
+**Notice:** If you leave name, description, or id blank, it will be generated automatically. 
+
+    </help>
+</tool>

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import tempfile
+import optparse
+import subprocess
+
+from galaxy.util.json import from_json_string, to_json_string
+
+
+CHUNK_SIZE = 2**20
+
+DEFAULT_DATA_TABLE_NAME = "bowtie_indexes"
+
+def get_id_name( params, dbkey, fasta_description=None):
+    #TODO: ensure sequence_id is unique and does not already appear in location file
+    sequence_id = params['param_dict']['sequence_id']
+    if not sequence_id:
+        sequence_id = dbkey
+
+    sequence_name = params['param_dict']['sequence_name']
+    if not sequence_name:
+        sequence_name = fasta_description
+        if not sequence_name:
+            sequence_name = dbkey
+    return sequence_id, sequence_name
+
+
+def build_bowtie_index( data_manager_dict, fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_name=DEFAULT_DATA_TABLE_NAME, color_space = False ):
+    #TODO: allow multiple FASTA input files
+    #tmp_dir = tempfile.mkdtemp( prefix='tmp-data-manager-bowtie-index-builder-' )
+    fasta_base_name = os.path.split( fasta_filename )[-1]
+    sym_linked_fasta_filename = os.path.join( target_directory, fasta_base_name )
+    os.symlink( fasta_filename, sym_linked_fasta_filename )
+    args = [ 'bowtie-build' ]
+    if color_space:
+        args.append( '-c' )
+    args.append( sym_linked_fasta_filename)
+    args.append( fasta_base_name )
+    args.append( sym_linked_fasta_filename )
+    tmp_stderr = tempfile.NamedTemporaryFile( prefix = "tmp-data-manager-bowtie-index-builder-stderr" )
+    proc = subprocess.Popen( args=args, shell=False, cwd=target_directory, stderr=tmp_stderr.fileno() )
+    return_code = proc.wait()
+    if return_code:
+        tmp_stderr.flush()
+        tmp_stderr.seek(0)
+        print >> sys.stderr, "Error building index:"
+        while True:
+            chunk = tmp_stderr.read( CHUNK_SIZE )
+            if not chunk:
+                break
+            sys.stderr.write( chunk )
+        sys.exit( return_code )
+    tmp_stderr.close()
+    data_table_entry = dict( value=sequence_id, dbkey=dbkey, name=sequence_name, path=fasta_base_name )
+    _add_data_table_entry( data_manager_dict, data_table_name, data_table_entry )
+
+
+def _add_data_table_entry( data_manager_dict, data_table_name, data_table_entry ):
+    data_manager_dict['data_tables'] = data_manager_dict.get( 'data_tables', {} )
+    data_manager_dict['data_tables'][ data_table_name ] = data_manager_dict['data_tables'].get( data_table_name, [] )
+    data_manager_dict['data_tables'][ data_table_name ].append( data_table_entry )
+    return data_manager_dict
+
+
+def main():
+    #Parse Command Line
+    parser = optparse.OptionParser()
+    parser.add_option( '-f', '--fasta_filename', dest='fasta_filename', action='store', type="string", default=None, help='fasta_filename' )
+    parser.add_option( '-d', '--fasta_dbkey', dest='fasta_dbkey', action='store', type="string", default=None, help='fasta_dbkey' )
+    parser.add_option( '-t', '--fasta_description', dest='fasta_description', action='store', type="string", default=None, help='fasta_description' )
+    parser.add_option( '-n', '--data_table_name', dest='data_table_name', action='store', type="string", default=None, help='data_table_name' )
+    parser.add_option( '-c', '--color_space', dest='color_space', action='store_true', default=False, help='color_space' )
+    (options, args) = parser.parse_args()
+
+    filename = args[0]
+
+    params = from_json_string( open( filename ).read() )
+    target_directory = params[ 'output_data' ][0]['extra_files_path']
+    os.mkdir( target_directory )
+    data_manager_dict = {}
+
+    dbkey = options.fasta_dbkey
+
+    if dbkey in [ None, '', '?' ]:
+        raise Exception( '"%s" is not a valid dbkey. You must specify a valid dbkey.' % ( dbkey ) )
+
+    sequence_id, sequence_name = get_id_name( params, dbkey=dbkey, fasta_description=options.fasta_description )
+
+    #build the index
+    build_bowtie_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_name=options.data_table_name or DEFAULT_DATA_TABLE_NAME, color_space=options.color_space )
+
+    #save info to json file
+    open( filename, 'wb' ).write( to_json_string( data_manager_dict ) )
+
+if __name__ == "__main__":
+    main()

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
@@ -1,0 +1,31 @@
+<tool id="bowtie_index_builder_data_manager" name="Bowtie index" tool_type="manage_data" version="0.0.2">
+    <description>builder</description>
+    <requirements>
+        <requirement type="package" version="0.12.7">bowtie</requirement>
+    </requirements>
+    <command interpreter="python">
+        bowtie_index_builder.py
+            "${out_file}"
+            --fasta_filename "${all_fasta_source.fields.path}"
+            --fasta_dbkey "${all_fasta_source.fields.dbkey}"
+            --fasta_description "${all_fasta_source.fields.name}"
+            --data_table_name "bowtie_indexes"
+    </command>
+    <inputs>
+        <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
+            <options from_data_table="all_fasta"/>
+        </param>
+        <param type="text" name="sequence_name" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
+        <param type="text" name="sequence_id" value="" label="ID for sequence" help="Leave blank to use all_fasta id "/>
+    </inputs>
+    <outputs>
+        <data name="out_file" format="data_manager_json"/>
+    </outputs>
+    <help>
+
+.. class:: infomark
+
+**Notice:** If you leave name, description, or id blank, it will be generated automatically. 
+
+    </help>
+</tool>

--- a/data_managers/data_manager_bowtie_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager_conf.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<data_managers>
+    <data_manager tool_file="data_manager/bowtie_index_builder.xml" id="bowtie_index_builder" version="0.0.1">
+        <data_table name="bowtie_indexes">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" >
+                    <move type="directory" relativize_symlinks="True">
+                        <!-- <source>${path}</source>--> <!-- out_file.extra_files_path is used as base by default --> <!-- if no source, eg for type=directory, then refers to base -->
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${dbkey}/bowtie_index</target>
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${dbkey}/bowtie_index/${path}</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+    </data_manager>
+    <data_manager tool_file="data_manager/bowtie_color_space_index_builder.xml" id="bowtie_color_space_index_builder" version="0.0.1">
+        <data_table name="bowtie_indexes_color">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" >
+                    <move type="directory" relativize_symlinks="True">
+                        <!-- <source>${path}</source>--> <!-- out_file.extra_files_path is used as base by default --> <!-- if no source, eg for type=directory, then refers to base -->
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${dbkey}/bowtie_index/color</target> <!-- confirm this as preferred location -->
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${dbkey}/bowtie_index/color/${path}</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/data_managers/data_manager_bowtie_index_builder/tool-data/all_fasta.loc.sample
+++ b/data_managers/data_manager_bowtie_index_builder/tool-data/all_fasta.loc.sample
@@ -1,0 +1,18 @@
+#This file lists the locations and dbkeys of all the fasta files
+#under the "genome" directory (a directory that contains a directory
+#for each build). The script extract_fasta.py will generate the file
+#all_fasta.loc. This file has the format (white space characters are
+#TAB characters):
+#
+#<unique_build_id>	<dbkey>		<display_name>	<file_path>
+#
+#So, all_fasta.loc could look something like this:
+#
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3		/path/to/genome/apiMel3/apiMel3.fa
+#hg19canon	hg19		Human (Homo sapiens): hg19 Canonical		/path/to/genome/hg19/hg19canon.fa
+#hg19full	hg19		Human (Homo sapiens): hg19 Full			/path/to/genome/hg19/hg19full.fa
+#
+#Your all_fasta.loc file should contain an entry for each individual
+#fasta file. So there will be multiple fasta files for each build,
+#such as with hg19 above.
+#

--- a/data_managers/data_manager_bowtie_index_builder/tool-data/bowtie_indices.loc.sample
+++ b/data_managers/data_manager_bowtie_index_builder/tool-data/bowtie_indices.loc.sample
@@ -1,0 +1,37 @@
+#This is a sample file distributed with Galaxy that enables tools
+#to use a directory of Bowtie indexed sequences data files. You will
+#need to create these data files and then create a bowtie_indices.loc
+#file similar to this one (store it in this directory) that points to
+#the directories in which those files are stored. The bowtie_indices.loc
+#file has this format (longer white space characters are TAB characters):
+#
+#<unique_build_id>   <dbkey>   <display_name>   <file_base_path>
+#
+#So, for example, if you had hg18 indexed stored in
+#/depot/data2/galaxy/bowtie/hg18/,
+#then the bowtie_indices.loc entry would look like this:
+#
+#hg18	hg18	hg18	/depot/data2/galaxy/bowtie/hg18/hg18
+#
+#and your /depot/data2/galaxy/bowtie/hg18/ directory
+#would contain hg18.*.ebwt files:
+#
+#-rw-r--r--  1 james    universe 830134 2005-09-13 10:12 hg18.1.ebwt
+#-rw-r--r--  1 james    universe 527388 2005-09-13 10:12 hg18.2.ebwt
+#-rw-r--r--  1 james    universe 269808 2005-09-13 10:12 hg18.3.ebwt
+#...etc...
+#
+#Your bowtie_indices.loc file should include an entry per line for each
+#index set you have stored. The "file" in the path does not actually
+#exist, but it is the prefix for the actual index files. For example:
+#
+#hg18canon			hg18	hg18 Canonical	/depot/data2/galaxy/bowtie/hg18/hg18canon
+#hg18full			hg18	hg18 Full		/depot/data2/galaxy/bowtie/hg18/hg18full
+#/orig/path/hg19	hg19	hg19			/depot/data2/galaxy/bowtie/hg19/hg19
+#...etc...
+#
+#Note that for backwards compatibility with workflows, the unique ID of
+#an entry must be the path that was in the original loc file, because that
+#is the value stored in the workflow for that parameter. That is why the
+#hg19 entry above looks odd. New genomes can be better-looking.
+#

--- a/data_managers/data_manager_bowtie_index_builder/tool-data/bowtie_indices_color.loc.sample
+++ b/data_managers/data_manager_bowtie_index_builder/tool-data/bowtie_indices_color.loc.sample
@@ -1,0 +1,37 @@
+#This is a sample file distributed with Galaxy that enables tools
+#to use a directory of Bowtie indexed sequences data files. You will
+#need to create these data files and then create a bowtie_indices.loc
+#file similar to this one (store it in this directory) that points to
+#the directories in which those files are stored. The bowtie_indices.loc
+#file has this format (longer white space characters are TAB characters):
+#
+#<unique_build_id>		<dbkey>		<display_name>		<file_base_path>
+#
+#So, for example, if you had hg18 indexed stored in 
+#/depot/data2/galaxy/bowtie/hg18/, 
+#then the bowtie_indices.loc entry would look like this:
+#
+#hg18   hg18   hg18   /depot/data2/galaxy/bowtie/hg18/hg18
+#
+#and your /depot/data2/galaxy/bowtie/hg18/ directory
+#would contain hg18.*.ebwt files:
+#
+#-rw-r--r--  1 james    universe 830134 2005-09-13 10:12 hg18.1.ebwt
+#-rw-r--r--  1 james    universe 527388 2005-09-13 10:12 hg18.2.ebwt
+#-rw-r--r--  1 james    universe 269808 2005-09-13 10:12 hg18.3.ebwt
+#...etc...
+#
+#Your bowtie_indices.loc file should include an entry per line for each
+#index set you have stored. The "file" in the path does not actually
+#exist, but it is the prefix for the actual index files. For example:
+#
+#hg18canon			hg18	hg18 Canonical	/depot/data2/galaxy/bowtie/hg18/hg18canon
+#hg18full			hg18	hg18 Full		/depot/data2/galaxy/bowtie/hg18/hg18full
+#/orig/path/hg19	hg19	hg19			/depot/data2/galaxy/bowtie/hg19/hg19
+#...etc...
+#
+#Note that for backwards compatibility with workflows, the unique ID of
+#an entry must be the path that was in the original loc file, because that
+#is the value stored in the workflow for that parameter. That is why the
+#hg19 entry above looks odd. New genomes can be better-looking.
+#

--- a/data_managers/data_manager_bowtie_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_bowtie_index_builder/tool_data_table_conf.xml.sample
@@ -1,0 +1,17 @@
+<tables>
+    <!-- Locations of all fasta files under genome directory -->
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+    <!-- Locations of indexes in the Bowtie mapper format -->
+    <table name="bowtie_indexes" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/bowtie_indices.loc" />
+    </table>
+    <!-- Locations of indexes in the Bowtie color-space mapper format -->
+    <table name="bowtie_indexes_color" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/bowtie_indices_color.loc" />
+    </table>
+</tables>

--- a/data_managers/data_manager_bowtie_index_builder/tool_dependencies.xml
+++ b/data_managers/data_manager_bowtie_index_builder/tool_dependencies.xml
@@ -1,0 +1,5 @@
+<tool_dependency>
+    <package name="bowtie" version="0.12.7">
+        <repository name="package_bowtie_0_12_7" owner="devteam" />
+    </package>
+</tool_dependency>


### PR DESCRIPTION
This data manager was developed by @jj-umn and is already part of the TTS. 
As discussed with @jj-umn we would like to include it into the IUC repository and release a IUC branded version to the TSS and the TS under the IUC account.

In addition to the version available from the TTS I cleaned up the wrappers a little bit and added a new `tool_dependencies.xml` file to use the `devteam` version of bowtie1.