### PR TITLE
Restrict available VCF files to load into Gemini to hg19, Homo_sapiens_nuHg19_mtrCRS, hg_g1k_v37

### DIFF
--- a/tools/gemini/gemini_load.xml
+++ b/tools/gemini/gemini_load.xml
@@ -33,7 +33,13 @@
     </command>
     <expand macro="stdio" />
     <inputs>
-        <param name="infile" type="data" format="vcf" label="VCF file to be loaded in the GEMINI database" />
+        <param name="infile" type="data" format="vcf" label="VCF file to be loaded in the GEMINI database" help="Only build 37 (aka hg19) of the human genome is supported.">
+            <options>
+                <filter type="add_value" value="hg19" />
+                <filter type="add_value" value="Homo_sapiens_nuHg19_mtrCRS" />
+                <filter type="add_value" value="hg_g1k_v37" />
+            </options>
+        </param>
 
         <param name="annotation_type" type="select" label="The annotations to be used with the input vcf" help="(-t)">
             <option value="None">None (not recommended)</option>


### PR DESCRIPTION
See Note 1 in http://gemini.readthedocs.org/en/latest/