### PR TITLE
Fix readline related compilation failure

### DIFF
--- a/packages/package_r_3_1_2/tool_dependencies.xml
+++ b/packages/package_r_3_1_2/tool_dependencies.xml
@@ -15,8 +15,8 @@
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                   <action type="download_by_url">http://cran.rstudio.com/src/base/R-3/R-3.1.2.tar.gz</action>
-                   <package name="readline" version="6.2">
+                    <action type="download_by_url">http://cran.rstudio.com/src/base/R-3/R-3.1.2.tar.gz</action>
+                    <package name="readline" version="6.2">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True" />
                     </package>
                     <package name="libpng" version="1.6.7">
@@ -30,6 +30,9 @@
                     </package>
                     <package name="freetype" version="2.5.2">
                         <repository name="package_freetype_2_5_2" owner="devteam" prior_installation_required="True" />
+                    </package>
+                    <package name="ncurses" version="5.9">
+                        <repository name="package_ncurses_5_9" owner="iuc" prior_installation_required="True" />
                     </package>
                     <action type="set_environment_for_install">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True" >
@@ -47,16 +50,20 @@
                         <repository name="package_freetype_2_5_2" owner="devteam" prior_installation_required="True" >
                             <package name="freetype" version="2.5.2" />
                         </repository>
+                        <repository name="package_ncurses_5_9" owner="iuc" prior_installation_required="True" >
+                            <package name="ncurses" version="5.9" />
+                        </repository>
                     </action>
                     <action type="shell_command"><![CDATA[
-                        export LDFLAGS="-L$PNG_LIBS -L$READLINE_LIB_PATH" &&
+                        export LDFLAGS="-L$PNG_LIBS -L$NCURSES_LIB_PATH -L$READLINE_LIB_PATH" &&
+                        export LDFLAGS="$LDFLAGS -Wl,-rpath,$NCURSES_LIB_PATH" && 
                         export LDFLAGS="$LDFLAGS -Wl,-rpath,$READLINE_LIB_PATH" &&
                         export LDFLAGS="$LDFLAGS -Wl,-rpath,$PIXMAN_LIB_PATH" &&
                         export LDFLAGS="$LDFLAGS -Wl,-rpath,$PNG_LIB_PATH" &&
                         export LDFLAGS="$LDFLAGS -Wl,-rpath,$FREETYPE_LIB_PATH" &&
-                        export CFLAGS="-I$PNG_INCLUDES -I$READLINE_INCLUDE_PATH" &&
-                        export CXXFLAGS="-I$PNG_INCLUDES -I$READLINE_INCLUDE_PATH" &&
-                        export CPPFLAGS="-I$PNG_INCLUDES -I$READLINE_INCLUDE_PATH" &&
+                        export CFLAGS="-I$PNG_INCLUDES -I$NCURSES_INCLUDE_PATH -I$READLINE_INCLUDE_PATH" &&
+                        export CXXFLAGS="-I$PNG_INCLUDES -I$NCURSES_INCLUDE_PATH -I$READLINE_INCLUDE_PATH" &&
+                        export CPPFLAGS="-I$PNG_INCLUDES -I$NCURSES_INCLUDE_PATH -I$READLINE_INCLUDE_PATH" &&
                         ./configure --with-tcltk \
                                     --with-blas \
                                     --with-lapack \


### PR DESCRIPTION
The readline errors reported in #101 turned out to be due to ncurses not being in the list of linked libraries.