### PR TITLE
Make travis work harder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
   - pip install git+git://github.com/galaxyproject/planemo.git@master
 
 script:
-  - planemo shed_lint --recursive .
+  - planemo shed_lint --report_level warn --tools --fail_level error --recursive .


### PR DESCRIPTION
- Lint tools
- Fail on errors only (too many missing citations WARNINGS to fail on that)
- Only report warnings+, all is too noisy for easy log viewing