### PR TITLE
Fix widely used copy-paste error

### DIFF
--- a/packages/package_blat_35x1/.shed.yml
+++ b/packages/package_blat_35x1/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  35x1 of the the UCSC blat package.
+  35x1 of the UCSC blat package.
 long_description: |
   Blat is an alignment tool like BLAST, but it is structured differently.
 

--- a/packages/package_chemfp_1_1/.shed.yml
+++ b/packages/package_chemfp_1_1/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.1.x of the the chemfp package.
+  1.1.x of the chemfp package.
 long_description: |
   Chemfp provides toolkit independent generation of fingerprints
   and high-performance similarity search. The tools support the FPS fingerprint

--- a/packages/package_eigen_2_0/.shed.yml
+++ b/packages/package_eigen_2_0/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and extract version
-  2.0.x of the the eigen template library.
+  2.0.x of the eigen template library.
 long_description: |
   Eigen is a C++ template library for linear algebra: matrices, vectors,
   numerical solvers, and related algorithms.

--- a/packages/package_eigen_3_1/.shed.yml
+++ b/packages/package_eigen_3_1/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads, compiles and extracts
-  version 3.1.x of the the eigen template library.
+  version 3.1.x of the eigen template library.
 long_description: |
   Eigen is a C++ template library for linear algebra: matrices, vectors,
   numerical solvers, and related algorithms.

--- a/packages/package_ghostscript_9_07/.shed.yml
+++ b/packages/package_ghostscript_9_07/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  9.07 of the the ghostscript package.
+  9.07 of the ghostscript package.
 long_description: |
   Ghostscript is a package of software that provides:
 

--- a/packages/package_libtool_2_4/.shed.yml
+++ b/packages/package_libtool_2_4/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  2.4 of the the GNU libtool package.
+  2.4 of the GNU libtool package.
 long_description: |
   GNU Libtool - The GNU Portable Library Tool
 

--- a/packages/package_numpy_1_7/.shed.yml
+++ b/packages/package_numpy_1_7/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.7 of the the python numpy package
+  1.7 of the python numpy package
 long_description: |
     NumPy is the fundamental package for scientific computing with
     Python.

--- a/packages/package_numpy_1_7_with_atlas/.shed.yml
+++ b/packages/package_numpy_1_7_with_atlas/.shed.yml
@@ -3,7 +3,7 @@ owner: iuc
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.7 of the the python numpy package with Atlas
+  1.7 of the python numpy package with Atlas
 long_description: |
   NumPy is the fundamental package for scientific computing with
   Python.

--- a/packages/package_numpy_1_8/.shed.yml
+++ b/packages/package_numpy_1_8/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.8 of the the python numpy package
+  1.8 of the python numpy package
 long_description: |
   NumPy is the fundamental package for scientific computing with
   Python.

--- a/packages/package_numpy_1_9/.shed.yml
+++ b/packages/package_numpy_1_9/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.9 of the the python numpy package.
+  1.9 of the python numpy package.
 long_description: |
   NumPy is the fundamental package for scientific computing with
   Python. This is the version 1.9 of numpy.

--- a/packages/package_perl_5_18/.shed.yml
+++ b/packages/package_perl_5_18/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  5.18.x of the the perl language.
+  5.18.x of the perl language.
 long_description: |
   Perl is a family of high-level, general-purpose, interpreted, dynamic programming languages.
 

--- a/packages/package_qt_4_8/.shed.yml
+++ b/packages/package_qt_4_8/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  4.8.x of the the Qt library.
+  4.8.x of the Qt library.
 long_description: |
   Qt is a cross-platform application and UI framework for developers
   using C++ or QML, a CSS & JavaScript like language. Qt Creator is the supporting

--- a/packages/package_qt_5_1/.shed.yml
+++ b/packages/package_qt_5_1/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  5.1.x of the the Qt library.
+  5.1.x of the Qt library.
 long_description: |
   Qt is a cross-platform application and UI framework for developers
   using C++ or QML, a CSS & JavaScript like language. Qt Creator is the supporting

--- a/packages/package_r_3_0_1/.shed.yml
+++ b/packages/package_r_3_0_1/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  3.0.1 of the the R package.
+  3.0.1 of the R package.
 long_description: |
   R is a free software environment for statistical computing and
   graphics.

--- a/packages/package_r_3_0_2/.shed.yml
+++ b/packages/package_r_3_0_2/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  3.0.2 of the the R package.
+  3.0.2 of the R package.
 long_description: |
   R is a free software environment for statistical computing and
   graphics.

--- a/packages/package_r_3_0_3/.shed.yml
+++ b/packages/package_r_3_0_3/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  3.0.3 of the the R package.
+  3.0.3 of the R package.
 long_description: |
   This package is configured with tcltk, blas, lapack, readline, cairo, png, R-shlib and without X and R-framework
 name: package_r_3_0_3

--- a/packages/package_r_3_1_2/.shed.yml
+++ b/packages/package_r_3_1_2/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  3.0.3 of the the R package.
+  3.0.3 of the R package.
 long_description: |
   This package is configured with the following options:
 

--- a/packages/package_readline_6_2/.shed.yml
+++ b/packages/package_readline_6_2/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and extract version
-  6.2.x of the the GNU readline library.
+  6.2.x of the GNU readline library.
 long_description: |
   The GNU Readline library provides a set of functions for use by
   applications that allow users to edit command lines as they are typed in. Both Emacs

--- a/packages/package_scikit_learn_0_13/.shed.yml
+++ b/packages/package_scikit_learn_0_13/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.13.x of the the scikit-learn package.
+  0.13.x of the scikit-learn package.
 long_description: |
   Easy-to-use and general-purpose machine learning in Python
 

--- a/packages/package_scikit_learn_0_13_with_atlas/.shed.yml
+++ b/packages/package_scikit_learn_0_13_with_atlas/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.13.x of the the scikit-learn package.
+  0.13.x of the scikit-learn package.
 long_description: |
   Easy-to-use and general-purpose machine learning in Python Scikit-learn
   integrates machine learning algorithms in the tightly-knit scientific

--- a/packages/package_scikit_learn_0_14/.shed.yml
+++ b/packages/package_scikit_learn_0_14/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.14.x of the the scikit-learn package.
+  0.14.x of the scikit-learn package.
 long_description: |
   Easy-to-use and general-purpose machine learning in Python Scikit-learn
   integrates machine learning algorithms in the tightly-knit scientific

--- a/packages/package_scikit_learn_0_14_with_atlas/.shed.yml
+++ b/packages/package_scikit_learn_0_14_with_atlas/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.14.x of the the scikit-learn package with Atlas support
+  0.14.x of the scikit-learn package with Atlas support
 long_description: |
   Easy-to-use and general-purpose machine learning in Python Scikit-learn
   integrates machine learning algorithms in the tightly-knit scientific

--- a/packages/package_scikit_learn_0_15/.shed.yml
+++ b/packages/package_scikit_learn_0_15/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.15.x of the the scikit-learn package.
+  0.15.x of the scikit-learn package.
 long_description: |
   Easy-to-use and general-purpose machine learning in Python
 

--- a/packages/package_scipy_0_12_with_atlas/.shed.yml
+++ b/packages/package_scipy_0_12_with_atlas/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.12.x of the the scipy package with Atlas support.
+  0.12.x of the scipy package with Atlas support.
 long_description: |
   SciPy is an open source Python library used by scientists, analysts, and
   engineers doing scientific computing and technical computing. SciPy contains

--- a/packages/package_scipy_0_14/.shed.yml
+++ b/packages/package_scipy_0_14/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.14 of the the scipy python library.
+  0.14 of the scipy python library.
 long_description: |
   SciPy is open-source software for mathematics, science, and engineering.
   The SciPy library is built to work with NumPy arrays, and provides many user-friendly

--- a/packages/package_segemehl_0_1_6/.shed.yml
+++ b/packages/package_segemehl_0_1_6/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.1.6 of the the segemehl package.
+  0.1.6 of the segemehl package.
 long_description: |
   segemehl is a software to map short sequencer reads to reference genomes.
   Unlike other methods, segemehl is able to detect not only mismatches but also

--- a/packages/package_segemehl_0_2_0/.shed.yml
+++ b/packages/package_segemehl_0_2_0/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.2.0 of the the segemehl package.
+  0.2.0 of the segemehl package.
 long_description: |
   segemehl is a software to map short sequencer reads to reference genomes.
   Unlike other methods, segemehl is able to detect not only mismatches but also

--- a/packages/package_seqtk_1_0_r75/.shed.yml
+++ b/packages/package_seqtk_1_0_r75/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  0.1.0-r75 of the the segtk package.
+  0.1.0-r75 of the segtk package.
 long_description: |
   Sequence Toolkit is a suite of utilities to work with FastA and FastQ data
 

--- a/packages/package_weblogo_2_8_2/.shed.yml
+++ b/packages/package_weblogo_2_8_2/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  2.8.2 of the the weblogo package.
+  2.8.2 of the weblogo package.
 long_description: |
   WebLogo is application designed to make the generation of sequence
   logos as easy and painless as possible.

--- a/packages/package_zlib_1_2_8/.shed.yml
+++ b/packages/package_zlib_1_2_8/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Tool Dependency Packages
 description: Contains a tool dependency definition that downloads and compiles version
-  1.2.8 of the the zlib library.
+  1.2.8 of the zlib library.
 long_description: |
   A Massively Spiffy Yet Delicately Unobtrusive Compression Library
 


### PR DESCRIPTION
`the the` -> `the`