### PR TITLE
Packages numpy 1.8 and 1.9 now declare ATLAS

### DIFF
--- a/packages/package_numpy_1_8/tool_dependencies.xml
+++ b/packages/package_numpy_1_8/tool_dependencies.xml
@@ -21,6 +21,7 @@
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[ATLAS_LIB_DIR]</environment_variable>
                         <environment_variable action="set_to" name="PYTHONPATH_NUMPY">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="set_to" name="PATH_NUMPY">$INSTALL_DIR/bin</environment_variable>
                     </action>

--- a/packages/package_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_numpy_1_9/tool_dependencies.xml
@@ -21,6 +21,7 @@
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[ATLAS_LIB_DIR]</environment_variable>
                         <environment_variable action="set_to" name="PYTHONPATH_NUMPY">$INSTALL_DIR/lib/python</environment_variable>
                         <environment_variable action="set_to" name="PATH_NUMPY">$INSTALL_DIR/bin</environment_variable>
                     </action>


### PR DESCRIPTION
libf77blas.so.3 was not being found when using tools that depended on
one these two numpy packages/versions.

Also, possibly related to #104 .