### PR TITLE
Remove hardcoded changesets

### DIFF
--- a/packages/package_bioperl_1_6/tool_dependencies.xml
+++ b/packages/package_bioperl_1_6/tool_dependencies.xml
@@ -6,7 +6,7 @@
         <install version="1.0">
             <actions>
                 <action type="setup_perl_environment">
-                    <repository changeset_revision="091a97f8c585" name="package_perl_5_18" owner="iuc" toolshed="http://testtoolshed.g2.bx.psu.edu">
+                    <repository name="package_perl_5_18" owner="iuc">
                         <package name="perl" version="5.18.1" />
                     </repository>
                    <!-- allow downloading and installing an Perl package from cpan.org-->

--- a/test_repositories/setup_perl_environment/tool_dependencies.xml
+++ b/test_repositories/setup_perl_environment/tool_dependencies.xml
@@ -6,7 +6,7 @@
         <install version="1.0">
             <actions>
                 <action type="setup_perl_environment">
-                    <repository changeset_revision="091a97f8c585" name="package_perl_5_18" owner="iuc" toolshed="http://testtoolshed.g2.bx.psu.edu">
+                    <repository name="package_perl_5_18" owner="iuc">
                         <package name="perl" version="5.18.1" />
                     </repository>
                    <!-- allow downloading and installing an Perl package from cpan.org-->


### PR DESCRIPTION
Had a user report that they'd seen a hardcoded changeset revision, this removes those. 

@jmchilton how would you feel about adding warnings on `changeset_revision`/`toolshed` to planemo?