### PR TITLE
Update tool_dependencies.xml

### DIFF
--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -46,6 +46,7 @@
                         <environment_variable action="set_to" name="ATLAS_LAPACK_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
                         <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
                         <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib/atlas</environment_variable>
                     </action>
                 </actions>
             </actions_group>


### PR DESCRIPTION
LD_LIBRARY_PATH $INSTALL_DIR/lib/atlas was also required for numpy and scipy compilation on our Centos6 system, and had to precede $INSTALL_DIR/lib on the LD_LIBRARY_PATH