### PR TITLE
Update tool_dependencies.xml

### DIFF
--- a/packages/package_python_2_7_scipy_0_14/tool_dependencies.xml
+++ b/packages/package_python_2_7_scipy_0_14/tool_dependencies.xml
@@ -31,6 +31,7 @@
                     <environment_variable action="prepend_to" name="PYTHONPATH">$ENV[PYTHONPATH_NUMPY]</environment_variable>
                     <environment_variable action="prepend_to" name="PATH">$ENV[PATH_NUMPY]</environment_variable>
                     <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[ATLAS_LIB_DIR]</environment_variable>
+                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[ATLAS_LIB_DIR]/atlas</environment_variable>
                     <environment_variable action="set_to" name="PYTHONPATH_SCIPY">$INSTALL_DIR</environment_variable>
                     <environment_variable action="set_to" name="PATH_SCIPY">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable action="set_to" name="SCIPY_ROOT_DIR">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
Propagate LD_LIBRARY_PATH with $ENV[ATLAS_LIB_DIR]/atlas:$ENV[ATLAS_LIB_DIR]   Was required for package_python_2_7_msproteomicstools_0_3_2 compilation