### PR TITLE
add suite of FASTA tools to the IUC repository

### DIFF
--- a/suites/suite_fasta_tools/.shed.yml
+++ b/suites/suite_fasta_tools/.shed.yml
@@ -1,0 +1,9 @@
+categories:
+- Sequence Analysis
+description: Contains tools for manipulating FASTA files
+long_description: |
+  Various tools to manipulate and filter FASTA file, maintained by the Galaxy community.
+name: suite_fasta_tools
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/suites/suite_fasta_tools
+type: repository_suite_definition 

--- a/suites/suite_fasta_tools/repository_dependencies.xml
+++ b/suites/suite_fasta_tools/repository_dependencies.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<repositories description="This is a metapackage that will install all vcftools wrappers and dependencies.">
+<repositories description="This is a metapackage that will install various tools to manipulate and filter FASTA files.">
     <repository name="fasta_compute_length" owner="devteam" />
     <repository name="fasta_filter_by_length" owner="devteam" />
     <repository name="seq_filter_by_id" owner="peterjc" />

--- a/suites/suite_fasta_tools/repository_dependencies.xml
+++ b/suites/suite_fasta_tools/repository_dependencies.xml
@@ -11,6 +11,7 @@
     <repository name="fasta_nucleotide_changer" owner="devteam" />
     <repository name="find_subsequences" owner="bgruening" />
     <repository name="suite_fastx_toolkit_0_0_13" owner="devteam" />
+    <repository name="seqtk" owner="iuc" />
 </repositories>
 
 

--- a/suites/suite_fasta_tools/repository_dependencies.xml
+++ b/suites/suite_fasta_tools/repository_dependencies.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<repositories description="This is a metapackage that will install all vcftools wrappers and dependencies.">
+    <repository name="fasta_compute_length" owner="devteam" />
+    <repository name="fasta_filter_by_length" owner="devteam" />
+    <repository name="seq_filter_by_id" owner="peterjc" />
+    <repository name="seq_select_by_id" owner="peterjc" />
+    <repository name="seq_rename" owner="peterjc" />
+    <repository name="fasta_formatter" owner="devteam" />
+    <repository name="fasta_to_tabular" owner="devteam" />
+    <repository name="tabular_to_fasta" owner="devteam" />
+    <repository name="fasta_nucleotide_changer" owner="devteam" />
+    <repository name="find_subsequences" owner="bgruening" />
+    <repository name="suite_fastx_toolkit_0_0_13" owner="devteam" />
+</repositories>
+
+


### PR DESCRIPTION
I would like to create some basic tools suites and collect a bunch of high quality tools that we as IUC can recommend. 

The first one is: Tools to manipulate FASTA files

The following suites I would like to add if we agree this is a good idea for the IUC.
* GFF/GTF tools
* Sequence Searches (BLAST, Diamond, Kraken etc...)
* Exome-Seq (all different callers + Annotation)
* Statistics
