### PR TITLE
Support clustal format in hmmer tools

### DIFF
--- a/tools/hmmer3/hmmconvert.xml
+++ b/tools/hmmer3/hmmconvert.xml
@@ -20,10 +20,10 @@ $hmmfile > $output
     </param>
   </inputs>
   <outputs>
-    <data format="hmmer3" name="output" label="$msafile.name">
+    <data format="hmm3" name="output" label="$msafile.name">
       <change_format>
-        <when input="format" value="-a" format="hmmer3"/>
-        <when input="format" value="-2" format="hmmer2"/>
+        <when input="format" value="-a" format="hmm3"/>
+        <when input="format" value="-2" format="hmm2"/>
       </change_format>
     </data>
   </outputs>

--- a/tools/hmmer3/hmmfetch.xml
+++ b/tools/hmmer3/hmmfetch.xml
@@ -15,7 +15,7 @@ hmmfetch -f $hmmfile $keyfile > $output;
     <param name="keyfile" type="data" format="tabular,txt" label="List of HMM names to extract"/>
   </inputs>
   <outputs>
-    <data format="hmmer3" name="output" label="Selected HMM Models from $hmmfile.name">
+    <data format="hmm3" name="output" label="Selected HMM Models from $hmmfile.name">
     </data>
   </outputs>
   <tests>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -395,7 +395,8 @@ $aps_select
     <param name="hmmfile" type="data" label="HMM model" format="hmmer2,hmmer3"/>
   </xml>
   <xml name="input_msa">
-    <param name="msafile" type="data" label="MSA File" format="stockholm"/>
+    <param name="msafile" type="data" label="Multiple Sequence Alignment" format="stockholm,clustal,fasta"
+      help="in Stockholm, Clustal, or Fasta format. While this tool accepts fasta, please ensure that the sequences are not unaligned"/>
   </xml>
 
 

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -392,7 +392,7 @@ $aps_select
         help="(--w_length)" optional="True" type="integer" />
   </xml>
   <xml name="input_hmm">
-    <param name="hmmfile" type="data" label="HMM model" format="hmmer2,hmmer3"/>
+    <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>
   </xml>
   <xml name="input_msa">
     <param name="msafile" type="data" label="Multiple Sequence Alignment" format="stockholm,clustal,fasta"


### PR DESCRIPTION
Now that I'm actually using them...I find that they support clustal/fasta (after not having a clustal/fasta -> stockholm converter on hand, @jmchilton where are we on biopython? I'd like to add in AlignIO converters...)