### PR TITLE
Fix muscle installation on 64-bit OS X.

### DIFF
--- a/packages/package_muscle_3_8_31/tool_dependencies.xml
+++ b/packages/package_muscle_3_8_31/tool_dependencies.xml
@@ -7,8 +7,8 @@
                 <actions os="darwin" architecture="x86_64">
                     <action type="download_by_url">http://www.drive5.com/muscle/downloads3.8.31/muscle3.8.31_i86darwin64.tar.gz</action>
                     <action type="move_file" rename_to="muscle">
-                        <source>../muscle3.8.31_i86darwin64</source>
-                        <destination>$INSTALL_DIR/muscle</destination>
+                        <source>muscle3.8.31_i86darwin64</source>
+                        <destination>$INSTALL_DIR</destination>
                     </action>
                 </actions>
                 <!-- Download the binaries for MUSCLE compatible with 32-bit OSX. -->


### PR DESCRIPTION
I don't have an OS X to test, but it should pretty safe.