### PR TITLE
Fix install recipe for cummeRbund.

### DIFF
--- a/packages/package_cummerbund_2_8_2/tool_dependencies.xml
+++ b/packages/package_cummerbund_2_8_2/tool_dependencies.xml
@@ -10,11 +10,11 @@
         <install version="1.0">
             <actions>
                 <action type="setup_r_environment">
-                    <repository  name="package_r_3_1_2" owner="iuc" >
-                        <package name="R" version="3.1.2" />
-                    </repository>
                     <repository name="package_libcurl_7_35" owner="iuc" prior_installation_required="True">
                         <package name="libcurl" version="7.35" />
+                    </repository>
+                    <repository  name="package_r_3_1_2" owner="iuc" >
+                        <package name="R" version="3.1.2" />
                     </repository>
                     <package>https://depot.galaxyproject.org/package/noarch/DBI_0.3.1.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/bitops_1.0-6.tar.gz</package>

--- a/packages/package_cummerbund_2_8_2/tool_dependencies.xml
+++ b/packages/package_cummerbund_2_8_2/tool_dependencies.xml
@@ -13,7 +13,7 @@
                     <repository name="package_libcurl_7_35" owner="iuc" prior_installation_required="True">
                         <package name="libcurl" version="7.35" />
                     </repository>
-                    <repository  name="package_r_3_1_2" owner="iuc" >
+                    <repository name="package_r_3_1_2" owner="iuc" >
                         <package name="R" version="3.1.2" />
                     </repository>
                     <package>https://depot.galaxyproject.org/package/noarch/DBI_0.3.1.tar.gz</package>

--- a/packages/package_cummerbund_2_8_2/tool_dependencies.xml
+++ b/packages/package_cummerbund_2_8_2/tool_dependencies.xml
@@ -74,7 +74,7 @@
                     <package>http://bioarchive.galaxyproject.org/biomaRt_2.22.0.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/GenomicAlignments_1.2.1.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/rtracklayer_1.26.2.tar.gz</package>
-                    <package>https://depot.galaxyproject.org/package/noarch/BSgenome_1.34.1.tar.gz</package>
+                    <package>https://bioarchive.galaxyproject.org/BSgenome_1.34.0.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/GenomicFeatures_1.18.3.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/VariantAnnotation_1.12.7.tar.gz</package>
                     <package>https://depot.galaxyproject.org/package/noarch/biovizBase_1.14.1.tar.gz</package>


### PR DESCRIPTION
If multiple packages are specified in the setup_r_environment,
only the final one will be used to generate the resulting env.sh
file. This commit ensures that R is the last package, so that
cummeRbund will load correctly on usegalaxy.org

Also replaced \r\n with \n throughout.