### PR TITLE
Fix move of downloaded vsearch binaries for package_vsearch_1_1_3

### DIFF
--- a/packages/package_vsearch_1_1_3/tool_dependencies.xml
+++ b/packages/package_vsearch_1_1_3/tool_dependencies.xml
@@ -5,17 +5,17 @@
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
                     <action type="download_file">https://github.com/torognes/vsearch/releases/download/v1.1.3/vsearch-1.1.3-osx-x86_64</action>
-                    <action type="move_file">
+                    <action type="move_file" rename_to="vsearch">
                         <source>vsearch-1.1.3-osx-x86_64</source>
-                        <destination>$INSTALL_DIR/bin/vsearch</destination>
+                        <destination>$INSTALL_DIR/bin</destination>
                     </action>
                     <action type="shell_command">chmod +x $INSTALL_DIR/bin/vsearch</action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
                     <action type="download_file">https://github.com/torognes/vsearch/releases/download/v1.1.3/vsearch-1.1.3-linux-x86_64</action>
-                    <action type="move_file">
+                    <action type="move_file" rename_to="vsearch">
                         <source>vsearch-1.1.3-linux-x86_64</source>
-                        <destination>$INSTALL_DIR/bin/vsearch</destination>
+                        <destination>$INSTALL_DIR/bin</destination>
                     </action>
                     <action type="shell_command">chmod +x $INSTALL_DIR/bin/vsearch</action>
                 </actions>


### PR DESCRIPTION
This is a bug fix for the installation of the `vsearch` binaries for `package_vsearch_1_1_3`, which appears to be broken.

Specifically, the `move_file` action erroneously moved the downloaded binary to a subdirectory of the target `bin` directory and failed to change its name; the binary was then unavailable to the `vsearch` Galaxy tools after installation.

The fix is to add an explicit `rename_to` attribute and update the `destination` element to point to the `bin` directory.

The changes in this pull request have been made for both `darwin` and `linux` target architectures. I have tested the `linux` target locally but cannot verify the `darwin` target as I don't have access to a Mac.