### PR TITLE
Update package to get a version copy of all binaries.

### DIFF
--- a/packages/package_fatotwobit_35x1/tool_dependencies.xml
+++ b/packages/package_fatotwobit_35x1/tool_dependencies.xml
@@ -1,31 +1,36 @@
 <tool_dependency>
     <package name="faToTwoBit" version="35x1">
         <install version="1.0">
-            <actions>
-                <action type="download_binary">
-                    <url_template os="linux" architecture="x86_64">https://github.com/bgruening/download_store/raw/master/ucsc/linux/x86_64/faToTwoBit_35x1</url_template>
-                    <url_template os="darwin" architecture="i686">https://github.com/bgruening/download_store/raw/master/ucsc/darwin/i386/faToTwoBit_35x1</url_template>
-                    <url_template os="darwin" architecture="i386">https://github.com/bgruening/download_store/raw/master/ucsc/darwin/i386/faToTwoBit_35x1</url_template>
-                    <url_template os="darwin" architecture="x86_64">https://github.com/bgruening/download_store/raw/master/ucsc/darwin/x86_64/faToTwoBit_35x1</url_template>
-                </action>
-
-                <action type="move_file">
-                    <source>faToTwoBit_35x1</source>
-                    <destination>$INSTALL_DIR/bin/faToTwoBit</destination>
-                </action>
-                <action type="chmod">
-                    <file mode="755">$INSTALL_DIR/bin/faToTwoBit</file>
-                </action>
+            <actions_group>
+                <actions architecture="x86_64" os="linux">
+                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/ucsc/ucsc-312-Linux-x86_64.tar.gz</action>
+                    <action type="shell_command">rm ucsc-312-Linux-x86_64.tar.gz</action>
+                    <action type="move_directory_files">
+                        <source_directory>.</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                </actions>
+                <!--actions architecture="x86_64" os="darwin">
+                    <action type="download_by_url"></action>
+                    <action type="move_directory_files">
+                        <source_directory>.</source_directory>
+                        <destination_directory>$INSTALL_DIR/bin</destination_directory>
+                    </action>
+                </actions-->
                 <action type="set_environment">
-                    <environment_variable name="PATH" action="append_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="UCSC_TOOLS_ROOT_PATH" action="set_to">$INSTALL_DIR</environment_variable>
                     <environment_variable name="FATOTWOBIT_ROOT_PATH" action="append_to">$INSTALL_DIR</environment_variable>
                 </action>
-
-            </actions>
+            </actions_group>
         </install>
         <readme>
 faToTwoBit: convert Fasta format sequence files to a dense randomly-accessable .2bit format that gfClient can use.
 http://genome.ucsc.edu/goldenPath/help/blatSpec.html
+
+This is a transitional package you should migrate to use packages with the name package_ucsc_tools_312 and upwards.
+
         </readme>
     </package>
 </tool_dependency>


### PR DESCRIPTION
This is a transitional package you should migrate to use packages with the name package_ucsc_tools_312 and upwards.

Should fix: https://github.com/galaxyproject/tools-iuc/issues/175