### PR TITLE
replace 5.6 in the code for 5.7

### DIFF
--- a/packages/package_rnastructure_5_7/tool_dependencies.xml
+++ b/packages/package_rnastructure_5_7/tool_dependencies.xml
@@ -4,6 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">http://depot.galaxyproject.org/package/source/RNAstructure-5.7.tgz</action>
+                <action type="shell_command">sed -i.bak "s/version = 5\.6/version = 5.7/" "./src/ParseCommandLine.cpp"</action>
                 <action type="shell_command">make all</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>


### PR DESCRIPTION
The code refers to version 5.6 in ./src/ParseCommandLine.cpp. This doesn't allow galaxy tools to set <version_command> tags that match the package's version 5_7 because 5.6 is passed through to the *--version* argument.