### PR TITLE
Fix install recipe for kraken.

### DIFF
--- a/packages/package_kraken_0_10_5/tool_dependencies.xml
+++ b/packages/package_kraken_0_10_5/tool_dependencies.xml
@@ -4,7 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/kraken/kraken-0.10.5-beta-Linux_x86_64.zip</action>
+                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/kraken/kraken-0.10.5-beta-Linux-x86_64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -12,7 +12,7 @@
                 </actions>
                 <actions>
                     <action type="download_by_url">https://ccb.jhu.edu/software/kraken/dl/kraken-0.10.5-beta.tgz</action>
-                    <action type="shell_command">install_kraken.sh $INSTALL_DIR/bin</action>
+                    <action type="shell_command">sh install_kraken.sh $INSTALL_DIR/bin ; /bin/true</action>
                 </actions>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>


### PR DESCRIPTION
Precompiled package had the wrong extension, and install_kraken.sh always exits with code 1.