### PR TITLE
ATLAS: Use system version of libgfortran when available

### DIFF
--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -25,7 +25,10 @@
                         LGF=`ldd test | grep libgfortran | awk '{print $3}'` &&
                         LGF_CANON=`readlink -f $LGF` &&
                         LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
-                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] && cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled && cp -p $LGF_CANON $BUNDLED_LGF_CANON
+                        if [ $LGF_VERS -gt $BUNDLED_LGF_VERS ]; then
+                            cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &&
+                            cp -p $LGF_CANON $BUNDLED_LGF_CANON
+                        fi
                     ]]></action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">

--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -20,17 +20,12 @@
                         command -v gfortran || return 0
                         BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &&
                         BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
-                        CWD=`pwd` &&
-                        FTMP=`mktemp -d galaxy_atlas_XXXXXX` &&
-                        cd $FTMP &&
                         echo 'program test; end program test' > test.f90 &&
                         gfortran -o test test.f90 &&
                         LGF=`ldd test | grep libgfortran | awk '{print $3}'` &&
                         LGF_CANON=`readlink -f $LGF` &&
                         LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
-                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] && cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled && cp -p $LGF_CANON $BUNDLED_LGF_CANON &&
-                        cd "$CWD" &&
-                        rm -rf $FTMP
+                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] && cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled && cp -p $LGF_CANON $BUNDLED_LGF_CANON
                     ]]></action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">

--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -16,22 +16,22 @@
                         <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
                         <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
                     </action>
-                    <action type="shell_command">
+                    <action type="shell_command"><![CDATA[
                         command -v gfortran || return 0
-                        BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &amp;&amp;
-                        BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &amp;&amp;
-                        CWD=`pwd` &amp;&amp;
-                        FTMP=`mktemp -d galaxy_atlas_XXXXXX` &amp;&amp;
-                        cd $FTMP &amp;&amp;
-                        echo 'program test; end program test' &gt; test.f90 &amp;&amp;
-                        gfortran -o test test.f90 &amp;&amp;
-                        LGF=`ldd test | grep libgfortran | awk '{print $3}'` &amp;&amp;
-                        LGF_CANON=`readlink -f $LGF` &amp;&amp;
-                        LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &amp;&amp;
-                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] &amp;&amp; cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &amp;&amp; cp -p $LGF_CANON $BUNDLED_LGF_CANON &amp;&amp;
-                        cd "$CWD" &amp;&amp;
+                        BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &&
+                        BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
+                        CWD=`pwd` &&
+                        FTMP=`mktemp -d galaxy_atlas_XXXXXX` &&
+                        cd $FTMP &&
+                        echo 'program test; end program test' > test.f90 &&
+                        gfortran -o test test.f90 &&
+                        LGF=`ldd test | grep libgfortran | awk '{print $3}'` &&
+                        LGF_CANON=`readlink -f $LGF` &&
+                        LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
+                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] && cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled && cp -p $LGF_CANON $BUNDLED_LGF_CANON &&
+                        cd "$CWD" &&
                         rm -rf $FTMP
-                    </action>
+                    ]]></action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
                     <!-- NOOP: On OS X we will use Apple's vecLib -->
@@ -44,17 +44,17 @@
                     <action type="download_file">https://depot.galaxyproject.org/patch/atlas/cpu-throttling-check.diff</action>
                     <action type="shell_command">tar -jxvf atlas3.10.2.tar.bz2</action>
                     <!-- a 64-bit architecture is assumed for compilation -->
-                    <action type="shell_command">
-                        cd ATLAS &amp;&amp;
-                        mkdir ATLAS/build &amp;&amp;
-                        patch -p1 &lt;/host/static_full_blas_lapack.diff &amp;&amp;
-                        patch -p1 &lt;/host/shared_libraries.diff &amp;&amp;
-                        patch -p1 &lt;/host/cpu-throttling-check.diff &amp;&amp;
-                        cd build &amp;&amp;
-                        ../configure --prefix="$INSTALL_DIR" -D c -DWALL -b 64 -Fa alg '-fPIC' --with-netlib-lapack-tarfile=../../lapack-3.5.0.tgz -v 2 -t 0 -Si cputhrchk 0 &amp;&amp;
-                        make &amp;&amp;
+                    <action type="shell_command"><![CDATA[
+                        cd ATLAS &&
+                        mkdir ATLAS/build &&
+                        patch -p1 </host/static_full_blas_lapack.diff &&
+                        patch -p1 </host/shared_libraries.diff &&
+                        patch -p1 </host/cpu-throttling-check.diff &&
+                        cd build &&
+                        ../configure --prefix="$INSTALL_DIR" -D c -DWALL -b 64 -Fa alg '-fPIC' --with-netlib-lapack-tarfile=../../lapack-3.5.0.tgz -v 2 -t 0 -Si cputhrchk 0 &&
+                        make &&
                         make install
-                    </action>
+                    ]]></action>
                     <action type="set_environment">
                         <environment_variable action="set_to" name="ATLAS_LIB_DIR">$INSTALL_DIR/lib</environment_variable>
                         <environment_variable action="set_to" name="ATLAS_INCLUDE_DIR">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -16,6 +16,22 @@
                         <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
                         <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
                     </action>
+                    <action type="shell_command">
+                        command -v gfortran || return 0
+                        BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &amp;&amp;
+                        BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &amp;&amp;
+                        CWD=`pwd` &amp;&amp;
+                        FTMP=`mktemp -d galaxy_atlas_XXXXXX` &amp;&amp;
+                        cd $FTMP &amp;&amp;
+                        echo 'program test; end program test' &gt; test.f90 &amp;&amp;
+                        gfortran -o test test.f90 &amp;&amp;
+                        LGF=`ldd test | grep libgfortran | awk '{print $3}'` &amp;&amp;
+                        LGF_CANON=`readlink -f $LGF` &amp;&amp;
+                        LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &amp;&amp;
+                        [ $LGF_VERS -gt $BUNDLED_LGF_VERS ] &amp;&amp; cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &amp;&amp; cp -p $LGF_CANON $BUNDLED_LGF_CANON &amp;&amp;
+                        cd "$CWD" &amp;&amp;
+                        rm -rf $FTMP
+                    </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
                     <!-- NOOP: On OS X we will use Apple's vecLib -->


### PR DESCRIPTION
As documented in #190, if the version of (lib)gfortran on the system is newer than the version bundled with the version in this package, compiling dependant packages (SciPy) will fail. As proposed in that issue, this will copy the system version to the tool dependency's lib directory if the system version exists and is newer.

I could not find a reliable way to locate a shared library and gfortran itself doesn't provide a way to locate it (or link to it) that I could find, so I'm:

1. Creating an empty Fortran program
2. Compiling it with gfortran
3. Using ldd to find the linked libgfortran
4. Comparing the minor version numbers embedded in the GNU ELF format's symbol version section
5. Copying in the system version if its minor version is greater than the bundled version

If gfortran is not installed, all of this is skipped and the package is marked successfully installed. This may cause problems if the administrator installs this package without gfortran installed, then installs gfortran, and attempts to install SciPy. My rationale for this is that other things that could link against ATLAS may not necessarily require gfortran (or do they? I don't know).

This works for me on Ubuntu 14.04, but I'd certainly appreciate some tests on other (especially non-Debianish) Linux distros.