### PR TITLE
RNA-STAR: Not enough memory error captured in stdio

### DIFF
--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -6,6 +6,7 @@
     </requirements>
     <stdio>
         <regex match="EXITING: FATAL INPUT ERROR:" source="both" level="fatal"/>
+        <regex match="EXITING: fatal error trying to allocate genome arrays, exception thrown: std::bad_alloc" source="both" level="fatal"/>
         <regex match="\[sam_read1\] missing header\? Abort!" source="both" level="fatal"/>
         <regex match=".*" source="both" level="warning" description="Some stderr/stdout text"/>
     </stdio>


### PR DESCRIPTION
RNA STAR requires \~27GB of RAM for hg19.
This patch will make the tool ends up in error state if STAR crashes because it can't allocate enough memory.


Instead of allowing all lines in stderr and making exceptions for those that are critical errors (```<regex match=".*" source="both" level="warning" description="Some stderr/stdout text"/>```), I think it would be more convenient to disallow all lines in stderr and make an exception for those lines that are not critical, like these:

```
Jun 30 15:49:24 ..... Started STAR run
Jun 30 15:50:07 ..... Started mapping
Jun 30 15:50:09 ..... Finished successfully
```

Please share your thoughts on this.