### PR TITLE
Added new dependency definition for barrnap v0.7 - package_barrnap_0_7

### DIFF
--- a/packages/package_barrnap_0_7/.shed.yml
+++ b/packages/package_barrnap_0_7/.shed.yml
@@ -1,0 +1,13 @@
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version 0.7 of barrnap.
+long_description: |
+  Barrnap predicts the location of 5S, 16S and 23S ribosomal RNA
+  genes in Bacterial genome sequ It takes FASTA DNA sequence as input, and write GFF3
+  as output.
+
+  https://github.com/tseemann/barrnap
+name: package_barrnap_0_7
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_barrnap_0_7
+type: tool_dependency_definition

--- a/packages/package_barrnap_0_7/tool_dependencies.xml
+++ b/packages/package_barrnap_0_7/tool_dependencies.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="package_barrnap_0_7" version="0.7">
+        <install version="1.0">
+            <actions>
+                <action type="download_by_url">https://github.com/tseemann/barrnap/archive/0.7.tar.gz</action>
+                <action type="move_directory_files">
+                    <source_directory>.</source_directory>
+                    <destination_directory>$INSTALL_DIR</destination_directory>
+                </action>
+                <action type="shell_command">chmod ugo+x $INSTALL_DIR/bin/barrnap</action>
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                </action>
+            </actions>
+        </install>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
Barrnap is a rRNA finder in sequences. Version 0.7 supports bacteria, eukaryotes, mitochondria and Archaea..