### PR TITLE
Add .bak suffix to sed -i commands for OSX compatibility.

### DIFF
--- a/packages/package_muscle_3_8_31/tool_dependencies.xml
+++ b/packages/package_muscle_3_8_31/tool_dependencies.xml
@@ -39,7 +39,7 @@
                 <actions>
                     <action type="download_by_url" target_filename="muscle3.8.31.tar.gz">http://www.drive5.com/muscle/downloads3.8.31/muscle3.8.31_src.tar.gz</action>
                     <!-- When compiling, need to remove the '-static' linker option from the src/mk file used by src/Makefile -->
-                    <action type="shell_command">sed -i -e 's/-static//g' src/mk</action>
+                    <action type="shell_command">sed -i.bak -e 's/-static//g' src/mk</action>
                     <action type="shell_command">make -C src/</action>
                     <action type="move_file">
                         <source>src/muscle</source>

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -20,7 +20,7 @@
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepanding means that the new install perl binary will be used after the pipe -->
                 <action type="shell_command">export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
-                <action type="shell_command">sed -i -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
+                <action type="shell_command">sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
 
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_python_2_7/tool_dependencies.xml
+++ b/packages/package_python_2_7/tool_dependencies.xml
@@ -60,7 +60,7 @@
           </repository>
         </action>
         <!-- by default python is not looking af LD_INCLUDE_PATH and Co. -->
-        <action type="shell_command">sed -i -e "s/if host_platform == 'atheos':/if True:/g" setup.py</action>
+        <action type="shell_command">sed -i.bak -e "s/if host_platform == 'atheos':/if True:/g" setup.py</action>
 
         <action type="autoconf"/>
         <action type="download_file">https://bitbucket.org/pypa/setuptools/get/6.1.tar.bz2</action>

--- a/packages/package_samtools_1_0/tool_dependencies.xml
+++ b/packages/package_samtools_1_0/tool_dependencies.xml
@@ -26,8 +26,8 @@
                             <package name="zlib" version="1.2.8" />
                         </repository>
                     </action>
-                    <action type="shell_command">sed -i -e 's/-lcurses/-lncurses/' Makefile</action>
-                    <action type="shell_command">sed -i -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
+                    <action type="shell_command">sed -i.bak -e 's/-lcurses/-lncurses/' Makefile</action>
+                    <action type="shell_command">sed -i.bak -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">
                         <source>samtools</source>

--- a/packages/package_samtools_1_1/tool_dependencies.xml
+++ b/packages/package_samtools_1_1/tool_dependencies.xml
@@ -26,8 +26,8 @@
                             <package name="zlib" version="1.2.8" />
                         </repository>
                     </action>
-                    <action type="shell_command">sed -i -e 's/-lcurses/-lncurses/' Makefile</action>
-                    <action type="shell_command">sed -i -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
+                    <action type="shell_command">sed -i.bak -e 's/-lcurses/-lncurses/' Makefile</action>
+                    <action type="shell_command">sed -i.bak -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">
                         <source>samtools</source>

--- a/packages/package_samtools_1_2/tool_dependencies.xml
+++ b/packages/package_samtools_1_2/tool_dependencies.xml
@@ -27,8 +27,8 @@
                         </repository>
                     </action>
                     <action type="shell_command">sed -i.bak 's#/usr/local#$INSTALL_DIR#' Makefile</action>
-                    <action type="shell_command">sed -i -e 's/-lcurses/-lncurses/' Makefile</action>
-                    <action type="shell_command">sed -i -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
+                    <action type="shell_command">sed -i.bak -e 's/-lcurses/-lncurses/' Makefile</action>
+                    <action type="shell_command">sed -i.bak -e "s|CFLAGS=\s*-g\s*-Wall\s*-O2\s*|CFLAGS= -g -Wall -O2 -I$NCURSES_INCLUDE_PATH/ncurses/ -I$NCURSES_INCLUDE_PATH -L$NCURSES_LIB_PATH|g" Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">
                         <source>samtools</source>

--- a/packages/package_tpp_4_6_3/tool_dependencies.xml
+++ b/packages/package_tpp_4_6_3/tool_dependencies.xml
@@ -72,9 +72,9 @@
                     TPP is fails with a error due to an deprecated use of qw()
                     See the rant @ http://blogs.perl.org/users/rurban/2010/09/qw-in-list-context-deprecated.html
                 -->
-                <action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../perl/tpp_models.pl</action>
-                <action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../CGI/show_nspbin.pl</action>
-                <action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../perl/exporTPP.pl</action>
+                <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../perl/tpp_models.pl</action>
+                <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../CGI/show_nspbin.pl</action>
+                <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../perl/exporTPP.pl</action>
                 <!--action type="shell_command">echo '' &gt; ../perl/tpp_models.pl</action-->
 
                 <action type="shell_command">export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB &amp;&amp; export PATH=$PERL_ROOT_DIR/bin/:$PATH &amp;&amp; export PERL5LIB=$PERL_ROOT_DIR/lib/perl5:$PERL5LIB &amp;&amp; make</action>

--- a/packages/package_tpp_4_7_0/tool_dependencies.xml
+++ b/packages/package_tpp_4_7_0/tool_dependencies.xml
@@ -93,14 +93,14 @@
                 <!-- do not use the build-in boost version
                     Boost version 1.54 is known to have a build bug and can't be used on some systems without a patch.
                 -->
-                <action type="shell_command">sed -i -e 's/# www.boost.org/ifeq "$(strip $(BOOST_LIBDIR))" ""/' Makefile.incl</action>
-                <action type="shell_command">sed -i -e 's/# Proteowizrd/endif/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# www.boost.org/ifeq "$(strip $(BOOST_LIBDIR))" ""/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# Proteowizrd/endif/' Makefile.incl</action>
                 <!-- replace build-in expat library with the more recent toolshed one -->
-                <action type="shell_command">sed -i -e 's/# Build expat library/ifeq "$(strip $(EXPAT_LIB))" ""/' Makefile.incl</action>
-                <action type="shell_command">sed -i -e 's/# Build HDF5/endif\n# Build HDF5/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# Build expat library/ifeq "$(strip $(EXPAT_LIB))" ""/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# Build HDF5/endif\n# Build HDF5/' Makefile.incl</action>
 
-                <action type="shell_command">sed -i -e 's/# HTMLDOC/ifeq "$(strip $(HTMLDOC_BIN))" "not-needed"/' Makefile.incl</action>
-                <action type="shell_command">sed -i -e 's/# put common.*/endif/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# HTMLDOC/ifeq "$(strip $(HTMLDOC_BIN))" "not-needed"/' Makefile.incl</action>
+                <action type="shell_command">sed -i.bak -e 's/# put common.*/endif/' Makefile.incl</action>
 
                 <action type="shell_command">cat Makefile.incl &gt; /home/bag/makefile.incl.txt</action>
 
@@ -110,9 +110,9 @@
                     TPP is fails with a error due to an deprecated use of qw()
                     See the rant @ http://blogs.perl.org/users/rurban/2010/09/qw-in-list-context-deprecated.html
                 -->
-                <!--<action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../perl/tpp_models.pl</action>-->
-                <action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../CGI/show_nspbin.pl</action>
-                <action type="shell_command">sed -i -e 's/qw(.*) /(&amp;) /' ../perl/exporTPP.pl</action>
+                <!--<action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../perl/tpp_models.pl</action>-->
+                <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../CGI/show_nspbin.pl</action>
+                <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../perl/exporTPP.pl</action>
                 <action type="shell_command">echo '' &gt; ../perl/tpp_models.pl</action>
 
                 <action type="shell_command">make</action>

--- a/packages/package_trnascan_1_3_1/tool_dependencies.xml
+++ b/packages/package_trnascan_1_3_1/tool_dependencies.xml
@@ -7,9 +7,9 @@
                 <action type="make_directory">$INSTALL_DIR/lib/tRNAscan-SE/</action>
                 <action type="make_directory">$INSTALL_DIR/man/</action>
                 <!-- replacing the hardcoded pathvariables with the real ones -->
-                <action type="shell_command">sed -i -e "s|^BINDIR  = .*|BINDIR = $INSTALL_DIR/bin/|" Makefile</action>
-                <action type="shell_command">sed -i -e "s|^LIBDIR  = .*|LIBDIR = $INSTALL_DIR/lib/tRNAscan-SE/|" Makefile</action>
-                <action type="shell_command">sed -i -e "s|^MANDIR  = .*|MANDIR = $INSTALL_DIR/man|" Makefile</action>
+                <action type="shell_command">sed -i.bak -e "s|^BINDIR  = .*|BINDIR = $INSTALL_DIR/bin/|" Makefile</action>
+                <action type="shell_command">sed -i.bak -e "s|^LIBDIR  = .*|LIBDIR = $INSTALL_DIR/lib/tRNAscan-SE/|" Makefile</action>
+                <action type="shell_command">sed -i.bak -e "s|^MANDIR  = .*|MANDIR = $INSTALL_DIR/man|" Makefile</action>
                 <action type="make_install"/>
 
                 <!-- for some reason infernal needs to be directly under the bin/ from tRNAScan -->


### PR DESCRIPTION
OSX encounters an error when `sed -i` is run without a suffix for in-place substitution, this resolves that issue.