### PR TITLE
Fixes to package_atlas_3_10 and package_numpy_1_7

### DIFF
--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -15,6 +15,7 @@
                         <environment_variable action="set_to" name="ATLAS_LAPACK_LIB_DIR">$INSTALL_DIR/lib/atlas</environment_variable>
                         <environment_variable action="set_to" name="ATLAS_ROOT_PATH">$INSTALL_DIR</environment_variable>
                         <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib/atlas</environment_variable>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">

--- a/packages/package_numpy_1_7/tool_dependencies.xml
+++ b/packages/package_numpy_1_7/tool_dependencies.xml
@@ -13,6 +13,17 @@
                             <package name="atlas" version="3.10.2" />
                         </repository>
                     </action>
+		    <action type="shell_command">
+		      cat &gt; site.cfg &lt;&lt;EOF
+[DEFAULT]
+library_dirs = $ATLAS_LIB_DIR
+include_dirs = $ATLAS_INCLUDE_DIR
+[blas_opt]
+libraries = blas, atlas
+[lapack_opt]
+libraries = lapack, atlas
+EOF
+		    </action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; 
                         export ATLAS=$ATLAS_ROOT_PATH &amp;&amp;


### PR DESCRIPTION
This PR attempts to address issues with the tool dependency packages `package_atlas_3_10` and `package_numpy_1_7`.

Specifically: although the packages appear to install correctly from the toolshed into a Galaxy instance, when other tools or dependencies attempt to `import numpy` then the import fails with errors of the form e.g.:

    ImportError: /path/to/tool_dependencies/atlas/3.10.2/iuc/package_atlas_3_10/b36c9ee883e9/lib/atlas/libblas.so.3: undefined symbol: ATL_zger2

I've encountered this problem on Fedora 19 and Scientific Linux 6.2, affecting installation of dependencies for the `iuc` tool `macs2` (unable to install the `scipy` dependency) and Bjoern's `deepTools` suite (unable to install the `matplotlib` dependency). It may be that this problem only occurs when the ATLAS libraries are already installed on the system independently of Galaxy.

There are two fixes:

1. Minor update to the `atlas` package to fix an inconsistency between the post-install environments for Linux and Darwin;

2. Create a `site.cfg` for the `numpy` package to ensure that the libraries defined by `package_atlas_3_10` are picked up when other applications attempt to import `numpy`.