### PR TITLE
Changed URL of source code from sourceforge to GitHub.

### DIFF
--- a/packages/package_matplotlib_1_2/tool_dependencies.xml
+++ b/packages/package_matplotlib_1_2/tool_dependencies.xml
@@ -22,7 +22,7 @@
         <install version="1.0">
             <actions>
                 <!-- first action is always downloading -->
-                <action type="download_by_url">http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.2.1/matplotlib-1.2.1.tar.gz</action>
+                <action type="download_by_url" target_filename="matplotlib-1.2.1.tar.gz">https://github.com/matplotlib/matplotlib/archive/v1.2.1.tar.gz#md5#47ee56f51200b8760b98d97ee86f57c6</action>
 
                 <!-- populate the environment variables from the dependend repos -->
                 <action type="set_environment_for_install">


### PR DESCRIPTION
Downloads via sourceforge are returning (for me) JavaScript which is
being used to rewrite the URL to use a mirror site.  For example,

  http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.2.1/matplotlib-1.2.1.tar.gz

could be rewritten to:

  http://ufpr.dl.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.2.1/matplotlib-1.2.1.tar.gz

```html
<html>
  <head>
    <title>SourceForge</title>
    <!-- <script src="/js/jquery.com/jquery-1.11.0.min.js"></script> -->
    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
    <script src="//sourceforge.net/js/mirrors.js"></script>
    <script src="/js/sf.js"></script>
    <script>
      var DR_loc = DR_parse_hash_url();
      if (DR_loc) {
          DR_sf_main(DR_loc);
      } else {
          window.location.href = 'http://sourceforge.net/home.html';
      }
    </script>
  </head>
  <body>
  <noscript>
  We're sorry -- the Sourceforge site is currently in Disaster Recovery mode
  the use of javascript to function.  Please check back later.
  </noscript>
  </body>
</html>
```
As matplotlib uses GitHub for development, the easiest solution may be
to use the release from there:

  https://github.com/matplotlib/matplotlib/archive/v1.2.1.tar.gz