### PR TITLE
Fix LD_LIBRARY_PATH and LIBRARY_PATH environment variable settings for

### DIFF
--- a/packages/package_bzlib_1_0/tool_dependencies.xml
+++ b/packages/package_bzlib_1_0/tool_dependencies.xml
@@ -16,9 +16,9 @@
                     <environment_variable name="BZLIB_INCLUDE_DIR" action="set_to">$INSTALL_DIR/bzlib/include</environment_variable>
                     <environment_variable name="BZLIB_SOURCE_DIR" action="set_to">$INSTALL_DIR/bzlib/source</environment_variable>
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/lib</environment_variable>
-                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/lib/source</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/source</environment_variable>
                     <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/lib</environment_variable>
-                    <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/lib/source</environment_variable>
+                    <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/bzlib/source</environment_variable>
                     <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/bzlib/include</environment_variable>
                     <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/bzlib/include</environment_variable>
                 </action>


### PR DESCRIPTION
the package_bzlib_1_0 recipe.  The source directory is at the same level
as the lib directory.