### PR TITLE
Add .shed.yml for taxonomy_krona_chart using crs4 as owner.

### DIFF
--- a/tools/taxonomy_krona_chart/.shed.yml
+++ b/tools/taxonomy_krona_chart/.shed.yml
@@ -1,0 +1,11 @@
+categories:
+- Assembly
+description: Krona pie chart from taxonomic profile
+long_description: |
+  This tool converts the standard result file of a metagenomic profiling in a zoomable pie chart using Krona.
+
+  http://sourceforge.net/projects/krona/
+name: taxonomy_krona_chart
+owner: crs4
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/taxonomy_krona_chart
+type: unrestricted


### PR DESCRIPTION
We agreed with @nekrut on IRC that the best experience for users would be to update  https://toolshed.g2.bx.psu.edu/view/crs4/taxonomy_krona_chart/ instead of creating a new iuc repository. I think that https://toolshed.g2.bx.psu.edu/view/iuc/taxonomy_krona_chart/ creation was an oversight and can be deprecated.

N.B.: iuc has write access to the crs4 repository, which I have just updated to the latest commit with planemo using this .shed.yml file and the iuc API key.