### PR TITLE
Fix "sed: RE error: illegal byte sequence" error on OSX and

### DIFF
--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -1,4 +1,7 @@
 <tool_dependency>
+    <package name="gnu_coreutils" version="8.22">
+        <repository name="package_gnu_coreutils_8_22" owner="iuc" prior_installation_required="True"></repository>
+    </package>
     <package name="perl" version="5.18.1">
         <install version="1.0">
             <actions>
@@ -12,18 +15,16 @@
                 <action type="shell_command">tar xfvz local-lib-1.008009.tar.gz</action>
                 <action type="change_directory">local-lib-1.008009</action>
                 <!-- TODO: Here we need to use the new installed perl binary -->
-                <action type="shell_command">export HOME=$INSTALL_DIR; export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
+                <action type="shell_command">export HOME=`mktemp -d`; export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
                 <action type="shell_command">make install</action>
                 <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; eval $(perl -I$INSTALL_DIR/local-lib/lib/perl5 -Mlocal::lib=$INSTALL_DIR/local-lib)</action>
                 <action type="change_directory">..</action>
                 <!-- install cpanminus into our new perl environment -->
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepending means that the new install perl binary will be used after the pipe -->
-                <action type="shell_command">export HOME=$INSTALL_DIR ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
+                <action type="shell_command">export HOME=`mktemp -d` ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
                 <action type="shell_command">LC_ALL=C sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
-
                 <action type="set_environment">
-                    <environment_variable name="HOME" action="prepend_to">$INSTALL_DIR</environment_variable>
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable name="PERL5LIB" action="prepend_to">$INSTALL_DIR/lib/perl5</environment_variable>
                     <environment_variable name="PERL_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -19,8 +19,8 @@
                 <!-- install cpanminus into our new perl environment -->
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepanding means that the new install perl binary will be used after the pipe -->
-                <action type="shell_command">export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
-                <action type="shell_command">sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
+                <action type="shell_command">export HOME=$INSTALL_DIR; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; export PERL_ROOT_DIR=$INSTALL_DIR; export PERL_LOCALLIB_DIR=$INSTALL_DIR/local-lib; cat cpanm | perl - App::cpanminus</action>
+                <action type="shell_command">LC_ALL=C sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
 
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -5,7 +5,12 @@
     <package name="perl" version="5.18.1">
         <install version="1.0">
             <actions>
-
+                <!-- get coreutils in path, to avoid using system's mktemp, which might have differing syntax-->
+                <action type="set_environment_for_install">
+                    <repository name="package_gnu_coreutils_8_22" owner="iuc">
+                        <package name="gnu_coreutils" version="8.22"/>
+                    </repository>
+                </action>
                 <!-- install perl -->
                 <action type="download_by_url">http://www.cpan.org/src/5.0/perl-5.18.1.tar.gz</action>
                 <action type="shell_command">./Configure -des -Dprefix=$INSTALL_DIR -Dstartperl='#!/usr/bin/env perl'</action>

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -5,14 +5,14 @@
     <package name="perl" version="5.18.1">
         <install version="1.0">
             <actions>
-                <!-- get coreutils in path, to avoid using system's mktemp, which might have differing syntax-->
+                <!-- install perl -->
+                <action type="download_by_url">http://www.cpan.org/src/5.0/perl-5.18.1.tar.gz</action>
+                <!-- get coreutils in path, to avoid using system's mktemp, which might have differing syntax -->
                 <action type="set_environment_for_install">
                     <repository name="package_gnu_coreutils_8_22" owner="iuc">
                         <package name="gnu_coreutils" version="8.22"/>
                     </repository>
                 </action>
-                <!-- install perl -->
-                <action type="download_by_url">http://www.cpan.org/src/5.0/perl-5.18.1.tar.gz</action>
                 <action type="shell_command">./Configure -des -Dprefix=$INSTALL_DIR -Dstartperl='#!/usr/bin/env perl'</action>
                 <action type="make_install" />
                 <action type="change_directory">..</action>
@@ -20,14 +20,16 @@
                 <action type="shell_command">tar xfvz local-lib-1.008009.tar.gz</action>
                 <action type="change_directory">local-lib-1.008009</action>
                 <!-- TODO: Here we need to use the new installed perl binary -->
-                <action type="shell_command">export HOME=`mktemp -d`; export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
+                <!-- Test whether $TMP_WORK_DIR exists (introduced in galaxy release 15.07).
+                If not, fall back to using mktemp. Should be set to HOME=$TEMP_WORK_DIR in the future. -->
+                <action type="shell_command">if [ -d "$TMP_WORK_DIR" ] ; then export HOME=$TMP_WORK_DIR ; else export HOME=`mktemp -d` ; fi ; export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
                 <action type="shell_command">make install</action>
                 <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; eval $(perl -I$INSTALL_DIR/local-lib/lib/perl5 -Mlocal::lib=$INSTALL_DIR/local-lib)</action>
                 <action type="change_directory">..</action>
                 <!-- install cpanminus into our new perl environment -->
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepending means that the new install perl binary will be used after the pipe -->
-                <action type="shell_command">export HOME=`mktemp -d` ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
+                <action type="shell_command">if [ -d "$TMP_WORK_DIR" ] ; then export HOME=$TMP_WORK_DIR ; else export HOME=`mktemp -d` ; fi ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
                 <action type="shell_command">LC_ALL=C sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -12,17 +12,18 @@
                 <action type="shell_command">tar xfvz local-lib-1.008009.tar.gz</action>
                 <action type="change_directory">local-lib-1.008009</action>
                 <!-- TODO: Here we need to use the new installed perl binary -->
-                <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
+                <action type="shell_command">export HOME=$INSTALL_DIR; export PATH=$INSTALL_DIR/bin/:$PATH; perl Makefile.PL --bootstrap=$INSTALL_DIR/local-lib/ --no-manpages</action>
                 <action type="shell_command">make install</action>
-                <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; eval $(perl -I$INSTALL_DIR/local-lib/perl5 -Mlocal::lib=$INSTALL_DIR/local-lib)</action>
+                <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; eval $(perl -I$INSTALL_DIR/local-lib/lib/perl5 -Mlocal::lib=$INSTALL_DIR/local-lib)</action>
                 <action type="change_directory">..</action>
                 <!-- install cpanminus into our new perl environment -->
                 <action type="download_file">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
-                <!-- prepanding means that the new install perl binary will be used after the pipe -->
-                <action type="shell_command">export HOME=$INSTALL_DIR; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; export PERL_ROOT_DIR=$INSTALL_DIR; export PERL_LOCALLIB_DIR=$INSTALL_DIR/local-lib; cat cpanm | perl - App::cpanminus</action>
+                <!-- prepending means that the new install perl binary will be used after the pipe -->
+                <action type="shell_command">export HOME=$INSTALL_DIR ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
                 <action type="shell_command">LC_ALL=C sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>
 
                 <action type="set_environment">
+                    <environment_variable name="HOME" action="prepend_to">$INSTALL_DIR</environment_variable>
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable name="PERL5LIB" action="prepend_to">$INSTALL_DIR/lib/perl5</environment_variable>
                     <environment_variable name="PERL_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
set $HOME during perl installation, to prevent cpanm installation
into ~/.cpan.

Tested on OSX and ubuntu-14.04.
Should fix issue #205