### PR TITLE
Package wrapper for Cython 0.23.1 (UCS2 python compatible)

### DIFF
--- a/packages/package_cython_0_23_1/.shed.yml
+++ b/packages/package_cython_0_23_1/.shed.yml
@@ -1,0 +1,14 @@
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version
+  0.23.1 of cython.
+long_description: |
+  Cython is an optimising static compiler for both the Python programming
+  language and the extended Cython programming language (based on Pyrex). It makes
+  writing C extensions for Python as easy as Python itself.
+
+  http://cython.org
+name: package_cython_0_23_1
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_cython_0_23_1
+type: tool_dependency_definition

--- a/packages/package_cython_0_23_1/tool_dependencies.xml
+++ b/packages/package_cython_0_23_1/tool_dependencies.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="python" version="2.7">
+        <repository name="package_python_2_7" owner="iuc" prior_installation_required="True" />
+    </package>
+    
+    <package name="cython" version="0.23.1">
+        <install version="1.0">
+            <actions>
+                <action type="download_by_url" sha256sum="bdfd12d6a2a2e34b9a1bbc1af5a772cabdeedc3851703d249a52dcda8378018a">https://pypi.python.org/packages/source/C/Cython/Cython-0.23.1.tar.gz</action>
+
+                <action type="setup_python_environment">
+                   <repository name="package_python_2_7" owner="iuc">
+                       <package name="python" version="2.7" />
+                   </repository>
+                </action>
+                
+                <action type="make_directory">$INSTALL_DIR/lib/python</action>
+                <action type="make_directory">$INSTALL_DIR/bin</action>
+                <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable action="set_to" name="CYTHON_PATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>
+            Installation of cython requieres python. The installation can be accessed via CYTHON_PATH.
+            http://cython.org
+        </readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
To address issue https://github.com/galaxyproject/tools-iuc/issues/256, the package wrapper for version 0.23.1 of Cython, compatible with the python 2.7 build from galaxy.