### PR TITLE
Small star changes

### DIFF
--- a/tools/rgrnastar/.shed.yml
+++ b/tools/rgrnastar/.shed.yml
@@ -1,6 +1,6 @@
 categories:
 - Next Gen Mappers
-description: RNA STAR 2.4
+description: RNA STAR 2.4.0
 long_description: |
   WARNING! This will eat all your cluster node RAM and then some.
 

--- a/tools/rgrnastar/.shed.yml
+++ b/tools/rgrnastar/.shed.yml
@@ -6,8 +6,7 @@ long_description: |
 
   hg19 uses about 30GB but it's really fast. See http://gettinggeneticsdone.blogspot.com.au/2012/11/star-ultrafast-universal-rna-seq-aligner.html
 
-  You also need a new set of genome indexes. Sigh. So you have to build those yourself
-  until I figure out how to make an index manager.
+  You also need a new set of genome indexes. Sigh. So you have to build those yourself.
 
   Most of this wrapper was originally written by Jeremy Goecks, with kibbitzing and
   automated dependency installation by Ross Lazarus.

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -1,4 +1,4 @@
-<tool id="rna_star" name="rnastar" version="2.4.0d">
+<tool id="rna_star" name="RNA STAR" version="2.4.0d">
     <description>Gapped-read mapper for RNA-seq data</description>
     <requirements>
         <requirement type="package" version="2.4.0d">rnastar</requirement>
@@ -321,7 +321,9 @@ canonical junctions will be kept.
 
 **Attributions**
 
-Note that each component has its own license. Good luck with figuring out your obligations.
+Note that each component has its own license:
+ - RNA STAR: GPLv3
+ - samtools: MIT/Expat License
 
 rna_star - see the web site at rna_star_
 
@@ -339,13 +341,13 @@ written by Ross Lazarus and that part is licensed_ the same way as other rgeneti
 
 .. _STAR: https://bitbucket.org/jgoecks/jeremys-code/raw/fa1930a689b8e2f6b59cc1706e5ba0ed8ad357be/galaxy/tool-wrappers/star.xml
 .. _licensed: http://creativecommons.org/licenses/by-nc-nd/3.0/
-.. _rna_star: http://code.google.com/p/rna-star/
+.. _rna_star: https://github.com/alexdobin/STAR
 .. _rna_starMS: http://bioinformatics.oxfordjournals.org/content/29/1/15.full
 .. _Galaxy: http://getgalaxy.org
 
 </help>
 <citations>
-    <citation type="doi">doi: 10.1093/bioinformatics/bts635</citation>
+    <citation type="doi">10.1093/bioinformatics/bts635</citation>
 </citations>
 </tool>
 


### PR DESCRIPTION
This PR changes:
 - A link was broken (STAR moved from google code to github)
 - The DOI was broken due to the 'doi: '-prefix and couldn't compile ('Failed to fetch BibTeX for DOI.')
 - The name into 'RNA STAR' which I think is more appropriate than 'rnastar'.

