### PR TITLE
Fix github raw links in selected packages

### DIFF
--- a/packages/package_chemfp_1_1/tool_dependencies.xml
+++ b/packages/package_chemfp_1_1/tool_dependencies.xml
@@ -11,7 +11,7 @@
 
                 <!-- apply one small patched file, to support the query-format target-format commandline options
                 <action type="download_file">http://chem-fingerprints.googlecode.com/hg-history/1281bfcb470b84f5e75250dfa041345d280dde30/chemfp/commandline/simsearch.py</action>-->
-                <action type="download_file">https://github.com/bgruening/download_store/blob/master/chemfp/simsearch.py</action>
+                <action type="download_file">https://github.com/bgruening/download_store/raw/master/chemfp/simsearch.py</action>
                 <action type="shell_command">rm $INSTALL_DIR/lib/python/chemfp/commandline/simsearch.py</action>
                 <action type="move_file">
                     <source>simsearch.py</source>

--- a/packages/package_monocle_1_0_0/tool_dependencies.xml
+++ b/packages/package_monocle_1_0_0/tool_dependencies.xml
@@ -10,35 +10,35 @@
                     <repository name="package_r_3_1_2" owner="iuc">
                         <package name="R" version="3.1.2" />
                     </repository>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/VGAM_0.9-6.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/HSMMSingleCell_1.0.0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/BiocGenerics_0.12.1.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/Biobase_2.26.0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/Rcpp_0.11.4.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/plyr_1.8.1.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/digest_0.6.8.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/gtable_0.1.2.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/stringr_0.6.2.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/reshape2_1.4.1.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/RColorBrewer_1.1-2.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/dichromat_2.0-0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/colorspace_1.2-4.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/munsell_0.4.2.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/labeling_0.3.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/scales_0.2.4.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/proto_0.3-10.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/MASS_7.3-39.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/ggplot2_1.0.0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/lattice_0.20-30.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/Matrix_1.1-5.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/igraph_0.7.1.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/cluster_2.0.1.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/combinat_0.0-8.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/fastICA_1.2-0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/irlba_1.0.3.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/matrixStats_0.14.0.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/limma_3.22.4.tar.gz</package>
-                    <package>https://github.com/bgruening/download_store/blob/master/monocle/monocle_1.0.0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/VGAM_0.9-6.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/HSMMSingleCell_1.0.0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/BiocGenerics_0.12.1.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/Biobase_2.26.0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/Rcpp_0.11.4.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/plyr_1.8.1.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/digest_0.6.8.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/gtable_0.1.2.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/stringr_0.6.2.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/reshape2_1.4.1.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/RColorBrewer_1.1-2.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/dichromat_2.0-0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/colorspace_1.2-4.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/munsell_0.4.2.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/labeling_0.3.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/scales_0.2.4.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/proto_0.3-10.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/MASS_7.3-39.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/ggplot2_1.0.0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/lattice_0.20-30.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/Matrix_1.1-5.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/igraph_0.7.1.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/cluster_2.0.1.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/combinat_0.0-8.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/fastICA_1.2-0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/irlba_1.0.3.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/matrixStats_0.14.0.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/limma_3.22.4.tar.gz</package>
+                    <package>https://github.com/bgruening/download_store/raw/master/monocle/monocle_1.0.0.tar.gz</package>
                 </action>
             </actions>
         </install>

--- a/packages/package_rnashapes_2_1_6/tool_dependencies.xml
+++ b/packages/package_rnashapes_2_1_6/tool_dependencies.xml
@@ -5,7 +5,7 @@
             <actions_group>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit OSX. -->
                 <actions os="darwin" architecture="i386">
-                    <action type="download_by_url">https://github.com/bgruening/download_store/blob/master/RNAshapes/RNAshapes-2.1.6-osx.tar.gz</action>
+                    <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/RNAshapes/RNAshapes-2.1.6-osx.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -13,7 +13,7 @@
                 </actions>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit Linux (i386). -->
                 <actions os="linux" architecture="i386">
-                    <action type="download_by_url">https://github.com/bgruening/download_store/blob/master/RNAshapes/RNAshapes-2.1.6-i386-linux.tar.gz</action>
+                    <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/RNAshapes/RNAshapes-2.1.6-i386-linux.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -21,7 +21,7 @@
                 </actions>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit Linux (i686). -->
                 <actions os="linux" architecture="i686">
-                    <action type="download_by_url">https://github.com/bgruening/download_store/blob/master/RNAshapes/RNAshapes-2.1.6-i386-linux.tar.gz</action>
+                    <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/RNAshapes/RNAshapes-2.1.6-i386-linux.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -29,7 +29,7 @@
                 </actions>
                 <!-- This actions tag is only processed if none of the above tags resulted in a successful installation. -->
                 <actions>
-                    <action type="download_by_url">https://github.com/bgruening/download_store/blob/master/RNAshapes/RNAshapes-2.1.6.tar.gz</action>
+                    <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/RNAshapes/RNAshapes-2.1.6.tar.gz</action>
                     <action type="autoconf" />
                 </actions>
                 <!-- The $PATH environment variable is only set if one of the above <actions> tags resulted in a successful installation. -->


### PR DESCRIPTION
The old links gave HTML downloads, these now match the other links to https://github.com/bgruening/download_store - does this look fine @bgruening ?

This was done with an in-place sed search and replace to the packages folder.

Found while testing https://github.com/galaxyproject/planemo/pull/310