### PR TITLE
HMMER 3.1b1 package fix and new 3.1b2

### DIFF
--- a/packages/package_hmmer_3_1b1/.shed.yml
+++ b/packages/package_hmmer_3_1b1/.shed.yml
@@ -1,5 +1,5 @@
 owner: iuc
-name: package_hmmer3_1b1
+name: package_hmmer_3_1b1
 description: Contains a tool dependency definition that downloads and compiles version
   3.1b1 of the HMMER software
 long_description: |
@@ -11,5 +11,5 @@ long_description: |
   http://hmmer.janelia.org/
 categories:
   - Tool Dependency Packages
-remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_hmmer3_1b1
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_hmmer_3_1b1
 type: tool_dependency_definition

--- a/packages/package_hmmer_3_1b1/tool_dependencies.xml
+++ b/packages/package_hmmer_3_1b1/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="hmmer3_1b1" version="3.1b1">
+    <package name="hmmer" version="3.1b1">
         <install version="1.0">
             <actions>
                 <action type="download_by_url">ftp://selab.janelia.org/pub/software/hmmer3/3.1b1/hmmer-3.1b1.tar.gz</action>
@@ -9,9 +9,9 @@
                 <action type="make_install" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
-                    <environment_variable name="HMMER31_ROOT_PATH" action="set_to">$INSTALL_DIR</environment_variable>
                     <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
                     <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                 </action>
             </actions>
         </install>
@@ -34,7 +34,6 @@ the wide scientific community, we now provide servers that allow sequence
 searches to be performed interactively via the Web.
 
 http://hmmer.janelia.org/
-
         </readme>
     </package>
 </tool_dependency>

--- a/packages/package_hmmer_3_1b2/.shed.yml
+++ b/packages/package_hmmer_3_1b2/.shed.yml
@@ -1,0 +1,15 @@
+owner: iuc
+name: package_hmmer_3_1b2
+description: Contains a tool dependency definition that downloads and compiles version
+  3.1b2 of the HMMER software
+long_description: |
+  HMMER is used for searching sequence databases for homologs of protein
+  sequences, and for making protein sequence alignments. It implements
+  methods using probabilistic models called profile hidden Markov models
+  (profile HMMs).
+
+  http://hmmer.janelia.org/
+categories:
+  - Tool Dependency Packages
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_hmmer_3_1b2
+type: tool_dependency_definition

--- a/packages/package_hmmer_3_1b2/tool_dependencies.xml
+++ b/packages/package_hmmer_3_1b2/tool_dependencies.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="hmmer" version="3.1b2">
+        <install version="1.0">
+            <actions>
+                <action type="download_by_url">ftp://selab.janelia.org/pub/software/hmmer3/3.1b2/hmmer-3.1b2.tar.gz</action>
+                <action type="autoconf" />
+                <action type="change_directory">easel/miniapps/</action>
+                <action type="make_install" />
+                <action type="set_environment">
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>
+HMMER is used for searching sequence databases for homologs of protein
+sequences, and for making protein sequence alignments. It implements methods
+using probabilistic models called profile hidden Markov models (profile HMMs).
+
+Compared to BLAST, FASTA, and other sequence alignment and database search
+tools based on older scoring methodology, HMMER aims to be significantly more
+accurate and more able to detect remote homologs because of the strength of its
+underlying mathematical models. In the past, this strength came at significant
+computational expense, but in the new HMMER3 project, HMMER is now essentially
+as fast as BLAST.
+
+As part of this evolution in the HMMER software, we are committed to making the
+software available to as many scientists as possible. Earlier releases of HMMER
+were restricted to command line use. To make the software more accessible to
+the wide scientific community, we now provide servers that allow sequence
+searches to be performed interactively via the Web.
+
+http://hmmer.janelia.org/
+        </readme>
+    </package>
+</tool_dependency>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -2,7 +2,7 @@
 <macros>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="3.1b1">hmmer3_1b1</requirement>
+      <requirement type="package" version="3.1b1">hmmer</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/hmmer3/tool_dependencies.xml
+++ b/tools/hmmer3/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-  <package name="hmmer3_1b1" version="3.1b1">
-    <repository name="package_hmmer3_1b1" owner="iuc"/>
+  <package name="hmmer" version="3.1b1">
+    <repository name="package_hmmer_3_1b1" owner="iuc"/>
   </package>
 </tool_dependency>


### PR DESCRIPTION
`package_hmmer3_1b1` is renamed to the standard `package_hmmer_3_1b1` . The old package was broken due to the missing PATH prepending, so I see no harm in deprecating the old package.

This also adds the new `package_hmmer_3_1b2`.