### PR TITLE
Fix cairo compilation on gcc-4.9 and fix non-fatal make error.

### DIFF
--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -24,14 +24,17 @@
                       <package name="freetype" version="2.5.2" />
                     </repository>
                 </action>
+                <!-- edit configure and build/configure.ac.warnings to allow compiling cairo on gcc-4.9. Fixed in more recent versions of cairo -->
                 <action type="shell_command">
+                    sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &amp;&amp; \
                     export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &amp;&amp; \ 
                     ./configure --prefix=$INSTALL_DIR \
                         --with-x=no \
                         --enable-xcb-shm=no \
                         --enable-xlib-xcb=no \
                         --enable-xcb=no \
-                        --enable-xlib-xrender=no
+                        --enable-xlib-xrender=no \
+                        --enable-gtk-doc-html=no
                 </action>
                 <action type="make_install" />
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->


### PR DESCRIPTION
As discussed in issue #304 
Additionally, do not build html documentation, which fails if gtk-rebase is not available.
Requires re-upload or metadata reset (not sure if metadata reset is enough?!) of r packages
- package_r_3_1_1
- package_r_2_15_0
- package_r_2_11_0
- package_r_3_2_0
- package_r_3_1_0
- package_r_3_0_3
- package_r_3_1_2
- package_r_3_2_1

Tested on gcc version 4.9.2 (Ubuntu 4.9.2-10ubuntu13) and gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)