### PR TITLE
Reorder compile from source recipes

### DIFF
--- a/packages/package_bcftools_1_2/tool_dependencies.xml
+++ b/packages/package_bcftools_1_2/tool_dependencies.xml
@@ -14,12 +14,12 @@
                     </action>
                 </actions>
                 <actions>
+                    <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_zlib_1_2_8" owner="iuc">
                             <package name="zlib" version="1.2.8" />
                         </repository>
                     </action>
-                    <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2</action>
                     <action type="shell_command">sed -i.bak 's#/usr/local#$INSTALL_DIR#' Makefile</action>
                     <action type="make_install" />
                 </actions>

--- a/packages/package_meme_4_10_0/tool_dependencies.xml
+++ b/packages/package_meme_4_10_0/tool_dependencies.xml
@@ -21,12 +21,12 @@
                     </action>
                 </actions>
                 <actions>
+                    <action type="download_by_url">http://ebi.edu.au/ftp/software/MEME/4.10.0/meme_4.10.0_4.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_libxslt_1_1_28" owner="devteam" prior_installation_required="True">
                             <package name="libxslt" version="1.1.28" />
                         </repository>
                     </action>
-                    <action type="download_by_url">http://ebi.edu.au/ftp/software/MEME/4.10.0/meme_4.10.0_4.tar.gz</action>
                     <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
                     <action type="shell_command">make</action>
                     <action type="shell_command">make install</action>


### PR DESCRIPTION
The first action has a subtle effect on the working directory used, see https://github.com/galaxyproject/galaxy/issues/896

@bgruening are you able to test this which is the change you suggested here: https://github.com/galaxyproject/planemo/pull/321#issuecomment-147486763

The path issue does not appear to be important in this case, but I think currently the source code for these tools would be left under ``$INSTALL_DIR`` which would be used as the working directory. After my change the download and compilation should happen in a temporary folder.