### PR TITLE
Use autoconf and make_install actions more

### DIFF
--- a/packages/package_cmake_3_2_3/tool_dependencies.xml
+++ b/packages/package_cmake_3_2_3/tool_dependencies.xml
@@ -5,8 +5,7 @@
             <actions>
                 <action type="download_by_url" sha256sum="a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297">http://www.cmake.org/files/v3.2/cmake-3.2.3.tar.gz</action>
                 <action type="shell_command">./bootstrap --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_freetype_2_4/tool_dependencies.xml
+++ b/packages/package_freetype_2_4/tool_dependencies.xml
@@ -5,9 +5,7 @@
                 <action type="download_by_url" sha256sum="ef9d0bcb64647d9e5125dc7534d7ca371c98310fec87677c410f397f71ffbe3f">
                     http://download.savannah.gnu.org/releases/freetype/freetype-2.4.11.tar.bz2
                 </action>
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR/freetype/</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf">--prefix=$INSTALL_DIR/freetype/</action>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/freetype/bin/</environment_variable>
                     <environment_variable name="FREETYPE_LIB_DIR" action="set_to">$INSTALL_DIR/freetype/lib/</environment_variable>

--- a/packages/package_gnu_coreutils_8_21/tool_dependencies.xml
+++ b/packages/package_gnu_coreutils_8_21/tool_dependencies.xml
@@ -7,10 +7,8 @@
                 repacked version of http://ftp.gnu.org/gnu/coreutils/coreutils-8.21.tar.xz,
                 because tarfile did not understand LZMA compression
             -->
-            <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/coreutils-8.21.tar.bz2</action>
-            <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/coreutils-8.21.tar.bz2</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_gnu_coreutils_8_22/tool_dependencies.xml
+++ b/packages/package_gnu_coreutils_8_22/tool_dependencies.xml
@@ -7,10 +7,8 @@
                 repacked version of http://ftp.gnu.org/gnu/coreutils/coreutils-8.22.tar.xz,
                 because tarfile did not understand LZMA compression
             -->
-            <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/coreutils-8.22.tar.bz2</action>
-            <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/coreutils-8.22.tar.bz2</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_gnu_grep_2_14/tool_dependencies.xml
+++ b/packages/package_gnu_grep_2_14/tool_dependencies.xml
@@ -6,18 +6,16 @@
     <package name="gnu_grep" version="2.14">
         <install version="1.0">
             <actions>
-            <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/grep-2.14.tar.bz2</action>
-            <action type="set_environment_for_install">
-                <repository name="package_pcre_8_34" owner="iuc">
-                    <package name="pcre" version="8.34" />
-                </repository>
-            </action>
-            <action type="shell_command">./configure --enable-perl-regexp --prefix=$INSTALL_DIR</action>
-            <action type="shell_command">make</action>
-            <action type="shell_command">make install</action>
-            <action type="set_environment">
-                <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
-             </action>
+                <action type="download_by_url">https://github.com/bgruening/download_store/raw/master/GNU/grep-2.14.tar.bz2</action>
+                <action type="set_environment_for_install">
+                    <repository name="package_pcre_8_34" owner="iuc">
+                        <package name="pcre" version="8.34" />
+                    </repository>
+                </action>
+                <action type="autoconf">--enable-perl-regexp</action>
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                </action>
             </actions>
         </install>
         <readme>

--- a/packages/package_graphicsmagick_1_3/tool_dependencies.xml
+++ b/packages/package_graphicsmagick_1_3/tool_dependencies.xml
@@ -3,14 +3,10 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">http://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.18/GraphicsMagick-1.3.18.tar.gz</action>
-
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR/gmagick/ --enable-shared=yes</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf">--prefix=$INSTALL_DIR/gmagick/ --enable-shared=yes</action>
                 <!-- drop-in replacement for imagemagick's convert -->
                 <action type="shell_command">echo -e '#!/usr/bin/env bash\ngm convert $@' > $INSTALL_DIR/gmagick/bin/convert</action>
                 <action type="shell_command">chmod +x $INSTALL_DIR/gmagick/bin/convert</action>
-
                 <action type="set_environment">
                     <environment_variable name="GRAPHICSMAGICK_ROOT_DIR" action="set_to">$INSTALL_DIR/gmagick</environment_variable>
                     <environment_variable name="PATH" action="append_to">$INSTALL_DIR/gmagick/bin</environment_variable>

--- a/packages/package_infernal_1_1/tool_dependencies.xml
+++ b/packages/package_infernal_1_1/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">ftp://selab.janelia.org/pub/software/infernal/infernal-1.1.tar.gz</action>
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_infernal_1_1rc4/tool_dependencies.xml
+++ b/packages/package_infernal_1_1rc4/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">ftp://selab.janelia.org/pub/software/infernal/infernal-1.1rc4.tar.gz</action>
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_libpng_1_6_7/tool_dependencies.xml
+++ b/packages/package_libpng_1_6_7/tool_dependencies.xml
@@ -4,8 +4,7 @@
       <install version="1.0">
           <actions>
               <action type="download_by_url">http://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.7/libpng-1.6.7.tar.gz</action>
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                <action type="shell_command">make &amp;&amp; make install</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                   <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                   <environment_variable action="set_to" name="LIBPNG_ROOT">$INSTALL_DIR</environment_variable>

--- a/packages/package_libxml2_2_9_1/tool_dependencies.xml
+++ b/packages/package_libxml2_2_9_1/tool_dependencies.xml
@@ -3,8 +3,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">ftp://xmlsoft.org/libxml2/libxml2-2.9.1.tar.gz</action>
-                <action type="shell_command">./configure --prefix=$INSTALL_DIR --without-python</action>
-                <action type="shell_command">make &amp;&amp; make install</action>
+                <action type="autoconf">--without-python</action>
                 <action type="set_environment">
                     <environment_variable name="PKG_CONFIG_PATH" action="prepend_to">$INSTALL_DIR/lib/pkgconfig</environment_variable>
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_mcl_12_135/tool_dependencies.xml
+++ b/packages/package_mcl_12_135/tool_dependencies.xml
@@ -4,10 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">http://micans.org/mcl/src/mcl-12-135.tar.gz</action>
-                <action type="shell_command">
-                    ./configure --prefix=$INSTALL_DIR
-                </action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                 </action>

--- a/packages/package_meme_4_10_0/tool_dependencies.xml
+++ b/packages/package_meme_4_10_0/tool_dependencies.xml
@@ -27,9 +27,7 @@
                             <package name="libxslt" version="1.1.28" />
                         </repository>
                     </action>
-                    <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                    <action type="shell_command">make</action>
-                    <action type="shell_command">make install</action>
+                    <action type="autoconf"/>
                 </actions>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_ncurses_5_9/tool_dependencies.xml
+++ b/packages/package_ncurses_5_9/tool_dependencies.xml
@@ -4,11 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
-                <action type="shell_command">
-                    ./configure --prefix $INSTALL_DIR --with-shared --enable-symlinks
-                </action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf">--with-shared --enable-symlinks</action>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="NCURSES_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                     <environment_variable action="set_to" name="NCURSES_LIB_PATH">$INSTALL_DIR/lib/</environment_variable>

--- a/packages/package_ncurses_6_0/tool_dependencies.xml
+++ b/packages/package_ncurses_6_0/tool_dependencies.xml
@@ -4,11 +4,7 @@
         <install version="1.0">
             <actions>
                 <action type="download_by_url" sha256sum="3c1d9534d6d5b3a691d23199a7621f25ffbfa0ccc333f680fcdfc192ea362c84">ftp://invisible-island.net/ncurses/current/ncurses-6.0-20150725.tgz</action>
-                <action type="shell_command">
-                    ./configure --prefix $INSTALL_DIR --with-shared --enable-symlinks
-                </action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="autoconf">--with-shared --enable-symlinks</action>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="NCURSES_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                     <environment_variable action="set_to" name="NCURSES_LIB_PATH">$INSTALL_DIR/lib/</environment_variable>

--- a/packages/package_openbabel_2_3/tool_dependencies.xml
+++ b/packages/package_openbabel_2_3/tool_dependencies.xml
@@ -18,8 +18,7 @@
                     Huge hack, to point to the actual python lib path. Cmake gets confused with mixed python versions (2.x and 3.x) and we need to point explicitely to the recent version.
                 -->
                 <action type="shell_command">cmake . -DPYTHON_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN3_SOURCE_PATH -DPYTHON_LIBRARY=`python -c 'import distutils.sysconfig; print "%s/libpython%s.so" % (distutils.sysconfig.get_config_var("LIBPL"), distutils.sysconfig.get_python_version())'`</action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable name="PYTHONPATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_openms_2_0/tool_dependencies.xml
+++ b/packages/package_openms_2_0/tool_dependencies.xml
@@ -63,8 +63,7 @@
 
                     <action type="change_directory">..</action>
                     <action type="shell_command">cmake . -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DHAS_XSERVER=OFF -DENABLE_TUTORIALS=OFF -DENABLE_STYLE_TESTING=OFF -DENABLE_UNITYBUILD=OFF -DWITH_GUI=OFF</action>
-                    <action type="shell_command">make OpenMS TOPP UTILS</action>
-                    <action type="shell_command">make install</action>
+                    <action type="make_install">OpenMS TOPP UTILS</action>
                     <action type="set_environment">
                         <environment_variable action="set_to" name="OPENMS_ROOT_PATH">$INSTALL_DIR</environment_variable>
                         <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_piranha_1_2_1/tool_dependencies.xml
+++ b/packages/package_piranha_1_2_1/tool_dependencies.xml
@@ -19,8 +19,7 @@
           </repository>
         </action>
         <action type="shell_command">./configure --prefix=$INSTALL_DIR --with-bam_tools_headers=$BAMTOOLS_ROOT_PATH/include/  --with-bam_tools_library=$BAMTOOLS_ROOT_PATH/lib/</action>
-        <action type="shell_command">make all</action>
-        <action type="shell_command">make install</action>
+        <action type="make_install">all</action>
         <action type="move_directory_files">
             <source_directory>./bin/</source_directory>
             <destination_directory>$INSTALL_DIR/bin</destination_directory>

--- a/packages/package_r_3_0_1/tool_dependencies.xml
+++ b/packages/package_r_3_0_1/tool_dependencies.xml
@@ -18,12 +18,10 @@
                         <package name="ncurses" version="5.9" />
                     </repository>
                 </action>
-
                 <action type="shell_command">
                     ./configure CPPFLAGS=-I$READLINE_INCLUDE_PATH LDFLAGS="-L$READLINE_LIB_PATH -L$NCURSES_LIB_PATH -lreadline -lncurses" --enable-R-shlib  --with-x=no --libdir=$INSTALL_DIR/lib/ --bindir=$INSTALL_DIR/bin/ --datarootdir=$INSTALL_DIR/share/
                 </action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="R_HOME">$INSTALL_DIR</environment_variable>
                     <environment_variable action="set_to" name="R_LIBS">$INSTALL_DIR/lib/R/library</environment_variable>

--- a/packages/package_r_3_0_1_with_atlas/tool_dependencies.xml
+++ b/packages/package_r_3_0_1_with_atlas/tool_dependencies.xml
@@ -36,8 +36,7 @@
                     #set $cmd += ' --enable-R-shlib  --with-x=no --libdir=%s/lib/ --bindir=%s/bin/ --datarootdir=%s/share/' % ($env.INSTALL_DIR, $env.INSTALL_DIR, $env.INSTALL_DIR)
                     $cmd
                 </action>
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="R_HOME">$INSTALL_DIR/lib/R</environment_variable>
                     <environment_variable action="set_to" name="R_LIBS">$INSTALL_DIR/lib/R/library</environment_variable>

--- a/packages/package_r_3_0_2/tool_dependencies.xml
+++ b/packages/package_r_3_0_2/tool_dependencies.xml
@@ -24,13 +24,10 @@
                         <package name="libpng" version="1.6.7" />
                     </repository>
                 </action>
-
                 <action type="shell_command">
                     ./configure CPPFLAGS="-I$READLINE_INCLUDE_PATH -I${LIBPNG_ROOT}/include" LDFLAGS="-L$READLINE_LIB_PATH -L$NCURSES_LIB_PATH -L${LIBPNG_ROOT}/lib -lreadline -lncurses" --with-libpng --enable-R-shlib  --with-x=no --libdir=$INSTALL_DIR/lib/ --bindir=$INSTALL_DIR --datarootdir=$INSTALL_DIR/share/
                 </action>
-
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="R_HOME">$INSTALL_DIR</environment_variable>
                     <environment_variable action="set_to" name="R_LIBS">$INSTALL_DIR/lib/R/library</environment_variable>

--- a/packages/package_readline_6_2/tool_dependencies.xml
+++ b/packages/package_readline_6_2/tool_dependencies.xml
@@ -14,8 +14,7 @@
                 <action type="shell_command">
                     ./configure CPPFLAGS=-I$NCURSES_INCLUDE_PATH LDFLAGS=-L$NCURSES_LIB_PATH --prefix $INSTALL_DIR
                 </action>
-                <action type="shell_command">make SHLIB_LIBS=-lncurses</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install">SHLIB_LIBS=-lncurses</action>
                 <action type="set_environment">
                     <environment_variable name="READLINE_INCLUDE_PATH" action="set_to">$INSTALL_DIR/include</environment_variable>
                     <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_readline_6_3/tool_dependencies.xml
+++ b/packages/package_readline_6_3/tool_dependencies.xml
@@ -16,8 +16,7 @@
                 <action type="shell_command">
                     ./configure CPPFLAGS=-I$NCURSES_INCLUDE_PATH LDFLAGS=-L$NCURSES_LIB_PATH --prefix $INSTALL_DIR
                 </action>
-                <action type="shell_command">make SHLIB_LIBS=-lncurses</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install">SHLIB_LIBS=-lncurses</action>
                 <action type="set_environment">
                     <environment_variable name="READLINE_INCLUDE_PATH" action="set_to">$INSTALL_DIR/include</environment_variable>
                     <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_tophat_2_0_14/tool_dependencies.xml
+++ b/packages/package_tophat_2_0_14/tool_dependencies.xml
@@ -20,8 +20,7 @@
                 </actions>
                 <actions>
                     <action type="download_by_url">http://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.14.tar.gz</action>
-                    <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-                    <action type="make_install" />
+                    <action type="autoconf"/>
                 </actions>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_tpp_4_7_0/tool_dependencies.xml
+++ b/packages/package_tpp_4_7_0/tool_dependencies.xml
@@ -111,9 +111,7 @@
                 <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../CGI/show_nspbin.pl</action>
                 <action type="shell_command">sed -i.bak -e 's/qw(.*) /(&amp;) /' ../perl/exporTPP.pl</action>
                 <action type="shell_command">echo '' &gt; ../perl/tpp_models.pl</action>
-
-                <action type="shell_command">make</action>
-                <action type="shell_command">make install</action>
+                <action type="make_install"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/tpp/bin</environment_variable>
                     <environment_variable action="prepend_to" name="PERL5LIB">$INSTALL_DIR/lib/perl5</environment_variable>


### PR DESCRIPTION
I deliberately only covered what looked like easy cases. This also fixed the indentation in a few cases - we should lint all the XML files to a standard indentation pattern.

There are lots more recipes which could be re-factored to use these more advanced actions, making them shorter. On the other hand I do quite like the alternative ``shell_command`` action with CDATA approach to embed an entire bash script ;)

**This is untested**

Do we have a mechanism for mass testing all the dependency installations scripts? (I used to depend on the TTS for doing this)