### PR TITLE
Overwrite bundled libgfortran with system libgfortran if it is newer …

### DIFF
--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -9,6 +9,20 @@
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
+                    <action type="shell_command"><![CDATA[
+                        command -v gfortran || return 0
+                        BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &&
+                        BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
+                        echo 'program test; end program test' > test.f90 &&
+                        gfortran -o test test.f90 &&
+                        LGF=`ldd test | grep libgfortran | awk '{print $3}'` &&
+                        LGF_CANON=`readlink -f $LGF` &&
+                        LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
+                        if [ $LGF_VERS -gt $BUNDLED_LGF_VERS ]; then
+                            cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &&
+                            cp -p $LGF_CANON $BUNDLED_LGF_CANON
+                        fi
+                    ]]></action>
                     <action type="set_environment">
                         <environment_variable action="set_to" name="TCL_LIBRARY">$INSTALL_DIR/lib/libtcl8.4.so</environment_variable>
                         <environment_variable action="set_to" name="TK_LIBRARY">$INSTALL_DIR/lib/libtk8.4.so</environment_variable>

--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -12,6 +12,7 @@
                     <action type="shell_command"><![CDATA[
                         command -v gfortran || return 0
                         BUNDLED_LGF_CANON=$INSTALL_DIR/lib/libgfortran.so.3.0.0 &&
+                        BUNDLED_LGF_FQSO=$INSTALL_DIR/lib/libgfortran.so.3 &&
                         BUNDLED_LGF_VERS=`objdump -p $BUNDLED_LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
                         echo 'program test; end program test' > test.f90 &&
                         gfortran -o test test.f90 &&
@@ -20,7 +21,9 @@
                         LGF_VERS=`objdump -p $LGF_CANON | grep GFORTRAN_1 | sed -r 's/.*GFORTRAN_1\.([0-9])+/\1/' | sort -n | tail -1` &&
                         if [ $LGF_VERS -gt $BUNDLED_LGF_VERS ]; then
                             cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &&
-                            cp -p $LGF_CANON $BUNDLED_LGF_CANON
+                            cp -p $BUNDLED_LGF_FQSO ${BUNDLED_LGF_FQSO}.bundled &&
+                            cp -p $LGF_CANON $BUNDLED_LGF_CANON &&
+                            ln -s $BUNDLED_LGF_CANON BUNDLED_LGF_FQSO
                         fi
                     ]]></action>
                     <action type="set_environment">

--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -23,7 +23,7 @@
                             cp -p $BUNDLED_LGF_CANON ${BUNDLED_LGF_CANON}.bundled &&
                             cp -p $BUNDLED_LGF_FQSO ${BUNDLED_LGF_FQSO}.bundled &&
                             cp -p $LGF_CANON $BUNDLED_LGF_CANON &&
-                            ln -s $BUNDLED_LGF_CANON BUNDLED_LGF_FQSO
+                            cp -p $LGF_CANON $BUNDLED_LGF_FQSO
                         fi
                     ]]></action>
                     <action type="set_environment">


### PR DESCRIPTION
…as in PR #199.

Unfortunately I couldn't reproduce @bcclaywell's issue #325 on a clean ubuntu 14.04 install,
so it is untested right now.