### PR TITLE
Fix cairo cflags

### DIFF
--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -28,7 +28,7 @@
                 <action type="shell_command"><![CDATA[
                     sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &&
                     export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &&
-                    ./configure --prefix=$INSTALL_DIR &&
+                    ./configure --prefix=$INSTALL_DIR \
                         --with-x=no \
                         --enable-xcb-shm=no \
                         --enable-xlib-xcb=no \

--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -25,17 +25,18 @@
                     </repository>
                 </action>
                 <!-- edit configure and build/configure.ac.warnings to allow compiling cairo on gcc-4.9. Fixed in more recent versions of cairo -->
-                <action type="shell_command">
-                    sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &amp;&amp; \
-                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &amp;&amp; \ 
-                    ./configure --prefix=$INSTALL_DIR \
+                <action type="shell_command"><![CDATA[
+                    sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &&
+                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &&
+                    ./configure --prefix=$INSTALL_DIR &&
                         --with-x=no \
                         --enable-xcb-shm=no \
                         --enable-xlib-xcb=no \
                         --enable-xcb=no \
+                        --enable-gtk-doc=no \
+                        --enable-gtk-doc-html=no \
                         --enable-xlib-xrender=no \
-                        --enable-gtk-doc-html=no
-                </action>
+                ]]></action>
                 <action type="make_install" />
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
@@ -48,6 +49,8 @@
                     <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$INSTALL_DIR/include/cairo</environment_variable>
                     <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$INSTALL_DIR/include/cairo</environment_variable>
                     <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
+                    <environment_variable action="set_to" name="CAIRO_CFLAGS">-I$INSTALL_DIR/include/cairo</environment_variable>
+                    <environment_variable action="set_to" name="CAIRO_LIBS">"-L$INSTALL_DIR/lib -lcairo"</environment_variable>
                 </action>
             </actions>
         </install>

--- a/packages/package_cairo_1_14_2/tool_dependencies.xml
+++ b/packages/package_cairo_1_14_2/tool_dependencies.xml
@@ -30,8 +30,8 @@
                         <package name="fontconfig" version="2.11.1" />
                     </repository>
                 </action>
-                <action type="shell_command">
-                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &amp;&amp; \ 
+                <action type="shell_command"><![CDATA[
+                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &&
                     ./configure --prefix=$INSTALL_DIR \
                         --disable-dependency-tracking \
                         --with-x=no \
@@ -39,10 +39,12 @@
                         --enable-xlib-xcb=no \
                         --enable-xcb=no \
                         --enable-xlib-xrender=no \
+                        --enable-gtk-doc=no \
+                        --enable-gtk-doc-html=no \
                         --enable-ft=yes \
                         --enable-svg=yes \
                         --enable-tee=yes
-                </action>
+                ]]></action>
                 <action type="make_install" />
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
@@ -52,6 +54,8 @@
                     <environment_variable action="prepend_to" name="CAIRO_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                     <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
                     <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable action="set_to" name="CAIRO_CFLAGS">-I$INSTALL_DIR/include/cairo</environment_variable>
+                    <environment_variable action="set_to" name="CAIRO_LIBS">"-L$INSTALL_DIR/lib -lcairo"</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
Exposing CAIRO_CFLAGS and CAIRO_LIBS is needed for some R packages, even if cairo support is compiled into R. xref https://github.com/galaxyproject/galaxy/pull/929#issuecomment-148710483