### PR TITLE
Enable bowtie2 2.2.5 installation on osx

### DIFF
--- a/packages/package_bowtie_2_2_5/tool_dependencies.xml
+++ b/packages/package_bowtie_2_2_5/tool_dependencies.xml
@@ -10,6 +10,13 @@
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
+                <actions os="darwin" architecture="x86_64">
+                    <action type="download_by_url">http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.5/bowtie2-2.2.5-macos-x86_64.zip</action>
+                    <action type="move_directory_files">
+                        <source_directory>.</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                </actions>
                 <actions>
                     <action type="download_by_url">http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.5/bowtie2-2.2.5-source.zip</action>
                     <action type="shell_command">make</action>


### PR DESCRIPTION
Per report from @jgoecks, bowtie2 2.2.5 fails to compile on osx, but precompiled binaries are available.