### PR TITLE
Add python-2.7.10 dependency to package_khmer_2_0

### DIFF
--- a/packages/package_bz2file_0_98/.shed.yml
+++ b/packages/package_bz2file_0_98/.shed.yml
@@ -1,0 +1,13 @@
+categories:
+- Tool Dependency Packages
+description: Read and write bzip2-compressed files.
+long_description: |
+  Bz2file is a Python library for reading and writing bzip2-compressed files.
+  It contains a drop-in replacement for the file interface in the standard library’s bz2 module,
+  including features from the latest development version of CPython that are not available in older releases.
+  Bz2file is compatible with CPython 2.6, 2.7, and 3.0 through 3.4, as well as PyPy 2.0.
+name: package_bz2file_0_98
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_bz2file_0_98
+homepage_url: https://github.com/nvawda/bz2file
+type: tool_dependency_definition

--- a/packages/package_bz2file_0_98/tool_dependencies.xml
+++ b/packages/package_bz2file_0_98/tool_dependencies.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<tool_dependency>
+        <package name="bz2file" version="0.98">
+            <install version="1.0">
+                <actions>
+                    <action type="download_by_url" md5sum="27d6f711ae0db6cfd1eb37f95621dfb5">https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz</action>
+                    <action type="shell_command">
+                        export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                        python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+                        <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    </action>
+                </actions>
+            </install>
+            <readme>
+                Downloads and installs bz2file.
+            </readme>
+        </package>
+</tool_dependency>

--- a/packages/package_khmer_2_0/tool_dependencies.xml
+++ b/packages/package_khmer_2_0/tool_dependencies.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0"?>
 <tool_dependency>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
     <package name="khmer" version="2.0">
         <install version="1.0">
             <actions>
                 <action type="setup_python_environment">
-                    <repository name="package_python_2_7" owner="iuc">
-                        <package name="python" version="2.7" />
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
                     </repository>
+                    <package md5sum="27d6f711ae0db6cfd1eb37f95621dfb5">https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz</package>
+                    <package md5sum="611dd11105489e4153265e055f13debd">https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz</package>
                     <package md5sum="1f610abd021254e21b082179a100cd39">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</package>
                 </action>
             </actions>

--- a/packages/package_khmer_2_0/tool_dependencies.xml
+++ b/packages/package_khmer_2_0/tool_dependencies.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="python" version="2.7.10">
-        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    <package name="bz2file" version="0.98">
+        <repository name="package_bz2file_0_98" owner="iuc"/>
+    </package>
+    <package name="screed" version="0.9">
+        <repository name="package_screed_0_9" owner="iuc"/>
     </package>
     <package name="khmer" version="2.0">
         <install version="1.0">
             <actions>
-                <action type="setup_python_environment">
-                    <repository name="package_python_2_7_10" owner="iuc">
-                        <package name="python" version="2.7.10" />
-                    </repository>
-                    <package md5sum="27d6f711ae0db6cfd1eb37f95621dfb5">https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz</package>
-                    <package md5sum="611dd11105489e4153265e055f13debd">https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz</package>
-                    <package md5sum="1f610abd021254e21b082179a100cd39">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</package>
+                <action type="download_by_url" md5sum="1f610abd021254e21b082179a100cd39">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</action>
+                <action type="shell_command">
+                    export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                    python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
+                </action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                 </action>
             </actions>
         </install>

--- a/packages/package_python_2_7_10_khmer_2_0/.shed.yml
+++ b/packages/package_python_2_7_10_khmer_2_0/.shed.yml
@@ -1,0 +1,23 @@
+name: package_python_2_7_10_khmer_2_0
+owner: iuc
+description: In-memory nucleotide sequence k-mer counting, filtering, graph
+        traversal and more
+long_description: |
+  khmer is a library and suite of command line tools for working with DNA
+  sequence. It is primarily aimed at short-read sequencing data such as that
+  produced by the Illumina platform. khmer takes a k-mer-centric approach to
+  sequence analysis, hence the name.
+
+  The official repository is at https://github.com/ged-lab/khmer
+  and you can read the docs online here: http://khmer.readthedocs.org/
+
+  There are two mailing lists dedicated to khmer, an announcements-only list
+  and a discussion list. To search their archives and sign-up for them, please
+  visit the following URLs:
+  
+  Discussion http://lists.idyll.org/listinfo/khmer
+  Announcements http://lists.idyll.org/listinfo/khmer-announce
+categories:
+  - Tool Dependency Packages
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/blob/master/tools/khmer/
+homepage_url: https://khmer.readthedocs.org/

--- a/packages/package_python_2_7_10_khmer_2_0/tool_dependencies.xml
+++ b/packages/package_python_2_7_10_khmer_2_0/tool_dependencies.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="khmer" version="2.0">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <package md5sum="27d6f711ae0db6cfd1eb37f95621dfb5">https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz</package>
+                    <package md5sum="611dd11105489e4153265e055f13debd">https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz</package>
+                    <package md5sum="1f610abd021254e21b082179a100cd39">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</package>
+                </action>
+            </actions>
+        </install>
+    </package>
+</tool_dependency>

--- a/packages/package_screed_0_9/.shed.yml
+++ b/packages/package_screed_0_9/.shed.yml
@@ -1,0 +1,12 @@
+categories:
+- Tool Dependency Packages
+description: screed – short read sequence utils in Python.
+long_description: |
+  screed parses FASTA and FASTQ files, generates databases, and lets you query these databases.
+  Values such as sequence name, sequence description, sequence quality, and the sequence itself
+  can be retrieved from these databases.
+name: package_screed_0_9
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_screed_0_9
+homepage_url: https://github.com/dib-lab/screed
+type: tool_dependency_definition

--- a/packages/package_screed_0_9/tool_dependencies.xml
+++ b/packages/package_screed_0_9/tool_dependencies.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<tool_dependency>
+        <package name="bz2file" version="0.98">
+            <repository name="package_bz2file_0_98" owner="iuc" prior_installation_required="True" />
+        </package>
+        <package name="screed" version="0.9">
+            <install version="1.0">
+                <actions>
+                    <action type="download_by_url" md5sum="611dd11105489e4153265e055f13debd">https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_bz2file_0_98" owner="iuc">
+                            <package name="bz2file" version="0.98" />
+                        </repository>
+                    </action>
+                    <action type="shell_command">
+                        export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                        python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+                        <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    </action>
+                </actions>
+            </install>
+            <readme>
+                Downloads and installs screed.
+            </readme>
+        </package>
+</tool_dependency>

--- a/tools/khmer/macros.xml
+++ b/tools/khmer/macros.xml
@@ -2,6 +2,8 @@
     <token name="@WRAPPER_VERSION@">2.0</token>
     <xml name="requirements">
         <requirements>
+            <requirement type="package" version="0.98">bz2file</requirement>
+            <requirement type="package" version="0.9">screed</requirement>
             <requirement type="package" version="@WRAPPER_VERSION@">khmer</requirement>
         </requirements>
     </xml>

--- a/tools/khmer/tool_dependencies.xml
+++ b/tools/khmer/tool_dependencies.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <tool_dependency>
+    <package name="bz2file" version="0.98">
+        <repository name="package_bz2file_0_98" owner="iuc"/>
+    </package>
+    <package name="screed" version="0.9">
+        <repository name="package_screed_0_9" owner="iuc"/>
+    </package>
     <package name="khmer" version="2.0">
         <repository name="package_khmer_2_0" owner="iuc" />
     </package>


### PR DESCRIPTION
The previous package would result in an empt khmer directory.
@bgruening should we change the name to package_python_2_7_10_khmer_2_0 ?