### PR TITLE
Cleanup packages

### DIFF
--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -10,39 +10,31 @@
         <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True" />
     </package>
     <package name="cairo" version="1.12.14">
-      <install version="1.0">
-          <actions>
-              <action type="download_by_url">http://depot.galaxyproject.org/package/source/cairo/cairo-1.12.14.tar.bz2</action>
+        <install version="1.0">
+            <action>
+                <action type="download_by_url">http://depot.galaxyproject.org/package/source/cairo/cairo-1.12.14.tar.bz2</action>
                 <action type="set_environment_for_install">
-                  <repository name="package_pixman_0_32_4" owner="iuc" prior_installation_required="True">
-                      <package name="pixman" version="0.32.4" />
+                    <repository name="package_pixman_0_32_4" owner="iuc" prior_installation_required="True">
+                        <package name="pixman" version="0.32.4" />
                     </repository>
                     <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
-                      <package name="libpng" version="1.6.7" />
+                        <package name="libpng" version="1.6.7" />
                     </repository>
                     <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True">
-                      <package name="freetype" version="2.5.2" />
+                        <package name="freetype" version="2.5.2" />
                     </repository>
                 </action>
                 <!-- edit configure and build/configure.ac.warnings to allow compiling cairo on gcc-4.9. Fixed in more recent versions of cairo -->
                 <action type="shell_command"><![CDATA[
                     sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &&
-                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &&
-                    ./configure --prefix=$INSTALL_DIR \
-                        --with-x=no \
-                        --enable-xcb-shm=no \
-                        --enable-xlib-xcb=no \
-                        --enable-xcb=no \
-                        --enable-gtk-doc=no \
-                        --enable-gtk-doc-html=no \
-                        --enable-xlib-xrender=no \
                 ]]></action>
-                <action type="make_install" />
+                <action type="autoconf">--prefix=$INSTALL_DIR --with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-xlib-xrender=no</action>
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
                 <action type="set_environment">
-                  <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable action="prepend_to" name="CAIRO_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
                     <environment_variable action="prepend_to" name="CAIRO_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                     <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                     <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -11,7 +11,7 @@
     </package>
     <package name="cairo" version="1.12.14">
         <install version="1.0">
-            <action>
+            <actions>
                 <action type="download_by_url">http://depot.galaxyproject.org/package/source/cairo/cairo-1.12.14.tar.bz2</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pixman_0_32_4" owner="iuc" prior_installation_required="True">

--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -28,7 +28,7 @@
                 <action type="shell_command"><![CDATA[
                     sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &&
                 ]]></action>
-                <action type="autoconf">--prefix=$INSTALL_DIR --with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-xlib-xrender=no</action>
+                <action type="autoconf">--with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-xlib-xrender=no</action>
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
                 <action type="set_environment">

--- a/packages/package_cairo_1_14_2/tool_dependencies.xml
+++ b/packages/package_cairo_1_14_2/tool_dependencies.xml
@@ -30,22 +30,7 @@
                         <package name="fontconfig" version="2.11.1" />
                     </repository>
                 </action>
-                <action type="shell_command"><![CDATA[
-                    export LDFLAGS="-Wl,-rpath,$PIXMAN_LIB_PATH -Wl,-rpath,$LIBPNG_ROOT/lib -Wl,-rpath,$FREETYPE_LIB_PATH" &&
-                    ./configure --prefix=$INSTALL_DIR \
-                        --disable-dependency-tracking \
-                        --with-x=no \
-                        --enable-xcb-shm=no \
-                        --enable-xlib-xcb=no \
-                        --enable-xcb=no \
-                        --enable-xlib-xrender=no \
-                        --enable-gtk-doc=no \
-                        --enable-gtk-doc-html=no \
-                        --enable-ft=yes \
-                        --enable-svg=yes \
-                        --enable-tee=yes
-                ]]></action>
-                <action type="make_install" />
+                <action type="autoconf">--disable-dependency-tracking --with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-xlib-xrender=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-ft=yes --enable-svg=yes --enable-tee=yes</action>
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
                 <action type="set_environment">

--- a/packages/package_fontconfig_2_11_1/tool_dependencies.xml
+++ b/packages/package_fontconfig_2_11_1/tool_dependencies.xml
@@ -18,8 +18,7 @@
                         <package name="libxml2" version="2.9.1" />
                     </repository>
                     </action>
-                        <action type="shell_command">export LDFLAGS="-Wl,-rpath,$FREETYPE_LIB_PATH -L$FREETYPE_LIB_PATH" &amp;&amp; ./configure --prefix=$INSTALL_DIR --disable-docs --enable-libxml2</action>
-                        <action type="make_install" />
+                        <action type="autoconf">--disable-docs --enable-libxml2</action>
                         <action type="set_environment">
                     <environment_variable action="set_to" name="FONTCONFIG_ROOT_PATH">$INSTALL_DIR</environment_variable>
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_pixman_0_32_4/tool_dependencies.xml
+++ b/packages/package_pixman_0_32_4/tool_dependencies.xml
@@ -1,26 +1,46 @@
 <?xml version="1.0"?>
 <tool_dependency>
   <package name="libpng" version="1.6.7">
-      <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True" />
-    </package>
-    <package name="pixman" version="0.32.4">
-      <install version="1.0">
-          <actions>
-              <action type="download_by_url">http://cairographics.org/releases/pixman-0.32.4.tar.gz</action>
-                <action type="set_environment_for_install">
-                  <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
-                      <package name="libpng" version="1.6.7" />
-                    </repository>
-                </action>
-                <action type="shell_command">export LDFLAGS="-Wl,-rpath,$PNG_LIB_PATH" &amp;&amp; echo $LDFLAGS &amp;&amp; ./configure --prefix=$INSTALL_DIR</action>
-                <action type="make_install" />
-                <action type="set_environment">
-                  <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
-                    <environment_variable action="set_to" name="PIXMAN_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
-                    <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
-                </action>
-            </actions>
-        </install>
-        <readme />
-    </package>
+    <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True" />
+  </package>
+  <package name="pixman" version="0.32.4">
+    <install version="1.0">
+      <actions_group>
+        <actions architecture="x86_64" os="linux">
+          <action type="download_by_url" sha256sum="80c7ed420e8a3ae749800241e6347c3d55681296cab71384be7969cd9e657e84">
+            http://cairographics.org/releases/pixman-0.32.4.tar.gz
+          </action>
+          <action type="set_environment_for_install">
+            <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
+              <package name="libpng" version="1.6.7" />
+            </repository>
+          </action>
+          <action type="autoconf"/>
+          <action type="set_environment">
+            <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+            <environment_variable action="set_to" name="PIXMAN_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
+            <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
+          </action>
+        </actions>
+        <actions architecture="x86_64" os="darwin">
+          <action type="download_by_url" sha256sum="80c7ed420e8a3ae749800241e6347c3d55681296cab71384be7969cd9e657e84">
+            http://cairographics.org/releases/pixman-0.32.4.tar.gz
+          </action>
+          <action type="set_environment_for_install">
+            <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
+              <package name="libpng" version="1.6.7" />
+            </repository>
+          </action>
+          <action type="autoconf">--disable-mmx</action>
+          <action type="set_environment">
+            <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+            <environment_variable action="set_to" name="PIXMAN_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
+            <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+            <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
+          </action>
+        </actions>
+      </actions_group>
+    </install>
+    <readme />
+  </package>
 </tool_dependency>

--- a/packages/package_pixman_0_32_6/tool_dependencies.xml
+++ b/packages/package_pixman_0_32_6/tool_dependencies.xml
@@ -13,12 +13,7 @@
                             <package name="libpng" version="1.6.7" />
                         </repository>
                     </action>
-                    <action type="shell_command"><![CDATA[
-                    export LDFLAGS="-Wl,-rpath,$LIBPNG_LIB_PATH" &&
-                    ./configure --prefix=$INSTALL_DIR
-                    ]]>
-                    </action>
-                    <action type="make_install" />
+                    <action type="autoconf" />
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                         <environment_variable action="set_to" name="PIXMAN_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
@@ -32,15 +27,11 @@
                             <package name="libpng" version="1.6.7" />
                         </repository>
                     </action>
-                    <action type="shell_command"><![CDATA[
-                    export LDFLAGS="-Wl,-rpath,$LIBPNG_LIB_PATH" &&
-                    ./configure --prefix=$INSTALL_DIR --disable-mmx
-                    ]]>
-                    </action>
-                    <action type="make_install" />
+                    <action type="autoconf">--disable-mmx</action>
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                         <environment_variable action="set_to" name="PIXMAN_LIB_PATH">$INSTALL_DIR/lib</environment_variable>
+                        <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
                         <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
                     </action>
                 </actions>


### PR DESCRIPTION
This PR removes some of the unnecessary export statements when using `LD_LIBRARY_PATH` ad `LD_INCLUDE_PATH`, allowing use of autoconf.
This PR also contains a fix for pixman on OS X (--disable-mmx).
Marked WIP because needs more testing.