### PR TITLE
Correct destination path.

### DIFF
--- a/packages/package_bowtie_2_2_6/tool_dependencies.xml
+++ b/packages/package_bowtie_2_2_6/tool_dependencies.xml
@@ -7,14 +7,14 @@
                     <action md5sum="074884c2989437491685cfdec649d424" type="download_by_url">http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
-                        <destination_directory>$INSTALL_DIR</destination_directory>
+                        <destination_directory>$INSTALL_DIR/bin/</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
                     <action md5sum="2ff07b1358844bda4b2b1055507fee5b" type="download_by_url">http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.6/bowtie2-2.2.6-macos-x86_64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
-                        <destination_directory>$INSTALL_DIR</destination_directory>
+                        <destination_directory>$INSTALL_DIR/bin/</destination_directory>
                     </action>
                 </actions>
                 <actions>


### PR DESCRIPTION
Move precompiled binaries into the path set in the environment settings.