### PR TITLE
Make art package installable

### DIFF
--- a/tools/art/macros.xml
+++ b/tools/art/macros.xml
@@ -3,7 +3,7 @@
 
     <xml name="requirements">
       <requirements>
-        <requirement type="package" version="2014.11.03">art</requirement>
+        <requirement type="package" version="2014_11_03">art</requirement>
         <yield/>
       </requirements>
     </xml>

--- a/tools/art/tool_dependencies.xml
+++ b/tools/art/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-  <package name="art" version="2014.11.03">
+  <package name="art" version="2014_11_03">
     <repository name="package_art_2014_11_03" owner="iuc"/>
   </package>
 </tool_dependency>


### PR DESCRIPTION
Apparently you have to use the version number, giving a different name doesn't work. I was sorta under the impression that you declared a dependency in tool_dependencies and could call it whatever you wanted, however that is not the case. Instead we have to (this is insane) explicity duplicate the package name + version and it's incredibly unclear why. Whatever, this makes ART work again.