### PR TITLE
Fix infinite wait of hisat2_index_builder.py when default parameters are used

### DIFF
--- a/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.py
+++ b/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.py
@@ -62,7 +62,7 @@ def main():
     parser.add_argument( '--fasta_dbkey', dest='fasta_dbkey', action='store', type=str, default=None )
     parser.add_argument( '--fasta_description', dest='fasta_description', action='store', type=str, default=None )
     parser.add_argument( '--data_table_name', dest='data_table_name', action='store', type=str, default='hisat2_indexes' )
-    parser.add_argument( '--indexer_options', dest='indexer_options', action='store', type=str, default=None )
+    parser.add_argument( '--indexer_options', dest='indexer_options', action='store', type=str, default='' )
     options = parser.parse_args()
 
     filename = options.output


### PR DESCRIPTION
The argparse default for --indexer_options was set to None but has to be empty string. Evaluation of None by shlex.split( options.indexer_options) will make shlex.split try to read a string from stdin. This obviously never happens, so it blocks indefinitely.