### PR TITLE
Add paired collection support to sickle.

### DIFF
--- a/tools/sickle/sickle.xml
+++ b/tools/sickle/sickle.xml
@@ -47,6 +47,18 @@
             #end if
         #end if
 
+        #if str($readtype.single_or_paired) == "pe_collection":
+            pe -f "${readtype.input_paired.forward}" -r "${readtype.input_paired.reverse}" -o "${output_paired_coll.forward}" -p "${output_paired_coll.reverse}" -s "$output_paired_coll_single"
+
+            #if $readtype.input_paired.forward.ext in ("fastq", "fastqsanger"):
+                -t sanger
+            #else if $readtype.input_paired.forward.ext == "fastqillumina":
+                -t illumina
+            #else if $readtype.input_paired.forward.ext == "fastqsolexa":
+                -t solexa
+            #end if
+        #end if
+
         #if str($qual_threshold) != "":
             -q $qual_threshold
         #end if
@@ -70,6 +82,7 @@
                 <option value="se" selected="true">Single-end</option>
                 <option value="pe_combo">Paired-end (one interleaved input file)</option>
                 <option value="pe_sep">Paired-end (two separate input files)</option>
+                <option value="pe_collection">Paired-end (as collection)</option>
             </param>
 
             <when value="se">
@@ -84,6 +97,10 @@
             <when value="pe_sep">
                 <param format="fastq" name="input_paired1" type="data" label="Paired-end forward strand FASTQ reads" help="(-f)" />
                 <param format="fastq" name="input_paired2" type="data" label="Paired-end reverse strand FASTQ reads" help="(-r)" />
+            </when>
+
+            <when value="pe_collection">
+                <param format="fastq" name="input_paired" type="data_collection" collection_type="paired" label="Paired-end FASTQ reads as paired collection" />
             </when>
         </conditional>
 
@@ -119,30 +136,53 @@
         <data name="output_paired_single" format_source="input_paired1" label="Singletons from paired-end output of ${tool.name} on ${on_string}">
             <filter>readtype['single_or_paired'] == 'pe_sep'</filter>
         </data>
+
+        <collection name="output_paired_coll" type="paired" structured_like="input_paired" inherit_format="true" label="Paired-end output of ${tool.name} on ${on_string}">
+            <filter>readtype['single_or_paired'] == 'pe_collection'</filter>
+        </collection>
+
+        <data name="output_paired_coll_single" format_source="input_paired['forward']" label="Singletons from paired-end output of ${tool.name} on ${on_string}">
+            <filter>readtype['single_or_paired'] == 'pe_collection'</filter>
+        </data>
     </outputs>
     <tests>
         <test>
             <param name="single_or_paired" value="pe_combo" />
-            <param name="input_combo" value="test.fastq" />
+            <param name="input_combo" ftype="fastqsanger" value="test.fastq" />
             <param name="qual_threshold" value="34" />
-            <output name="output_combo" file="output.c1.fastq" />
-            <output name="output_combo_single" file="output.s.fastq" />
+            <output name="output_combo" ftype="fastqsanger" file="output.c1.fastq" />
+            <output name="output_combo_single" ftype="fastqsanger" file="output.s.fastq" />
         </test>
         <test>
             <param name="single_or_paired" value="pe_combo" />
-            <param name="input_combo" value="test.fastq" />
+            <param name="input_combo" ftype="fastqsanger" value="test.fastq" />
             <param name="qual_threshold" value="34" />
             <param name="output_n" value="true" />
-            <output name="output_combo" file="output.c2.fastq" />
+            <output name="output_combo" ftype="fastqsanger" file="output.c2.fastq" />
         </test>
         <test>
             <param name="single_or_paired" value="pe_sep" />
-            <param name="input_paired1" value="test.f.fastq" />
-            <param name="input_paired2" value="test.r.fastq" />
+            <param name="input_paired1" ftype="fastqsanger" value="test.f.fastq" />
+            <param name="input_paired2" ftype="fastqsanger" value="test.r.fastq" />
             <param name="qual_threshold" value="34" />
-            <output name="output_paired1" file="output.f.fastq" />
-            <output name="output_paired2" file="output.r.fastq" />
-            <output name="output_paired_single" file="output.s.fastq" />
+            <output name="output_paired1" ftype="fastqsanger" file="output.f.fastq" />
+            <output name="output_paired2" ftype="fastqsanger" file="output.r.fastq" />
+            <output name="output_paired_single" ftype="fastqsanger" file="output.s.fastq" />
+        </test>
+        <test>
+            <param name="single_or_paired" value="pe_collection" />
+            <param name="input_paired">
+                <collection type="paired">
+                    <element name="forward" ftype="fastqsanger" value="test.f.fastq" />
+                    <element name="reverse" ftype="fastqsanger" value="test.r.fastq" />
+                </collection>
+            </param>
+            <param name="qual_threshold" value="34" />
+            <output_collection name="output_paired_coll" type="paired">
+                <element name="forward" ftype="fastqsanger" file="output.f.fastq" />
+                <element name="reverse" ftype="fastqsanger" file="output.r.fastq" />
+            </output_collection>
+            <output name="output_paired_coll_single" ftype="fastqsanger" file="output.s.fastq" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
Follow up to https://github.com/galaxyproject/tools-iuc/pull/369#discussion_r43800084 now that https://github.com/galaxyproject/galaxy/issues/699 has been fixed.

The output format of `output_paired_coll_single` will be `data` for Galaxy < release_16.01 .