### PR TITLE
Add mash package

### DIFF
--- a/packages/package_mash_1_0_2/.shed.yml
+++ b/packages/package_mash_1_0_2/.shed.yml
@@ -1,0 +1,9 @@
+categories:
+- Tool Dependency Packages
+description: Downloads and compiles version 1.0.2 of mash.
+long_description: |
+  Fast genome and metagenome distance estimation using MinHash.
+name: package_mash_1_0_2
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_mash_1_0_2
+type: tool_dependency_definition

--- a/packages/package_mash_1_0_2/tool_dependencies.xml
+++ b/packages/package_mash_1_0_2/tool_dependencies.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="mash" version="1.0.2">
+        <install version="1.0">
+            <actions_group>
+                <actions architecture="x86_64" os="linux">
+                    <action type="download_by_url" md5sum="04969fd7cd02d088d61aef9527234eb8">https://github.com/marbl/Mash/releases/download/v1.0.2/mash-Linux64-v1.0.2.tar.gz</action>
+                    <action type="move_file">
+                        <source>mash</source>
+                        <destination>$INSTALL_DIR/bin</destination>
+                    </action>
+                </actions>
+                <actions architecture="x86_64" os="darwin">
+                    <action type="download_by_url" md5sum="59ea4260713b9a7467fe85a3d5eee0d5">https://github.com/marbl/Mash/releases/download/v1.0.2/mash-OSX64-v1.0.2.tar.gz</action>
+                    <action type="move_file">
+                        <source>mash</source>
+                        <destination>$INSTALL_DIR/bin</destination>
+                    </action>
+
+                </actions>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                </action>
+            </actions_group>
+        </install>
+        <readme>
+            Fast genome and metagenome distance estimation using MinHash.
+        </readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
This PR adds the mash package as part of the [2nd IUC hackathon](
https://github.com/galaxyproject/tools-iuc/issues/299).

Mash: https://github.com/marbl/Mash