### PR TITLE
Fix PEAR to work with only PHRED scaled quality score FASTQ files and properly pass the --phred-base argument.

### DIFF
--- a/tools/pear/pear.xml
+++ b/tools/pear/pear.xml
@@ -1,6 +1,5 @@
-<tool id="iuc_pear" name="Pear" version="0.9.6.0">
+<tool id="iuc_pear" name="Pear" version="0.9.6.1">
     <description>Paired-End read merger</description>
-    <!--<version_command>bismark version</version_command>-->
     <requirements>
         <requirement type="package" version="0.9.6">pear</requirement>
     </requirements>
@@ -16,10 +15,20 @@
         #if str( $library.type ) == "paired":
             -f "$library.forward"
             -r "$library.reverse"
+            #if $library.forward.is_of_type( 'fastqillumina' ):
+                --phred-base 64
+            #else:
+                --phred-base 33
+            #end if
         #else
             ## prepare collection
             -f $library.input_collection.forward
             -r $library.input_collection.reverse
+            #if $library.input_collection.forward.is_of_type( 'fastqillumina' ):
+                --phred-base 64
+            #else:
+                --phred-base 33
+            #end if
         #end if
 
         --output pear
@@ -47,15 +56,15 @@
               <option value="paired_collection">Paired-end Dataset Collection</option>
             </param>
             <when value="paired">
-                <param name="forward" type="data" format="fastqillumina, fastqsanger, fastq"
+                <param name="forward" type="data" format="fastqillumina,fastqsanger"
                     label="Name of file that contains the forward paired-end reads" help="-f" />
-                <param name="reverse" type="data" format="fastqillumina, fastqsanger, fastq"
+                <param name="reverse" type="data" format="fastqillumina,fastqsanger"
                     label="Name of file that contains the reverse paired-end reads" help="-r" />
             </when>
             <when value="paired_collection">
-                <param name="input_collection" format="fastqillumina, fastqsanger, fastq"
+                <param name="input_collection" format="fastqillumina,fastqsanger"
                     type="data_collection" collection_type="paired"
-                    label="FASTQ Paired Dataset" help="Nucleotide-space: Must have Sanger-scaled quality values with ASCII offset 33. (-f and -r)" />
+                    label="FASTQ Paired Dataset" help="Nucleotide-space: Must have PHRED-scaled quality values. (-f and -r)" />
             </when>
         </conditional>
 
@@ -108,29 +117,29 @@
         </param>
     </inputs>
     <outputs>
-        <data format="fastq" name="assembled_reads" from_work_dir="pear.assembled.fastq" label="${tool.name} on ${on_string}: Assembled reads">
+        <data format="input" name="assembled_reads" from_work_dir="pear.assembled.fastq" label="${tool.name} on ${on_string}: Assembled reads">
             <filter>'assembled' in outputs</filter>
         </data>
-        <data format="fastq" name="unassembled_forward_reads" from_work_dir="pear.unassembled.forward.fastq" label="${tool.name} on ${on_string}: Unassembled forward reads">
+        <data format="input" name="unassembled_forward_reads" from_work_dir="pear.unassembled.forward.fastq" label="${tool.name} on ${on_string}: Unassembled forward reads">
             <filter>'forward' in outputs</filter>
         </data>
-        <data format="fastq" name="unassembled_reverse_reads" from_work_dir="pear.unassembled.reverse.fastq" label="${tool.name} on ${on_string}: Unassembled reverse reads">
+        <data format="input" name="unassembled_reverse_reads" from_work_dir="pear.unassembled.reverse.fastq" label="${tool.name} on ${on_string}: Unassembled reverse reads">
             <filter>'reverse' in outputs</filter>
         </data>
-        <data format="fastq" name="discarded_reads" from_work_dir="pear.discarded.fastq" label="${tool.name} on ${on_string}: Discarded reads">
+        <data format="input" name="discarded_reads" from_work_dir="pear.discarded.fastq" label="${tool.name} on ${on_string}: Discarded reads">
             <filter>'discarded' in outputs</filter>
         </data>
     </outputs>
     <tests>
         <test>
-            <param name="forward" value="forward.fastq" ftype="fastq" />
-            <param name="reverse" value="reverse.fastq" ftype="fastq" />
+            <param name="forward" value="forward.fastq" ftype="fastqsanger" />
+            <param name="reverse" value="reverse.fastq" ftype="fastqsanger" />
             <param name="min_overlap" value="10" />
             <param name="min_assembly_length" value="50" />
             <param name="cap" value="0" />
             <param name="outputs" value="assembled,forward" />
-            <output name="assembled_reads" file="pear_assembled_results1.fastq" ftype="fastq"/>
-            <output name="unassembled_forward_reads" file="pear_unassembled_forward_results1.fastq" ftype="fastq"/>
+            <output name="assembled_reads" file="pear_assembled_results1.fastq" ftype="fastqsanger"/>
+            <output name="unassembled_forward_reads" file="pear_unassembled_forward_results1.fastq" ftype="fastqsanger"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
Will also retain the original input datatype assignment.