### PR TITLE
Add tool wrapper for Qiime pick_open_reference_otus.py

### DIFF
--- a/tools/qiime/pick_open_reference_otus.xml
+++ b/tools/qiime/pick_open_reference_otus.xml
@@ -10,7 +10,8 @@
 
 	<version_command>pick_open_reference_otus.py --version</version_command>
 
-	<command><![CDATA[pick_open_reference_otus.py
+	<command><![CDATA[
+pick_open_reference_otus.py
 #def list_dict_to_string(list_dict):
 	#set $file_list = list_dict[0]['additional_input'].__getattr__('file_name')
 	#for d in list_dict[1:]:

--- a/tools/qiime/pick_open_reference_otus.xml
+++ b/tools/qiime/pick_open_reference_otus.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" ?>
+<tool id="pick_open_reference_otus" name="pick open reference otus" version="1.9.1galaxy1">
+    <description>Perform open-reference OTU picking</description>
+
+        <macros>
+             <import>macros.xml</import>
+	</macros>
+
+	<expand macro="requirements" />
+
+	<version_command>pick_open_reference_otus.py --version</version_command>
+
+	<command><![CDATA[pick_open_reference_otus.py
+#def list_dict_to_string(list_dict):
+	#set $file_list = list_dict[0]['additional_input'].__getattr__('file_name')
+	#for d in list_dict[1:]:
+		#set $file_list = $file_list + ',' + d['additional_input'].__getattr__('file_name')
+	#end for
+	#return $file_list
+#end def
+ -i $list_dict_to_string($input_files_input_fps) -o pick_open_reference_otus_output
+#if str($otu_picking_method) != 'None':
+ -m $otu_picking_method
+#end if
+
+#if str($reference_fp) != 'None':
+ -r $reference_fp
+#end if
+
+#if str($parameter_fp) != 'None':
+ -p $parameter_fp
+#end if
+
+#if str($prefilter_refseqs_fp) != 'None':
+ --prefilter_refseqs_fp=$prefilter_refseqs_fp
+#end if
+
+#if str($new_ref_set_id):
+ -n $new_ref_set_id
+#end if
+
+#if $parallel:
+ -a
+#end if
+
+#if $jobs_to_start:
+ -O $jobs_to_start
+#end if
+
+#if $percent_subsample:
+ -s $percent_subsample
+#end if
+
+#if $prefilter_percent_id:
+ --prefilter_percent_id=$prefilter_percent_id
+#end if
+
+#if str($step1_otu_map_fp) != 'None':
+ --step1_otu_map_fp=$step1_otu_map_fp
+#end if
+
+#if str($step1_failures_fasta_fp) != 'None':
+ --step1_failures_fasta_fp=$step1_failures_fasta_fp
+#end if
+
+#if $minimum_failure_threshold:
+ --minimum_failure_threshold=$minimum_failure_threshold
+#end if
+
+#if $suppress_step4:
+ --suppress_step4
+#end if
+
+#if $min_otu_size:
+ --min_otu_size=$min_otu_size
+#end if
+
+#if $suppress_taxonomy_assignment:
+ --suppress_taxonomy_assignment
+#end if
+
+#if $suppress_align_and_tree:
+ --suppress_align_and_tree
+#end if
+;
+compress_path.py -i pick_open_reference_otus_output -o $output_dir
+]]>
+	</command>
+	<inputs>
+	     <repeat name="input_files_input_fps" optional="False" title="input_fps">
+	           <param label="Input sequences" name="additional_input" type="data" format="fasta" help="-i/--input_fps"/>
+	     </repeat>
+	     <param label="The OTU picking method to use for reference and de novo steps. Passing usearch61, for example, means that usearch61 will be used for the de novo steps and usearch61_ref will be used for reference steps. [default: uclust]" name="otu_picking_method" optional="True" type="select" help="-m/--otu_picking_method">
+	           <option selected="True" value="None">Selection is Optional</option>
+		   <option value="uclust">uclust</option>
+		   <option value="usearch61">usearch61</option>
+		   <option value="sortmerna_sumaclust">sortmerna_sumaclust</option>
+	     </param>
+	     <param label="Reference sequences" name="reference_fp" optional="True" type="data" format="fasta" help="-r/--reference_fp: "/>
+	     <param label="Path to the parameter file, which specifies changes to the default behavior" name="parameter_fp" optional="True" type="data" format="text" help="-p/--parameter_fp (see http://www.qiime.org/documentation/file_formats.html#qiime-parameters)"/>
+	     <param label="Reference sequences to use for the prefilter, if different from the reference sequecnces to use for the OTU picking [default: same as passed for --reference_fp]" name="prefilter_refseqs_fp" optional="True" type="data" format="fasta" help="--prefilter_refseqs_fp" />
+	     <param default="New" label="Unique identifier for OTUs that get created in this ref set (this is useful to support combining of reference sets) [default:New]" name="new_ref_set_id" optional="True" type="txt" help="-n/--new_ref_set_id"/>
+	     <param label="Run in parallel where available [default: False]" name="parallel" selected="False" type="boolean" help="-a/--parallel"/>
+	     <param default="1" label="-O/--jobs_to_start: Number of jobs to start. NOTE: you must also pass -a to run in parallel, this defines the number of jobs to be started if and only if -a is passed [default: 1]" name="jobs_to_start" optional="True" type="integer"/>
+	     <param default="0.001" label="Percent of failure sequences to include in the subsample to cluster de novo, expressed as a fraction between 0 and 1 (larger numbers should give more comprehensive results but will be slower) [default:0.001]" name="percent_subsample" optional="True" type="float" min="0.0" max="1.0" help="-s/--percent_subsample"/>
+	     <param default="0.0" label="Sequences are pre-clustered at this percent id (expressed as a fraction between 0 and 1) against the reference and any reads which fail to hit are discarded (a quality filter); pass 0.0 to disable [default:0.0]" name="prefilter_percent_id" optional="True" type="float" min="0.0" max="1.0" help="--prefilter_percent_id" />
+	     <param label="Reference OTU picking OTU map, to avoid rebuilding if one has already been built. This must be an OTU map generated by this workflow, not (for example) pick_closed_reference_otus.py." name="step1_otu_map_fp" optional="True" type="data" format="txt" help="--step1_otu_map_fp"/>
+	     <param label="Reference OTU picking failures fasta filepath, to avoid rebuilding if one has already been built. This must be a failures file generated by this workflow, not (for example) pick_closed_reference_otus.py." name="step1_failures_fasta_fp" optional="True" type="data" format="fasta" help="--step1_failures_fasta_fp"/>
+	     <param default="100000" label="The minimum number of sequences that must fail to hit the reference for subsampling to be performed. If fewer than this number of sequences fail to hit the reference, the de novo clustering step will run serially rather than invoking the subsampled open reference approach to improve performance. [default: 100000]" name="minimum_failure_threshold" optional="True" type="integer" help="--minimum_failure_threshold"/>
+	     <param label="Suppress the final de novo OTU picking step  (may be necessary for extremely large data sets) [default: False]" name="suppress_step4" selected="False" type="boolean" help="--suppress_step4"/>
+	     <param default="2" label="The minimum otu size (in number of sequences) to retain the otu [default: 2]" name="min_otu_size" optional="True" type="integer" help="--min_otu_size"/>
+	     <param label="Skip the taxonomy assignment step, resulting in an OTU table without taxonomy [default: False]" name="suppress_taxonomy_assignment" selected="False" type="boolean" help="--suppress_taxonomy_assignment"/>
+	     <param label="Skip the sequence alignment and tree-building steps [default: False]" name="suppress_align_and_tree" selected="False" type="boolean" help="--suppress_align_and_tree"/>
+	</inputs>
+	<outputs>
+            <data format="tgz" name="output_dir"/>
+	</outputs>
+
+	<tests>
+            <test>
+                <param name="input_files_input_fps_0|additional_input" value="split_libraries_fastq_seqs.fna" />
+		<output name="output_fp">
+		  <assert_contents>
+                    <has_line_matching expression="86  : Total"/>
+		  </assert_contents>
+		</output>
+            </test>
+	</tests>
+	<help><![CDATA[
+This script is broken down into 4 possible OTU picking steps, and 2 steps
+involving the creation of OTU tables and trees. The commands for each step are
+described below, including what the input and resulting output files are.
+Additionally, the optional specified parameters of this script that can be passed
+are referenced.
+
+Step 1) Prefiltering and picking closed reference OTUs
+The first step is an optional prefiltering of the input fasta file to remove
+sequences that do not hit the reference database with a given sequence
+identity (PREFILTER_PERCENT_ID). This step can take a very long time, so is
+disabled by default. The prefilter parameters can be changed with the options:
+--prefilter_refseqs_fp
+--prefilter_percent_id
+This filtering is accomplished by picking closed reference OTUs at the specified
+prefilter percent id to produce:
+prefilter_otus/seqs_otus.log
+prefilter_otus/seqs_otus.txt
+prefilter_otus/seqs_failures.txt
+prefilter_otus/seqs_clusters.uc
+Next, the seqs_failures.txt file is used to remove these failed sequences from
+the original input fasta file to produce:
+prefilter_otus/prefiltered_seqs.fna
+This prefiltered_seqs.fna file is then considered to contain the reads
+of the marker gene of interest, rather than spurious reads such as host
+genomic sequence or sequencing artifacts.
+
+If prefiltering is applied, this step progresses with the prefiltered_seqs.fna.
+Otherwise it progresses with the input file. The Step 1 closed reference OTU
+picking is done against the supplied reference database. This command produces:
+step1_otus/_clusters.uc
+step1_otus/_failures.txt
+step1_otus/_otus.log
+step1_otus/_otus.txt
+
+The representative sequence for each of the Step 1 picked OTUs are selected to
+produce:
+step1_otus/step1_rep_set.fna
+
+Next, the sequences that failed to hit the reference database in Step 1 are
+filtered from the Step 1 input fasta file to produce:
+step1_otus/failures.fasta
+
+Then the failures.fasta file is randomly subsampled to PERCENT_SUBSAMPLE of
+the sequences to produce:
+step1_otus/subsampled_failures.fna.
+Modifying PERCENT_SUBSAMPLE can have a big effect on run time for this workflow,
+but will not alter the final OTUs.
+
+Step 2) The subsampled_failures.fna are next clustered de novo, and each cluster
+centroid is then chosen as a &quot;new reference sequence&quot; for use as the reference
+database in Step 3, to produce:
+step2_otus/subsampled_seqs_clusters.uc
+step2_otus/subsampled_seqs_otus.log
+step2_otus/subsampled_seqs_otus.txt
+step2_otus/step2_rep_set.fna
+
+Step 3) Pick Closed Reference OTUs against Step 2 de novo OTUs
+Closed reference OTU picking is performed using the failures.fasta file created
+in Step 1 against the 'reference' de novo database created in Step 2 to produce:
+step3_otus/failures_seqs_clusters.uc
+step3_otus/failures_seqs_failures.txt
+step3_otus/failures_seqs_otus.log
+step3_otus/failures_seqs_otus.txt
+
+Assuming the user has NOT passed the --suppress_step4 flag:
+The sequences which failed to hit the reference database in Step 3 are removed
+from the Step 3 input fasta file to produce:
+step3_otus/failures_failures.fasta
+
+Step 4) Additional de novo OTU picking
+It is assumed by this point that the majority of sequences have been assigned
+to an OTU, and thus the sequence count of failures_failures.fasta is small
+enough that de novo OTU picking is computationally feasible. However, depending
+on the sequences being used, it might be that the failures_failures.fasta file
+is still prohibitively large for de novo clustering, and the jobs might take
+too long to finish. In this case it is likely that the user would want to pass
+the --suppress_step4 flag to avoid this additional de novo step.
+
+A final round of de novo OTU picking is done on the failures_failures.fasta file
+to produce:
+step4_otus/failures_failures_cluster.uc
+step4_otus/failures_failures_otus.log
+step4_otus/failures_failures_otus.txt
+
+A representative sequence for each cluster is chosen to produce:
+step4_otus/step4_rep_set.fna
+
+Step 5) Produce the final OTU map and rep set
+If Step 4 is completed, the OTU maps from Step 1, Step 3, and Step 4 are
+concatenated to produce:
+final_otu_map.txt
+
+If Step 4 was not completed, the OTU maps from Steps 1 and Step 3 are
+concatenated together to produce:
+final_otu_map.txt
+
+Next, the minimum specified OTU size required to keep an OTU is specified with
+the --min_otu_size flag. For example, if the user left the --min_otu_size as the
+default value of 2, requiring each OTU to contain at least 2 sequences, the any
+OTUs which failed to meet this criteria would be removed from the
+final_otu_map.txt to produce:
+final_otu_map_mc2.txt
+
+If --min_otu_size 10 was passed, it would produce:
+final_otu_map_mc10.txt
+
+The final_otu_map_mc2.txt is used to build the final representative set:
+rep_set.fna
+
+Step 6) Making the OTU tables and trees
+An OTU table is built using the final_otu_map_mc2.txt file to produce:
+otu_table_mc2.biom
+
+As long as the --suppress_taxonomy_assignment flag is NOT passed,
+then taxonomy will be assigned to each of the representative sequences
+in the final rep_set produced in Step 5, producing:
+rep_set_tax_assignments.log
+rep_set_tax_assignments.txt
+This taxonomic metadata is then added to the otu_table_mc2.biom to produce:
+otu_table_mc_w_tax.biom
+
+As long as the --suppress_align_and_tree is NOT passed, then the rep_set.fna
+file will be used to align the sequences and build the phylogenetic tree,
+which includes the de novo OTUs. Any sequences that fail to align are
+omitted from the OTU table and tree to produce:
+otu_table_mc_no_pynast_failures.biom
+rep_set.tre
+
+If both --suppress_taxonomy_assignment and --suppress_align_and_tree are
+NOT passed, the script will produce:
+otu_table_mc_w_tax_no_pynast_failures.biom
+
+It is important to remember that with a large workflow script like this that
+the user can jump into intermediate steps. For example, imagine that for some
+reason the script was interrupted on Step 2, and the user did not want to go
+through the process of re-picking OTUs as was done in Step 1. They can simply
+rerun the script and pass in the:
+--step_1_otu_map_fp
+--step1_failures_fasta_fp
+parameters, and the script will continue with Steps 2 - 4.
+
+**Note:** If most or all of your sequences are failing to hit the reference
+during the prefiltering or closed-reference OTU picking steps, your sequences
+may be in the reverse orientation with respect to your reference database. To
+address this, you should add the following line to your parameters file
+(creating one, if necessary) and pass this file as -p:
+
+pick_otus:enable_rev_strand_match True
+
+Be aware that this doubles the amount of memory used in these steps of the
+workflow.
+]]>
+
+      </help>
+      <expand macro="citations" />
+</tool>

--- a/tools/qiime/pick_open_reference_otus.xml
+++ b/tools/qiime/pick_open_reference_otus.xml
@@ -19,7 +19,8 @@ pick_open_reference_otus.py
 	#end for
 	#return $file_list
 #end def
- -i $list_dict_to_string($input_files_input_fps) -o pick_open_reference_otus_output
+#set $output_dir = "pick_open_reference_otus_output"
+ -i $list_dict_to_string($input_files_input_fps) -o $output_dir
 #if str($otu_picking_method) != 'None':
  -m $otu_picking_method
 #end if
@@ -84,7 +85,15 @@ pick_open_reference_otus.py
  --suppress_align_and_tree
 #end if
 ;
-compress_path.py -i pick_open_reference_otus_output -o $output_dir
+mv $output_dir/rep_set.fna $output_rep_set
+;
+mv $output_dir/otu_table_mc2.biom $output_otu_table
+;
+mv $output_dir/otu_table_mc2_w_tax.biom $output_otu_table_taxonomy
+;
+mv $output_dir/otu_table_mc2_w_tax_no_pynast_failures.biom $output_otu_table_no_failures
+;
+mv $output_dir/rep_set.tre $output_rep_set_tree
 ]]>
 	</command>
 	<inputs>
@@ -100,7 +109,7 @@ compress_path.py -i pick_open_reference_otus_output -o $output_dir
 	     <param label="Reference sequences" name="reference_fp" optional="True" type="data" format="fasta" help="-r/--reference_fp: "/>
 	     <param label="Path to the parameter file, which specifies changes to the default behavior" name="parameter_fp" optional="True" type="data" format="text" help="-p/--parameter_fp (see http://www.qiime.org/documentation/file_formats.html#qiime-parameters)"/>
 	     <param label="Reference sequences to use for the prefilter, if different from the reference sequecnces to use for the OTU picking [default: same as passed for --reference_fp]" name="prefilter_refseqs_fp" optional="True" type="data" format="fasta" help="--prefilter_refseqs_fp" />
-	     <param default="New" label="Unique identifier for OTUs that get created in this ref set (this is useful to support combining of reference sets) [default:New]" name="new_ref_set_id" optional="True" type="txt" help="-n/--new_ref_set_id"/>
+	     <param default="New" label="Unique identifier for OTUs that get created in this ref set (this is useful to support combining of reference sets) [default:New]" name="new_ref_set_id" optional="True" type="text" help="-n/--new_ref_set_id"/>
 	     <param label="Run in parallel where available [default: False]" name="parallel" selected="False" type="boolean" help="-a/--parallel"/>
 	     <param default="1" label="-O/--jobs_to_start: Number of jobs to start. NOTE: you must also pass -a to run in parallel, this defines the number of jobs to be started if and only if -a is passed [default: 1]" name="jobs_to_start" optional="True" type="integer"/>
 	     <param default="0.001" label="Percent of failure sequences to include in the subsample to cluster de novo, expressed as a fraction between 0 and 1 (larger numbers should give more comprehensive results but will be slower) [default:0.001]" name="percent_subsample" optional="True" type="float" min="0.0" max="1.0" help="-s/--percent_subsample"/>
@@ -113,8 +122,13 @@ compress_path.py -i pick_open_reference_otus_output -o $output_dir
 	     <param label="Skip the taxonomy assignment step, resulting in an OTU table without taxonomy [default: False]" name="suppress_taxonomy_assignment" selected="False" type="boolean" help="--suppress_taxonomy_assignment"/>
 	     <param label="Skip the sequence alignment and tree-building steps [default: False]" name="suppress_align_and_tree" selected="False" type="boolean" help="--suppress_align_and_tree"/>
 	</inputs>
+
 	<outputs>
-            <data format="tgz" name="output_dir"/>
+            <data name="output_rep_set" format="fasta" label="${tool.name} on ${on_string} (final representative set)"/>
+            <data name="output_otu_table" format="biom" label="${tool.name} on ${on_string} (OTU table)"/>
+            <data name="output_otu_table_taxonomy" format="biom" label="${tool.name} on ${on_string} (OTU table with taxonomy)"/>
+            <data name="output_otu_table_no_failures" format="biom" label="${tool.name} on ${on_string} (OTU without sequences that failed to align)"/>
+            <data name="output_rep_set_tree" format="tre" label="${tool.name} on ${on_string} (representative set tree)"/>
 	</outputs>
 
 	<tests>


### PR DESCRIPTION
This PR is a first attempt at updating the wrapper for qiime's `pick_open_reference_otus.py` as part of issue #426, to tidy up the original generated wrapper from https://github.com/lparsons/galaxy_tools/tree/qiime/tools/qiime1.9.0 and output explicit datasets to the history rather than just a tar.gz file.

**This initial version is a WIP and still needs work before it can be merged** as it doesn't yet define any tests and fails when run manually.