### PR TITLE
Remove double ampersand that remained after switching to autoconf

### DIFF
--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -26,7 +26,7 @@
                 </action>
                 <!-- edit configure and build/configure.ac.warnings to allow compiling cairo on gcc-4.9. Fixed in more recent versions of cairo -->
                 <action type="shell_command"><![CDATA[
-                    sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings &&
+                    sed -i.bak 's|MAYBE_WARN="$MAYBE_WARN -flto"|MAYBE_WARN="$MAYBE_WARN -flto -ffat-lto-objects -fuse-linker-plugin" |' configure build/configure.ac.warnings
                 ]]></action>
                 <action type="autoconf">--with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-xlib-xrender=no</action>
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->


### PR DESCRIPTION
My bad ... :(.
I will also open a PR for the devteam version.