### PR TITLE
Add package_python_2_7_10_pybigwig, which will by needed by the next …

### DIFF
--- a/packages/package_python_2_7/tool_dependencies.xml
+++ b/packages/package_python_2_7/tool_dependencies.xml
@@ -52,7 +52,7 @@
         <!-- by default python is not looking af LD_INCLUDE_PATH and Co. -->
         <action type="shell_command">sed -i.bak -e "s/if host_platform == 'atheos':/if True:/g" setup.py</action>
 
-        <action type="autoconf"/>
+        <action type="autoconf">--enable-shared --enable-unicode=ucs4</action>
         <action type="download_file">https://bitbucket.org/pypa/setuptools/get/18.2.tar.bz2</action>
         <action type="shell_command">tar -xjf 18.2.tar.bz2</action>
         <action type="change_directory">pypa-setuptools-1a981f2e5031</action>

--- a/packages/package_python_2_7/tool_dependencies.xml
+++ b/packages/package_python_2_7/tool_dependencies.xml
@@ -74,6 +74,9 @@
             <environment_variable action="set_to" name="PYTHONHOME">$INSTALL_DIR</environment_variable>
             <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
             <environment_variable action="prepend_to" name="PYTHON_ROOT_DIR">$INSTALL_DIR</environment_variable>
+            <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+            <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$INSTALL_DIR/include/python2.7</environment_variable>
+            <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$INSTALL_DIR/include/python2.7</environment_variable>
             <!--
             <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$ENV[OPENSSL_ROOT_DIR]/lib/pkgconfig</environment_variable>
             <environment_variable action="prepend_to" name="LIBRARY_PATH">$ENV[OPENSSL_ROOT_DIR]/lib/</environment_variable>

--- a/packages/package_python_2_7_10/tool_dependencies.xml
+++ b/packages/package_python_2_7_10/tool_dependencies.xml
@@ -73,6 +73,9 @@
             <environment_variable action="set_to" name="PYTHONHOME">$INSTALL_DIR</environment_variable>
             <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
             <environment_variable action="prepend_to" name="PYTHON_ROOT_DIR">$INSTALL_DIR</environment_variable>
+            <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+            <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$INSTALL_DIR/include/python2.7</environment_variable>
+            <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$INSTALL_DIR/include/python2.7</environment_variable>
         </action>
       </actions>
     </install>

--- a/packages/package_python_2_7_10/tool_dependencies.xml
+++ b/packages/package_python_2_7_10/tool_dependencies.xml
@@ -51,7 +51,7 @@
         </action>
         <!-- by default python is not looking af LD_INCLUDE_PATH and Co. -->
         <action type="shell_command">sed -i.bak -e "s/if host_platform == 'atheos':/if True:/g" setup.py</action>
-        <action type="autoconf" />
+        <action type="autoconf">--enable-shared --enable-unicode=ucs4</action>
         <action type="download_file">https://bitbucket.org/pypa/setuptools/get/18.2.tar.bz2</action>
         <action type="shell_command">tar -xjf 18.2.tar.bz2</action>
         <action type="change_directory">pypa-setuptools-1a981f2e5031</action>

--- a/packages/package_python_2_7_10_pybigwig/tool_dependencies.xml
+++ b/packages/package_python_2_7_10_pybigwig/tool_dependencies.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="libcurl" version="7.35">
+        <repository name="package_libcurl_7_35" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="pybigwig" version="0.1.9">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_libcurl_7_35" owner="iuc">
+                        <package name="libcurl" version="7.35" />
+                    </repository>
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <!-- Just download from pypi -->
+                    <package md5sum="8ed6a7c2d03c94ae534f8bc549300f5e">https://pypi.python.org/packages/source/p/pyBigWig/pyBigWig-0.1.9.tar.gz</package>
+                </action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>Compiles and installs pyBigWig, which requires a compiler (typically gcc) and libcurl.</readme>
+    </package>
+</tool_dependency>
+

--- a/packages/package_python_2_7_10_pybigwig_0_1_9/tool_dependencies.xml
+++ b/packages/package_python_2_7_10_pybigwig_0_1_9/tool_dependencies.xml
@@ -27,4 +27,3 @@
         <readme>Compiles and installs pyBigWig, which requires a compiler (typically gcc) and libcurl.</readme>
     </package>
 </tool_dependency>
-


### PR DESCRIPTION
…deepTools release. Also, python should really produce shared libraries.

The next version of the IUC deepTools package will require pyBigWig, so this PR adds it. Note that this requires linking against libpython, which wasn't possible before because `package_python_2_7` and `package_python_2_7_10` weren't configured to produce it (instead you end up linking against the system libpython...which is just asking for trouble). The `--enable-unicode=ucs4` is required to get python to compile, since otherwise ctypes sometimes tries to use ucs2 while the rest of python uses ucs4 (this is likely a python bug).

It might be good to use additional common options with python's autoconf, such as `--enable-ipv6`, though I don't know of any packages that need that (yet).