### PR TITLE
Disable aqua and add fontconfig to cairo dependencies.

### DIFF
--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -9,6 +9,9 @@
     <package name="freetype" version="2.5.2">
         <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True" />
     </package>
+    <package name="fontconfig" version="2.11.1">
+        <repository name="package_fontconfig_2_11_1" owner="iuc" prior_installation_required="True" />
+    </package>
     <package name="cairo" version="1.12.14">
         <install version="1.0">
             <actions>
@@ -22,6 +25,9 @@
                     </repository>
                     <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True">
                         <package name="freetype" version="2.5.2" />
+                    </repository>
+                    <repository name="package_fontconfig_2_11_1" owner="iuc" prior_installation_required="True" >
+                        <package name="fontconfig" version="2.11.1" />
                     </repository>
                 </action>
                 <!-- edit configure and build/configure.ac.warnings to allow compiling cairo on gcc-4.9. Fixed in more recent versions of cairo -->

--- a/packages/package_cairo_1_14_2/tool_dependencies.xml
+++ b/packages/package_cairo_1_14_2/tool_dependencies.xml
@@ -30,7 +30,7 @@
                         <package name="fontconfig" version="2.11.1" />
                     </repository>
                 </action>
-                <action type="autoconf">--disable-dependency-tracking --with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-xlib-xrender=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-ft=yes --enable-svg=yes --enable-tee=yes</action>
+                <action type="autoconf">--disable-dependency-tracking --enable-quartz=no --enable-quartz-font=no --with-x=no --enable-xcb-shm=no --enable-xlib-xcb=no --enable-xcb=no --enable-xlib-xrender=no --enable-gtk-doc=no --enable-gtk-doc-html=no --enable-ft=yes --enable-svg=yes --enable-tee=yes</action>
                 <!-- Create an empty cairo-xlib.h file, because R's configure script explicitly includes it even if X is disabled. -->
                 <action type="shell_command">touch $INSTALL_DIR/include/cairo/cairo-xlib.h</action>
                 <action type="set_environment">

--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -80,7 +80,7 @@
                             <package name="fontconfig" version="2.11.1" />
                         </repository>
                     </action>
-                    <action type="autoconf">--with-tcltk --with-blas --with-lapack --with-readline --with-cairo --with-libpng --without-x --enable-R-shlib --disable-R-framework --libdir=$INSTALL_DIR/lib</action>
+                    <action type="autoconf">--with-tcltk --with-blas --with-lapack --without-aqua --with-readline --with-cairo --with-libpng --without-x --enable-R-shlib --disable-R-framework --libdir=$INSTALL_DIR/lib</action>
                     <action type="make_install" />
                     <action type="shell_command">sed -i.bak -e 's;$INSTALL_DIR;\${R_ROOT_DIR};g' $INSTALL_DIR/bin/R</action>
                     <action type="shell_command">sed -i.bak -e 's;$INSTALL_DIR;\${R_ROOT_DIR};g' $INSTALL_DIR/lib/R/bin/R</action>


### PR DESCRIPTION
fontconfig needs to be a dependency of cairo (as done for package_cairo_14_2).
Disable aqua (else R in conjunction with cairo will default to plotting on-screen on OS X).
