### PR TITLE
Include recent version of setuptools in dependencies of package_khmer…

### DIFF
--- a/packages/package_khmer_2_0/tool_dependencies.xml
+++ b/packages/package_khmer_2_0/tool_dependencies.xml
@@ -6,10 +6,18 @@
     <package name="screed" version="0.9">
         <repository name="package_screed_0_9" owner="iuc"/>
     </package>
+    <package name="setuptools" version="19.0">
+        <repository name="package_setuptools_19_0" owner="iuc" prior_installation_required="True"/>
+    </package>
     <package name="khmer" version="2.0">
         <install version="1.0">
             <actions>
                 <action type="download_by_url" md5sum="1f610abd021254e21b082179a100cd39">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</action>
+                <action type="set_environment_for_install">
+                    <repository name="package_setuptools_19_0" owner="iuc">
+                        <package name="setuptools" version="19.0" />
+                    </repository>
+                </action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">
                     export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;

--- a/packages/package_setuptools_19_0/.shed.yml
+++ b/packages/package_setuptools_19_0/.shed.yml
@@ -1,0 +1,18 @@
+categories:
+- Tool Dependency Packages
+description: setuptools – Easily download, build, install, upgrade, and uninstall Python packages.
+long_description: |
+  Setuptools is a fully-featured, actively-maintained, and stable library designed to facilitate packaging Python projects,
+  where packaging includes:
+
+  Python package and module definitions
+  Distribution package metadata
+  Test hooks
+  Project installation
+  Platform-specific details
+  Python 3 support
+name: package_setuptools_19_0
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_setuptools_19_0
+homepage_url: https://pypi.python.org/pypi/setuptools
+type: tool_dependency_definition

--- a/packages/package_setuptools_19_0/tool_dependencies.xml
+++ b/packages/package_setuptools_19_0/tool_dependencies.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<tool_dependency>
+        <package name="setuptools" version="0.19.0">
+            <install version="1.0">
+                <actions>
+                    <action type="download_by_url" md5sum="b921200449c8b52d62c7e70a47956b69">https://pypi.python.org/packages/source/s/setuptools/setuptools-19.0.tar.gz</action>
+                    <action type="make_directory">$INSTALL_DIR/lib/python</action>
+                    <action type="shell_command">
+                        export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                        python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python</environment_variable>
+                        <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    </action>
+                </actions>
+            </install>
+            <readme>
+                Downloads and installs setuptools.
+            </readme>
+        </package>
+</tool_dependency>


### PR DESCRIPTION
…_2_0

Else the installation will fail on stock Ubuntu 14.04 (and older ...) due to
```
The required version of setuptools (>=3.4.1) is not available,
and can't be installed while this script is running. Please
install a more recent version first, using
'easy_install -U setuptools'.

(Currently using setuptools 2.2 (/home/galaxy/galaxy/.venv/lib/python2.7/site-packages))
```