### PR TITLE
Package edgeR: depends now on R 3.2.1

### DIFF
--- a/packages/package_r_edger_3_11_0/tool_dependencies.xml
+++ b/packages/package_r_edger_3_11_0/tool_dependencies.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="R" version="3.1.2">
-        <repository name="package_r_3_1_2" owner="iuc" prior_installation_required="True" />
+    <package name="R" version="3.2.1">
+        <repository name="package_r_3_2_1" owner="iuc" prior_installation_required="True" />
     </package>
     <package name="edger" version="3.11.0">
         <install version="1.0">
             <actions>
                 <action type="setup_r_environment">
-                    <repository name="package_r_3_1_2" owner="iuc">
-                        <package name="R" version="3.1.2" />
+                    <repository name="package_r_3_2_1" owner="iuc">
+                        <package name="R" version="3.2.1" />
                     </repository>
                     
                     <!-- bioarchive.github.io -->


### PR DESCRIPTION
Package edgeR: depends now on R 3.2.1 (instead of R 3.1.2) to avoid a… nested dependency on ncurses 5.9

I have updated the tool in the testtoolshed for testing.