### PR TITLE
Added package for bcftools 1.3

### DIFF
--- a/packages/package_bcftools_1_3/.shed.yml
+++ b/packages/package_bcftools_1_3/.shed.yml
@@ -1,0 +1,16 @@
+categories:
+ - Tool Dependency Packages
+ - Variant Analysis
+description: Contains a tool dependency definition that downloads and extracts version 1.3 of bcftools
+homepage_url: https://github.com/galaxyproject/tools-iuc/
+long_description: 'BCFtools is a set of utilities that manipulate variant calls in
+  the Variant Call Format (VCF) and its binary counterpart BCF. All commands work
+  transparently with both VCFs and BCFs, both uncompressed and BGZF-compressed.
+
+
+  Most commands accept VCF, bgzipped VCF and BCF with filetype detected automatically
+  even when streaming from a pipe. Indexed VCF and BCF will work in all situations.
+  Un-indexed VCF and BCF and streams will work in most, but not all situations.'
+name: package_bcftools_1_3
+owner: iuc
+type: tool_dependency_definition

--- a/packages/package_bcftools_1_3/tool_dependencies.xml
+++ b/packages/package_bcftools_1_3/tool_dependencies.xml
@@ -6,15 +6,13 @@
     <package name="bcftools" version="1.3">
         <install version="1.0">
             <actions_group>
-              <!--
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url">http://depot.galaxyproject.org/package/linux/x86_64/bcftools/bcftools-1.2-Linux-x86_64.tgz</action>
+                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/bcftools/bcftools-1.3-Linux-x86_64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
-              -->
                 <actions>
                     <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.3/bcftools-1.3.tar.bz2</action>
                     <action type="set_environment_for_install">

--- a/packages/package_bcftools_1_3/tool_dependencies.xml
+++ b/packages/package_bcftools_1_3/tool_dependencies.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="zlib" version="1.2.8">
+        <repository name="package_zlib_1_2_8" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="bcftools" version="1.3">
+        <install version="1.0">
+            <actions_group>
+              <!--
+                <actions architecture="x86_64" os="linux">
+                    <action type="download_by_url">http://depot.galaxyproject.org/package/linux/x86_64/bcftools/bcftools-1.2-Linux-x86_64.tgz</action>
+                    <action type="move_directory_files">
+                        <source_directory>.</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                </actions>
+              -->
+                <actions>
+                    <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.3/bcftools-1.3.tar.bz2</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_zlib_1_2_8" owner="iuc">
+                            <package name="zlib" version="1.2.8" />
+                        </repository>
+                    </action>
+                    <action type="shell_command">sed -i.bak 's#/usr/local#$INSTALL_DIR#' Makefile</action>
+                    <action type="make_install" />
+                </actions>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable action="set_to" name="BCFTOOLS_ROOT_PATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions_group>
+        </install>
+        <readme>
+<![CDATA[
+Program: bcftools (Tools for variant calling and manipulating VCFs and BCFs)
+Version: 1.3 (using htslib 1.3)
+
+Usage:   bcftools [--version|--version-only] [--help] <command> <argument>
+
+Commands:
+
+ -- Indexing
+    index        index VCF/BCF files
+
+ -- VCF/BCF manipulation
+    annotate     annotate and edit VCF/BCF files
+    concat       concatenate VCF/BCF files from the same set of samples
+    convert      convert VCF/BCF files to different formats and back
+    isec         intersections of VCF/BCF files
+    merge        merge VCF/BCF files files from non-overlapping sample sets
+    norm         left-align and normalize indels
+    plugin       user-defined plugins
+    query        transform VCF/BCF into user-defined formats
+    reheader     modify VCF/BCF header, change sample names
+    view         VCF/BCF conversion, view, subset and filter VCF/BCF files
+
+ -- VCF/BCF analysis
+    call         SNP/indel calling
+    consensus    create consensus sequence by applying VCF variants
+    cnv          HMM CNV calling
+    filter       filter VCF/BCF files using fixed thresholds
+    gtcheck      check sample concordance, detect sample swaps and contamination
+    roh          identify runs of autozygosity (HMM)
+    stats        produce VCF/BCF stats
+
+ Most commands accept VCF, bgzipped VCF, and BCF with the file type detected
+ automatically even when streaming from a pipe. Indexed VCF and BCF will work
+ in all situations. Un-indexed VCF and BCF and streams will work in most but
+ not all situations.
+
+]]>
+        </readme>
+    </package>
+</tool_dependency>

--- a/packages/package_bcftools_1_3/tool_dependencies.xml
+++ b/packages/package_bcftools_1_3/tool_dependencies.xml
@@ -14,7 +14,7 @@
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.3/bcftools-1.3.tar.bz2</action>
+                    <action type="download_by_url" sha256sum="fc5332e49546d55120551b0d5fb690f79e4f2216b8492c7b53033cdaa4256a3d">https://github.com/samtools/bcftools/releases/download/1.3/bcftools-1.3.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_zlib_1_2_8" owner="iuc">
                             <package name="zlib" version="1.2.8" />

--- a/packages/package_bcftools_1_3/tool_dependencies.xml
+++ b/packages/package_bcftools_1_3/tool_dependencies.xml
@@ -7,7 +7,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url">https://depot.galaxyproject.org/package/linux/x86_64/bcftools/bcftools-1.3-Linux-x86_64.tar.gz</action>
+                    <action type="download_by_url" sha256sum="e5c8ccdc2b5c0f09d7b467ab194cb78609bb8ec83b70949354b2794e403a904a">https://depot.galaxyproject.org/package/linux/x86_64/bcftools/bcftools-1.3-Linux-x86_64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>


### PR DESCRIPTION
BCFTools 1.3 just came out. So I added a package (pretty much identical to your 1.2 except with 1.3 references, URL, and help output instead.

Currently bcftools1.3 is not in the depot so that commented part can just be uncommented and updated with the 1.3 depot URL whenever it's on there.
