### PR TITLE
package_ncurses_5_9: Fixes critical compilation error for GCC5.1+

### DIFF
--- a/packages/package_ncurses_5_9/tool_dependencies.xml
+++ b/packages/package_ncurses_5_9/tool_dependencies.xml
@@ -5,6 +5,10 @@
             <actions_group>
                 <actions os="linux" architecture="x86_64">
                     <action type="download_by_url" md5sum="8cb9c412e5f2d96bc6f459aa8c6282a1">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
+                    <action type="shell_command">
+                        wget https://raw.githubusercontent.com/cloudius-systems/osv/07e2d9032dbb3f4f2b0d0133e0eccd5be05dd05d/modules/ncurses/ncurses-5.9-gcc-5.patch &amp;&amp;
+                        patch ncurses/base/MKlib_gen.sh ncurses-5.9-gcc-5.patch
+                    </action>
                     <action type="autoconf">--with-shared --enable-symlinks</action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">

--- a/packages/package_ncurses_5_9/tool_dependencies.xml
+++ b/packages/package_ncurses_5_9/tool_dependencies.xml
@@ -5,14 +5,18 @@
             <actions_group>
                 <actions os="linux" architecture="x86_64">
                     <action type="download_by_url" md5sum="8cb9c412e5f2d96bc6f459aa8c6282a1">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
+                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch</action>
                     <action type="shell_command">
-                        wget https://raw.githubusercontent.com/cloudius-systems/osv/07e2d9032dbb3f4f2b0d0133e0eccd5be05dd05d/modules/ncurses/ncurses-5.9-gcc-5.patch &amp;&amp;
-                        patch ncurses/base/MKlib_gen.sh ncurses-5.9-gcc-5.patch
+                        patch ncurses/base/MKlib_gen.sh ../ncurses_patch_5.9p_src_all.patch
                     </action>
                     <action type="autoconf">--with-shared --enable-symlinks</action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
                     <action type="download_by_url" md5sum="8cb9c412e5f2d96bc6f459aa8c6282a1">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
+                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch</action>
+                    <action type="shell_command">
+                        patch ncurses/base/MKlib_gen.sh ../ncurses_patch_5.9p_src_all.patch
+                    </action>
                     <action type="autoconf">--with-shared --enable-symlinks --without-cxx --without-cxx-binding --without-ada --without-progs --without-curses-h --without-debug --enable-widec --enable-const --enable-ext-colors --enable-sigwinch --enable-wgetch-events</action>
                 </actions>
                 <action type="set_environment">


### PR DESCRIPTION
A fix for issue https://github.com/galaxyproject/tools-iuc/issues/477
Could testers report their GCC version as well?