### PR TITLE
Fix package_python_2_7_bx_python_0_7, since eggs and PYTHONPATH don't mix

### DIFF
--- a/packages/package_python_2_7_bx_python_0_7_2/tool_dependencies.xml
+++ b/packages/package_python_2_7_bx_python_0_7_2/tool_dependencies.xml
@@ -21,6 +21,7 @@
                 </action>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib/python/bx_python-0.7.2-py2.7-linux-x86_64.egg</environment_variable>
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                     <environment_variable action="set_to" name="BX_PYTHON_ROOT_DIR">$INSTALL_DIR</environment_variable>
                     <environment_variable action="set_to" name="PYTHONPATH_BX_PYTHON">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
`package_python_2_7_bx_python_0_7` ends up getting installed as an egg. This requires `site.py` in `package_python_2_7_bx_python_0_7/a6b1f4f37b64/lib/python` getting run, but that won't happen **unless** this package happens to be the first thing in `sys.path`. This gets around that by manually added the egg to PYTHONPATH. This package also installs distribute as an egg, but I assume that that side-effect isn't needed by anything.