### PR TITLE
Make output param label the same as that for repmatch_gff3

### DIFF
--- a/tools/cwpair2/cwpair2.xml
+++ b/tools/cwpair2/cwpair2.xml
@@ -48,8 +48,8 @@
                 <param name="absolute_threshold" type="float" value="0.0" min="0.0" label="Absolute value to filter below" />
             </when>
         </conditional>
-        <param name="output_files" type="select" label="Please select the output you want to have" help="Statistics will always be generated." >
-            <option value="all" selected="True">no restrictions (output everything: C,D,F,O,P,MP)</option>
+        <param name="output_files" type="select" label="Select output" help="Statistics will always be generated." >
+            <option value="all" selected="True">everything (C,D,F,O,P,MP)</option>
             <option value="matched_pair">matched pairs only (MP)</option>
             <option value="matched_pair_orphan">matched pairs and orphans only (O,MP)</option>
             <option value="matched_pair_orphan_detail">matched pairs, orphans and details only (D,O,MP)</option>


### PR DESCRIPTION
This one is not critical, but just wanted to standardize the parameter label across tools.