### PR TITLE
Replace dead link in package_circos_0_67_5

### DIFF
--- a/packages/package_circos_0_67_5/tool_dependencies.xml
+++ b/packages/package_circos_0_67_5/tool_dependencies.xml
@@ -27,7 +27,7 @@
                     <package>http://www.cpan.org/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/M/MH/MHOSKEN/Font-TTF-1.05.tar.gz</package>
                     <package>http://share.gruenings.eu/GD-2.56.tar.gz</package>
-                    <package>http://www.cpan.org/authors/id/J/JV/JV/Getopt-Long-2.45.tar.gz</package>
+                    <package>http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long/Getopt-Long-2.45.tar.gz/md5/ea5c085b30915efe522f9ac58fcc343d/Getopt-Long-2.45.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/T/TO/TOBYINK/Exporter-Tiny-0.042.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-0.404.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.41.tar.gz</package>


### PR DESCRIPTION
Replaced the dead link:
http://www.cpan.org/authors/id/J/JV/JV/Getopt-Long-2.45.tar.gz
With the following link:
http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long/Getopt-Long-2.45.tar.gz/md5/ea5c085b30915efe522f9ac58fcc343d/Getopt-Long-2.45.tar.gz