### PR TITLE
Perl Getopt-Long v2.4.5: cargo-port url + sha256sum

### DIFF
--- a/packages/package_circos_0_67_5/tool_dependencies.xml
+++ b/packages/package_circos_0_67_5/tool_dependencies.xml
@@ -27,7 +27,7 @@
                     <package>http://www.cpan.org/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/M/MH/MHOSKEN/Font-TTF-1.05.tar.gz</package>
                     <package>http://share.gruenings.eu/GD-2.56.tar.gz</package>
-                    <package>http://pkgs.fedoraproject.org/repo/pkgs/perl-Getopt-Long/Getopt-Long-2.45.tar.gz/md5/ea5c085b30915efe522f9ac58fcc343d/Getopt-Long-2.45.tar.gz</package>
+                    <package sha256sum="93fdea2b24130dd748cd1dd8579513a4d46965b2e9869cf47649ab5a66053af1">https://depot.galaxyproject.org/software/Perl-Getopt-Long/Perl-Getopt-Long_2.45_src_all.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/T/TO/TOBYINK/Exporter-Tiny-0.042.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-0.404.tar.gz</package>
                     <package>http://www.cpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.41.tar.gz</package>


### PR DESCRIPTION
Uses the cargo-port url for https://github.com/galaxyproject/tools-iuc/pull/526