### PR TITLE
package_circos_0_67_5 revision change

### DIFF
--- a/packages/package_circostools_0_20/tool_dependencies.xml
+++ b/packages/package_circostools_0_20/tool_dependencies.xml
@@ -4,7 +4,7 @@
         <repository name="package_perl_5_18" owner="iuc" prior_installation_required="True" />
     </package>
     <package name="circos" version="0.67.5">
-        <repository name="package_circos_0_67_5" owner="iuc" prior_installation_required="True" />
+        <repository changeset_revision="76e18491a582" name="package_circos_0_67_5" owner="iuc" prior_installation_required="True" />
     </package>
     <package name="circostools" version="0.20">
         <install version="1.0">


### PR DESCRIPTION
update the dependency of package_circos_0_67_5 to the right revision.
related to https://github.com/galaxyproject/tools-iuc/pull/532 and https://github.com/galaxyproject/tools-iuc/pull/526