### PR TITLE
HISAT2: Fixes 2 issues for using advanced parameters

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -70,7 +70,7 @@
             #if str($spliced_options.known_splice_gtf) != 'None':
                 --known-splicesite-infile splice_sites.txt
             #end if
-            ${spliced_options.ignore_quals}
+            ${spliced_options.no_spliced_alignment}
             --min-intronlen ${spliced_options.min_intron}
             --max-intronlen ${spliced_options.max_intron}
             ${spliced_options.tma}

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -70,7 +70,7 @@
             #if str($spliced_options.known_splice_gtf) != 'None':
                 --known-splicesite-infile splice_sites.txt
             #end if
-            ${spliced_options.no_spliced_alignment}
+            ${spliced_options.ignore_quals}
             --min-intronlen ${spliced_options.min_intron}
             --max-intronlen ${spliced_options.max_intron}
             ${spliced_options.tma}

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -56,7 +56,7 @@
             ${input_format.paired.paired_end_options.no_discordant}
         #end if
     </token>
-    <token name="strandedness_parameters">
+    <token name="@strandedness_parameters@">
         #if str($spliced_options.spliced_options_selector) == "advanced":
             #if str($spliced_options.rna_strandness).strip() != '':
                 --rna-strandness $spliced_options.rna_strandness


### PR DESCRIPTION
HISAT2 crashes when changing the *Spliced alignment parameters* because of 2 typo's.
These settings are necessary if you want to use the alignments with cufflinks/cuffdiff/cummerbund.

When you select those parameters you get a `failure preparing job` error and paster.log says:

```
Traceback (most recent call last):
  File "<galaxy home dir>/lib/galaxy/jobs/runners/pulsar.py", line 256, in __prepare_job
    job_wrapper.prepare( **prepare_kwds )
  File "<galaxy home dir>/lib/galaxy/jobs/__init__.py", line 859, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "<galaxy home dir>/lib/galaxy/tools/evaluation.py", line 422, in build
    raise e
NotFound: cannot find 'no_spliced_alignment' while searching for 'spliced_options.no_spliced_alignment'
```

Next Tuesday I will give a course on RNA-Seq in Galaxy and I would like to use HISAT2, so is anybody able to test it before then :flushed:?