### PR TITLE
package_python_2_7_numpy_1_9 update to explicitly specify ATLAS libs from toolshed

### DIFF
--- a/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
@@ -16,7 +16,7 @@
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />
                         </repository>
-                        <package sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://github.com/pjbriggs/download_archive/raw/master/numpy/numpy-1.9.2.tar.gz</package>
+                        <package sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://depot.galaxyproject.org/software/9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318</package>
                     </action>
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>

--- a/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
@@ -16,7 +16,7 @@
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />
                         </repository>
-                        <package sha256sum="325e5f2b0b434ecb6e6882c7e1034cc6cdde3eeeea87dbc482575199a6aeef2a">https://depot.galaxyproject.org/software/325e5f2b0b434ecb6e6882c7e1034cc6cdde3eeeea87dbc482575199a6aeef2a</package>
+                        <package sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://github.com/pjbriggs/download_archive/raw/master/numpy/numpy-1.9.2.tar.gz</package>
                     </action>
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>

--- a/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
@@ -16,9 +16,7 @@
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />
                         </repository>
-                        <package sha256sum="0075bbe07e30b659ae4415446f45812dc1b96121a493a4a1f8b1ba77b75b1e1c">
-                            https://pypi.python.org/packages/source/n/numpy/numpy-1.9.1.tar.gz
-                        </package>
+                        <package sha256sum="325e5f2b0b434ecb6e6882c7e1034cc6cdde3eeeea87dbc482575199a6aeef2a">https://depot.galaxyproject.org/software/325e5f2b0b434ecb6e6882c7e1034cc6cdde3eeeea87dbc482575199a6aeef2a</package>
                     </action>
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>

--- a/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_python_2_7_numpy_1_9/tool_dependencies.xml
@@ -16,7 +16,7 @@
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />
                         </repository>
-                        <package sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://depot.galaxyproject.org/software/9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318</package>
+                        <package sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://depot.galaxyproject.org/software/numpy/numpy_1.9p1_src_all.tar.gz</package>
                     </action>
                     <action type="set_environment">
                         <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
This PR attempts to fix an issue with `package_python_2_7_numpy_1_9` and its dependency on `package_atlas_3_10`; essentially the former fails to use the ATLAS libraries provided by the latter when building `numpy`:

* In cases where there is a pre-existing set of ATLAS libraries on the system, `numpy` may compile against these instead and cause installation failures subsequently for other packages that depend on `numpy` (for example `package_python_2_7_scipy_0_14`). This is what I'm observing on our production server when trying to update the `deepTools` tool (we are running Scientific Linux and have the `devel` package for the ATLAS libraries installed).

* In cases where the system ATLAS is not picked up (or doesn't exist), the installation failures may not be observed - however the `numpy` installation logs suggest that the toolshed ATLAS libs are not picked up either.

To address this I've updated the `tool_dependencies.xml` file for `package_python_2_7_numpy_1_9` to create a `site.cfg` file that explicitly specifies the location of the toolshed ATLAS libraries (as per the instructions in `numpy`'s `INSTALL.txt`). Unfortunately this has meant that I've also had to replace the "magic" `<package ...>` command (which appears to download, unpack and install `numpy` in a single stage), so I don't know if there is a better/more concise way to do this.

Hopefully this makes sense - I'm happy to provide more details etc. Thanks for your consideration.