### PR TITLE
Fix package_libpng_1_6_7 to link explicitly against toolshed zlib

### DIFF
--- a/packages/package_libpng_1_6_7/tool_dependencies.xml
+++ b/packages/package_libpng_1_6_7/tool_dependencies.xml
@@ -12,7 +12,13 @@
             <package name="zlib" version="1.2.8" />
           </repository>
         </action>
-        <action type="autoconf"/>
+	<!--
+	   Need to explicitly specify location of ZLIB files
+	   For background see
+	   http://stackoverflow.com/questions/19738464/pngfix-c2151-undefined-reference-to-inflatereset2
+	  -->
+	<action type="shell_command">LDFLAGS=-L$ZLIB_ROOT_PATH/lib CPPFLAGS=-I$ZLIB_ROOT_PATH/include ./configure --prefix=$INSTALL_DIR &amp;&amp;
+	  make &amp;&amp; make install</action>
         <action type="set_environment">
           <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
           <environment_variable action="set_to" name="LIBPNG_ROOT">$INSTALL_DIR</environment_variable>

--- a/packages/package_libpng_1_6_7/tool_dependencies.xml
+++ b/packages/package_libpng_1_6_7/tool_dependencies.xml
@@ -17,8 +17,8 @@
 	   For background see
 	   http://stackoverflow.com/questions/19738464/pngfix-c2151-undefined-reference-to-inflatereset2
 	  -->
-	<action type="shell_command">LDFLAGS=-L$ZLIB_ROOT_PATH/lib CPPFLAGS=-I$ZLIB_ROOT_PATH/include ./configure --prefix=$INSTALL_DIR &amp;&amp;
-	  make &amp;&amp; make install</action>
+	<action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
+	<action type="make_install">LDFLAGS=-L$ZLIB_ROOT_PATH/lib CPPFLAGS=-I$ZLIB_ROOT_PATH/include</action>
         <action type="set_environment">
           <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
           <environment_variable action="set_to" name="LIBPNG_ROOT">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
This PR updates `package_libpng_1_6_7` to explicitly set the `include` and `lib` directories for the version of the `zlib` libraries provided by its dependency `package_zlib_1_2_8`.

Without this patch, on Scientific Linux 6.2 the installation of `package_libpng_1_6_7` fails with an error of the form:

    contrib/tools/pngfix.o: In function `zlib_reset':
    /opt/apps/galaxy/tmp/tmp-toolshed-mtdvSxsyE/libpng-1.6.7/contrib/tools/pngfix.c:
    2175: undefined reference to `inflateReset2'
    collect2: ld returned 1 exit status
    make[1]: *** [pngfix] Error 1
    make: *** [all] Error 2

My patch uses the solution suggested in this StackOverflow answer: http://stackoverflow.com/a/26367243/579925

I don't know if there is a more canonical way to set the environment variables within `<action type="autoconf"/>`, so I have just swapped it for what I understand are the equivalent shell commands. Any comments or questions welcome - thanks for your consideration.