### PR TITLE
Add pyBigWig-0.2.3, which will be a deepTools-2.0.0 requirement

### DIFF
--- a/packages/package_python_2_7_10_pybigwig_0_2_3/.shed.yml
+++ b/packages/package_python_2_7_10_pybigwig_0_2_3/.shed.yml
@@ -1,0 +1,10 @@
+name: package_python_2_7_10_pybigwig_0_2_3
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version
+  0.2.3 of pybigwig
+long_description: |
+  A python extension written in C for quick access to bigWig files. This extension uses libBigWig for local and remote file access.
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_python_2_7_10_pybigwig_0_2_3
+type: tool_dependency_definition

--- a/packages/package_python_2_7_10_pybigwig_0_2_3/tool_dependencies.xml
+++ b/packages/package_python_2_7_10_pybigwig_0_2_3/tool_dependencies.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="libcurl" version="7.35">
+        <repository name="package_libcurl_7_35" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="pybigwig" version="0.1.9">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_libcurl_7_35" owner="iuc">
+                        <package name="libcurl" version="7.35" />
+                    </repository>
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <!-- Just download from pypi -->
+                    <package md5sum="8ed6a7c2d03c94ae534f8bc549300f5e">https://pypi.python.org/packages/source/p/pyBigWig/pyBigWig-0.1.9.tar.gz</package>
+                </action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>Compiles and installs pyBigWig, which requires a compiler (typically gcc) and libcurl.</readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
This adds a copy of the most recent version of pyBigWig to the toolshed. It's just an updated version of the files used for the current copy. This python package is used by deepTools, the next release of which will be released within the next week.