### PR TITLE
Fix output tag set for the modern extract_genomic_dna tool

### DIFF
--- a/tools/extract_genomic_dna/extract_genomic_dna.xml
+++ b/tools/extract_genomic_dna/extract_genomic_dna.xml
@@ -1,4 +1,4 @@
-<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="3.0.0">
+<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="3.0.1">
     <description>using coordinates from assembled/unassembled genomes</description>
     <requirements>
         <requirement type="package" version="0.7.1">bx-python</requirement>

--- a/tools/extract_genomic_dna/extract_genomic_dna.xml
+++ b/tools/extract_genomic_dna/extract_genomic_dna.xml
@@ -66,9 +66,9 @@
         </param>
     </inputs>
     <outputs>
-        <data name="output" format="gff">
+        <data format_source="input" name="output" metadata_source="input">
             <change_format>
-                <when output_format="interval" format="interval" />
+                <when input="output_format" value="fasta" format="fasta" />
             </change_format>
         </data>
     </outputs>


### PR DESCRIPTION
so it exactly mimics the behavior of the original tool.