### PR TITLE
genometools: linking cairo explicitly

### DIFF
--- a/packages/package_genometools_1_5_7/tool_dependencies.xml
+++ b/packages/package_genometools_1_5_7/tool_dependencies.xml
@@ -6,6 +6,11 @@
                 <action type="download_by_url" sha256sum="b84a2eab9e7b8fb3e7acb5a1b9df40e8d07394d18357b4bb85c5a9004f3339e5">
                         https://depot.galaxyproject.org/software/genometools/genometools_1.5.7_src_all.tar.gz
                 </action>
+                <action type="set_environment_for_install">
+                    <repository name="package_cairo_1_14_2" owner="iuc">
+                        <package name="cairo" version="1.14.2" />
+                    </repository>
+                </action>
                 <action type="shell_command">make 64bit=yes cairo=no prefix=$INSTALL_DIR install</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">cd gtpython &amp;&amp;  python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>

--- a/packages/package_genometools_1_5_7/tool_dependencies.xml
+++ b/packages/package_genometools_1_5_7/tool_dependencies.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <tool_dependency>
+    <package name="cairo" version="1.14.2">
+        <repository name="package_cairo_1_14_2" owner="iuc" prior_installation_required="True" />
+    </package>
     <package name="genometools" version="1.5.7">
         <install version="1.0">
             <actions>


### PR DESCRIPTION
Solves the following error:
```
In file included from /usr/local/src/galaxy/database/tmp/tmp-toolshed-mtdZYb7ae/genometools-1.5.7/src/annotationsketch/text_width_calculator_cairo.h:21:0,
                 from src/annotationsketch/layout.c:26:
/usr/local/src/galaxy/database/tmp/tmp-toolshed-mtdZYb7ae/genometools-1.5.7/src/annotationsketch/text_width_calculator_cairo_api.h:21:19: fatal error: cairo.h: No such file or directory
compilation terminated.
```