### PR TITLE
Patch macs2 install for old gcc versions

### DIFF
--- a/packages/package_macs2_2_1_0_20151222/tool_dependencies.xml
+++ b/packages/package_macs2_2_1_0_20151222/tool_dependencies.xml
@@ -21,6 +21,10 @@
                 </action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <!-- exporting the CFLAGS and CPPFLAGS are due to http://stackoverflow.com/questions/22313407/clang-error-unknown-argument-mno-fused-madd-python-package-installation-fa -->
+                <!-- Addressing compiler compatibility issues for gcc < 4.6 https://github.com/taoliu/MACS/issues/75 --> 
+                <action type="shell_command">
+                    echo | cc -E - -Ofast; if [ $? -ne 0 ]; then sed -i.bak s/-Ofast/-O3/ setup.py; fi
+                </action>
                 <action type="shell_command">
                     export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
                     python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin


### PR DESCRIPTION
Installation of MACS2 is problematic when gcc version is < 4.6. See https://github.com/taoliu/MACS/issues/75. This is implements the suggested patch from the author.

PR (https://github.com/taoliu/MACS/pull/109) was issued upstream to address this, but hopefully this patch addresses things in this version.