### PR TITLE
Fix compling error with no curses.h

### DIFF
--- a/packages/package_trinity_2_0_6/tool_dependencies.xml
+++ b/packages/package_trinity_2_0_6/tool_dependencies.xml
@@ -23,6 +23,7 @@
                 <action type="shell_command">sed -i.bak -e 's/-lcurses/-lncurses/' trinity-plugins/Makefile</action>
                 <action type="shell_command">sed -i.bak -e 's/-ltinfo//' trinity-plugins/Makefile</action> <!-- tinfo is included in ncurses lib-->
                 <action type="shell_command">sed -i.bak -e '/tar -zxvf ${RSEM_CODE}.tar.gz/a \\tsed -i.bak -e "s|-lz|-lz -L${ZLIB_ROOT_PATH}/lib|" ${RSEM_CODE}/Makefile ${RSEM_CODE}/sam/Makefile' trinity-plugins/Makefile</action> <!-- In case you have an obsolete zlib in /usr/lib -->
+					 <action type="shell_command">sed -i.bak -e '/tar -zxvf ${RSEM_CODE}.tar.gz/a \\tsed -i.bak -e "s|INCLUDES=\\s*-I.|INCLUDES= -I. -I${NCURSES_INCLUDE_PATH}/ncurses|" ${RSEM_CODE}/sam/Makefile' trinity-plugins/Makefile</action>
                 <action type="shell_command">make</action>
                 <action type="shell_command">make plugins</action>
 


### PR DESCRIPTION
Makefile for samtools doesn't use environment variables for the ncurses library, but it uses the system library.

bam_tview_curses.c:5:20: error: curses.h: No such file or directory
bam_tview_curses.c:7:2: warning: #warning "_CURSES_LIB=1 but NCURSES_VERSION not defined; tview is NOT compiled"
bam_tview_curses.c:287:2: warning: #warning "No curses library is available; tview with curses is disabled."
make[3]: *** [bam_tview_curses.o] Error 1
