### PR TITLE
Fix closestBed output name

### DIFF
--- a/tools/bedtools/closestBed.xml
+++ b/tools/bedtools/closestBed.xml
@@ -43,12 +43,12 @@
         <expand macro="strand2" />
 
         <param name="addition" type="boolean" checked="false" truevalue="-d" falsevalue=""
-            label="In addition to the closest feature in B, report its distance to A as an extra column" 
+            label="In addition to the closest feature in B, report its distance to A as an extra column"
             help="The reported distance for overlapping features will be 0. (-d)" />
 
         <conditional name="addition2">
-            <param name="addition2_select" type="select" optional="True"
-                label="Add additional columns to report distance to upstream feature. Distance defintion" 
+            <param name="addition2_select" type="select"
+                label="Add additional columns to report distance to upstream feature. Distance defintion"
                 help="Like -d, report the closest feature in B, and its distance to A as an extra column. However unlike -d, use negative distances to report upstream features. (-D)">
                 <option value="" selected="True">Do not report the distance et all.</option>
                 <option value="ref">Report distance with respect to the reference genome. B features with a lower (start, stop) are upstream. (-ref)</option>
@@ -71,18 +71,20 @@
             label="Report the k closest hits" help="(-k)"/>
 
         <param name="io" type="boolean" checked="false" truevalue="-io" falsevalue=""
-            label="Ignore features in B that overlap A" 
+            label="Ignore features in B that overlap A"
             help="That is, we want close, yet not touching features only. (-io)" />
 
         <param name="mdb" type="select" optional="True"
-            label="How multiple databases are resolved" 
+            label="How multiple databases are resolved"
             help="(-mdb)">
             <option value="each" selected="True">Report closest records for each database. (-each)</option>
             <option value="all">Report closest records among all databases. (-all)</option>
         </param>
     </inputs>
     <outputs>
-        <data format_source="inputA" name="output" metadata_source="inputA" label="Clostest region of ${inputA} in ${inputB}"/>
+        <!-- Would like to use a nicer name, but since there are possibly many inputB datasets, falling back to ${on_string} -->
+        <!-- <data format_source="inputA" name="output" metadata_source="inputA" label="Closest regions from ${inputB[0].name} to ${inputA.name}"/> -->
+        <data format_source="inputA" name="output" metadata_source="inputA" label="Closest regions from ${on_string}"/>
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
Output name was exposing the actual file location on disk, fall back to
using ${on_string} since no simple solution when there are multiple
inputs.

Also, dropped the deprecated optional attribute from the
addition2_select param.