### PR TITLE
Fix broken lib-local install in package_perl_5_18

### DIFF
--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -13,9 +13,7 @@
                 <action type="shell_command">./Configure -des -Dprefix=$INSTALL_DIR -Dstartperl='#!/usr/bin/env perl'</action>
                 <action type="make_install" />
                 <action type="change_directory">..</action>
-                <action type="download_file" sha256sum="5c69adb47ab828aa3e8b5be89b88cd49c6a0d0dae2e8b3bca17a9ce699190e7b">
-                    http://www.cpan.org/authors/id/A/AP/APEIRON/local-lib-1.008009.tar.gz
-                </action>
+                <action type="download_file" sha256sum="5c69adb47ab828aa3e8b5be89b88cd49c6a0d0dae2e8b3bca17a9ce699190e7b">http://www.cpan.org/authors/id/A/AP/APEIRON/local-lib-1.008009.tar.gz</action>
                 <action type="shell_command">tar xfvz local-lib-1.008009.tar.gz</action>
                 <action type="change_directory">local-lib-1.008009</action>
                 <!-- TODO: Here we need to use the new installed perl binary -->


### PR DESCRIPTION
This PR fixes a problem in `package_perl_5_18`, which is observed to fail when installing from the toolshed on Ubuntu 14.04 and Scientific Linux 6.5.

The problem seems to be related to the download and unpacking of the `local-lib` library post-Perl installation. This fails at the explicit untarring step with the error:

    tar (child): local-lib-1.008009.tar.gz: Cannot open: No such file or directory
    tar (child): Error is not recoverable: exiting now
    tar: Child returned status 2
    tar: Error is not recoverable: exiting now

Using `download_by_url` and removing the explicit `tar xvfz ...` appears to fix the problem.