### PR TITLE
Remove whitespaces in download_by_url and download_file actions.

### DIFF
--- a/packages/package_abyss_1_9_0/tool_dependencies.xml
+++ b/packages/package_abyss_1_9_0/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="abyss" version="1.9.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1030fcea4bfae942789deefd3a4ffb30653143e02eb6a74c7e4087bb4bf18a14">
-                    https://depot.galaxyproject.org/software/abyss/abyss_1.9-0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1030fcea4bfae942789deefd3a4ffb30653143e02eb6a74c7e4087bb4bf18a14">https://depot.galaxyproject.org/software/abyss/abyss_1.9-0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_boost_1_57" owner="iuc">
                         <package name="boost" version="1.57" />

--- a/packages/package_anaconda_2_3_0/tool_dependencies.xml
+++ b/packages/package_anaconda_2_3_0/tool_dependencies.xml
@@ -4,15 +4,11 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="7c02499e9511c127d225992cfe1cd815e88fd46cd8a5b3cdf764f3fb4d8d4576" target_filename="Anaconda-2.3.0-Linux-x86_64.sh">
-                        https://depot.galaxyproject.org/software/Anaconda/Anaconda_2.3.0_linux_x64.sh
-                    </action>
+                    <action type="download_by_url" sha256sum="7c02499e9511c127d225992cfe1cd815e88fd46cd8a5b3cdf764f3fb4d8d4576" target_filename="Anaconda-2.3.0-Linux-x86_64.sh">https://depot.galaxyproject.org/software/Anaconda/Anaconda_2.3.0_linux_x64.sh</action>
                     <action type="shell_command">bash Anaconda_2.3.0_linux_x64.sh -b -f -p $INSTALL_DIR</action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="c4bb59a57bf44dde80612041bbbcfd2e5cab8534842209ef456da7a46f919c33" target_filename="Anaconda-2.3.0-MacOSX-x86_64.sh">
-                        https://depot.galaxyproject.org/software/Anaconda/Anaconda_2.3.0_darwin_x64.sh
-                    </action>
+                    <action type="download_by_url" sha256sum="c4bb59a57bf44dde80612041bbbcfd2e5cab8534842209ef456da7a46f919c33" target_filename="Anaconda-2.3.0-MacOSX-x86_64.sh">https://depot.galaxyproject.org/software/Anaconda/Anaconda_2.3.0_darwin_x64.sh</action>
                     <action type="shell_command">bash Anaconda_2.3.0_darwin_x64.sh -b -f -p $INSTALL_DIR</action>
                 </actions>
                 <action type="set_environment">

--- a/packages/package_aragorn_1_2_36/tool_dependencies.xml
+++ b/packages/package_aragorn_1_2_36/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="aragorn" version="1.2.36">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ab06032589e45aa002f8616333568e9ab11034b3a675f922421e5f1c3e95e7b5">
-                    https://depot.galaxyproject.org/software/aragorn/aragorn_1.2.36_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ab06032589e45aa002f8616333568e9ab11034b3a675f922421e5f1c3e95e7b5">https://depot.galaxyproject.org/software/aragorn/aragorn_1.2.36_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/bin/</action>
                 <action type="shell_command">gcc -O3 -ffast-math -finline-functions -o aragorn aragorn1.2.36.c</action>
                 <action type="move_file">

--- a/packages/package_art_2014_11_03/tool_dependencies.xml
+++ b/packages/package_art_2014_11_03/tool_dependencies.xml
@@ -6,9 +6,7 @@
   <package name="art" version="2014_11_03">
     <install version="1.0">
       <actions>
-        <action type="download_by_url" sha256sum="31f172ac5953ec32e4ae7787b2aa25e62d55b086647ac1e3e6298bbe39e89645">
-            https://depot.galaxyproject.org/software/art/art_2014.11.03_src_all.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="31f172ac5953ec32e4ae7787b2aa25e62d55b086647ac1e3e6298bbe39e89645">https://depot.galaxyproject.org/software/art/art_2014.11.03_src_all.tar.gz</action>
         <action type="set_environment_for_install">
           <repository name="package_gsl_1_16" owner="iuc">
             <package name="gsl" version="1.16" />

--- a/packages/package_atlas_3_10/tool_dependencies.xml
+++ b/packages/package_atlas_3_10/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="c36a9edf352aa3652ae2c3cccf752351e12291c1d018da842093f9dc70fa2da3">
-                        https://depot.galaxyproject.org/software/atlas/atlas_3.10.2_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="c36a9edf352aa3652ae2c3cccf752351e12291c1d018da842093f9dc70fa2da3">https://depot.galaxyproject.org/software/atlas/atlas_3.10.2_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -40,21 +38,11 @@
                     <!-- NOOP: On OS X we will use Apple's vecLib -->
                 </actions>
                 <actions>
-                    <action type="download_file" sha256sum="3aab139b118bf3fcdb4956fbd71676158d713ab0d3bccb2ae1dc3769db22102f">
-                        https://depot.galaxyproject.org/software/atlas/atlas_3.10.2+gx0_src_all.tar.bz2
-                    </action>
-                    <action type="download_file" sha256sum="9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352">
-                        https://depot.galaxyproject.org/software/lapack/lapack_3.5.0_src_all.tar.gz
-                    </action>
-                    <action type="download_file" sha256sum="adbe462b179a2d626cd229cddcb08e39ae2f2544eccf80ab617790b307667146">
-                        https://depot.galaxyproject.org/software/atlas/atlas_patch-blas-lapack-1.0_src_all.diff
-                    </action>
-                    <action type="download_file" sha256sum="95862478f7d276f948a58c583acd2935ada9ad3bb55944a303d94e161e202d89">
-                        https://depot.galaxyproject.org/software/atlas/atlas_patch-shared-lib-1.0_src_all.diff
-                    </action>
-                    <action type="download_file" sha256sum="f805600c46719f74752e9026e1461d084a385ba67838364a81c36cdfb69cad82">
-                        https://depot.galaxyproject.org/software/atlas/atlas_patch-cpu-throttle-1.0_src_all.diff
-                    </action>
+                    <action type="download_file" sha256sum="3aab139b118bf3fcdb4956fbd71676158d713ab0d3bccb2ae1dc3769db22102f">https://depot.galaxyproject.org/software/atlas/atlas_3.10.2+gx0_src_all.tar.bz2</action>
+                    <action type="download_file" sha256sum="9ad8f0d3f3fb5521db49f2dd716463b8fb2b6bc9dc386a9956b8c6144f726352">https://depot.galaxyproject.org/software/lapack/lapack_3.5.0_src_all.tar.gz</action>
+                    <action type="download_file" sha256sum="adbe462b179a2d626cd229cddcb08e39ae2f2544eccf80ab617790b307667146">https://depot.galaxyproject.org/software/atlas/atlas_patch-blas-lapack-1.0_src_all.diff</action>
+                    <action type="download_file" sha256sum="95862478f7d276f948a58c583acd2935ada9ad3bb55944a303d94e161e202d89">https://depot.galaxyproject.org/software/atlas/atlas_patch-shared-lib-1.0_src_all.diff</action>
+                    <action type="download_file" sha256sum="f805600c46719f74752e9026e1461d084a385ba67838364a81c36cdfb69cad82">https://depot.galaxyproject.org/software/atlas/atlas_patch-cpu-throttle-1.0_src_all.diff</action>
                     <action type="shell_command">tar -jxvf atlas_3.10.2+gx0_src_all.tar.bz2</action>
                     <!-- a 64-bit architecture is assumed for compilation -->
                     <action type="shell_command"><![CDATA[

--- a/packages/package_atlas_3_11/tool_dependencies.xml
+++ b/packages/package_atlas_3_11/tool_dependencies.xml
@@ -4,13 +4,9 @@
         <install version="1.0">
             <actions>
                 <!-- first action is always downloading -->
-                <action target_filename="ATLAS.tar.bz2" type="download_by_url" sha256sum="4d90bdd0ec7a88494a67e5ed5f9663e71262949181dbb44e3a0eb4fb5d3f4576">
-                    https://depot.galaxyproject.org/software/atlas/atlas_3.11.11_src_all.tar.bz2
-                </action>
+                <action target_filename="ATLAS.tar.bz2" type="download_by_url" sha256sum="4d90bdd0ec7a88494a67e5ed5f9663e71262949181dbb44e3a0eb4fb5d3f4576">https://depot.galaxyproject.org/software/atlas/atlas_3.11.11_src_all.tar.bz2</action>
 
-                <action type="download_file" sha256sum="60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0">
-                    https://depot.galaxyproject.org/software/lapack/lapack_3.4.2_src_all.tar.gz
-                </action>
+                <action type="download_file" sha256sum="60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0">https://depot.galaxyproject.org/software/lapack/lapack_3.4.2_src_all.tar.gz</action>
 
                 <action type="shell_command">
                 # try to disable cpu throttling

--- a/packages/package_augustus_3_1/tool_dependencies.xml
+++ b/packages/package_augustus_3_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="augustus" version="3.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="6db15a859537ccab8739e09c9c28f59c31dd9781e19d91f0d4489f60c7c15486">
-                    https://depot.galaxyproject.org/software/augustus/augustus_3.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="6db15a859537ccab8739e09c9c28f59c31dd9781e19d91f0d4489f60c7c15486">https://depot.galaxyproject.org/software/augustus/augustus_3.1_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_directory_files">
                     <source_directory>bin</source_directory>

--- a/packages/package_barrnap_0_2/tool_dependencies.xml
+++ b/packages/package_barrnap_0_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="barrnap" version="0.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b664b68cec8f881c47785ffe81167c2ec106aedf09be32ed71452398609d6310">
-                    https://depot.galaxyproject.org/software/barrnap/barrnap_0.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b664b68cec8f881c47785ffe81167c2ec106aedf09be32ed71452398609d6310">https://depot.galaxyproject.org/software/barrnap/barrnap_0.2_src_all.tar.gz</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR/bin</destination_directory>

--- a/packages/package_barrnap_0_3/tool_dependencies.xml
+++ b/packages/package_barrnap_0_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="barrnap" version="0.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="f99a808a3b304748fff0394e4e048a8efb0a52ee309b6a4f7296e3e2cf05ce69">
-                    https://depot.galaxyproject.org/software/barrnap/barrnap_0.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="f99a808a3b304748fff0394e4e048a8efb0a52ee309b6a4f7296e3e2cf05ce69">https://depot.galaxyproject.org/software/barrnap/barrnap_0.3_src_all.tar.gz</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_barrnap_0_7/tool_dependencies.xml
+++ b/packages/package_barrnap_0_7/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="barrnap" version="0.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ef2173e250f06cca7569c03404c9d4ab6a908ef7643e28901fbe9a732d20c09b">
-                    https://depot.galaxyproject.org/software/barrnap/barrnap_0.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ef2173e250f06cca7569c03404c9d4ab6a908ef7643e28901fbe9a732d20c09b">https://depot.galaxyproject.org/software/barrnap/barrnap_0.7_src_all.tar.gz</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_bcftools_1_2/tool_dependencies.xml
+++ b/packages/package_bcftools_1_2/tool_dependencies.xml
@@ -7,23 +7,18 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="82d36151aebe1785c283ab0a98bf7e1714e11ee82ff5efc032fc18a33136975b">
-                        https://depot.galaxyproject.org/software/bcftools/bcftools_1.2_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="82d36151aebe1785c283ab0a98bf7e1714e11ee82ff5efc032fc18a33136975b">https://depot.galaxyproject.org/software/bcftools/bcftools_1.2_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url">https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2</action>
+                    <action type="download_by_url" sha256sum="53c628339020dd45334a007c9cefdaf1cba3f1032492ec813b116379fa684fd6">https://depot.galaxyproject.org/software/bcftools/bcftools_1.2_src_all.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_zlib_1_2_8" owner="iuc">
                             <package name="zlib" version="1.2.8" />
                         </repository>
-                    </action>
-                    <action type="download_by_url" sha256sum="53c628339020dd45334a007c9cefdaf1cba3f1032492ec813b116379fa684fd6">
-                        https://depot.galaxyproject.org/software/bcftools/bcftools_1.2_src_all.tar.bz2
                     </action>
                     <action type="shell_command">sed -i.bak 's#/usr/local#$INSTALL_DIR#' Makefile</action>
                     <action type="make_install" />

--- a/packages/package_bedtools_2_19/tool_dependencies.xml
+++ b/packages/package_bedtools_2_19/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bedtools" version="2.19.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="17253439e8191cb51a8bffba640c580e09ba158d3a0c66649e53d23ee3e50f77">
-                    https://depot.galaxyproject.org/software/bedtools/bedtools_2.19_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="17253439e8191cb51a8bffba640c580e09ba158d3a0c66649e53d23ee3e50f77">https://depot.galaxyproject.org/software/bedtools/bedtools_2.19_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_directory_files">
                     <source_directory>bin</source_directory>

--- a/packages/package_bedtools_2_20/tool_dependencies.xml
+++ b/packages/package_bedtools_2_20/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bedtools" version="2.20.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b5401810f8b12b683575f0119521dda64ff2f0a59faa308357405c4ae4e328d3">
-                    https://depot.galaxyproject.org/software/bedtools/bedtools_2.20_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b5401810f8b12b683575f0119521dda64ff2f0a59faa308357405c4ae4e328d3">https://depot.galaxyproject.org/software/bedtools/bedtools_2.20_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_directory_files">
                     <source_directory>bin</source_directory>

--- a/packages/package_bedtools_2_22/tool_dependencies.xml
+++ b/packages/package_bedtools_2_22/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bedtools" version="2.22">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="43ab5da6b41350bbef78ea2ee5be0609fb02d76b920a3301b687a39af7017233">
-                    https://depot.galaxyproject.org/software/bedtools/bedtools_2.22_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="43ab5da6b41350bbef78ea2ee5be0609fb02d76b920a3301b687a39af7017233">https://depot.galaxyproject.org/software/bedtools/bedtools_2.22_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_directory_files">
                     <source_directory>bin</source_directory>

--- a/packages/package_bedtools_2_24/tool_dependencies.xml
+++ b/packages/package_bedtools_2_24/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bedtools" version="2.24">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ea73b8620468c5a15d4ed96dc98c83e5564880bb9651cd75f1dcc96694be60e4">
-                    https://depot.galaxyproject.org/software/bedtools/bedtools_2.24_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ea73b8620468c5a15d4ed96dc98c83e5564880bb9651cd75f1dcc96694be60e4">https://depot.galaxyproject.org/software/bedtools/bedtools_2.24_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_directory_files">
                     <source_directory>bin</source_directory>

--- a/packages/package_biopython_1_61/tool_dependencies.xml
+++ b/packages/package_biopython_1_61/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="biopython" version="1.61">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="899a3e3779b303a708a8afdd2184d51026da79b0e71eefae65bb0b08200ed791">
-                    https://depot.galaxyproject.org/software/biopython/biopython_1.61_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="899a3e3779b303a708a8afdd2184d51026da79b0e71eefae65bb0b08200ed791">https://depot.galaxyproject.org/software/biopython/biopython_1.61_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">
                         <package name="numpy" version="1.7.1" />

--- a/packages/package_bison_3_0/tool_dependencies.xml
+++ b/packages/package_bison_3_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bison" version="3.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="e5b7ec75d0b9a2655d8d1854c4a26789a370db8777ef77874dd453ed181482d2">
-                    https://depot.galaxyproject.org/software/bison/bison_3.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="e5b7ec75d0b9a2655d8d1854c4a26789a370db8777ef77874dd453ed181482d2">https://depot.galaxyproject.org/software/bison/bison_3.0_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_boost_1_53/tool_dependencies.xml
+++ b/packages/package_boost_1_53/tool_dependencies.xml
@@ -7,9 +7,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64">
-                    <action type="download_by_url" sha256sum="f88a041b01882b0c9c5c05b39603ec8383fb881f772f6f9e6e6fd0e0cddb9196">
-                        https://depot.galaxyproject.org/software/boost/boost_1.53.0_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="f88a041b01882b0c9c5c05b39603ec8383fb881f772f6f9e6e6fd0e0cddb9196">https://depot.galaxyproject.org/software/boost/boost_1.53.0_src_all.tar.bz2</action>
 
                     <!-- populate the environment variables from the dependend repos -->
                     <action type="set_environment_for_install">
@@ -24,9 +22,7 @@
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="f88a041b01882b0c9c5c05b39603ec8383fb881f772f6f9e6e6fd0e0cddb9196">
-                        https://depot.galaxyproject.org/software/boost/boost_1.53.0_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="f88a041b01882b0c9c5c05b39603ec8383fb881f772f6f9e6e6fd0e0cddb9196">https://depot.galaxyproject.org/software/boost/boost_1.53.0_src_all.tar.bz2</action>
 
                     <!-- populate the environment variables from the dependend repos -->
                     <action type="set_environment_for_install">

--- a/packages/package_boost_1_55/tool_dependencies.xml
+++ b/packages/package_boost_1_55/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="boost" version="1.55.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="19c4305cd6669f2216260258802a7abc73c1624758294b2cad209d45cc13a767">
-                    https://depot.galaxyproject.org/software/boost/boost_1.55.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="19c4305cd6669f2216260258802a7abc73c1624758294b2cad209d45cc13a767">https://depot.galaxyproject.org/software/boost/boost_1.55.0_src_all.tar.gz</action>
 
                 <!-- populate the environment variables from the dependend repos -->
                 <action type="set_environment_for_install">

--- a/packages/package_boost_1_57/tool_dependencies.xml
+++ b/packages/package_boost_1_57/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="boost" version="1.57">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="fea9c7472f7a52cec2a1640958145b2144bf17903a21db65b95efb6ae5817fa5">
-                    https://depot.galaxyproject.org/software/boost/boost_1.57.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="fea9c7472f7a52cec2a1640958145b2144bf17903a21db65b95efb6ae5817fa5">https://depot.galaxyproject.org/software/boost/boost_1.57.0_src_all.tar.gz</action>
 
                 <!-- populate the environment variables from the dependend repos -->
                 <action type="set_environment_for_install">

--- a/packages/package_bowtie_1_0_0/tool_dependencies.xml
+++ b/packages/package_bowtie_1_0_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bowtie" version="1.0.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="51e434a78e053301f82ae56f4e94f71f97b19f7175324777a7305c8f88c5bac5">
-                    https://depot.galaxyproject.org/software/bowtie/bowtie_1.0.0_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="51e434a78e053301f82ae56f4e94f71f97b19f7175324777a7305c8f88c5bac5">https://depot.galaxyproject.org/software/bowtie/bowtie_1.0.0_src_all.zip</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>bowtie</source>

--- a/packages/package_bowtie_1_1_2/tool_dependencies.xml
+++ b/packages/package_bowtie_1_1_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bowtie" version="1.1.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b72c62bb00046d10e83ad1fb51049bb88fd8fa01745ce13c5aeadb8c008f0a73">
-                    https://codeload.github.com/BenLangmead/bowtie/zip/v1.1.2
-                </action>
+                <action type="download_by_url" sha256sum="b72c62bb00046d10e83ad1fb51049bb88fd8fa01745ce13c5aeadb8c008f0a73">https://codeload.github.com/BenLangmead/bowtie/zip/v1.1.2</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>bowtie</source>

--- a/packages/package_bowtie_2_2_5/tool_dependencies.xml
+++ b/packages/package_bowtie_2_2_5/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="be99a1a2249c8f7097a89244b15e078b0a3489e136284a0dd876978db0a9024a">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="be99a1a2249c8f7097a89244b15e078b0a3489e136284a0dd876978db0a9024a">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="0f142477738accc73276f3e47877d54a64b6f7ac7911d0609b662adcd15374a0">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_darwin_x64.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="0f142477738accc73276f3e47877d54a64b6f7ac7911d0609b662adcd15374a0">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_darwin_x64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="e22766dd9421c10e82a3e207ee1f0eb924c025b909ad5fffa36633cd7978d3b0">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_src_all.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="e22766dd9421c10e82a3e207ee1f0eb924c025b909ad5fffa36633cd7978d3b0">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.5_src_all.zip</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">
                         <source>bowtie2</source>

--- a/packages/package_bowtie_2_2_6/tool_dependencies.xml
+++ b/packages/package_bowtie_2_2_6/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="831f969e76d3968a6f007bff6018b8e09ae2b9c613feb0fa46137ed65f93fbac">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_linux_x64.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="831f969e76d3968a6f007bff6018b8e09ae2b9c613feb0fa46137ed65f93fbac">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_linux_x64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin/</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="6b2bf02135951d1ad61128dd0b39cf3fcd5a0a04fb402b13db763961efb9244a">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_darwin_x64.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="6b2bf02135951d1ad61128dd0b39cf3fcd5a0a04fb402b13db763961efb9244a">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_darwin_x64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin/</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action sha256sum="1000e90cdd90c3ca43c69d0d0ad951e190d36a6981a546f430a90ce86d64bfc8" type="download_by_url">
-                        https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_src_all.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="1000e90cdd90c3ca43c69d0d0ad951e190d36a6981a546f430a90ce86d64bfc8">https://depot.galaxyproject.org/software/bowtie2/bowtie2_2.2.6_src_all.zip</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">
                         <source>bowtie2</source>

--- a/packages/package_bwa_0_7_7/tool_dependencies.xml
+++ b/packages/package_bwa_0_7_7/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bwa" version="0.7.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2c44b63c23b04b878e28d5dc0c6145bbb2d6244ef9b588cdc0cdfeebac75e569">
-                    https://depot.galaxyproject.org/software/bwa/bwa_0.7.7_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="2c44b63c23b04b878e28d5dc0c6145bbb2d6244ef9b588cdc0cdfeebac75e569">https://depot.galaxyproject.org/software/bwa/bwa_0.7.7_src_all.tar.bz2</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>bwa</source>

--- a/packages/package_bx_python_0_7/tool_dependencies.xml
+++ b/packages/package_bx_python_0_7/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="bx-python" version="0.7.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="9ff7b5354de03c463da6d245d3256a41966e718a16f4021b7f8d4861305c9ea1">
-                    https://depot.galaxyproject.org/software/bx_python/bx_python_0.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="9ff7b5354de03c463da6d245d3256a41966e718a16f4021b7f8d4861305c9ea1">https://depot.galaxyproject.org/software/bx_python/bx_python_0.7_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">

--- a/packages/package_bz2file_0_98/tool_dependencies.xml
+++ b/packages/package_bz2file_0_98/tool_dependencies.xml
@@ -3,9 +3,7 @@
         <package name="bz2file" version="0.98">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="64c1f811e31556ba9931953c8ec7b397488726c63e09a4c67004f43bdd28da88">
-                        https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="64c1f811e31556ba9931953c8ec7b397488726c63e09a4c67004f43bdd28da88">https://pypi.python.org/packages/source/b/bz2file/bz2file-0.98.tar.gz</action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
                         python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin

--- a/packages/package_bzlib_1_0/tool_dependencies.xml
+++ b/packages/package_bzlib_1_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="bzlib" version="1.0.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd">
-                    https://depot.galaxyproject.org/software/bzlib/bzlib_1.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd">https://depot.galaxyproject.org/software/bzlib/bzlib_1.0_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="shell_command">make install PREFIX=$INSTALL_DIR/bzlib</action>
                 <action type="move_directory_files">

--- a/packages/package_cairo_1_12_14/tool_dependencies.xml
+++ b/packages/package_cairo_1_12_14/tool_dependencies.xml
@@ -15,9 +15,7 @@
     <package name="cairo" version="1.12.14">
       <install version="1.0">
           <actions>
-              <action type="download_by_url" sha256sum="700df574b953dac1b974bfde869a8dc1af011b7cb73080d7ca7b7dec3e68ce69">
-                  https://depot.galaxyproject.org/software/cairo/cairo_1.12.14_src_all.tar.bz2
-              </action>
+              <action type="download_by_url" sha256sum="700df574b953dac1b974bfde869a8dc1af011b7cb73080d7ca7b7dec3e68ce69">https://depot.galaxyproject.org/software/cairo/cairo_1.12.14_src_all.tar.bz2</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pixman_0_32_4" owner="iuc" prior_installation_required="True">
                         <package name="pixman" version="0.32.4" />

--- a/packages/package_cairo_1_14_2/tool_dependencies.xml
+++ b/packages/package_cairo_1_14_2/tool_dependencies.xml
@@ -15,9 +15,7 @@
     <package name="cairo" version="1.14.2">
       <install version="1.0">
           <actions>
-              <action type="download_by_url" sha256sum="0772ce92cabbcc18d4c699430d7eb89e56d5c0659de64e92cb88ec1496e8e18e">
-                    https://depot.galaxyproject.org/software/cairo/cairo_1.14.2_src_all.tar.bz2
-              </action>
+              <action type="download_by_url" sha256sum="0772ce92cabbcc18d4c699430d7eb89e56d5c0659de64e92cb88ec1496e8e18e">https://depot.galaxyproject.org/software/cairo/cairo_1.14.2_src_all.tar.bz2</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pixman_0_32_6" owner="iuc" prior_installation_required="True">
                         <package name="pixman" version="0.32.6" />

--- a/packages/package_ccat_3_0/tool_dependencies.xml
+++ b/packages/package_ccat_3_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="CCAT" version="3.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="d8944465c8327bec22eb41059ba73f780fcdcedf4470507bfdae5a54c59a9b07">
-                    https://depot.galaxyproject.org/software/ccat/ccat_3.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="d8944465c8327bec22eb41059ba73f780fcdcedf4470507bfdae5a54c59a9b07">https://depot.galaxyproject.org/software/ccat/ccat_3.0_src_all.tar.gz</action>
                 <action type="change_directory">src</action>
                 <action type="shell_command">./make</action>
                 <action type="move_file">

--- a/packages/package_chemfp_1_1/tool_dependencies.xml
+++ b/packages/package_chemfp_1_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="chemfp" version="1.1p1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1beb7d0d19eeac231d21d59446db117e2e4f0f31bb03af57a59d2ad2e672a482">
-                    https://depot.galaxyproject.org/software/chemfp/chemfp_1.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1beb7d0d19eeac231d21d59446db117e2e4f0f31bb03af57a59d2ad2e672a482">https://depot.galaxyproject.org/software/chemfp/chemfp_1.1_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">
                     export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
@@ -14,9 +12,7 @@
 
                 <!-- apply one small patched file, to support the query-format target-format commandline options
                 <action type="download_file">https://chem-fingerprints.googlecode.com/hg-history/1281bfcb470b84f5e75250dfa041345d280dde30/chemfp/commandline/simsearch.py</action>-->
-                <action type="download_file" sha256sum="7faa1dfecf390ae39461fa8e59c4ac174bca3c363f4cb299394c770324a9eddf">
-                    https://depot.galaxyproject.org/software/chemfp/chemfp_0.1-simsearch_src_all.py
-                </action>
+                <action type="download_file" sha256sum="7faa1dfecf390ae39461fa8e59c4ac174bca3c363f4cb299394c770324a9eddf">https://depot.galaxyproject.org/software/chemfp/chemfp_0.1-simsearch_src_all.py</action>
                 <action type="shell_command">rm $INSTALL_DIR/lib/python/chemfp/commandline/simsearch.py</action>
                 <action type="move_file">
                     <source>simsearch.py</source>

--- a/packages/package_cmake_3_2_3/tool_dependencies.xml
+++ b/packages/package_cmake_3_2_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="cmake" version="3.2.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297">
-                    https://depot.galaxyproject.org/software/cmake/cmake_3.2.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="a1ebcaf6d288eb4c966714ea457e3b9677cdfde78820d0f088712d7320850297">https://depot.galaxyproject.org/software/cmake/cmake_3.2.3_src_all.tar.gz</action>
                 <action type="shell_command">./bootstrap --prefix=$INSTALL_DIR</action>
                 <action type="make_install"/>
                 <action type="set_environment">

--- a/packages/package_cutadapt_1_8/tool_dependencies.xml
+++ b/packages/package_cutadapt_1_8/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="cutadapt" version="1.8">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b72e55b36d319567ecc586b99db91cc8b3240e1e5fcd8237ad0e22d69ea317b8">
-                    https://depot.galaxyproject.org/software/cutadapt/cutadapt_1.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b72e55b36d319567ecc586b99db91cc8b3240e1e5fcd8237ad0e22d69ea317b8">https://depot.galaxyproject.org/software/cutadapt/cutadapt_1.8_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_cython_0_20_1" owner="iuc">
                         <package name="cython" version="0.20.1" />

--- a/packages/package_cython_0_20_1/tool_dependencies.xml
+++ b/packages/package_cython_0_20_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="cython" version="0.20.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="31a563744a21d7b10355f25a3bca96b37ec5d32bdecfc75e93d65a5f7e62766c">
-                    https://depot.galaxyproject.org/software/cython/cython_0.20.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="31a563744a21d7b10355f25a3bca96b37ec5d32bdecfc75e93d65a5f7e62766c">https://depot.galaxyproject.org/software/cython/cython_0.20.1_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="make_directory">$INSTALL_DIR/bin</action>
                 <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>

--- a/packages/package_datamash_1_0_6/tool_dependencies.xml
+++ b/packages/package_datamash_1_0_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="datamash" version="1.0.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="0154c25c45b5506b6d618ca8e18d0ef093dac47946ac0df464fb21e77b504118">
-                    https://depot.galaxyproject.org/software/datamash/datamash_1.0.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="0154c25c45b5506b6d618ca8e18d0ef093dac47946ac0df464fb21e77b504118">https://depot.galaxyproject.org/software/datamash/datamash_1.0.6_src_all.tar.gz</action>
                 <action type="autoconf">--disable-dependency-tracking</action>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_dill_0_2/tool_dependencies.xml
+++ b/packages/package_dill_0_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
         <package name="dill" version="0.2">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="c0223a75afeef28734c6cd1ca40bd676e010209789f2e3986bbb4ca66d3754d4">
-                        https://depot.galaxyproject.org/software/dill/dill_0.2_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="c0223a75afeef28734c6cd1ca40bd676e010209789f2e3986bbb4ca66d3754d4">https://depot.galaxyproject.org/software/dill/dill_0.2_src_all.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;

--- a/packages/package_e2fsprogs_1_42_9/tool_dependencies.xml
+++ b/packages/package_e2fsprogs_1_42_9/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="e2fsprogs" version="1.42.9">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2f92ac06e92fa00f2ada3ee67dad012d74d685537527ad1241d82f2d041f2802">
-                    https://depot.galaxyproject.org/software/e2fsprogs/e2fsprogs_1.42.9_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2f92ac06e92fa00f2ada3ee67dad012d74d685537527ad1241d82f2d041f2802">https://depot.galaxyproject.org/software/e2fsprogs/e2fsprogs_1.42.9_src_all.tar.gz</action>
                 <action type="autoconf" />
 
                 <action type="set_environment">

--- a/packages/package_eden_1_1/tool_dependencies.xml
+++ b/packages/package_eden_1_1/tool_dependencies.xml
@@ -7,9 +7,7 @@
     <package name="eden" version="1.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="6709b7dac2dc90f6d914fda33ecc807390a136306e04c63b0ae6f764081db050">
-                    https://depot.galaxyproject.org/software/EDeN/EDeN_1.1.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="6709b7dac2dc90f6d914fda33ecc807390a136306e04c63b0ae6f764081db050">https://depot.galaxyproject.org/software/EDeN/EDeN_1.1.0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc">
                         <package name="zlib" version="1.2.8" />

--- a/packages/package_eden_1_3/tool_dependencies.xml
+++ b/packages/package_eden_1_3/tool_dependencies.xml
@@ -4,9 +4,7 @@
     <package name="eden" version="1.3.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="c73d50928126c2532e264ff120bddfe380e13249b9157c335e724038841c83c3">
-                    https://depot.galaxyproject.org/software/EDeN/EDeN_1.3.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="c73d50928126c2532e264ff120bddfe380e13249b9157c335e724038841c83c3">https://depot.galaxyproject.org/software/EDeN/EDeN_1.3.5_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>EDeN</source>

--- a/packages/package_eigen_2_0/tool_dependencies.xml
+++ b/packages/package_eigen_2_0/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="eigen2" version="2.0.17">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="705028db65db7c1e393cdf55018754bf0696e376603a48a33b781bc85406ff1e">
-                    https://depot.galaxyproject.org/software/eigen/eigen_2.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="705028db65db7c1e393cdf55018754bf0696e376603a48a33b781bc85406ff1e">https://depot.galaxyproject.org/software/eigen/eigen_2.0_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/unpacked_source</action>
                 <action type="shell_command">cp -r * $INSTALL_DIR/unpacked_source</action>
                 <action type="make_directory">build</action>

--- a/packages/package_eigen_3_1/tool_dependencies.xml
+++ b/packages/package_eigen_3_1/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="eigen3" version="3.1.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2ea0ba3eb9ac7ec623d8be92be4ee651191532cb311e0c979d65da9bc6c5143a">
-                    https://depot.galaxyproject.org/software/eigen/eigen_3.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2ea0ba3eb9ac7ec623d8be92be4ee651191532cb311e0c979d65da9bc6c5143a">https://depot.galaxyproject.org/software/eigen/eigen_3.1_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/unpacked_source</action>
                 <action type="shell_command">cp -r * $INSTALL_DIR/unpacked_source</action>
                 <action type="make_directory">build</action>

--- a/packages/package_eigen_3_2/tool_dependencies.xml
+++ b/packages/package_eigen_3_2/tool_dependencies.xml
@@ -5,9 +5,7 @@
     <package name="eigen3" version="3.2">
         <install version="1.0">
             <actions>
-                <action sha256sum="8a3352f9a5361fe90e451a7305fb1896fc7f771dc16cc0edd8e6b157f52c343e" type="download_by_url" target_filename="eigen-eigen-c58038c56923.tar.bz2">
-                    https://bitbucket.org/eigen/eigen/get/3.2.6.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="8a3352f9a5361fe90e451a7305fb1896fc7f771dc16cc0edd8e6b157f52c343e" target_filename="eigen-eigen-c58038c56923.tar.bz2">https://bitbucket.org/eigen/eigen/get/3.2.6.tar.bz2</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_cmake_3_2_3" owner="iuc">

--- a/packages/package_expat_2_1/tool_dependencies.xml
+++ b/packages/package_expat_2_1/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions>
                 <!-- first action is always downloading -->
-                <action type="download_by_url" sha256sum="823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86">
-                    https://depot.galaxyproject.org/software/expat/expat_2.1.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86">https://depot.galaxyproject.org/software/expat/expat_2.1.0_src_all.tar.gz</action>
                 <action type="autoconf" />
 
                 <action type="set_environment">

--- a/packages/package_express_1_5_1/tool_dependencies.xml
+++ b/packages/package_express_1_5_1/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="50e268af69cd5f561ae238e7d155ebb4a6505219bd93bc25a7667f7bf92b7bd5">
-                        https://depot.galaxyproject.org/software/express/express_1.5.1_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="50e268af69cd5f561ae238e7d155ebb4a6505219bd93bc25a7667f7bf92b7bd5">https://depot.galaxyproject.org/software/express/express_1.5.1_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="0582ab08440570f1686c0b075c32bed12a21d3c53ad52517768b95538a4df44b">
-                        https://depot.galaxyproject.org/software/express/express_1.5.1_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="0582ab08440570f1686c0b075c32bed12a21d3c53ad52517768b95538a4df44b">https://depot.galaxyproject.org/software/express/express_1.5.1_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="0c5840a42da830fd8701dda8eef13f4792248bab4e56d665a0e2ca075aff2c0f">
-                        https://depot.galaxyproject.org/software/express/express_1.5.1_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="0c5840a42da830fd8701dda8eef13f4792248bab4e56d665a0e2ca075aff2c0f">https://depot.galaxyproject.org/software/express/express_1.5.1_src_all.tar.gz</action>
                     <action type="shell_command">cmake src -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_DIR</action>
                     <action type="shell_command">make &amp;&amp; make install</action>
                 </actions>

--- a/packages/package_ez_setup_0_9/tool_dependencies.xml
+++ b/packages/package_ez_setup_0_9/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="ez_setup" version="0.9">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642">
-                    https://depot.galaxyproject.org/software/ez_setup/ez_setup_0.9_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642">https://depot.galaxyproject.org/software/ez_setup/ez_setup_0.9_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>
                 <action type="set_environment">

--- a/packages/package_fatotwobit_35x1/tool_dependencies.xml
+++ b/packages/package_fatotwobit_35x1/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">
-                        https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz</action>
                     <action type="shell_command">rm ucsc_312_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_fido_f63cd47b8414f87d57b8c1b713d34a04b29c7aee/tool_dependencies.xml
+++ b/packages/package_fido_f63cd47b8414f87d57b8c1b713d34a04b29c7aee/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="Fido" version="f63cd47b8414f87d57b8c1b713d34a04b29c7aee">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="76e524aa4bfee5be1def7cac0f01dd200c349efff4f5c030c8c41c3de9966fd1">
-                    https://github.com/hendrikweisser/Fido/archive/f63cd47b8414f87d57b8c1b713d34a04b29c7aee.zip
-                </action>
+                <action type="download_by_url" sha256sum="76e524aa4bfee5be1def7cac0f01dd200c349efff4f5c030c8c41c3de9966fd1">https://github.com/hendrikweisser/Fido/archive/f63cd47b8414f87d57b8c1b713d34a04b29c7aee.zip</action>
                 <action type="make_directory">build</action>
                 <action type="change_directory">build</action>
                 <action type="shell_command">cmake ..</action>

--- a/packages/package_fontconfig_2_11_1/tool_dependencies.xml
+++ b/packages/package_fontconfig_2_11_1/tool_dependencies.xml
@@ -10,9 +10,7 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                  <action type="download_by_url" sha256sum="b6b066c7dce3f436fdc0dfbae9d36122b38094f4f53bd8dffd45e195b0540d8d">
-                      https://depot.galaxyproject.org/software/fontconfig/fontconfig_2.11.1_src_all.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="b6b066c7dce3f436fdc0dfbae9d36122b38094f4f53bd8dffd45e195b0540d8d">https://depot.galaxyproject.org/software/fontconfig/fontconfig_2.11.1_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True">
                             <package name="freetype" version="2.5.2" />

--- a/packages/package_freetype_2_4/tool_dependencies.xml
+++ b/packages/package_freetype_2_4/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="freetype" version="2.4.11">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ef9d0bcb64647d9e5125dc7534d7ca371c98310fec87677c410f397f71ffbe3f">
-                    https://depot.galaxyproject.org/software/freetype/freetype_2.4.11_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="ef9d0bcb64647d9e5125dc7534d7ca371c98310fec87677c410f397f71ffbe3f">https://depot.galaxyproject.org/software/freetype/freetype_2.4.11_src_all.tar.bz2</action>
                 <action type="autoconf">--prefix=$INSTALL_DIR/freetype/</action>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/freetype/bin/</environment_variable>

--- a/packages/package_freetype_2_5_2/tool_dependencies.xml
+++ b/packages/package_freetype_2_5_2/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="freetype" version="2.5.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="376bc32bd907cb6f1a826a9c52627747b6d95259129df0f2c8faf99491168b55">
-                    https://depot.galaxyproject.org/software/freetype/freetype_2.5.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="376bc32bd907cb6f1a826a9c52627747b6d95259129df0f2c8faf99491168b55">https://depot.galaxyproject.org/software/freetype/freetype_2.5.2_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc" prior_installation_required="True">
                         <package name="zlib" version="1.2.8" />

--- a/packages/package_gdbm_1_11/tool_dependencies.xml
+++ b/packages/package_gdbm_1_11/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gdbm" version="1.11">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8d912f44f05d0b15a4a5d96a76f852e905d051bb88022fcdfd98b43be093e3c3">
-                    https://depot.galaxyproject.org/software/gdbm/gdbm_1.11_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8d912f44f05d0b15a4a5d96a76f852e905d051bb88022fcdfd98b43be093e3c3">https://depot.galaxyproject.org/software/gdbm/gdbm_1.11_src_all.tar.gz</action>
                 <action type="autoconf">--enable-libgdbm-compat</action>
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_gemini_0_10_0/tool_dependencies.xml
+++ b/packages/package_gemini_0_10_0/tool_dependencies.xml
@@ -18,9 +18,7 @@
     <package name="gemini" version="0.10.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" target_filename="gemini_install.py" sha256sum="0e9a482c3f2b12a055fb73191b4d99c1e43a210471d16e539d85695b83ff3fc5">
-                    https://depot.galaxyproject.org/software/gemini-install/gemini-install_0.1_src_all.py
-                </action>
+                <action type="download_by_url" sha256sum="0e9a482c3f2b12a055fb73191b4d99c1e43a210471d16e539d85695b83ff3fc5" target_filename="gemini_install.py">https://depot.galaxyproject.org/software/gemini-install/gemini-install_0.1_src_all.py</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc">

--- a/packages/package_gengetopt_2_22_6/tool_dependencies.xml
+++ b/packages/package_gengetopt_2_22_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gengetopt" version="2.22.6">
         <install version="1.0">
             <actions>
-            <action type="download_by_url" sha256sum="30b05a88604d71ef2a42a2ef26cd26df242b41f5b011ad03083143a31d9b01f7">
-                https://depot.galaxyproject.org/software/gengetopt/gengetopt_2.22.6_src_all.tar.gz
-            </action>
+            <action type="download_by_url" sha256sum="30b05a88604d71ef2a42a2ef26cd26df242b41f5b011ad03083143a31d9b01f7">https://depot.galaxyproject.org/software/gengetopt/gengetopt_2.22.6_src_all.tar.gz</action>
             <action type="autoconf" />
             <action type="set_environment">
                 <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_genometools_1_5_7/tool_dependencies.xml
+++ b/packages/package_genometools_1_5_7/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="genometools" version="1.5.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b84a2eab9e7b8fb3e7acb5a1b9df40e8d07394d18357b4bb85c5a9004f3339e5">
-                        https://depot.galaxyproject.org/software/genometools/genometools_1.5.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b84a2eab9e7b8fb3e7acb5a1b9df40e8d07394d18357b4bb85c5a9004f3339e5">https://depot.galaxyproject.org/software/genometools/genometools_1.5.7_src_all.tar.gz</action>
                 <action type="shell_command">make 64bit=yes cairo=no prefix=$INSTALL_DIR install</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">cd gtpython &amp;&amp;  python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>

--- a/packages/package_ghostscript_9_07/tool_dependencies.xml
+++ b/packages/package_ghostscript_9_07/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="ghostscript" version="9.07">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="44800d004c53f13192d1b5db413119198ddfc8a11c4d2a030aac2f2fda822ebf">
-                    https://depot.galaxyproject.org/software/ghostscript/ghostscript_9.07_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="44800d004c53f13192d1b5db413119198ddfc8a11c4d2a030aac2f2fda822ebf">https://depot.galaxyproject.org/software/ghostscript/ghostscript_9.07_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_libx11_1_5_0" owner="devteam">
                         <package name="libx11" version="1.5.0" />

--- a/packages/package_gnu_awk_4_1_0/tool_dependencies.xml
+++ b/packages/package_gnu_awk_4_1_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gnu_awk" version="4.1.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="79f81b09bc3cce50e083f78acc0f91783821ad30866615d30dd1731f17ec440b">
-                    http://ftp.gnu.org/gnu/gawk/gawk-4.1.0.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="79f81b09bc3cce50e083f78acc0f91783821ad30866615d30dd1731f17ec440b">http://ftp.gnu.org/gnu/gawk/gawk-4.1.0.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_gnu_coreutils_8_21/tool_dependencies.xml
+++ b/packages/package_gnu_coreutils_8_21/tool_dependencies.xml
@@ -7,9 +7,7 @@
                 repacked version of http://ftp.gnu.org/gnu/coreutils/coreutils-8.21.tar.xz,
                 because tarfile did not understand LZMA compression
             -->
-                <action type="download_by_url" sha256sum="2d0fa1aff8ab612e37cbc96f8d4c2538aab836e7369b072a39c3314699424883">
-                    https://depot.galaxyproject.org/software/coreutils/coreutils_8.21_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="2d0fa1aff8ab612e37cbc96f8d4c2538aab836e7369b072a39c3314699424883">https://depot.galaxyproject.org/software/coreutils/coreutils_8.21_src_all.tar.bz2</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_gnu_coreutils_8_22/tool_dependencies.xml
+++ b/packages/package_gnu_coreutils_8_22/tool_dependencies.xml
@@ -7,9 +7,7 @@
                 repacked version of http://ftp.gnu.org/gnu/coreutils/coreutils-8.22.tar.xz,
                 because tarfile did not understand LZMA compression
             -->
-                <action type="download_by_url" sha256sum="ee9f39144f96ca29c862c0c4fd09e5d186b9079b12ff509653f390fc1fda67cc">
-                    https://depot.galaxyproject.org/software/coreutils/coreutils_8.22_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="ee9f39144f96ca29c862c0c4fd09e5d186b9079b12ff509653f390fc1fda67cc">https://depot.galaxyproject.org/software/coreutils/coreutils_8.22_src_all.tar.bz2</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_gnu_grep_2_14/tool_dependencies.xml
+++ b/packages/package_gnu_grep_2_14/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="gnu_grep" version="2.14">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="abff7acabf664fc7c25a29c9ae8b3b5b44a84e95a553810f275019e568f7c6e3">
-                    https://depot.galaxyproject.org/software/grep/grep_2.14_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="abff7acabf664fc7c25a29c9ae8b3b5b44a84e95a553810f275019e568f7c6e3">https://depot.galaxyproject.org/software/grep/grep_2.14_src_all.tar.bz2</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pcre_8_34" owner="iuc">
                         <package name="pcre" version="8.34" />

--- a/packages/package_gnu_parallel_20131122/tool_dependencies.xml
+++ b/packages/package_gnu_parallel_20131122/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gnu_parallel" version="20131122">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ef5e0af618cd71c2a2d96ab3aa800ca44e6fab830092176db4b3468b747e29d0">
-                    https://depot.galaxyproject.org/software/gnu_parallel/gnu_parallel_20131122_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="ef5e0af618cd71c2a2d96ab3aa800ca44e6fab830092176db4b3468b747e29d0">https://depot.galaxyproject.org/software/gnu_parallel/gnu_parallel_20131122_src_all.tar.bz2</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_gnu_sed_4_2_2_sandbox/tool_dependencies.xml
+++ b/packages/package_gnu_sed_4_2_2_sandbox/tool_dependencies.xml
@@ -3,14 +3,10 @@
     <package name="gnu_sed" version="4.2.2-sandbox">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="fea0a94d4b605894f3e2d5572e3f96e4413bcad3a085aae7367c2cf07908b2ff">
-                    https://depot.galaxyproject.org/software/gnu_sed/gnu_sed_4.2.2.sandbox_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="fea0a94d4b605894f3e2d5572e3f96e4413bcad3a085aae7367c2cf07908b2ff">https://depot.galaxyproject.org/software/gnu_sed/gnu_sed_4.2.2.sandbox_src_all.tar.gz</action>
 
                 <!-- add sandbox feature from Assaf Gordon to disable critial functions. -->
-                <action type="download_file" sha256sum="b9d5b4ea8b60ffaea4185db7d390baf9c9ca6d27e475c68648bcf4d625900442">
-                    https://depot.galaxyproject.org/software/gnu_sed/gnu_sed_e1626689.sandbox.patch_src_all.patch
-                </action>
+                <action type="download_file" sha256sum="b9d5b4ea8b60ffaea4185db7d390baf9c9ca6d27e475c68648bcf4d625900442">https://depot.galaxyproject.org/software/gnu_sed/gnu_sed_e1626689.sandbox.patch_src_all.patch</action>
                 <action type="shell_command">patch -p1 -i gnu_sed_e1626689.sandbox.patch_src_all.patch</action>
                 <action type="autoconf" />
                 <action type="set_environment">

--- a/packages/package_gnuplot_4_6/tool_dependencies.xml
+++ b/packages/package_gnuplot_4_6/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="gnuplot" version="4.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1f19596fd09045f22225afbfec11fa91b9ad1d95b9f48406362f517d4f130274">
-                    https://depot.galaxyproject.org/software/gnuplot/gnuplot_4.6.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1f19596fd09045f22225afbfec11fa91b9ad1d95b9f48406362f517d4f130274">https://depot.galaxyproject.org/software/gnuplot/gnuplot_4.6.6_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_libgd_2_1" owner="iuc">

--- a/packages/package_gnuplot_py_1_8/tool_dependencies.xml
+++ b/packages/package_gnuplot_py_1_8/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gnuplot-py" version="1.8">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ab339be7847d30a8acfd616f27b5021bfde0999b7bf2d68400fbe62c53106e21">
-                    https://depot.galaxyproject.org/software/gnuplot-py/gnuplot-py_1.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ab339be7847d30a8acfd616f27b5021bfde0999b7bf2d68400fbe62c53106e21">https://depot.galaxyproject.org/software/gnuplot-py/gnuplot-py_1.8_src_all.tar.gz</action>
 
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">

--- a/packages/package_golang_1_5_1/tool_dependencies.xml
+++ b/packages/package_golang_1_5_1/tool_dependencies.xml
@@ -4,27 +4,21 @@
     <install version="1.0">
       <actions_group>
         <actions architecture="x86_64" os="linux">
-          <action type="download_by_url" sha256sum="2593132ca490b9ee17509d65ee2cd078441ff544899f6afb97a03d08c25524e7">
-              https://depot.galaxyproject.org/software/go/go_1.5.1_linux_x64.tar.gz
-          </action>
+          <action type="download_by_url" sha256sum="2593132ca490b9ee17509d65ee2cd078441ff544899f6afb97a03d08c25524e7">https://depot.galaxyproject.org/software/go/go_1.5.1_linux_x64.tar.gz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions architecture="i386" os="linux">
-          <action type="download_by_url" sha256sum="11bdd79a389a7c6220cc8049480b37227eae05778c0fde616b1edd10f713c5e2">
-              https://depot.galaxyproject.org/software/go/go_1.5.1_linux_x32.tar.gz
-          </action>
+          <action type="download_by_url" sha256sum="11bdd79a389a7c6220cc8049480b37227eae05778c0fde616b1edd10f713c5e2">https://depot.galaxyproject.org/software/go/go_1.5.1_linux_x32.tar.gz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions architecture="x86_64" os="darwin">
-          <action type="download_by_url" sha256sum="e94487b8cd2e0239f27dc51e6c6464383b10acb491f753584605e9b28abf48fb">
-              https://depot.galaxyproject.org/software/go/go_1.5.1_darwin_x64.tar.gz
-          </action>
+          <action type="download_by_url" sha256sum="e94487b8cd2e0239f27dc51e6c6464383b10acb491f753584605e9b28abf48fb">https://depot.galaxyproject.org/software/go/go_1.5.1_darwin_x64.tar.gz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_graphicsmagick_1_3/tool_dependencies.xml
+++ b/packages/package_graphicsmagick_1_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="graphicsmagick" version="1.3.18">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="c7335428fd932cfb25383dd581ffc8d65131ce623864374847d5e4f4654c0b68">
-                    https://depot.galaxyproject.org/software/GraphicsMagick/GraphicsMagick_1.3.18_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="c7335428fd932cfb25383dd581ffc8d65131ce623864374847d5e4f4654c0b68">https://depot.galaxyproject.org/software/GraphicsMagick/GraphicsMagick_1.3.18_src_all.tar.gz</action>
                 <action type="autoconf">--prefix=$INSTALL_DIR/gmagick/ --enable-shared=yes</action>
                 <!-- drop-in replacement for imagemagick's convert -->
                 <action type="shell_command">echo -e '#!/usr/bin/env bash\ngm convert $@' > $INSTALL_DIR/gmagick/bin/convert</action>

--- a/packages/package_graphicsmagick_1_3_20/tool_dependencies.xml
+++ b/packages/package_graphicsmagick_1_3_20/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="graphicsmagick" version="1.3.20">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="0f7463318f5d9a4b429655dd43642a7a93dae561360637093182fbf5ac4fdc88">
-                    https://depot.galaxyproject.org/software/GraphicsMagick/GraphicsMagick_1.3.20_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="0f7463318f5d9a4b429655dd43642a7a93dae561360637093182fbf5ac4fdc88">https://depot.galaxyproject.org/software/GraphicsMagick/GraphicsMagick_1.3.20_src_all.tar.gz</action>
                 <action type="autoconf">--enable-shared=yes</action>
                 <action type="set_environment">
                     <environment_variable name="GRAPHICSMAGICK_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>

--- a/packages/package_gsl_1_16/tool_dependencies.xml
+++ b/packages/package_gsl_1_16/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="gsl" version="1.16">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="73bc2f51b90d2a780e6d266d43e487b3dbd78945dd0b04b14ca5980fe28d2f53">
-                    https://depot.galaxyproject.org/software/gsl/gsl_1.16_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="73bc2f51b90d2a780e6d266d43e487b3dbd78945dd0b04b14ca5980fe28d2f53">https://depot.galaxyproject.org/software/gsl/gsl_1.16_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_hdf5_1_8_12/tool_dependencies.xml
+++ b/packages/package_hdf5_1_8_12/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="hdf5" version="1.8.12">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b5cccea850096962b5fd9e96f22c4f47d2379224bb41130d9bc038bb6c37dfcb">
-                    https://depot.galaxyproject.org/software/hdf5/hdf5_1.8.12_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b5cccea850096962b5fd9e96f22c4f47d2379224bb41130d9bc038bb6c37dfcb">https://depot.galaxyproject.org/software/hdf5/hdf5_1.8.12_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc" prior_installation_required="True">

--- a/packages/package_hisat_0_1_6/tool_dependencies.xml
+++ b/packages/package_hisat_0_1_6/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="a29dc43d9d66c2579803ff1c3ad0788266824640cd07b073d005321f1c125e69">
-                        https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="a29dc43d9d66c2579803ff1c3ad0788266824640cd07b073d005321f1c125e69">https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="80cb2ab3d58889abf4c25a7fe1e92e39273259fb706f71b9f3ec2bf181495248">
-                        https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="80cb2ab3d58889abf4c25a7fe1e92e39273259fb706f71b9f3ec2bf181495248">https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                  <action type="download_by_url" sha256sum="69fbd79d8f29b221aa72f0db33148d67d44a3e2cfe16dadf0663a58b7741ff9c">
-                      https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_src_all.zip
-                  </action>
+                  <action type="download_by_url" sha256sum="69fbd79d8f29b221aa72f0db33148d67d44a3e2cfe16dadf0663a58b7741ff9c">https://depot.galaxyproject.org/software/hisat/hisat_0.1.6_src_all.zip</action>
                     <action type="shell_command">make</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_hisat_2_0/tool_dependencies.xml
+++ b/packages/package_hisat_2_0/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="23c65f4bf33c87f7e7aa84da4e8bfd872413ee42237c8ca127a57f6e82e8c2c0">
-                        https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_linux_x64.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="23c65f4bf33c87f7e7aa84da4e8bfd872413ee42237c8ca127a57f6e82e8c2c0">https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_linux_x64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="a71f5b5af05c942b8311805a98d2aeaec4b882b5876ea67a810fe46d544741b4">
-                        https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_darwin_x64.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="a71f5b5af05c942b8311805a98d2aeaec4b882b5876ea67a810fe46d544741b4">https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_darwin_x64.zip</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="12ce17a34d3c3e5f546e6204a49aeb65c860c42fce7ac2a77c6c0b690d934fbf">
-                        https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_src_all.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="12ce17a34d3c3e5f546e6204a49aeb65c860c42fce7ac2a77c6c0b690d934fbf">https://depot.galaxyproject.org/software/hisat/hisat_2.0.0_src_all.zip</action>
                     <action type="shell_command">make</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_hmmer_3_1b1/tool_dependencies.xml
+++ b/packages/package_hmmer_3_1b1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="hmmer" version="3.1b1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="246f5e32545d3a5706d065d8413fc8fc5445e779a97019e98ba319e5ef9dc1d8">
-                    https://depot.galaxyproject.org/software/hmmer/hmmer_3.1b1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="246f5e32545d3a5706d065d8413fc8fc5445e779a97019e98ba319e5ef9dc1d8">https://depot.galaxyproject.org/software/hmmer/hmmer_3.1b1_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="change_directory">easel/miniapps/</action>
                 <action type="make_install" />

--- a/packages/package_hmmer_3_1b2/tool_dependencies.xml
+++ b/packages/package_hmmer_3_1b2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="hmmer" version="3.1b2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="dd16edf4385c1df072c9e2f58c16ee1872d855a018a2ee6894205277017b5536">
-                    https://depot.galaxyproject.org/software/hmmer/hmmer_3.1b2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="dd16edf4385c1df072c9e2f58c16ee1872d855a018a2ee6894205277017b5536">https://depot.galaxyproject.org/software/hmmer/hmmer_3.1b2_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="change_directory">easel/miniapps/</action>
                 <action type="make_install" />

--- a/packages/package_homer_4_2/tool_dependencies.xml
+++ b/packages/package_homer_4_2/tool_dependencies.xml
@@ -15,9 +15,7 @@
     <package name="homer" version="4.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="a52aebb3435e40f1fed7551cbf112b59cf33327692994943814869442398a459">
-                    https://depot.galaxyproject.org/software/homer/homer_4.2_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="a52aebb3435e40f1fed7551cbf112b59cf33327692994943814869442398a459">https://depot.galaxyproject.org/software/homer/homer_4.2_src_all.zip</action>
                 <action type="set_environment_for_install">
                     <repository name="package_ghostscript_9_07" owner="iuc">
                         <package name="ghostscript" version="9.07" />

--- a/packages/package_htseq_0_6/tool_dependencies.xml
+++ b/packages/package_htseq_0_6/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="htseq" version="0.6.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="9bff6779595ea13c10137dad3bc4ecfd046b0bc620990eaa08920a29dcbd05c5">
-                    https://depot.galaxyproject.org/software/htseq/htseq_0.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="9bff6779595ea13c10137dad3bc4ecfd046b0bc620990eaa08920a29dcbd05c5">https://depot.galaxyproject.org/software/htseq/htseq_0.6_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">
                         <package name="numpy" version="1.7.1" />

--- a/packages/package_imagemagick_6_9_3/tool_dependencies.xml
+++ b/packages/package_imagemagick_6_9_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="imagemagick" version="6.9.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="5617e14d624be393209d77674b935165bddc797e65661774f81785f6c05ca0e9">
-                    https://depot.galaxyproject.org/software/ImageMagick/ImageMagick_6.9.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="5617e14d624be393209d77674b935165bddc797e65661774f81785f6c05ca0e9">https://depot.galaxyproject.org/software/ImageMagick/ImageMagick_6.9.3_src_all.tar.gz</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="IMAGEMAGICK_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>

--- a/packages/package_imaging_1_1_7/tool_dependencies.xml
+++ b/packages/package_imaging_1_1_7/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="imaging" version="1.1.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211">
-                    https://depot.galaxyproject.org/software/pil/pil_1.1.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211">https://depot.galaxyproject.org/software/pil/pil_1.1.7_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="set_environment_for_install">
                    <repository name="package_zlib_1_2_8" owner="iuc">

--- a/packages/package_infernal_1_1/tool_dependencies.xml
+++ b/packages/package_infernal_1_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="infernal" version="1.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="d1f2f70e952e8a8a9ba3bae8a7b45666049dddca3bfc5e1fb9e8e845e0ed995b">
-                    https://depot.galaxyproject.org/software/infernal/infernal_1.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="d1f2f70e952e8a8a9ba3bae8a7b45666049dddca3bfc5e1fb9e8e845e0ed995b">https://depot.galaxyproject.org/software/infernal/infernal_1.1_src_all.tar.gz</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_infernal_1_1rc4/tool_dependencies.xml
+++ b/packages/package_infernal_1_1rc4/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="infernal" version="1.1rc4">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8891822c7935bdfb4fc9a28e6a563584a0564c17745a54984ef3242af704b3f8">
-                    https://depot.galaxyproject.org/software/infernal/infernal_1.1rc4_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8891822c7935bdfb4fc9a28e6a563584a0564c17745a54984ef3242af704b3f8">https://depot.galaxyproject.org/software/infernal/infernal_1.1rc4_src_all.tar.gz</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_jbrowse_1_11_6/tool_dependencies.xml
+++ b/packages/package_jbrowse_1_11_6/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="jbrowse" version="1.11.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="4beb1bf53d1843a96e326b71f814c0d55081a63b7204bf75e9c28b8b0e93cf4b">
-                    https://depot.galaxyproject.org/software/jbrowse/jbrowse_1.11.6_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="4beb1bf53d1843a96e326b71f814c0d55081a63b7204bf75e9c28b8b0e93cf4b">https://depot.galaxyproject.org/software/jbrowse/jbrowse_1.11.6_src_all.zip</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_jbrowse_1_12_0/tool_dependencies.xml
+++ b/packages/package_jbrowse_1_12_0/tool_dependencies.xml
@@ -8,14 +8,10 @@
     <package name="jbrowse" version="1.12.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="a8bb2a56f1ca0470df2d072811db1f90fd6756feed92d8656eba1e6f67f438d3">
-                    http://jbrowse.org/wordpress/wp-content/plugins/download-monitor/download.php?id=101&amp;fmt=.zip
-                </action>
-                <action type="download_by_url" sha256sum="84dfdc81c8cae61ee61e03fe6be1b9d76813d933c268609a2c24dc85349b5840" target_filename="dojo.js.patch">
-                    https://gist.github.com/erasche/9cf020138d787eb47891/raw/e6ac8852be51c4869bd10d1977d2f68c731ffbc1/dojo.js.patch
-                </action>
+                <action type="download_by_url" sha256sum="a8bb2a56f1ca0470df2d072811db1f90fd6756feed92d8656eba1e6f67f438d3">http://jbrowse.org/wordpress/wp-content/plugins/download-monitor/download.php?id=101&amp;fmt=.zip</action>
+                <action type="download_file" sha256sum="84dfdc81c8cae61ee61e03fe6be1b9d76813d933c268609a2c24dc85349b5840">https://gist.github.com/erasche/9cf020138d787eb47891/raw/e6ac8852be51c4869bd10d1977d2f68c731ffbc1/dojo.js.patch</action>
                 <action type="shell_command">
-                    patch -p1 &lt; ../dojo.js.patch
+                    patch -p1 &lt; dojo.js.patch
                 </action>
                 <action type="change_directory">..</action>
                 <action type="move_directory_files">

--- a/packages/package_jellyfish_1_1_11/tool_dependencies.xml
+++ b/packages/package_jellyfish_1_1_11/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="jellyfish" version="1.1.11">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="496645d96b08ba35db1f856d857a159798c73cbc1eccb852ef1b253d1678c8e2">
-                    https://depot.galaxyproject.org/software/jellyfish/jellyfish_1.1.11_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="496645d96b08ba35db1f856d857a159798c73cbc1eccb852ef1b253d1678c8e2">https://depot.galaxyproject.org/software/jellyfish/jellyfish_1.1.11_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_khmer_2_0/tool_dependencies.xml
+++ b/packages/package_khmer_2_0/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="khmer" version="2.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8b14dd91b52862e09b8e6a963507b74bc2580787d171feda197badfa7034032c">
-                    https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8b14dd91b52862e09b8e6a963507b74bc2580787d171feda197badfa7034032c">https://pypi.python.org/packages/source/k/khmer/khmer-2.0.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_setuptools_19_0" owner="iuc">
                         <package name="setuptools" version="19.0" />

--- a/packages/package_kraken_0_10_5/tool_dependencies.xml
+++ b/packages/package_kraken_0_10_5/tool_dependencies.xml
@@ -4,18 +4,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="091fb2bfa6e834921f4cc404ef828181d51408f4413ed189b65f777db4295115">
-                        https://depot.galaxyproject.org/software/kraken/kraken_0.10.5-beta_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="091fb2bfa6e834921f4cc404ef828181d51408f4413ed189b65f777db4295115">https://depot.galaxyproject.org/software/kraken/kraken_0.10.5-beta_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="7c0ac64ee0acdcce18e16b51b636b7cdc6d07ea7ab465bb64df078c5a710346b">
-                        https://depot.galaxyproject.org/software/kraken/kraken_0.10.5_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="7c0ac64ee0acdcce18e16b51b636b7cdc6d07ea7ab465bb64df078c5a710346b">https://depot.galaxyproject.org/software/kraken/kraken_0.10.5_src_all.tar.gz</action>
                     <action type="shell_command">sh install_kraken.sh $INSTALL_DIR/bin ; /bin/true</action>
                 </actions>
                 <action type="set_environment">

--- a/packages/package_krona_2_5/tool_dependencies.xml
+++ b/packages/package_krona_2_5/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="krona" version="2.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="0a0f04949b153df7ec0a06192278c138cd3215ede3dec36063a3a5708f07fa8a">
-                    https://depot.galaxyproject.org/software/KronaTools/KronaTools_2.5_src_all.tar
-                </action>
+                <action type="download_by_url" sha256sum="0a0f04949b153df7ec0a06192278c138cd3215ede3dec36063a3a5708f07fa8a">https://depot.galaxyproject.org/software/KronaTools/KronaTools_2.5_src_all.tar</action>
                 <action type="set_environment_for_install">
                     <repository name="package_perl_5_18" owner="iuc" prior_installation_required="True">
                         <package name="perl" version="5.18.1" />

--- a/packages/package_labels_1_0_5/tool_dependencies.xml
+++ b/packages/package_labels_1_0_5/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="labels" version="1.0.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2af0a857c0d0281190ca7b0335220c2ab9c14b207b15126c45529394f2c3164e">
-                    https://depot.galaxyproject.org/software/labels/labels_1.0.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2af0a857c0d0281190ca7b0335220c2ab9c14b207b15126c45529394f2c3164e">https://depot.galaxyproject.org/software/labels/labels_1.0.5_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pysam_0_7_7" owner="iuc">
                         <package name="pysam" version="0.7.7" />

--- a/packages/package_lapack_3_4/tool_dependencies.xml
+++ b/packages/package_lapack_3_4/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="lapack" version="3.4.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0">
-                    https://depot.galaxyproject.org/software/lapack/lapack_3.4.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0">https://depot.galaxyproject.org/software/lapack/lapack_3.4.2_src_all.tar.gz</action>
 
                 <action type="shell_command">mkdir build</action>
                 <action type="shell_command">

--- a/packages/package_libcurl_7_35/tool_dependencies.xml
+++ b/packages/package_libcurl_7_35/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="libcurl" version="7.35">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="917d118fc5d61e9dd1538d6519bd93bbebf2e866882419781c2e0fdb2bc42121">
-                    https://depot.galaxyproject.org/software/libcurl/libcurl_7.35_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="917d118fc5d61e9dd1538d6519bd93bbebf2e866882419781c2e0fdb2bc42121">https://depot.galaxyproject.org/software/libcurl/libcurl_7.35_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc">

--- a/packages/package_libffi_3_0/tool_dependencies.xml
+++ b/packages/package_libffi_3_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="libffi" version="3.0.13">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1dddde1400c3bcb7749d398071af88c3e4754058d2d4c0b3696c2f82dc5cf11c">
-                    https://depot.galaxyproject.org/software/libffi/libffi_3.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1dddde1400c3bcb7749d398071af88c3e4754058d2d4c0b3696c2f82dc5cf11c">https://depot.galaxyproject.org/software/libffi/libffi_3.0_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_libgd_2_1/tool_dependencies.xml
+++ b/packages/package_libgd_2_1/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="libgd" version="2.1.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="3ceef69d5454a392e8793ae90b5f0d632dd3e20879c12856aa1d1d3d063a51c8">
-                    https://depot.galaxyproject.org/software/libgd/libgd_2.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="3ceef69d5454a392e8793ae90b5f0d632dd3e20879c12856aa1d1d3d063a51c8">https://depot.galaxyproject.org/software/libgd/libgd_2.1_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_libpng_1_6_7" owner="devteam">

--- a/packages/package_libpng_1_2/tool_dependencies.xml
+++ b/packages/package_libpng_1_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="libpng" version="1.2.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2ff1b671b89b04e9288b7282a33f69afcd1db07bf0c16e80c7bbdf2b56056fda">
-                    https://depot.galaxyproject.org/software/libpng/libpng_1.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2ff1b671b89b04e9288b7282a33f69afcd1db07bf0c16e80c7bbdf2b56056fda">https://depot.galaxyproject.org/software/libpng/libpng_1.2_src_all.tar.gz</action>
                 <action type="autoconf"></action>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_libpng_1_6_7/tool_dependencies.xml
+++ b/packages/package_libpng_1_6_7/tool_dependencies.xml
@@ -6,9 +6,7 @@
   <package name="libpng" version="1.6.7">
     <install version="1.0">
       <actions>
-        <action type="download_by_url" sha256sum="5d3be409d4ed4425923ad8677fc45497abb43c6b9cfd5beafe7dfc6f2a94f24b">
-            https://depot.galaxyproject.org/software/libpng/libpng_1.6.7_src_all.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="5d3be409d4ed4425923ad8677fc45497abb43c6b9cfd5beafe7dfc6f2a94f24b">https://depot.galaxyproject.org/software/libpng/libpng_1.6.7_src_all.tar.gz</action>
         <action type="set_environment_for_install">
           <repository name="package_zlib_1_2_8" owner="iuc" prior_installation_required="True">
             <package name="zlib" version="1.2.8" />

--- a/packages/package_libtool_2_4/tool_dependencies.xml
+++ b/packages/package_libtool_2_4/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="libtool" version="2.4">
         <install version="1.0">
             <actions>
-              <action type="download_by_url" sha256sum="13df57ab63a94e196c5d6e95d64e53262834fe780d5e82c28f177f9f71ddf62e">
-                  https://depot.galaxyproject.org/software/libtool/libtool_2.4_src_all.tar.gz
-              </action>
+              <action type="download_by_url" sha256sum="13df57ab63a94e196c5d6e95d64e53262834fe780d5e82c28f177f9f71ddf62e">https://depot.galaxyproject.org/software/libtool/libtool_2.4_src_all.tar.gz</action>
               <action type="autoconf" />
               <action type="set_environment">
                 <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_libxml2_2_9_1/tool_dependencies.xml
+++ b/packages/package_libxml2_2_9_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="libxml2" version="2.9.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="fd3c64cb66f2c4ea27e934d275904d92cec494a8e8405613780cbc8a71680fdb">
-                    https://depot.galaxyproject.org/software/libxml2/libxml2_2.9.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="fd3c64cb66f2c4ea27e934d275904d92cec494a8e8405613780cbc8a71680fdb">https://depot.galaxyproject.org/software/libxml2/libxml2_2.9.1_src_all.tar.gz</action>
                 <action type="autoconf">--without-python</action>
                 <action type="set_environment">
                     <environment_variable name="PKG_CONFIG_PATH" action="prepend_to">$INSTALL_DIR/lib/pkgconfig</environment_variable>

--- a/packages/package_libyaml_0_1_5/tool_dependencies.xml
+++ b/packages/package_libyaml_0_1_5/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="libyaml" version="0.1.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="fa87ee8fb7b936ec04457bc044cd561155e1000a4d25029867752e543c2d3bef">
-                    https://depot.galaxyproject.org/software/libyaml/libyaml_0.1.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="fa87ee8fb7b936ec04457bc044cd561155e1000a4d25029867752e543c2d3bef">https://depot.galaxyproject.org/software/libyaml/libyaml_0.1.5_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_macs2_2_1_0/tool_dependencies.xml
+++ b/packages/package_macs2_2_1_0/tool_dependencies.xml
@@ -10,9 +10,7 @@
     <package name="macs2" version="2.1.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="c68a58d3cb6861d7535feee591819853e43c1d252f15abcbb11ce2ad0c8f9586">
-                    https://depot.galaxyproject.org/software/MACS2/MACS2_2.1.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="c68a58d3cb6861d7535feee591819853e43c1d252f15abcbb11ce2ad0c8f9586">https://depot.galaxyproject.org/software/MACS2/MACS2_2.1.0_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">

--- a/packages/package_matplotlib_1_2/tool_dependencies.xml
+++ b/packages/package_matplotlib_1_2/tool_dependencies.xml
@@ -21,9 +21,7 @@
     <package name="matplotlib" version="1.2.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="52e18972aed85f30b05cef41778ec77685df6012f0598cd216e996de9b9ea29b">
-                    https://depot.galaxyproject.org/software/matplotlib/matplotlib_1.2.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="52e18972aed85f30b05cef41778ec77685df6012f0598cd216e996de9b9ea29b">https://depot.galaxyproject.org/software/matplotlib/matplotlib_1.2.1_src_all.tar.gz</action>
                 <!-- populate the environment variables from the dependend repos -->
                 <action type="set_environment_for_install">
                    <repository name="package_zlib_1_2_8" owner="iuc">

--- a/packages/package_matplotlib_1_4/tool_dependencies.xml
+++ b/packages/package_matplotlib_1_4/tool_dependencies.xml
@@ -15,9 +15,7 @@
     <package name="matplotlib" version="1.4">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="7417cedc598fdd98d8eb02130345d70d1a4b103e41560363267f625cb711d314">
-                    https://pypi.python.org/packages/source/m/matplotlib/matplotlib-1.4.0.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="7417cedc598fdd98d8eb02130345d70d1a4b103e41560363267f625cb711d314">https://pypi.python.org/packages/source/m/matplotlib/matplotlib-1.4.0.tar.gz</action>
 
                 <!-- populate the environment variables from the dependend repos -->
                 <action type="set_environment_for_install">

--- a/packages/package_mcl_12_135/tool_dependencies.xml
+++ b/packages/package_mcl_12_135/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="mcl" version="12.135">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="3f5e0e7ad1074c7c4ef0139aa3318f92971fede7292dc3571eca2fd1da20a283">
-                    https://depot.galaxyproject.org/software/mcl/mcl_12.135_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="3f5e0e7ad1074c7c4ef0139aa3318f92971fede7292dc3571eca2fd1da20a283">https://depot.galaxyproject.org/software/mcl/mcl_12.135_src_all.tar.gz</action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_meme_4_10_0/tool_dependencies.xml
+++ b/packages/package_meme_4_10_0/tool_dependencies.xml
@@ -7,27 +7,21 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="742700a1473f3e5dc049f2426cb556c69a4fc575f208184e8fcdc0b27b3a08d8">
-                        https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="742700a1473f3e5dc049f2426cb556c69a4fc575f208184e8fcdc0b27b3a08d8">https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="1828367166f8c00182bda05e310ef2b7f562e74e2d589f5f4c92caf556546057">
-                        https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1828367166f8c00182bda05e310ef2b7f562e74e2d589f5f4c92caf556546057">https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="2e0266102f5a510ed75b9275e8c1d138891bb8012ee4261a7f9f5c011c315a50">
-                        https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="2e0266102f5a510ed75b9275e8c1d138891bb8012ee4261a7f9f5c011c315a50">https://depot.galaxyproject.org/software/meme/meme_4.10.0.4_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_libxslt_1_1_28" owner="devteam" prior_installation_required="True">
                             <package name="libxslt" version="1.1.28" />

--- a/packages/package_minced_0_1_4/tool_dependencies.xml
+++ b/packages/package_minced_0_1_4/tool_dependencies.xml
@@ -3,12 +3,8 @@
     <package name="minced" version="0.1.4">
         <install version="1.0">
             <actions>
-                <action type="download_file" sha256sum="1f404083c477ab87f30368091be9fdaa25f2791f14eed2b59a56ca157a276666">
-                    https://depot.galaxyproject.org/software/minced/minced_0.1.4_src_all
-                </action>
-                <action type="download_file" sha256sum="234ab0f2d432f610363cf0adb404eae577d04b459da24c930dcf0dc363c30ad0" target_filename="minced.jar">
-                    https://depot.galaxyproject.org/software/minced/minced_0.1.4-jar_src_all.jar
-                </action>
+                <action type="download_file" sha256sum="1f404083c477ab87f30368091be9fdaa25f2791f14eed2b59a56ca157a276666">https://depot.galaxyproject.org/software/minced/minced_0.1.4_src_all</action>
+                <action type="download_file" sha256sum="234ab0f2d432f610363cf0adb404eae577d04b459da24c930dcf0dc363c30ad0" target_filename="minced.jar">https://depot.galaxyproject.org/software/minced/minced_0.1.4-jar_src_all.jar</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_minced_0_1_5/tool_dependencies.xml
+++ b/packages/package_minced_0_1_5/tool_dependencies.xml
@@ -3,12 +3,8 @@
     <package name="minced" version="0.1.5">
         <install version="1.0">
             <actions>
-                <action type="download_file" sha256sum="1f404083c477ab87f30368091be9fdaa25f2791f14eed2b59a56ca157a276666">
-                    https://depot.galaxyproject.org/software/minced/minced_0.1.4_src_all
-                </action>
-                <action type="download_file" sha256sum="7e2696f139b3cf65571a61e74b4a94c388a4b85c0317942f0fe75898e9fba7b3" target_filename="minced.jar">
-                    https://depot.galaxyproject.org/software/minced/minced_0.1.5-jar_src_all.jar
-                </action>
+                <action type="download_file" sha256sum="1f404083c477ab87f30368091be9fdaa25f2791f14eed2b59a56ca157a276666">https://depot.galaxyproject.org/software/minced/minced_0.1.4_src_all</action>
+                <action type="download_file" sha256sum="7e2696f139b3cf65571a61e74b4a94c388a4b85c0317942f0fe75898e9fba7b3" target_filename="minced.jar">https://depot.galaxyproject.org/software/minced/minced_0.1.5-jar_src_all.jar</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_mono_4_0/tool_dependencies.xml
+++ b/packages/package_mono_4_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="mono" version="4.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ff1f15f3b8d43c6a2818c00fabe377b2d8408ad14acd9d507658b4cae00f5bce">
-                    https://depot.galaxyproject.org/software/mono/mono_4.0_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="ff1f15f3b8d43c6a2818c00fabe377b2d8408ad14acd9d507658b4cae00f5bce">https://depot.galaxyproject.org/software/mono/mono_4.0_src_all.tar.bz2</action>
                 <action type="autoconf">--with-glib=embedded --enable-nls=no</action>
 
                 <action type="set_environment">

--- a/packages/package_morpheus_171/tool_dependencies.xml
+++ b/packages/package_morpheus_171/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="morpheus" version="171">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="d3543222cfbcda0ea4d9c55f12007535f02d3f52dd213718c98a5f00f01904c4">
-                    https://depot.galaxyproject.org/software/morpheus/morpheus_171_linux_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="d3543222cfbcda0ea4d9c55f12007535f02d3f52dd213718c98a5f00f01904c4">https://depot.galaxyproject.org/software/morpheus/morpheus_171_linux_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_mono_4_0" owner="iuc">
                         <package name="mono" version="4.0" />

--- a/packages/package_msgfplus_20140210/tool_dependencies.xml
+++ b/packages/package_msgfplus_20140210/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="msgfplus" version="20140210">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="14b0ca2a168a46650a0d73991f828363e2681f242a0c259e2a47e914653b3e16">
-                    https://depot.galaxyproject.org/software/msgfplus/msgfplus_20140210_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="14b0ca2a168a46650a0d73991f828363e2681f242a0c259e2a47e914653b3e16">https://depot.galaxyproject.org/software/msgfplus/msgfplus_20140210_src_all.zip</action>
                 <action type="move_file">
                     <source>MSGFPlus.jar</source>
                     <destination>$INSTALL_DIR</destination>

--- a/packages/package_mummer_3_23/tool_dependencies.xml
+++ b/packages/package_mummer_3_23/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="mummer" version="3.23">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f">
-                    https://depot.galaxyproject.org/software/mummer/mummer_3.23_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f">https://depot.galaxyproject.org/software/mummer/mummer_3.23_src_all.tar.gz</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_muscle_3_8_31/tool_dependencies.xml
+++ b/packages/package_muscle_3_8_31/tool_dependencies.xml
@@ -5,9 +5,7 @@
             <actions_group>
                 <!-- Download the binaries for MUSCLE compatible with 64-bit OSX. -->
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="8d94e94f3ce58aa4cfa5ed297b99f7008962eaecb5f55d42a74e51018b6816be">
-                        https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="8d94e94f3ce58aa4cfa5ed297b99f7008962eaecb5f55d42a74e51018b6816be">https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_darwin_x64.tar.gz</action>
                     <action type="move_file" rename_to="muscle">
                         <source>muscle3.8.31_i86darwin64</source>
                         <destination>$INSTALL_DIR</destination>
@@ -15,9 +13,7 @@
                 </actions>
                 <!-- Download the binaries for MUSCLE compatible with 32-bit OSX. -->
                 <actions os="darwin" architecture="i386">
-                    <action type="download_by_url" sha256sum="12986ce091d72875e5eae6e7cfb3db94ea63007f83c3426e278fe569cdb810f0">
-                        https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_darwin_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="12986ce091d72875e5eae6e7cfb3db94ea63007f83c3426e278fe569cdb810f0">https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_darwin_x32.tar.gz</action>
                     <action type="move_file" rename_to="muscle">
                         <source>muscle3.8.31_i86darwin32</source>
                         <destination>$INSTALL_DIR</destination>
@@ -25,9 +21,7 @@
                 </actions>
                 <!-- Download the binaries for MUSCLE compatible with 64-bit Linux. -->
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="818dc1132b3c929d85355d6db6b0f1fe752dd4e276903a3cf91036cdb7247953">
-                        https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="818dc1132b3c929d85355d6db6b0f1fe752dd4e276903a3cf91036cdb7247953">https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_linux_x64.tar.gz</action>
                     <action type="move_file" rename_to="muscle">
                         <source>muscle3.8.31_i86linux64</source>
                         <destination>$INSTALL_DIR</destination>
@@ -35,9 +29,7 @@
                 </actions>
                 <!-- Download the binaries for MUSCLE compatible with 32-bit Linux. -->
                 <actions os="linux" architecture="i386">
-                    <action type="download_by_url" sha256sum="1b595dc5231244d4e7c340eb986bd269d8dda5f77335b1666b93d97ee8c460d9">
-                        https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_linux_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1b595dc5231244d4e7c340eb986bd269d8dda5f77335b1666b93d97ee8c460d9">https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_linux_x32.tar.gz</action>
                     <action type="move_file" rename_to="muscle">
                         <source>muscle3.8.31_i86linux32</source>
                         <destination>$INSTALL_DIR</destination>
@@ -45,9 +37,7 @@
                 </actions>
                 <!-- This actions tag is only processed if none of the above tags resulted in a successful installation. -->
                 <actions>
-                    <action target_filename="muscle3.8.31.tar.gz" type="download_by_url" sha256sum="43c5966a82133bd7da5921e8142f2f592c2b5f53d802f0527a2801783af809ad">
-                        https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="43c5966a82133bd7da5921e8142f2f592c2b5f53d802f0527a2801783af809ad" target_filename="muscle3.8.31.tar.gz">https://depot.galaxyproject.org/software/muscle/muscle_3.8.31_src_all.tar.gz</action>
                     <!-- When compiling, need to remove the '-static' linker option from the src/mk file used by src/Makefile -->
                     <action type="shell_command">sed -i.bak -e 's/-static//g' src/mk</action>
                     <action type="shell_command">make -C src/</action>

--- a/packages/package_ncurses_5_9/tool_dependencies.xml
+++ b/packages/package_ncurses_5_9/tool_dependencies.xml
@@ -4,24 +4,16 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b">
-                        http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
-                    </action>
-                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">
-                        https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch
-                    </action>
+                    <action type="download_by_url" sha256sum="9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
+                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch</action>
                     <action type="shell_command">
                         patch ncurses/base/MKlib_gen.sh ../ncurses_patch_5.9p_src_all.patch
                     </action>
                     <action type="autoconf">--with-shared --enable-symlinks</action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b">
-                        http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
-                    </action>
-                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">
-                        https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch
-                    </action>
+                    <action type="download_by_url" sha256sum="9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b">http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz</action>
+                    <action type="download_by_url" sha256sum="c9033021022979a02621af43883e6ca5a4df14d2c3a5a821e4c67923d13d5e78">https://depot.galaxyproject.org/software/ncurses_patch/ncurses_patch_5.9p_src_all.patch</action>
                     <action type="shell_command">
                         patch ncurses/base/MKlib_gen.sh ../ncurses_patch_5.9p_src_all.patch
                     </action>

--- a/packages/package_ncurses_6_0/tool_dependencies.xml
+++ b/packages/package_ncurses_6_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="ncurses" version="6.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="3c1d9534d6d5b3a691d23199a7621f25ffbfa0ccc333f680fcdfc192ea362c84">
-                    https://depot.galaxyproject.org/software/ncurses/ncurses_6.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="3c1d9534d6d5b3a691d23199a7621f25ffbfa0ccc333f680fcdfc192ea362c84">https://depot.galaxyproject.org/software/ncurses/ncurses_6.0_src_all.tar.gz</action>
                 <action type="autoconf">--with-shared --enable-symlinks</action>
                 <action type="set_environment">
                     <environment_variable action="set_to" name="NCURSES_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_netcdf_4_3/tool_dependencies.xml
+++ b/packages/package_netcdf_4_3/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="netcdf" version="4.3.1.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="09a4123d631714f488a2dc43292a7218e5241f2cf9288d2dbc8347d2fe176cad">
-                    https://depot.galaxyproject.org/software/netcdf/netcdf_4.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="09a4123d631714f488a2dc43292a7218e5241f2cf9288d2dbc8347d2fe176cad">https://depot.galaxyproject.org/software/netcdf/netcdf_4.3_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_hdf5_1_8_12" owner="iuc">

--- a/packages/package_networkx_1_9/tool_dependencies.xml
+++ b/packages/package_networkx_1_9/tool_dependencies.xml
@@ -6,9 +6,7 @@
         <package name="networkx" version="1.9">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="6380eb38d0b5770d7e50813c8a48ff7c373b2187b4220339c1adce803df01c59">
-                        https://depot.galaxyproject.org/software/networkx/networkx_1.9.1_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="6380eb38d0b5770d7e50813c8a48ff7c373b2187b4220339c1adce803df01c59">https://depot.galaxyproject.org/software/networkx/networkx_1.9.1_src_all.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="shell_command">
                         export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;

--- a/packages/package_numpy_1_7/tool_dependencies.xml
+++ b/packages/package_numpy_1_7/tool_dependencies.xml
@@ -6,9 +6,7 @@
         <package name="numpy" version="1.7.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="5525019a3085c3d860e6cfe4c0a30fb65d567626aafc50cf1252a641a418084a">
-                        https://depot.galaxyproject.org/software/numpy/numpy_1.7_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="5525019a3085c3d860e6cfe4c0a30fb65d567626aafc50cf1252a641a418084a">https://depot.galaxyproject.org/software/numpy/numpy_1.7_src_all.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">

--- a/packages/package_numpy_1_7_with_atlas/tool_dependencies.xml
+++ b/packages/package_numpy_1_7_with_atlas/tool_dependencies.xml
@@ -9,9 +9,7 @@
         <package name="numpy" version="1.7.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="5525019a3085c3d860e6cfe4c0a30fb65d567626aafc50cf1252a641a418084a">
-                        https://depot.galaxyproject.org/software/numpy/numpy_1.7_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="5525019a3085c3d860e6cfe4c0a30fb65d567626aafc50cf1252a641a418084a">https://depot.galaxyproject.org/software/numpy/numpy_1.7_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.1" />

--- a/packages/package_numpy_1_8/tool_dependencies.xml
+++ b/packages/package_numpy_1_8/tool_dependencies.xml
@@ -6,9 +6,7 @@
         <package name="numpy" version="1.8.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="3d722fc3ac922a34c50183683e828052cd9bb7e9134a95098441297d7ea1c7a9">
-                        https://depot.galaxyproject.org/software/numpy/numpy_1.8_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3d722fc3ac922a34c50183683e828052cd9bb7e9134a95098441297d7ea1c7a9">https://depot.galaxyproject.org/software/numpy/numpy_1.8_src_all.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">

--- a/packages/package_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_numpy_1_9/tool_dependencies.xml
@@ -9,9 +9,7 @@
         <package name="numpy" version="1.9">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="2745b1d64445da3c29a34450320025c11897ae4af77475f861966e98b2cb1a0f">
-                        https://pypi.python.org/packages/source/n/numpy/numpy-1.9.0.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="2745b1d64445da3c29a34450320025c11897ae4af77475f861966e98b2cb1a0f">https://pypi.python.org/packages/source/n/numpy/numpy-1.9.0.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">

--- a/packages/package_nwalign_0_3_1/tool_dependencies.xml
+++ b/packages/package_nwalign_0_3_1/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="nwalign" version="0.3.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="bdbf1948df8421ef744ebf2993341df1f8431bbe41f4ce31241fff88d4d8e781">
-                    https://depot.galaxyproject.org/software/nwalign/nwalign_0.3.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="bdbf1948df8421ef744ebf2993341df1f8431bbe41f4ce31241fff88d4d8e781">https://depot.galaxyproject.org/software/nwalign/nwalign_0.3.1_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_9" owner="iuc">

--- a/packages/package_octave_3_8/tool_dependencies.xml
+++ b/packages/package_octave_3_8/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="octave" version="3.8">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ead2c481eac9bc0d46922eca87007e7103270b259388a359e3cdba82420f8305">
-                    https://depot.galaxyproject.org/software/octave/octave_3.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ead2c481eac9bc0d46922eca87007e7103270b259388a359e3cdba82420f8305">https://depot.galaxyproject.org/software/octave/octave_3.8_src_all.tar.gz</action>
                 <action type="autoconf">--disable-readline</action>
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_openbabel_2_3/tool_dependencies.xml
+++ b/packages/package_openbabel_2_3/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="openbabel" version="2.3.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="4eaca26679aa6cc85ebf96af19191472ac63ca442c36b0427b369c3a25705188">
-                    https://depot.galaxyproject.org/software/openbabel/openbabel_2.3.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="4eaca26679aa6cc85ebf96af19191472ac63ca442c36b0427b369c3a25705188">https://depot.galaxyproject.org/software/openbabel/openbabel_2.3.2_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_eigen_3_1" owner="iuc">
                         <package name="eigen3" version="3.1.3" />

--- a/packages/package_openms_2_0/tool_dependencies.xml
+++ b/packages/package_openms_2_0/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="924c25ec4e6704b831ef6173126b629a831fd44c7bbc456acf3dfc7702939202">
-                        https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="924c25ec4e6704b831ef6173126b629a831fd44c7bbc456acf3dfc7702939202">https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0_linux_x64.tar.gz</action>
                     <!-- The archive doesn't contain a subdirectory, just
                          files. We don't want to copy the archive + unpacked
                          files into INSTALL DIR -->
@@ -23,12 +21,8 @@
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="924c25ec4e6704b831ef6173126b629a831fd44c7bbc456acf3dfc7702939202">
-                        https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0_src_all.zip
-                    </action>
-                    <action target_filename="contrib-f6b44d770b6c1b23972a8891753472e60a356253.zip" type="download_by_url" sha256sum="cb67b14d907b0737004cafd785d08a515603f31ebf71a25e8b8fc05387ef9f96">
-                        https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0-contrib_src_all.zip
-                    </action>
+                    <action type="download_by_url" sha256sum="924c25ec4e6704b831ef6173126b629a831fd44c7bbc456acf3dfc7702939202">https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0_src_all.zip</action>
+                    <action type="download_by_url" sha256sum="cb67b14d907b0737004cafd785d08a515603f31ebf71a25e8b8fc05387ef9f96" target_filename="contrib-f6b44d770b6c1b23972a8891753472e60a356253.zip">https://depot.galaxyproject.org/software/OpenMS/OpenMS_2.0-contrib_src_all.zip</action>
                     <action type="shell_command">mv contrib-f6b44d770b6c1b23972a8891753472e60a356253 ../contrib</action>
                     <package name="libtool" version="2.4">
                         <repository name="package_libtool_2_4" owner="iuc" prior_installation_required="True" />

--- a/packages/package_openssl_1_0/tool_dependencies.xml
+++ b/packages/package_openssl_1_0/tool_dependencies.xml
@@ -10,9 +10,7 @@
     <package name="openssl" version="1.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8">
-                    https://depot.galaxyproject.org/software/openssl/openssl_1.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8">https://depot.galaxyproject.org/software/openssl/openssl_1.0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_zlib_1_2_8" owner="iuc">
                         <package name="zlib" version="1.2.8" />

--- a/packages/package_pandas_0_14/tool_dependencies.xml
+++ b/packages/package_pandas_0_14/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="pandas" version="0.14.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8d36f69e63f4c36999d142d60e476a6359c77069ad0ed1e4aa16a7005884dd21">
-                    https://depot.galaxyproject.org/software/pandas/pandas_0.14_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8d36f69e63f4c36999d142d60e476a6359c77069ad0ed1e4aa16a7005884dd21">https://depot.galaxyproject.org/software/pandas/pandas_0.14_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">
                         <package name="numpy" version="1.7.1" />

--- a/packages/package_pcre_8_34/tool_dependencies.xml
+++ b/packages/package_pcre_8_34/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="pcre" version="8.34">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b6043ae1ff2720be665ffa28dc22b7c637cdde96f389a116c0c3020caeae583f">
-                    https://depot.galaxyproject.org/software/pcre/pcre_8.34_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="b6043ae1ff2720be665ffa28dc22b7c637cdde96f389a116c0c3020caeae583f">https://depot.galaxyproject.org/software/pcre/pcre_8.34_src_all.tar.bz2</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_pear_0_9_6/tool_dependencies.xml
+++ b/packages/package_pear_0_9_6/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="1b3f621745f6ad786b0b20100a730d0d1e1feb018a7a7bcff5557a4925349e49">
-                        https://depot.galaxyproject.org/software/pear/pear_0.9.6_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1b3f621745f6ad786b0b20100a730d0d1e1feb018a7a7bcff5557a4925349e49">https://depot.galaxyproject.org/software/pear/pear_0.9.6_linux_x64.tar.gz</action>
                     <action type="move_file">
                         <source>pear-0.9.6-bin-64</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -14,9 +12,7 @@
                     <action type="shell_command">mv $INSTALL_DIR/bin/pear-0.9.6-bin-64 $INSTALL_DIR/bin/pear</action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                   <action type="download_by_url" sha256sum="f7728371e26a5b46fa928b0f7ae1b552ed6a78815b117ba48ef1af98e96c8e2b">
-                       https://depot.galaxyproject.org/software/pear/pear_0.9.6_src_all.tar.gz
-                   </action>
+                   <action type="download_by_url" sha256sum="f7728371e26a5b46fa928b0f7ae1b552ed6a78815b117ba48ef1af98e96c8e2b">https://depot.galaxyproject.org/software/pear/pear_0.9.6_src_all.tar.gz</action>
                     <action type="autoconf" />
                 </actions>
                 <action type="set_environment">

--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -7,9 +7,7 @@
         <install version="1.0">
             <actions>
                 <!-- install perl -->
-                <action type="download_by_url" sha256sum="655e11a8ffba8853efcdce568a142c232600ed120ac24aaebb4e6efe74e85b2b">
-                    https://depot.galaxyproject.org/software/perl/perl_5.18_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="655e11a8ffba8853efcdce568a142c232600ed120ac24aaebb4e6efe74e85b2b">https://depot.galaxyproject.org/software/perl/perl_5.18_src_all.tar.gz</action>
                 <action type="shell_command">./Configure -des -Dprefix=$INSTALL_DIR -Dstartperl='#!/usr/bin/env perl'</action>
                 <action type="make_install" />
                 <action type="change_directory">..</action>
@@ -24,9 +22,7 @@
                 <action type="shell_command">export PATH=$INSTALL_DIR/bin/:$PATH; eval $(perl -I$INSTALL_DIR/local-lib/lib/perl5 -Mlocal::lib=$INSTALL_DIR/local-lib)</action>
                 <action type="change_directory">..</action>
                 <!-- install cpanminus into our new perl environment -->
-                <action type="download_file" sha256sum="0b67f5c721259d4185bacdcbc87b835821246fe8ac7ad980d3b1a18ecdd10ff6">
-                    https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm
-                </action>
+                <action type="download_file" sha256sum="0b67f5c721259d4185bacdcbc87b835821246fe8ac7ad980d3b1a18ecdd10ff6">https://raw.github.com/miyagawa/cpanminus/c0c88f71118ecec334d62ba280e883933e7a6d39/cpanm</action>
                 <!-- prepending means that the new install perl binary will be used after the pipe -->
                 <action type="shell_command">if [ -d "$TMP_WORK_DIR" ] ; then export HOME=$TMP_WORK_DIR ; else export HOME=`mktemp -d` ; fi ; unset PERL_MB_OPT PERL_MM_OPT ; export PERL5LIB=$INSTALL_DIR/lib/perl5/:$PERL5LIB ; export PATH=$INSTALL_DIR/bin/:$PATH ; cat cpanm | perl - App::cpanminus</action>
                 <action type="shell_command">LC_ALL=C sed -i.bak -e 's|#!$INSTALL_DIR/bin/|#!/usr/bin/env |' $INSTALL_DIR/bin/*</action>

--- a/packages/package_pil_1_1_7/tool_dependencies.xml
+++ b/packages/package_pil_1_1_7/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="pil" version="1.1.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211">
-                    https://depot.galaxyproject.org/software/pil/pil_1.1.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211">https://depot.galaxyproject.org/software/pil/pil_1.1.7_src_all.tar.gz</action>
                 <action type="shell_command">
                     export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
                     python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin

--- a/packages/package_piranha_1_2_1/tool_dependencies.xml
+++ b/packages/package_piranha_1_2_1/tool_dependencies.xml
@@ -9,9 +9,7 @@
   <package name="piranha" version="1.2.1">
     <install version="1.0">
       <actions>
-        <action type="download_by_url" sha256sum="1e0ba205f585663343a1098eb75f9dc356c8867396943d6f06501c32fe008ea3">
-          https://depot.galaxyproject.org/software/piranha/piranha_1.2.1_src_all.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="1e0ba205f585663343a1098eb75f9dc356c8867396943d6f06501c32fe008ea3">https://depot.galaxyproject.org/software/piranha/piranha_1.2.1_src_all.tar.gz</action>
         <action type="set_environment_for_install">
           <repository name="package_gsl_1_16" owner="iuc">
             <package name="gsl" version="1.16"/>

--- a/packages/package_pixman_0_32_4/tool_dependencies.xml
+++ b/packages/package_pixman_0_32_4/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="pixman" version="0.32.4">
       <install version="1.0">
           <actions>
-              <action type="download_by_url" sha256sum="80c7ed420e8a3ae749800241e6347c3d55681296cab71384be7969cd9e657e84">
-                  https://depot.galaxyproject.org/software/pixman/pixman_0.32.4_src_all.tar.gz
-              </action>
+              <action type="download_by_url" sha256sum="80c7ed420e8a3ae749800241e6347c3d55681296cab71384be7969cd9e657e84">https://depot.galaxyproject.org/software/pixman/pixman_0.32.4_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                   <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
                       <package name="libpng" version="1.6.7" />

--- a/packages/package_pixman_0_32_6/tool_dependencies.xml
+++ b/packages/package_pixman_0_32_6/tool_dependencies.xml
@@ -7,9 +7,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904">
-                        https://depot.galaxyproject.org/software/pixman/pixman_0.32.6_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904">https://depot.galaxyproject.org/software/pixman/pixman_0.32.6_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
                             <package name="libpng" version="1.6.7" />
@@ -23,9 +21,7 @@
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904">
-                        https://depot.galaxyproject.org/software/pixman/pixman_0.32.6_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904">https://depot.galaxyproject.org/software/pixman/pixman_0.32.6_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_libpng_1_6_7" owner="iuc" prior_installation_required="True">
                             <package name="libpng" version="1.6.7" />

--- a/packages/package_prodigal_2_60/tool_dependencies.xml
+++ b/packages/package_prodigal_2_60/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="prodigal" version="2.60">
         <install version="1.0">
             <actions>
-                <action target_filename="Prodigal-2.60.tar.gz" type="download_by_url" sha256sum="5988cf4ff0cb40d8c17a421321b0a9a6b1e1ed25eb4a83629ca12298528f1eef">
-                    https://depot.galaxyproject.org/software/prodigal/prodigal_2.60_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="5988cf4ff0cb40d8c17a421321b0a9a6b1e1ed25eb4a83629ca12298528f1eef" target_filename="Prodigal-2.60.tar.gz">https://depot.galaxyproject.org/software/prodigal/prodigal_2.60_src_all.tar.gz</action>
                 <!-- Make -->
                 <action type="shell_command">make</action>
                 <action type="move_file">

--- a/packages/package_progressivemauve_2_4_0/tool_dependencies.xml
+++ b/packages/package_progressivemauve_2_4_0/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="66ba3c359b6534ca8498dab079b5e582acfece036067478a289fe363a74fd27b">
-                        https://depot.galaxyproject.org/software/mauve/mauve_2.4.0_linux_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="66ba3c359b6534ca8498dab079b5e582acfece036067478a289fe363a74fd27b">https://depot.galaxyproject.org/software/mauve/mauve_2.4.0_linux_all.tar.gz</action>
                     <action type="move_file">
                         <source>linux-x64/progressiveMauve</source>
                         <destination>$INSTALL_DIR/bin</destination>
@@ -18,9 +16,7 @@
                 </actions>
 
                 <actions os="darwin" architecture="x86_64">
-                    <action type="download_by_url" sha256sum="dfe4c174776240afaf9b97c512faf4d60a94bc101b4506ce9f05db5ddfd22057">
-                        https://depot.galaxyproject.org/software/progressivemauve/progressivemauve_2.4.0_darwin_all.dmg
-                    </action>
+                    <action type="download_by_url" sha256sum="dfe4c174776240afaf9b97c512faf4d60a94bc101b4506ce9f05db5ddfd22057">https://depot.galaxyproject.org/software/progressivemauve/progressivemauve_2.4.0_darwin_all.dmg</action>
                     <action type="shell_command">
                         hdiutil attach Mauve-2.4.0.dmg &amp;&amp;
                         mkdir -p $INSTALL_DIR/bin &amp;&amp;

--- a/packages/package_pybedtools_0_6_6/tool_dependencies.xml
+++ b/packages/package_pybedtools_0_6_6/tool_dependencies.xml
@@ -15,9 +15,7 @@
     <package name="pybedtools" version="0.6.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="7d9416f0901cafb37034164cc2fb27313641a9071f47e80a35efc7085eca4cb6">
-                    https://depot.galaxyproject.org/software/pybedtools/pybedtools_0.6.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="7d9416f0901cafb37034164cc2fb27313641a9071f47e80a35efc7085eca4cb6">https://depot.galaxyproject.org/software/pybedtools/pybedtools_0.6.6_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_cython_0_20_1" owner="iuc">

--- a/packages/package_pysam_0_7_5/tool_dependencies.xml
+++ b/packages/package_pysam_0_7_5/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="pysam" version="0.7.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="fa85900ead3d1c2c9ce24f28d2b1843c0a8ffb761cd21d440049e29eca2e2453">
-                    https://depot.galaxyproject.org/software/pysam/pysam_0.7.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="fa85900ead3d1c2c9ce24f28d2b1843c0a8ffb761cd21d440049e29eca2e2453">https://depot.galaxyproject.org/software/pysam/pysam_0.7.5_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>
                 <action type="set_environment">

--- a/packages/package_pysam_0_7_6/tool_dependencies.xml
+++ b/packages/package_pysam_0_7_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="pysam" version="0.7.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="d082ee3c8d7f105968719170956456d3660ef3a199bf53f9667f959ca4d11200">
-                    https://depot.galaxyproject.org/software/pysam/pysam_0.7.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="d082ee3c8d7f105968719170956456d3660ef3a199bf53f9667f959ca4d11200">https://depot.galaxyproject.org/software/pysam/pysam_0.7.6_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
                 <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin</action>
                 <action type="set_environment">

--- a/packages/package_pysam_0_7_7/tool_dependencies.xml
+++ b/packages/package_pysam_0_7_7/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="pysam" version="0.7.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="c9f3018482eec99ee199dda3fdef2aa7424dde6574672a4c0d209a10985755cc">
-                    https://depot.galaxyproject.org/software/pysam/pysam_0.7.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="c9f3018482eec99ee199dda3fdef2aa7424dde6574672a4c0d209a10985755cc">https://depot.galaxyproject.org/software/pysam/pysam_0.7.7_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_ez_setup_0_9" owner="iuc">
                         <package name="ez_setup" version="0.9" />

--- a/packages/package_python_2_7/tool_dependencies.xml
+++ b/packages/package_python_2_7/tool_dependencies.xml
@@ -24,9 +24,7 @@
   <package name="python" version="2.7">
     <install version="1.0">
       <actions>
-        <action type="download_by_url" sha256sum="eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a">
-            https://depot.galaxyproject.org/software/python/python_2.7_src_all.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a">https://depot.galaxyproject.org/software/python/python_2.7_src_all.tar.gz</action>
 
         <action type="set_environment_for_install">
           <repository name="package_zlib_1_2_8" owner="iuc">

--- a/packages/package_python_2_7_10/tool_dependencies.xml
+++ b/packages/package_python_2_7_10/tool_dependencies.xml
@@ -24,9 +24,7 @@
   <package name="python" version="2.7.10">
     <install version="1.0">
       <actions>
-          <action type="download_by_url" sha256sum="eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a">
-              https://depot.galaxyproject.org/software/python/python_2.7_src_all.tar.gz
-          </action>
+          <action type="download_by_url" sha256sum="eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a">https://depot.galaxyproject.org/software/python/python_2.7_src_all.tar.gz</action>
 
         <action type="set_environment_for_install">
           <repository name="package_zlib_1_2_8" owner="iuc">
@@ -54,9 +52,7 @@
         <!-- by default python is not looking af LD_INCLUDE_PATH and Co. -->
         <action type="shell_command">sed -i.bak -e "s/if host_platform == 'atheos':/if True:/g" setup.py</action>
         <action type="autoconf">--enable-shared --enable-unicode=ucs4</action>
-        <action type="download_file" sha256sum="7b2a76ec3aeb6dc95ae66eab173e7b46e26436c5ba4ee94744f2360bce493b25">
-            https://bitbucket.org/pypa/setuptools/get/18.2.tar.bz2
-        </action>
+        <action type="download_file" sha256sum="7b2a76ec3aeb6dc95ae66eab173e7b46e26436c5ba4ee94744f2360bce493b25">https://bitbucket.org/pypa/setuptools/get/18.2.tar.bz2</action>
         <action type="shell_command">tar -xjf 18.2.tar.bz2</action>
         <action type="change_directory">pypa-setuptools-1a981f2e5031</action>
 

--- a/packages/package_python_3_4/tool_dependencies.xml
+++ b/packages/package_python_3_4/tool_dependencies.xml
@@ -24,9 +24,7 @@
   <package name="python" version="3.4">
     <install version="1.0">
       <actions>
-        <action type="download_by_url" sha256sum="8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147">
-            https://depot.galaxyproject.org/software/python/python_3.4_src_all.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147">https://depot.galaxyproject.org/software/python/python_3.4_src_all.tar.gz</action>
 
         <action type="set_environment_for_install">
           <repository name="package_zlib_1_2_8" owner="iuc">
@@ -53,9 +51,7 @@
         </action>
 
         <action type="autoconf" />
-        <action type="download_file" sha256sum="beb3445cfc3a0f9a36df7de6489d2a488a5ac113c471c448e46e6d9c47cb7840">
-            https://depot.galaxyproject.org/software/setuptools/setuptools_5.2_src_all.tar.bz2
-        </action>
+        <action type="download_file" sha256sum="beb3445cfc3a0f9a36df7de6489d2a488a5ac113c471c448e46e6d9c47cb7840">https://depot.galaxyproject.org/software/setuptools/setuptools_5.2_src_all.tar.bz2</action>
         <action type="shell_command">tar -xjf setuptools_5.2_src_all.tar.bz2</action>
         <action type="change_directory">pypa-setuptools-f493e6c4ffd8</action>
 

--- a/packages/package_qorts_0_3_18/tool_dependencies.xml
+++ b/packages/package_qorts_0_3_18/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="QoRTs" version="0.3.18">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1e4876b9fb2fbb40f3bbf624a65bc07600521cd4e16211612da2f8d0161951b1">
-                    https://github.com/hartleys/QoRTs/raw/v0.3.18/QoRTs_0.3.18/QoRTs.jar
-                </action>
+                <action type="download_by_url" sha256sum="1e4876b9fb2fbb40f3bbf624a65bc07600521cd4e16211612da2f8d0161951b1">https://github.com/hartleys/QoRTs/raw/v0.3.18/QoRTs_0.3.18/QoRTs.jar</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_qt_4_8/tool_dependencies.xml
+++ b/packages/package_qt_4_8/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="Qt" version="4.8">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8b14dd91b52862e09b8e6a963507b74bc2580787d171feda197badfa7034032c">
-                    https://depot.galaxyproject.org/software/qt/qt_4.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8b14dd91b52862e09b8e6a963507b74bc2580787d171feda197badfa7034032c">https://depot.galaxyproject.org/software/qt/qt_4.8_src_all.tar.gz</action>
                 <action type="shell_command">./configure -prefix $INSTALL_DIR -opensource -confirm-license -no-xinerama -no-xinput -no-xcursor -no-xvideo -no-opengl -no-sm -no-xkb -no-gui -no-cups -no-openvg -no-xrandr -no-xrender -nomake examples -nomake demos</action>
                 <action type="shell_command">./bin/qmake -r QT_BUILD_PARTS="libs tools"</action>
                 <action type="make_install" />

--- a/packages/package_qt_5_1/tool_dependencies.xml
+++ b/packages/package_qt_5_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="Qt" version="5.1">
         <install version="1.0">
             <actions>
-              <action type="download_by_url" sha256sum="4c05742db52325e96b1d610a2388140dcc1e3d03d93faea2b2d3791015b186f6">
-                  https://depot.galaxyproject.org/software/qt/qt_5.1_src_all.tar.gz
-              </action>
+              <action type="download_by_url" sha256sum="4c05742db52325e96b1d610a2388140dcc1e3d03d93faea2b2d3791015b186f6">https://depot.galaxyproject.org/software/qt/qt_5.1_src_all.tar.gz</action>
               <action type="shell_command">./configure -prefix $INSTALL_DIR -opensource -confirm-license -qt-xcb</action>
               <action type="make_install" />
               <action type="set_environment">

--- a/packages/package_r_2_11_0/tool_dependencies.xml
+++ b/packages/package_r_2_11_0/tool_dependencies.xml
@@ -4,18 +4,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="83b5b3177302015b0895f781ee319bf1b1551875d1dc11f12c86521c50c24b75">
-                        https://depot.galaxyproject.org/software/r/r_2.11.0_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="83b5b3177302015b0895f781ee319bf1b1551875d1dc11f12c86521c50c24b75">https://depot.galaxyproject.org/software/r/r_2.11.0_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="c2c21bb038a17801becb227d9fbb4ef291e58396e7dd8e6df7b3cab78a03d48a">
-                        https://depot.galaxyproject.org/software/r/r_2.11.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="c2c21bb038a17801becb227d9fbb4ef291e58396e7dd8e6df7b3cab78a03d48a">https://depot.galaxyproject.org/software/r/r_2.11.0_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -41,9 +37,7 @@
                     <package name="freetype" version="2.5.2">
                         <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url" sha256sum="9b2a1769cdf21ad00500cbc0a1f7e09c872681d2ca0ea592e7692f15ff980a43">
-                        http://cran.rstudio.com/src/base/R-2/R-2.11.0.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="9b2a1769cdf21ad00500cbc0a1f7e09c872681d2ca0ea592e7692f15ff980a43">http://cran.rstudio.com/src/base/R-2/R-2.11.0.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True">
                             <package name="readline" version="6.2" />

--- a/packages/package_r_2_15_0/tool_dependencies.xml
+++ b/packages/package_r_2_15_0/tool_dependencies.xml
@@ -4,18 +4,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="d26e4d62b9b01cdd058ae94413dc26a738f4074b38022ca1312a5f1a6837a279">
-                        http://depot.galaxyproject.org/package/darwin/x86_64/R/R-2.15.0-Darwin-x86_64.tgz
-                    </action>
+                    <action type="download_by_url" sha256sum="d26e4d62b9b01cdd058ae94413dc26a738f4074b38022ca1312a5f1a6837a279">http://depot.galaxyproject.org/package/darwin/x86_64/R/R-2.15.0-Darwin-x86_64.tgz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="f4a48465e434d27cbc1703d215180595aff9a2d6c87c1e086838b897fee19403">
-                        http://depot.galaxyproject.org/package/linux/x86_64/R/R-2.15.0-Linux-x86_64.tgz
-                    </action>
+                    <action type="download_by_url" sha256sum="f4a48465e434d27cbc1703d215180595aff9a2d6c87c1e086838b897fee19403">http://depot.galaxyproject.org/package/linux/x86_64/R/R-2.15.0-Linux-x86_64.tgz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_r_3_0_1/tool_dependencies.xml
+++ b/packages/package_r_3_0_1/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="R_3_0_1" version="3.0.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134">
-                    https://depot.galaxyproject.org/software/r/r_3.0.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134">https://depot.galaxyproject.org/software/r/r_3.0.1_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_readline_6_2" owner="iuc">
                         <package name="readline" version="6.2" />

--- a/packages/package_r_3_0_1_with_atlas/tool_dependencies.xml
+++ b/packages/package_r_3_0_1_with_atlas/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="R_3_0_1" version="3.0.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134">
-                    https://depot.galaxyproject.org/software/r/r_3.0.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134">https://depot.galaxyproject.org/software/r/r_3.0.1_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_atlas_3_10" owner="iuc">
                         <package name="atlas" version="3.10.1" />

--- a/packages/package_r_3_0_2/tool_dependencies.xml
+++ b/packages/package_r_3_0_2/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="R_3_0_2" version="3.0.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="956e05ad60447955049285420b5a48e0526aa4db676fd9eadb4bcfb7ccdc024b">
-                    https://depot.galaxyproject.org/software/r/r_3.0.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="956e05ad60447955049285420b5a48e0526aa4db676fd9eadb4bcfb7ccdc024b">https://depot.galaxyproject.org/software/r/r_3.0.2_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_readline_6_2" owner="iuc">
                         <package name="readline" version="6.2" />

--- a/packages/package_r_3_0_3/tool_dependencies.xml
+++ b/packages/package_r_3_0_3/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="35d29d8e0ab4c860b1c4b436e7b690811ea9a3b879093bdb3555ac3e2b1bbcde">
-                        https://depot.galaxyproject.org/software/r/r_3.0.3_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="35d29d8e0ab4c860b1c4b436e7b690811ea9a3b879093bdb3555ac3e2b1bbcde">https://depot.galaxyproject.org/software/r/r_3.0.3_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -14,9 +12,7 @@
                     <action type="shell_command">sh $INSTALL_DIR/darwin_post_install.sh $INSTALL_DIR</action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="724ee7c3be16df44fa2b41adbe1358cdcf2830face99e897a4a77bbd6baa57d8">
-                        https://depot.galaxyproject.org/software/r/r_3.0.3_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="724ee7c3be16df44fa2b41adbe1358cdcf2830face99e897a4a77bbd6baa57d8">https://depot.galaxyproject.org/software/r/r_3.0.3_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -48,9 +44,7 @@
                     <package name="fontconfig" version="2.11.1">
                         <repository name="package_fontconfig_2_11_1" owner="iuc" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url" sha256sum="b97cfd9540f294ab786e846153f3dd8605610d7e27616bfb4296795bc4fde6d6">
-                        http://cran.rstudio.com/src/base/R-3/R-3.0.3.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="b97cfd9540f294ab786e846153f3dd8605610d7e27616bfb4296795bc4fde6d6">http://cran.rstudio.com/src/base/R-3/R-3.0.3.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True">
                             <package name="readline" version="6.2" />

--- a/packages/package_r_3_1_0/tool_dependencies.xml
+++ b/packages/package_r_3_1_0/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="121ef7ff503b6745b4b137344ba2179d5cd68d0373ce90a889fea571a4fe679c">
-                        https://depot.galaxyproject.org/software/r/r_3.1.0_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="121ef7ff503b6745b4b137344ba2179d5cd68d0373ce90a889fea571a4fe679c">https://depot.galaxyproject.org/software/r/r_3.1.0_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -14,9 +12,7 @@
                     <action type="shell_command">sh $INSTALL_DIR/darwin_post_install.sh $INSTALL_DIR</action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="b5521c91e5a4cab6e77e779327e25f6097b93d494ac7abcfc4ca1de6a203a18e">
-                        https://depot.galaxyproject.org/software/r/r_3.1.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="b5521c91e5a4cab6e77e779327e25f6097b93d494ac7abcfc4ca1de6a203a18e">https://depot.galaxyproject.org/software/r/r_3.1.0_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -48,9 +44,7 @@
                     <package name="fontconfig" version="2.11.1">
                         <repository name="package_fontconfig_2_11_1" owner="iuc" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url" sha256sum="8a680390f84c58c01dcdefd682eaa0e90389f09e6d2f2e090c71af40065f5fe2">
-                        http://cran.rstudio.com/src/base/R-3/R-3.1.0.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="8a680390f84c58c01dcdefd682eaa0e90389f09e6d2f2e090c71af40065f5fe2">http://cran.rstudio.com/src/base/R-3/R-3.1.0.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True">
                             <package name="readline" version="6.2" />

--- a/packages/package_r_3_1_1/tool_dependencies.xml
+++ b/packages/package_r_3_1_1/tool_dependencies.xml
@@ -24,9 +24,7 @@
     <package name="R" version="3.1.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ce5c4d5e34414ce8f1ec2d5642861435fa1ddc4cd89bd336172bbe25a62c7a19">
-                    http://cran.rstudio.com/src/base/R-3/R-3.1.1.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ce5c4d5e34414ce8f1ec2d5642861435fa1ddc4cd89bd336172bbe25a62c7a19">http://cran.rstudio.com/src/base/R-3/R-3.1.1.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True" >
                         <package name="readline" version="6.2" />

--- a/packages/package_r_3_1_2/tool_dependencies.xml
+++ b/packages/package_r_3_1_2/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="586dde39d6821bcc5079004450f5d19f836a26d4554083c7add3933f071451e0">
-                        https://depot.galaxyproject.org/software/r/r_3.1.2_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="586dde39d6821bcc5079004450f5d19f836a26d4554083c7add3933f071451e0">https://depot.galaxyproject.org/software/r/r_3.1.2_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -17,9 +15,7 @@
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="bcd150afcae0e02f6efb5f35a6ab72432be82e849ec52ce0bb89d8c342a8fa7a">
-                        http://cran.rstudio.com/src/base/R-3/R-3.1.2.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="bcd150afcae0e02f6efb5f35a6ab72432be82e849ec52ce0bb89d8c342a8fa7a">http://cran.rstudio.com/src/base/R-3/R-3.1.2.tar.gz</action>
                     <package name="readline" version="6.2">
                         <repository name="package_readline_6_2" owner="iuc" prior_installation_required="True" />
                     </package>

--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="0a27c632b6aacacfd96264ec815dfef4a68bfa807c48d90fa1eb6600872199e0">
-                        https://depot.galaxyproject.org/software/r/r_3.2.1_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="0a27c632b6aacacfd96264ec815dfef4a68bfa807c48d90fa1eb6600872199e0">https://depot.galaxyproject.org/software/r/r_3.2.1_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_randfold_2_0/tool_dependencies.xml
+++ b/packages/package_randfold_2_0/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="randfold" version="2.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="4d9e07912a010f41f57fa8aded336fd53313897aab79c326c90987eed5f43be2">
-                    https://depot.galaxyproject.org/software/randfold/randfold_2.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="4d9e07912a010f41f57fa8aded336fd53313897aab79c326c90987eed5f43be2">https://depot.galaxyproject.org/software/randfold/randfold_2.0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_squid_1_9g" owner="iuc">
                         <package name="squid" version="1.9g" />

--- a/packages/package_raxml_8_2_4/tool_dependencies.xml
+++ b/packages/package_raxml_8_2_4/tool_dependencies.xml
@@ -4,9 +4,7 @@
     <install version="1.0">
       <actions>
         <!-- Download source code -->
-        <action type="download_by_url" target_filename="standard-RAxML-8.2.4.tar.gz" sha256sum="e9fa4b3fe790094d832a640edc2b448890237dca0012d509d95be4cd4ef3d83b">
-            https://github.com/stamatak/standard-RAxML/archive/v8.2.4.tar.gz
-        </action>
+        <action type="download_by_url" sha256sum="e9fa4b3fe790094d832a640edc2b448890237dca0012d509d95be4cd4ef3d83b" target_filename="standard-RAxML-8.2.4.tar.gz">https://github.com/stamatak/standard-RAxML/archive/v8.2.4.tar.gz</action>
 
         <!-- Build raxml -->
         <action type="shell_command">make -f Makefile.PTHREADS.gcc</action>

--- a/packages/package_rdkit_2012_12/tool_dependencies.xml
+++ b/packages/package_rdkit_2012_12/tool_dependencies.xml
@@ -10,9 +10,7 @@
     <package name="rdkit" version="2012_12_1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="8393fbab30890a94cdcd976d66f4f0ee99679915e85f5f3c26338d2dd506e009">
-                    https://depot.galaxyproject.org/software/RDKit/RDKit_2012.12.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="8393fbab30890a94cdcd976d66f4f0ee99679915e85f5f3c26338d2dd506e009">https://depot.galaxyproject.org/software/RDKit/RDKit_2012.12.1_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">
                         <package name="numpy" version="1.7.1" />

--- a/packages/package_rdkit_2013_03/tool_dependencies.xml
+++ b/packages/package_rdkit_2013_03/tool_dependencies.xml
@@ -10,9 +10,7 @@
     <package name="rdkit" version="2013_03_2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="72264d5955c7c8d683a93cccdf56b8d2993ef54caf3f81b1c8cd1563fb582abd">
-                    https://depot.galaxyproject.org/software/rdkit/rdkit_2013.03_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="72264d5955c7c8d683a93cccdf56b8d2993ef54caf3f81b1c8cd1563fb582abd">https://depot.galaxyproject.org/software/rdkit/rdkit_2013.03_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_numpy_1_7" owner="iuc">
                         <package name="numpy" version="1.7.1" />

--- a/packages/package_readline_6_2/tool_dependencies.xml
+++ b/packages/package_readline_6_2/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="readline" version="6.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381">
-                    https://depot.galaxyproject.org/software/readline/readline_6.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381">https://depot.galaxyproject.org/software/readline/readline_6.2_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_ncurses_5_9" owner="iuc">
                         <package name="ncurses" version="5.9" />

--- a/packages/package_readline_6_3/tool_dependencies.xml
+++ b/packages/package_readline_6_3/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="readline" version="6.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43">
-                    https://depot.galaxyproject.org/software/readline/readline_6.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43">https://depot.galaxyproject.org/software/readline/readline_6.3_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_ncurses_6_0" owner="iuc">

--- a/packages/package_rnacode_0_3/tool_dependencies.xml
+++ b/packages/package_rnacode_0_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="rnacode" version="0.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="86c600a07ecd04d243fd6eb3c6cc5b20fd6159f34f69423e7391c0ce8f311048">
-                    https://depot.galaxyproject.org/software/RNAcode/RNAcode_0.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="86c600a07ecd04d243fd6eb3c6cc5b20fd6159f34f69423e7391c0ce8f311048">https://depot.galaxyproject.org/software/RNAcode/RNAcode_0.3_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="RNACODE_ROOT_PATH" action="set_to">$INSTALL_DIR</environment_variable>

--- a/packages/package_rnashapes_2_1_6/tool_dependencies.xml
+++ b/packages/package_rnashapes_2_1_6/tool_dependencies.xml
@@ -5,9 +5,7 @@
             <actions_group>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit OSX. -->
                 <actions os="darwin" architecture="i386">
-                    <action type="download_by_url" sha256sum="a55854b1989d6646aa77fd88b50c1499e53fe739c640601f034830b56bad080e">
-                        https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_darwin_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="a55854b1989d6646aa77fd88b50c1499e53fe739c640601f034830b56bad080e">https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_darwin_all.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -15,9 +13,7 @@
                 </actions>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit Linux (i386). -->
                 <actions os="linux" architecture="i386">
-                    <action type="download_by_url" sha256sum="ecf560c2ddf61893790dd25bfa1be3e51caf277b2a7a32cd3da234364fedd0fa">
-                        https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_linux_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="ecf560c2ddf61893790dd25bfa1be3e51caf277b2a7a32cd3da234364fedd0fa">https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_linux_x32.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
@@ -25,18 +21,14 @@
                 </actions>
                 <!-- Download the binaries for RNAshapes compatible with 32-bit Linux (i686). -->
                 <actions os="linux" architecture="i686">
-                    <action type="download_by_url" sha256sum="ecf560c2ddf61893790dd25bfa1be3e51caf277b2a7a32cd3da234364fedd0fa">
-                        https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_linux_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="ecf560c2ddf61893790dd25bfa1be3e51caf277b2a7a32cd3da234364fedd0fa">https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_linux_x32.tar.gz</action>
                     <action type="move_file">
                         <source>RNAshapes</source>
                         <destination>$INSTALL_DIR/bin/</destination>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="6923af49f931efa4f3ad2a05f87a8e5222b6f865d0347e5598de3661e73bb81b">
-                        https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="6923af49f931efa4f3ad2a05f87a8e5222b6f865d0347e5598de3661e73bb81b">https://depot.galaxyproject.org/software/rnashapes/rnashapes_2.1.6_src_all.tar.gz</action>
                     <action type="autoconf" />
                 </actions>
                 <action type="set_environment">

--- a/packages/package_rnastar_2_4_0d/tool_dependencies.xml
+++ b/packages/package_rnastar_2_4_0d/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="rnastar" version="2.4.0d">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b6b368092e91cca135145b631832048d7f508ee8bf8cbd52ffdcb04a413b593f">
-                    https://depot.galaxyproject.org/software/rnastar/rnastar_2.4.0d_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="b6b368092e91cca135145b631832048d7f508ee8bf8cbd52ffdcb04a413b593f">https://depot.galaxyproject.org/software/rnastar/rnastar_2.4.0d_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="make_directory">$INSTALL_DIR</action>
                 <action type="make_directory">$INSTALL_DIR/bin</action>

--- a/packages/package_rnastructure_5_7/tool_dependencies.xml
+++ b/packages/package_rnastructure_5_7/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="rnastructure" version="5.7">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="7d7060c2180b95e0d0e0a840499df48de3571e37ca6bef51325377fe7ca28ae6">
-                    https://depot.galaxyproject.org/software/rnastructure/rnastructure_5.7_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="7d7060c2180b95e0d0e0a840499df48de3571e37ca6bef51325377fe7ca28ae6">https://depot.galaxyproject.org/software/rnastructure/rnastructure_5.7_src_all.tar.gz</action>
                 <action type="shell_command">sed -i.bak "s/version = 5\.6/version = 5.7/" "./src/ParseCommandLine.cpp"</action>
                 <action type="shell_command">make all</action>
                 <action type="move_directory_files">

--- a/packages/package_rpy2_2_3_6/tool_dependencies.xml
+++ b/packages/package_rpy2_2_3_6/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="rpy2_2_3_6" version="2.3.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="a834e54ed6b98e71ef674f96628ab68e17f614db5b6246a9560048493a69f81c">
-                    https://depot.galaxyproject.org/software/rpy2/rpy2_2.3.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="a834e54ed6b98e71ef674f96628ab68e17f614db5b6246a9560048493a69f81c">https://depot.galaxyproject.org/software/rpy2/rpy2_2.3.6_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_readline_6_2" owner="iuc">
                         <package name="readline" version="6.2" />

--- a/packages/package_rpy2_2_7_5/tool_dependencies.xml
+++ b/packages/package_rpy2_2_7_5/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="rpy2" version="2.7.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="0d88f7fff21fbef523c8678ed8f850a36052edca4ce702c62f234fdcb52de441">
-                    https://depot.galaxyproject.org/software/rpy2/rpy2_2.7.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="0d88f7fff21fbef523c8678ed8f850a36052edca4ce702c62f234fdcb52de441">https://depot.galaxyproject.org/software/rpy2/rpy2_2.7.5_src_all.tar.gz</action>
 
 
                 <action type="set_environment_for_install">

--- a/packages/package_ruby_1_9/tool_dependencies.xml
+++ b/packages/package_ruby_1_9/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="ruby" version="1.9">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="d684bc3a5ba72cda9ef30039f783c0f8cdc325bae5c8738c7bf05577cbe8f31d">
-                    https://depot.galaxyproject.org/software/ruby/ruby_1.9_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="d684bc3a5ba72cda9ef30039f783c0f8cdc325bae5c8738c7bf05577cbe8f31d">https://depot.galaxyproject.org/software/ruby/ruby_1.9_src_all.tar.gz</action>
                 <action type="autoconf">--disable-install-doc</action>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_ruby_2_0/tool_dependencies.xml
+++ b/packages/package_ruby_2_0/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="ruby" version="2.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="e6d6900eb4084053058349cfdbf63ad1414b6a8d75d58b47ed81010a9947e73b">
-                    https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="e6d6900eb4084053058349cfdbf63ad1414b6a8d75d58b47ed81010a9947e73b">https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_libxml2_2_9_1" owner="devteam">
                         <package name="libxml2" version="2.9.1" />

--- a/packages/package_ruby_2_1/tool_dependencies.xml
+++ b/packages/package_ruby_2_1/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="ruby" version="2.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="1e1362ae7427c91fa53dc9c05aee4ee200e2d7d8970a891c5bd76bee28d28be4">
-                    https://depot.galaxyproject.org/software/ruby/ruby_2.1.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="1e1362ae7427c91fa53dc9c05aee4ee200e2d7d8970a891c5bd76bee28d28be4">https://depot.galaxyproject.org/software/ruby/ruby_2.1.6_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_libxml2_2_9_1" owner="devteam">
                         <package name="libxml2" version="2.9.1" />

--- a/packages/package_ruby_2_2/tool_dependencies.xml
+++ b/packages/package_ruby_2_2/tool_dependencies.xml
@@ -12,9 +12,7 @@
     <package name="ruby" version="2.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce">
-                    https://depot.galaxyproject.org/software/ruby/ruby_2.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce">https://depot.galaxyproject.org/software/ruby/ruby_2.2_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_libxml2_2_9_1" owner="devteam">
                         <package name="libxml2" version="2.9.1" />

--- a/packages/package_sailfish_0_6/tool_dependencies.xml
+++ b/packages/package_sailfish_0_6/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="sailfish" version="0.6.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="5fded7dc88e525d17eb7abe102ac8ce8d8c3c8e9997d8aa1c512dddbef813632">
-                    https://depot.galaxyproject.org/software/sailfish/sailfish_0.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="5fded7dc88e525d17eb7abe102ac8ce8d8c3c8e9997d8aa1c512dddbef813632">https://depot.galaxyproject.org/software/sailfish/sailfish_0.6_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_boost_1_53" owner="iuc">
                         <package name="boost" version="1.53.0" />

--- a/packages/package_sailfish_0_7_5/tool_dependencies.xml
+++ b/packages/package_sailfish_0_7_5/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="ed006d5d7297b1d2fa585052dd995e016aa7e6faaacdbc119499680d986f8891">
-                        https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.5/SailfishBeta-0.7.5_Linux-x86-64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="ed006d5d7297b1d2fa585052dd995e016aa7e6faaacdbc119499680d986f8891">https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.5/SailfishBeta-0.7.5_Linux-x86-64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -17,9 +15,7 @@
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="d7abbd35481e961bd54dde0e3f265d05288f14f6e829e5f7bb8147bfc1319913">
-                        https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.5/SailfishBeta-0.7.5_OSX_10.10.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="d7abbd35481e961bd54dde0e3f265d05288f14f6e829e5f7bb8147bfc1319913">https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.5/SailfishBeta-0.7.5_OSX_10.10.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -31,9 +27,7 @@
                 </actions>
                 <actions>
                     <!-- first action is always downloading -->
-                    <action type="download_by_url" sha256sum="74f589f6dfa8d9316a9a77bb8ad9c2962f08e3a285deedc134893f6f7b1d1b18">
-                        https://github.com/kingsfordgroup/sailfish/archive/v0.7.5.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="74f589f6dfa8d9316a9a77bb8ad9c2962f08e3a285deedc134893f6f7b1d1b18">https://github.com/kingsfordgroup/sailfish/archive/v0.7.5.tar.gz</action>
                     <package name="boost" version="1.57">
                         <repository name="package_boost_1_57" owner="iuc" prior_installation_required="True" />
                     </package>

--- a/packages/package_sailfish_0_7_6/tool_dependencies.xml
+++ b/packages/package_sailfish_0_7_6/tool_dependencies.xml
@@ -4,18 +4,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="61931bb1e9b881d9b6c9ce1b1d788c09f528d23619283c6f4c28f7e6e2ebe2a2">
-                        https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.6/SailfishBeta-0.7.6_Linux-x86-64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="61931bb1e9b881d9b6c9ce1b1d788c09f528d23619283c6f4c28f7e6e2ebe2a2">https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.6/SailfishBeta-0.7.6_Linux-x86-64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="5e9691160aae7c93346b227860be4d3362b37b1743af67ca64c097b418d499f7">
-                        https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.6/SailfishBeta-0.7.6_OSX_10.10.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="5e9691160aae7c93346b227860be4d3362b37b1743af67ca64c097b418d499f7">https://github.com/kingsfordgroup/sailfish/releases/download/v0.7.6/SailfishBeta-0.7.6_OSX_10.10.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -23,9 +19,7 @@
                 </actions>
                 <actions>
                     <!-- first action is always downloading -->
-                    <action type="download_by_url" sha256sum="c305017224555f22ff35d00d7c9f639c12f11c0ad29093c636354f9d4c8337ac">
-                        https://github.com/kingsfordgroup/sailfish/archive/v0.7.6.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="c305017224555f22ff35d00d7c9f639c12f11c0ad29093c636354f9d4c8337ac">https://github.com/kingsfordgroup/sailfish/archive/v0.7.6.tar.gz</action>
                     <package name="boost" version="1.57">
                         <repository name="package_boost_1_57" owner="iuc" prior_installation_required="True" />
                     </package>

--- a/packages/package_samtools_0_1_16/tool_dependencies.xml
+++ b/packages/package_samtools_0_1_16/tool_dependencies.xml
@@ -4,45 +4,35 @@
         <install version="1.0">
             <actions_group>
                 <actions os="linux" architecture="i386">
-                    <action target_filename="samtools-0.1.16.tgz" type="download_by_url" sha256sum="7090bd62142df0ed3a2b4000292fc0edc917e773d0269c2f3f5b0d36b7888c22">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_linux_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="7090bd62142df0ed3a2b4000292fc0edc917e773d0269c2f3f5b0d36b7888c22" target_filename="samtools-0.1.16.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_linux_x32.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions os="linux" architecture="x86_64">
-                    <action target_filename="samtools-0.1.16.tgz" type="download_by_url" sha256sum="1d050e70fb6570117f282e3ab827f1f37fd453a0558c55ea565092ec3b2b9db2">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1d050e70fb6570117f282e3ab827f1f37fd453a0558c55ea565092ec3b2b9db2" target_filename="samtools-0.1.16.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="i386">
-                    <action target_filename="samtools-0.1.16.tgz" type="download_by_url" sha256sum="4b89dd5542809098269939f6eb913abcf0011c746e02085221d171e3942b6e1f">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_darwin_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="4b89dd5542809098269939f6eb913abcf0011c746e02085221d171e3942b6e1f" target_filename="samtools-0.1.16.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_darwin_x32.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions os="darwin" architecture="x86_64">
-                    <action target_filename="samtools-0.1.16.tgz" type="download_by_url" sha256sum="4e74d7ce4eb5d26166ff6f9bb5939d9a0110d9bdb0baf9ff08cc9522a49e09cb">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="4e74d7ce4eb5d26166ff6f9bb5939d9a0110d9bdb0baf9ff08cc9522a49e09cb" target_filename="samtools-0.1.16.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="ae37c49f2414d1fabe597f68f2351f6cce4b6c0a1a512a5d739bbf759f80a726">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="ae37c49f2414d1fabe597f68f2351f6cce4b6c0a1a512a5d739bbf759f80a726">https://depot.galaxyproject.org/software/samtools/samtools_0.1.16_src_all.tar.bz2</action>
                     <action type="shell_command">sed -i.bak 's/-lcurses/-lncurses/' Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">

--- a/packages/package_samtools_0_1_18/tool_dependencies.xml
+++ b/packages/package_samtools_0_1_18/tool_dependencies.xml
@@ -4,45 +4,35 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="i386" os="linux">
-                    <action target_filename="samtools-0.1.18.tgz" type="download_by_url" sha256sum="0727ad4388feca3a29c6242e8a0ead38b31115af75b7acd5368e92fcaf89a775">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_linux_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="0727ad4388feca3a29c6242e8a0ead38b31115af75b7acd5368e92fcaf89a775" target_filename="samtools-0.1.18.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_linux_x32.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action target_filename="samtools-0.1.18.tgz" type="download_by_url" sha256sum="d02ed38f0ff47998d23a70f98c2577885d089fd66c72e5af58636759e459a500">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="d02ed38f0ff47998d23a70f98c2577885d089fd66c72e5af58636759e459a500" target_filename="samtools-0.1.18.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="i386" os="darwin">
-                    <action target_filename="samtools-0.1.18.tgz" type="download_by_url" sha256sum="dffd1788d6075bc158a0481978ee9662e9773653bb0c50d515c4fcad4b098f4d">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_darwin_x32.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="dffd1788d6075bc158a0481978ee9662e9773653bb0c50d515c4fcad4b098f4d" target_filename="samtools-0.1.18.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_darwin_x32.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action target_filename="samtools-0.1.18.tgz" type="download_by_url" sha256sum="ec199fa47f77fd5a4ac70b5b5c795600f9d5d456d8824d8d2f83cd6abbd8d690">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="ec199fa47f77fd5a4ac70b5b5c795600f9d5d456d8824d8d2f83cd6abbd8d690" target_filename="samtools-0.1.18.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="f3faaf34430d4782956562eb72906289e8e34d44d0c4d73837bdbeead7746b16">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="f3faaf34430d4782956562eb72906289e8e34d44d0c4d73837bdbeead7746b16">https://depot.galaxyproject.org/software/samtools/samtools_0.1.18_src_all.tar.bz2</action>
                     <action type="shell_command">sed -i.bak 's/-lcurses/-lncurses/' Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">

--- a/packages/package_samtools_0_1_19/tool_dependencies.xml
+++ b/packages/package_samtools_0_1_19/tool_dependencies.xml
@@ -4,27 +4,21 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action target_filename="samtools-0.1.19.tgz" type="download_by_url" sha256sum="3cc457cd66e077b70887155435d8f563154371a61e7ac6714bc10b6aa19841bd">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3cc457cd66e077b70887155435d8f563154371a61e7ac6714bc10b6aa19841bd" target_filename="samtools-0.1.19.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action target_filename="samtools-0.1.19.tgz" type="download_by_url" sha256sum="01e0a2cb38b1bcd433461cef43ff6555755a30dfbe83cb9c0a24cb028b104ac7">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="01e0a2cb38b1bcd433461cef43ff6555755a30dfbe83cb9c0a24cb028b104ac7" target_filename="samtools-0.1.19.tgz">https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_darwin_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="d080c9d356e5f0ad334007e4461cbcee3c4ca97b8a7a5a48c44883cf9dee63d4">
-                        https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="d080c9d356e5f0ad334007e4461cbcee3c4ca97b8a7a5a48c44883cf9dee63d4">https://depot.galaxyproject.org/software/samtools/samtools_0.1.19_src_all.tar.bz2</action>
                     <action type="shell_command">sed -i.bak 's/-lcurses/-lncurses/' Makefile</action>
                     <action type="shell_command">make</action>
                     <action type="move_file">

--- a/packages/package_samtools_1_0/tool_dependencies.xml
+++ b/packages/package_samtools_1_0/tool_dependencies.xml
@@ -10,18 +10,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="cf1b9a19d0e8ad0a29d489e62fa9d1720842a6097c7679f7398d21884ff65da9">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="cf1b9a19d0e8ad0a29d489e62fa9d1720842a6097c7679f7398d21884ff65da9">https://depot.galaxyproject.org/software/samtools/samtools_1.0_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="7340b843663c3f54a902a06f2f73c68198f3a62d29a2ed20671139957f7fd7c0">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.0_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="7340b843663c3f54a902a06f2f73c68198f3a62d29a2ed20671139957f7fd7c0">https://depot.galaxyproject.org/software/samtools/samtools_1.0_src_all.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_ncurses_5_9" owner="iuc">
                             <package name="ncurses" version="5.9" />

--- a/packages/package_samtools_1_1/tool_dependencies.xml
+++ b/packages/package_samtools_1_1/tool_dependencies.xml
@@ -10,18 +10,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="7791c2b44457fbbdda37936d678ce68c087334bbddf10d35a63a415e141090c8">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.1_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="7791c2b44457fbbdda37936d678ce68c087334bbddf10d35a63a415e141090c8">https://depot.galaxyproject.org/software/samtools/samtools_1.1_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="c24d26c303153d72b5bf3cc11f72c6c375a4ca1140cc485648c8c5473414b7f8">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.1_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="c24d26c303153d72b5bf3cc11f72c6c375a4ca1140cc485648c8c5473414b7f8">https://depot.galaxyproject.org/software/samtools/samtools_1.1_src_all.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_ncurses_5_9" owner="iuc">
                             <package name="ncurses" version="5.9" />

--- a/packages/package_samtools_1_2/tool_dependencies.xml
+++ b/packages/package_samtools_1_2/tool_dependencies.xml
@@ -10,18 +10,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="4bf5ee7bbf76c8260f032a7242c37f78cac5c33284f5a453b27de0ec131bafdb">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.2_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="4bf5ee7bbf76c8260f032a7242c37f78cac5c33284f5a453b27de0ec131bafdb">https://depot.galaxyproject.org/software/samtools/samtools_1.2_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="420e7a4a107fe37619b9d300b6379452eb8eb04a4a9b65c3ec69de82ccc26daa">
-                        https://depot.galaxyproject.org/software/samtools/samtools_1.2_src_all.tar.bz2
-                    </action>
+                    <action type="download_by_url" sha256sum="420e7a4a107fe37619b9d300b6379452eb8eb04a4a9b65c3ec69de82ccc26daa">https://depot.galaxyproject.org/software/samtools/samtools_1.2_src_all.tar.bz2</action>
                     <action type="set_environment_for_install">
                         <repository name="package_ncurses_5_9" owner="iuc">
                             <package name="ncurses" version="5.9" />

--- a/packages/package_scikit_learn_0_13/tool_dependencies.xml
+++ b/packages/package_scikit_learn_0_13/tool_dependencies.xml
@@ -12,9 +12,7 @@
         <package name="scikit_learn" version="0.13.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="a6e4759a779ba792435d096c882a0d66ee29d369755c09209f1a4e50877bdc94">
-                        https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.13_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="a6e4759a779ba792435d096c882a0d66ee29d369755c09209f1a4e50877bdc94">https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.13_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_lapack_3_4" owner="iuc">
                             <package name="lapack" version="3.4.2" />

--- a/packages/package_scikit_learn_0_13_with_atlas/tool_dependencies.xml
+++ b/packages/package_scikit_learn_0_13_with_atlas/tool_dependencies.xml
@@ -19,9 +19,7 @@
         <package name="scikit_learn" version="0.13.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="a6e4759a779ba792435d096c882a0d66ee29d369755c09209f1a4e50877bdc94">
-                        https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.13_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="a6e4759a779ba792435d096c882a0d66ee29d369755c09209f1a4e50877bdc94">https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.13_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.1" />

--- a/packages/package_scikit_learn_0_14/tool_dependencies.xml
+++ b/packages/package_scikit_learn_0_14/tool_dependencies.xml
@@ -12,9 +12,7 @@
         <package name="scikit_learn" version="0.14.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="34821b8f460bdb7aba8eb882353bacbd01671bfb8057649ffcdce7f7ffa4a21d">
-                        https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.14_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="34821b8f460bdb7aba8eb882353bacbd01671bfb8057649ffcdce7f7ffa4a21d">https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.14_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_lapack_3_4" owner="iuc">
                             <package name="lapack" version="3.4.2" />

--- a/packages/package_scikit_learn_0_14_with_atlas/tool_dependencies.xml
+++ b/packages/package_scikit_learn_0_14_with_atlas/tool_dependencies.xml
@@ -19,9 +19,7 @@
         <package name="scikit_learn" version="0.14.1">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="34821b8f460bdb7aba8eb882353bacbd01671bfb8057649ffcdce7f7ffa4a21d">
-                        https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.14_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="34821b8f460bdb7aba8eb882353bacbd01671bfb8057649ffcdce7f7ffa4a21d">https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.14_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.1" />

--- a/packages/package_scikit_learn_0_15/tool_dependencies.xml
+++ b/packages/package_scikit_learn_0_15/tool_dependencies.xml
@@ -12,9 +12,7 @@
         <package name="scikit_learn" version="0.15">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="1a8a881f6f13edc0ac58931ce21f899eb7920af50aa08802413d1239e2aa5fa6">
-                        https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.15_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1a8a881f6f13edc0ac58931ce21f899eb7920af50aa08802413d1239e2aa5fa6">https://depot.galaxyproject.org/software/scikit_learn/scikit_learn_0.15_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_numpy_1_9" owner="iuc">
                             <package name="numpy" version="1.9" />

--- a/packages/package_scipy_0_12/tool_dependencies.xml
+++ b/packages/package_scipy_0_12/tool_dependencies.xml
@@ -9,9 +9,7 @@
         <package name="scipy" version="0.12.0">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="b967e802dafe2db043cfbdf0043e1312f9ce9c1386863e1c801a08ddfccf9de6">
-                        https://depot.galaxyproject.org/software/scipy/scipy_0.12.0_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="b967e802dafe2db043cfbdf0043e1312f9ce9c1386863e1c801a08ddfccf9de6">https://depot.galaxyproject.org/software/scipy/scipy_0.12.0_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />

--- a/packages/package_scipy_0_12_with_atlas/tool_dependencies.xml
+++ b/packages/package_scipy_0_12_with_atlas/tool_dependencies.xml
@@ -12,9 +12,7 @@
         <package name="scipy" version="0.12.0">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="b967e802dafe2db043cfbdf0043e1312f9ce9c1386863e1c801a08ddfccf9de6">
-                        https://depot.galaxyproject.org/software/scipy/scipy_0.12.0_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="b967e802dafe2db043cfbdf0043e1312f9ce9c1386863e1c801a08ddfccf9de6">https://depot.galaxyproject.org/software/scipy/scipy_0.12.0_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.1" />

--- a/packages/package_scipy_0_14/tool_dependencies.xml
+++ b/packages/package_scipy_0_14/tool_dependencies.xml
@@ -9,9 +9,7 @@
         <package name="scipy" version="0.14">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="4b41a3e6bf178df1c7f0ef3bfeabf1f56610329aca5dbd7b6d64da8ac9af6b14">
-                        https://depot.galaxyproject.org/software/scipy/scipy_0.14_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="4b41a3e6bf178df1c7f0ef3bfeabf1f56610329aca5dbd7b6d64da8ac9af6b14">https://depot.galaxyproject.org/software/scipy/scipy_0.14_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">
                             <package name="atlas" version="3.10.2" />

--- a/packages/package_screed_0_9/tool_dependencies.xml
+++ b/packages/package_screed_0_9/tool_dependencies.xml
@@ -6,9 +6,7 @@
         <package name="screed" version="0.9">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="20a22681855f40387fe0b580d9da639aaae89ab9b3f893a591a34f97eed79fa1">
-                        https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="20a22681855f40387fe0b580d9da639aaae89ab9b3f893a591a34f97eed79fa1">https://pypi.python.org/packages/source/s/screed/screed-0.9.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_bz2file_0_98" owner="iuc">
                             <package name="bz2file" version="0.98" />

--- a/packages/package_segemehl_0_1_6/tool_dependencies.xml
+++ b/packages/package_segemehl_0_1_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="segemehl" version="0.1.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" target_filename="segemehl_0_1_6_1.tar.gz" sha256sum="bc6b17220305cd0e756ffd1dd401e7fcbc8c3ca0761abc588854762a99f3cad8">
-                    https://depot.galaxyproject.org/software/segemehl/segemehl_0.1.6_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="bc6b17220305cd0e756ffd1dd401e7fcbc8c3ca0761abc588854762a99f3cad8" target_filename="segemehl_0_1_6_1.tar.gz">https://depot.galaxyproject.org/software/segemehl/segemehl_0.1.6_src_all.tar.gz</action>
                 <action type="change_directory">segemehl</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">

--- a/packages/package_segemehl_0_2_0/tool_dependencies.xml
+++ b/packages/package_segemehl_0_2_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="segemehl" version="0.2.0">
         <install version="1.0">
             <actions>
-                <action target_filename="segemehl_0_2_0.tar.gz" type="download_by_url" sha256sum="2575139d2f2ba7bd534afcbe485c0570c177d1faaeb267c4cd873e65b8e72afb">
-                    https://depot.galaxyproject.org/software/segemehl/segemehl_0.2.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2575139d2f2ba7bd534afcbe485c0570c177d1faaeb267c4cd873e65b8e72afb" target_filename="segemehl_0_2_0.tar.gz">https://depot.galaxyproject.org/software/segemehl/segemehl_0.2.0_src_all.tar.gz</action>
                 <action type="change_directory">segemehl</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">

--- a/packages/package_snpeff_3_4/tool_dependencies.xml
+++ b/packages/package_snpeff_3_4/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="snpEff" version="3.4">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="57769d7cc21e2c93891de7250a09e9715383d392e5cffb6e55359148bb8c9b0c">
-                    https://depot.galaxyproject.org/software/snpEff/snpEff_3.4.core_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="57769d7cc21e2c93891de7250a09e9715383d392e5cffb6e55359148bb8c9b0c">https://depot.galaxyproject.org/software/snpEff/snpEff_3.4.core_src_all.zip</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_snpeff_3_6/tool_dependencies.xml
+++ b/packages/package_snpeff_3_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="snpEff" version="3.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="56acd33a7dd201381022c2ecbac07fe367e8d297acf8c5833df1e2e5facf27c2">
-                    https://depot.galaxyproject.org/software/snpEff/snpEff_3.6.core_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="56acd33a7dd201381022c2ecbac07fe367e8d297acf8c5833df1e2e5facf27c2">https://depot.galaxyproject.org/software/snpEff/snpEff_3.6.core_src_all.zip</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_snpeff_4_0/tool_dependencies.xml
+++ b/packages/package_snpeff_4_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="snpEff" version="4.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="e5c4c555b9ba5546ae885d2645b070ae81a1e30f3de96d298837ec40c45a9ffc">
-                    https://depot.galaxyproject.org/software/snpEff/snpEff_4.0.core_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="e5c4c555b9ba5546ae885d2645b070ae81a1e30f3de96d298837ec40c45a9ffc">https://depot.galaxyproject.org/software/snpEff/snpEff_4.0.core_src_all.zip</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR</destination_directory>

--- a/packages/package_sparsehash_2_0_2/tool_dependencies.xml
+++ b/packages/package_sparsehash_2_0_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="sparsehash" version="2.0.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2ed639a7155607c097c2029af5f4287296595080b2e5dd2e2ebd9bbb7450b87c">
-                    https://depot.galaxyproject.org/software/sparsehash/sparsehash_2.0.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2ed639a7155607c097c2029af5f4287296595080b2e5dd2e2ebd9bbb7450b87c">https://depot.galaxyproject.org/software/sparsehash/sparsehash_2.0.2_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>

--- a/packages/package_sqlite_3_8_3/tool_dependencies.xml
+++ b/packages/package_sqlite_3_8_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="sqlite" version="3.8.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="dabe38cf6732a9dfd57e9a2d2629dfb12ea3f2bf8948987f91318d01e6f72a26">
-                    https://depot.galaxyproject.org/software/sqlite/sqlite_3.8.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="dabe38cf6732a9dfd57e9a2d2629dfb12ea3f2bf8948987f91318d01e6f72a26">https://depot.galaxyproject.org/software/sqlite/sqlite_3.8.3_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>

--- a/packages/package_squid_1_9g/tool_dependencies.xml
+++ b/packages/package_squid_1_9g/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="squid" version="1.9g">
         <install version="1.0">
             <actions>
-                <action target_filename="squid-1.9g.tar.gz" type="download_by_url" sha256sum="302f42e8794aa4dbcfa0996c14fb7a70a7c4397fc45c2bbd2748055460d8dca7">
-                    https://depot.galaxyproject.org/software/squid/squid_1.9g_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="302f42e8794aa4dbcfa0996c14fb7a70a7c4397fc45c2bbd2748055460d8dca7" target_filename="squid-1.9g.tar.gz">https://depot.galaxyproject.org/software/squid/squid_1.9g_src_all.tar.gz</action>
                 <action type="autoconf">--enable-lfs</action>
                 <action type="set_environment">
                     <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>

--- a/packages/package_stringtie_0_97/tool_dependencies.xml
+++ b/packages/package_stringtie_0_97/tool_dependencies.xml
@@ -4,47 +4,41 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-	                <action type="download_by_url" sha256sum="3bad0150bc4ee6e0768a0cb77e13d1130e6103ffe0400f14e3daf1e6a617e6c6">
-	                    https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_linux_x64.tar.gz
-	                </action>
+                    <action type="download_by_url" sha256sum="3bad0150bc4ee6e0768a0cb77e13d1130e6103ffe0400f14e3daf1e6a617e6c6">https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_linux_x64.tar.gz</action>
                     <action type="move_file">
                         <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-	                <action type="download_by_url" sha256sum="53dfa6d2fadf7bd548b9932f1dd3e1c40f84c3e2877a801af5cd9059024fe577">
-	                    https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_darwin_x64.tar.gz
-	                </action>
+                    <action type="download_by_url" sha256sum="53dfa6d2fadf7bd548b9932f1dd3e1c40f84c3e2877a801af5cd9059024fe577">https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_darwin_x64.tar.gz</action>
                     <action type="move_file">
                         <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
-	            <actions>
+                <actions>
                     <package name="samtools" version="0.1.19">
                         <repository name="package_samtools_0_1_19" owner="devteam" prior_installation_required="true" />
                     </package>
-	                <action type="download_by_url" sha256sum="8a8371827a123a94333036d482cc45ccd39d6dd54f6d394fb536853265241d1d">
-	                    https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_src_all.tar.gz
-	                </action>
-	                <action type="set_environment_for_install">
-	                    <repository name="package_samtools_0_1_19" owner="devteam" prior_installation_required="true">
-	                        <package name="samtools" version="0.1.19" />
-	                    </repository>
-	                </action>
-	                <action type="shell_command">ln -s $SAMTOOLS_ROOT_DIR/src samtools</action>
-	                <action type="shell_command">cp $SAMTOOLS_ROOT_DIR/lib/libbam.* samtools/</action>
-	                <action type="shell_command">make</action>
-	                <action type="move_file">
-	                    <source>stringtie</source>
-	                    <destination>$INSTALL_DIR/bin</destination>
-	                </action>
-	            </actions>
-	            <action type="set_environment">
-	                <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
-	            </action>
-	        </actions_group>
+                    <action type="download_by_url" sha256sum="8a8371827a123a94333036d482cc45ccd39d6dd54f6d394fb536853265241d1d">https://depot.galaxyproject.org/software/stringtie/stringtie_0.97_src_all.tar.gz</action>
+                    <action type="set_environment_for_install">
+                        <repository name="package_samtools_0_1_19" owner="devteam" prior_installation_required="true">
+                            <package name="samtools" version="0.1.19" />
+                        </repository>
+                    </action>
+                    <action type="shell_command">ln -s $SAMTOOLS_ROOT_DIR/src samtools</action>
+                    <action type="shell_command">cp $SAMTOOLS_ROOT_DIR/lib/libbam.* samtools/</action>
+                    <action type="shell_command">make</action>
+                    <action type="move_file">
+                        <source>stringtie</source>
+                        <destination>$INSTALL_DIR/bin</destination>
+                    </action>
+                </actions>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                </action>
+            </actions_group>
         </install>
         <readme>StringTie is a fast and highly efficient assembler of RNA-Seq
         alignments into potential transcripts. It is primarily a genome-guided

--- a/packages/package_stringtie_1_0_1/tool_dependencies.xml
+++ b/packages/package_stringtie_1_0_1/tool_dependencies.xml
@@ -4,27 +4,21 @@
       <install version="1.0">
           <actions_group>
               <actions architecture="x86_64" os="linux">
-                  <action type="download_by_url" sha256sum="a1fe432068c75845c385f637105d360789c4defc0002841a7de3eb2d42587574">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_linux_x64.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="a1fe432068c75845c385f637105d360789c4defc0002841a7de3eb2d42587574">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_linux_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                  <action type="download_by_url" sha256sum="8815e3345567b413ad5a6567f499e71c16c316abb3828430f5e0affdb11c5ed3">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_darwin_x64.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="8815e3345567b413ad5a6567f499e71c16c316abb3828430f5e0affdb11c5ed3">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_darwin_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions>
-                  <action type="download_by_url" sha256sum="b0750b40214814270f7380d04efa350d57ef781eb67cf6f4cf168040e93fd98f">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_src_all.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="b0750b40214814270f7380d04efa350d57ef781eb67cf6f4cf168040e93fd98f">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.1_src_all.tar.gz</action>
                     <action type="shell_command">make release</action>
                     <action type="move_file">
                       <source>stringtie</source>

--- a/packages/package_stringtie_1_0_3/tool_dependencies.xml
+++ b/packages/package_stringtie_1_0_3/tool_dependencies.xml
@@ -4,27 +4,21 @@
       <install version="1.0">
           <actions_group>
               <actions architecture="x86_64" os="linux">
-                  <action type="download_by_url" sha256sum="3ec1aeb5f44491e2ffddaf308d00e1e43fad378cf91f735d72d06a0c6b4de75e">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_linux_x64.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="3ec1aeb5f44491e2ffddaf308d00e1e43fad378cf91f735d72d06a0c6b4de75e">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_linux_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                  <action type="download_by_url" sha256sum="a757cbdffe28f593a8161bb2350a5de7601ca8047f54a29d58baa243f226c5ca">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_darwin_x64.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="a757cbdffe28f593a8161bb2350a5de7601ca8047f54a29d58baa243f226c5ca">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_darwin_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions>
-                  <action type="download_by_url" sha256sum="1567d9d87d9375a3db03fa0b682eaef4e89899df64fd001c14d475cc9e737e08">
-                      https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_src_all.tar.gz
-                  </action>
+                  <action type="download_by_url" sha256sum="1567d9d87d9375a3db03fa0b682eaef4e89899df64fd001c14d475cc9e737e08">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.3_src_all.tar.gz</action>
                     <action type="shell_command">make release</action>
                     <action type="move_file">
                       <source>stringtie</source>

--- a/packages/package_stringtie_1_0_4/tool_dependencies.xml
+++ b/packages/package_stringtie_1_0_4/tool_dependencies.xml
@@ -4,27 +4,21 @@
       <install version="1.0">
           <actions_group>
               <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="03ad436e24daa54ef6b06a393e46e7173488f5a36da888a864d6ab7867ac798c">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="03ad436e24daa54ef6b06a393e46e7173488f5a36da888a864d6ab7867ac798c">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_linux_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="b50648a23cf0957fb25d34d3497bfe4cd270977272e4f6c7ea3da10c99dc7692">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="b50648a23cf0957fb25d34d3497bfe4cd270977272e4f6c7ea3da10c99dc7692">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_darwin_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="635099d543bfaf0ec1c84020eb4aa3375714c12e2d0d435dae44901d49fe3ef2">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="635099d543bfaf0ec1c84020eb4aa3375714c12e2d0d435dae44901d49fe3ef2">https://depot.galaxyproject.org/software/stringtie/stringtie_1.0.4_src_all.tar.gz</action>
                     <action type="shell_command">make release</action>
                     <action type="move_file">
                       <source>stringtie</source>

--- a/packages/package_stringtie_1_1_0/tool_dependencies.xml
+++ b/packages/package_stringtie_1_1_0/tool_dependencies.xml
@@ -4,27 +4,21 @@
       <install version="1.0">
           <actions_group>
               <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="a89b3c67291c4d501eb2c0ddf84ce941d066b628c72327edc3acd4275f878667">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="a89b3c67291c4d501eb2c0ddf84ce941d066b628c72327edc3acd4275f878667">https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_linux_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="65d94c7c44f25b61dfe65e02ad851622c7ed2618b38b4a1bac8217bb5d0b051f">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_darwin_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="65d94c7c44f25b61dfe65e02ad851622c7ed2618b38b4a1bac8217bb5d0b051f">https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_darwin_x64.tar.gz</action>
                     <action type="move_file">
                       <source>stringtie</source>
                         <destination>$INSTALL_DIR/bin</destination>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="1777adedfce1857f5f4bd1acbd3d01d8fc4f98bc2f80da9a54d7247401c9a487">
-                        https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="1777adedfce1857f5f4bd1acbd3d01d8fc4f98bc2f80da9a54d7247401c9a487">https://depot.galaxyproject.org/software/stringtie/stringtie_1.1.0_src_all.tar.gz</action>
                     <action type="shell_command">make release</action>
                     <action type="move_file">
                       <source>stringtie</source>

--- a/packages/package_suspenders_0_2_5/tool_dependencies.xml
+++ b/packages/package_suspenders_0_2_5/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="suspenders" version="0.2.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="27fcbeb0f71e5dd9d1085981640873812fa13ece0f4c0d0207b1733d13041b04">
-                    https://depot.galaxyproject.org/software/suspenders/suspenders_0.2.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="27fcbeb0f71e5dd9d1085981640873812fa13ece0f4c0d0207b1733d13041b04">https://depot.galaxyproject.org/software/suspenders/suspenders_0.2.5_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_pysam_0_7_7" owner="iuc">
                         <package name="pysam" version="0.7.7" />

--- a/packages/package_tabix_0_2_6/tool_dependencies.xml
+++ b/packages/package_tabix_0_2_6/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="tabix" version="0.2.6">
         <install version="1.0">
             <actions>
-             <action type="download_by_url" sha256sum="e4066be7101bae83bec62bc2bc6917013f6c2875b66eb5055fbb013488d68b73">
-                 https://depot.galaxyproject.org/software/tabix/tabix_0.2.6_src_all.tar.bz2
-             </action>
+             <action type="download_by_url" sha256sum="e4066be7101bae83bec62bc2bc6917013f6c2875b66eb5055fbb013488d68b73">https://depot.galaxyproject.org/software/tabix/tabix_0.2.6_src_all.tar.bz2</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>tabix</source>

--- a/packages/package_tiff_4_0_3/tool_dependencies.xml
+++ b/packages/package_tiff_4_0_3/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="tiff" version="4.0.3">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ea1aebe282319537fb2d4d7805f478dd4e0e05c33d0928baba76a7c963684872">
-                    https://depot.galaxyproject.org/software/tiff/tiff_4.0.3_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ea1aebe282319537fb2d4d7805f478dd4e0e05c33d0928baba76a7c963684872">https://depot.galaxyproject.org/software/tiff/tiff_4.0.3_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="shell_command">ln -s $INSTALL_DIR/lib/libtiff.so $INSTALL_DIR/lib/libtiff.so.4</action>
                 <action type="set_environment">

--- a/packages/package_tophat_2_0_14/tool_dependencies.xml
+++ b/packages/package_tophat_2_0_14/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="3eb415d861748257e7561b54abcb10a97d0d9e29d7aaea5be17e95c7dbd4765d">
-                        https://depot.galaxyproject.org/software/tophat/tophat_2.0.14_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3eb415d861748257e7561b54abcb10a97d0d9e29d7aaea5be17e95c7dbd4765d">https://depot.galaxyproject.org/software/tophat/tophat_2.0.14_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
@@ -14,18 +12,14 @@
                     <action type="shell_command">sed -i.bak 's#/build/dest#$INSTALL_DIR#' $INSTALL_DIR/bin/tophat2</action>
                 </actions>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_by_url" sha256sum="aa57a2f40b0813b4404d3b462db0ad54f93f6a2e71a826541dd15e04cda75d09">
-                        https://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.14.OSX_x86_64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="aa57a2f40b0813b4404d3b462db0ad54f93f6a2e71a826541dd15e04cda75d09">https://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.14.OSX_x86_64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="547c5c9d127cbf7d61bc73c4251ff98a07d57e59b3718666a18b58acfb8fcfbf">
-                        http://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.14.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="547c5c9d127cbf7d61bc73c4251ff98a07d57e59b3718666a18b58acfb8fcfbf">http://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.14.tar.gz</action>
                     <action type="autoconf"/>
                 </actions>
                 <action type="set_environment">

--- a/packages/package_tpp_4_6_3/tool_dependencies.xml
+++ b/packages/package_tpp_4_6_3/tool_dependencies.xml
@@ -33,9 +33,7 @@
                     </package>
                 </action>
                 <action type="change_directory">..</action>
-                <action type="download_file" sha256sum="371793db99956a9024a6057b2ba19fef4dac576b075176c0cd61d51ecac9ffe9">
-                    https://depot.galaxyproject.org/software/TPP/TPP_4.6.3_src_all.tar.gz
-                </action>
+                <action type="download_file" sha256sum="371793db99956a9024a6057b2ba19fef4dac576b075176c0cd61d51ecac9ffe9">https://depot.galaxyproject.org/software/TPP/TPP_4.6.3_src_all.tar.gz</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_libgd_2_1" owner="iuc">

--- a/packages/package_tpp_4_7_0/tool_dependencies.xml
+++ b/packages/package_tpp_4_7_0/tool_dependencies.xml
@@ -39,9 +39,7 @@
                     </package>
                 </action>
                 <action type="change_directory">..</action>
-                <action type="download_file" sha256sum="fea4e64c876ef3ddead15c0fc3c3f21480e44c2685ad195c16c4449145637034">
-                    https://depot.galaxyproject.org/software/TPP/TPP_4.7.0_src_all.tar.gz
-                </action>
+                <action type="download_file" sha256sum="fea4e64c876ef3ddead15c0fc3c3f21480e44c2685ad195c16c4449145637034">https://depot.galaxyproject.org/software/TPP/TPP_4.7.0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_libgd_2_1" owner="iuc">
                         <package name="libgd" version="2.1.0" />

--- a/packages/package_tpp_4_8_0/tool_dependencies.xml
+++ b/packages/package_tpp_4_8_0/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="d2b99b22c18091124b41c4ef13315b8fafc2a3451b43e2794122806d96a97a7f">
-                        https://depot.galaxyproject.org/software/tpp/tpp_4.8.0_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="d2b99b22c18091124b41c4ef13315b8fafc2a3451b43e2794122806d96a97a7f">https://depot.galaxyproject.org/software/tpp/tpp_4.8.0_linux_x64.tar.gz</action>
                     <action type="shell_command">rm tpp_4.8.0_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_transdecoder_2_0_1/tool_dependencies.xml
+++ b/packages/package_transdecoder_2_0_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="transdecoder" version="2.0.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="ce069da72c8a04e739f8c057af4f97187bf587d3f0d3db40465dfc2c89393e22">
-                    https://github.com/TransDecoder/TransDecoder/archive/2.0.1.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="ce069da72c8a04e739f8c057af4f97187bf587d3f0d3db40465dfc2c89393e22">https://github.com/TransDecoder/TransDecoder/archive/2.0.1.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>TransDecoder.LongOrfs</source>

--- a/packages/package_transtermhp_2_09/tool_dependencies.xml
+++ b/packages/package_transtermhp_2_09/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="transtermhp" version="2.09">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="b636db1c0fe9731cc760d8f3639209d07f7f35309d83013cc9f9e40798ce8be0">
-                    https://depot.galaxyproject.org/software/transtermhp/transtermhp_2.09_src_all.zip
-                </action>
+                <action type="download_by_url" sha256sum="b636db1c0fe9731cc760d8f3639209d07f7f35309d83013cc9f9e40798ce8be0">https://depot.galaxyproject.org/software/transtermhp/transtermhp_2.09_src_all.zip</action>
                 <action type="shell_command">make</action>
                 <action type="move_file">
                     <source>transterm</source>

--- a/packages/package_trinity_2_0_6/tool_dependencies.xml
+++ b/packages/package_trinity_2_0_6/tool_dependencies.xml
@@ -9,9 +9,7 @@
     <package name="trinity" version="2.0.6">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="e0c3ec885fdcfe3422ea492372518ddf5d1aed3daa187c69c4254516b0845de1">
-                    https://github.com/trinityrnaseq/trinityrnaseq/archive/v2.0.6.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="e0c3ec885fdcfe3422ea492372518ddf5d1aed3daa187c69c4254516b0845de1">https://github.com/trinityrnaseq/trinityrnaseq/archive/v2.0.6.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_ncurses_5_9"  owner="iuc" prior_installation_required="True">
                         <package name="ncurses" version="5.9" />

--- a/packages/package_trnascan_1_3_1/tool_dependencies.xml
+++ b/packages/package_trnascan_1_3_1/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="tRNAscan-SE" version="1.3.1">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="862924d869453d1c111ba02f47d4cd86c7d6896ff5ec9e975f1858682282f316">
-                    https://depot.galaxyproject.org/software/trnascan/trnascan_1.3.1_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="862924d869453d1c111ba02f47d4cd86c7d6896ff5ec9e975f1858682282f316">https://depot.galaxyproject.org/software/trnascan/trnascan_1.3.1_src_all.tar.gz</action>
                 <action type="make_directory">$INSTALL_DIR/bin/</action>
                 <action type="make_directory">$INSTALL_DIR/lib/tRNAscan-SE/</action>
                 <action type="make_directory">$INSTALL_DIR/man/</action>
@@ -16,9 +14,7 @@
                 <action type="make_install" />
 
                 <!-- for some reason infernal needs to be directly under the bin/ from tRNAScan -->
-                <action type="download_file" sha256sum="c4f89ac2e865c8b04a53a647703d88f96c31bb1d47d3e06f4b6090d7d15643ad">
-                    https://depot.galaxyproject.org/software/infernal/infernal_1.0.2_src_all.tar.gz
-                </action>
+                <action type="download_file" sha256sum="c4f89ac2e865c8b04a53a647703d88f96c31bb1d47d3e06f4b6090d7d15643ad">https://depot.galaxyproject.org/software/infernal/infernal_1.0.2_src_all.tar.gz</action>
                 <action type="shell_command">tar xfvz infernal_1.0.2_src_all.tar.gz</action>
                 <action type="shell_command">cd infernal-1.0.2 &amp;&amp; ./configure --prefix=$INSTALL_DIR &amp;&amp; make &amp;&amp; make install</action>
                 <action type="set_environment">

--- a/packages/package_ucsc_tools_0_1/tool_dependencies.xml
+++ b/packages/package_ucsc_tools_0_1/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">
-                        https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz</action>
                     <action type="shell_command">rm ucsc_312_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_ucsc_tools_312/tool_dependencies.xml
+++ b/packages/package_ucsc_tools_312/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">
-                        https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="706ba638e26e0e51f4c3a1ce82d64d71caaae259e2cabdd903bfa2b9c0510799">https://depot.galaxyproject.org/software/ucsc/ucsc_312_linux_x64.tar.gz</action>
                     <action type="shell_command">rm ucsc_312_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>

--- a/packages/package_unzip_6_0/tool_dependencies.xml
+++ b/packages/package_unzip_6_0/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="unzip" version="6.0">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37">
-                    https://depot.galaxyproject.org/software/unzip/unzip_6.0_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37">https://depot.galaxyproject.org/software/unzip/unzip_6.0_src_all.tar.gz</action>
                 <action type="shell_command">make -f unix/Makefile generic</action>
                 <action type="shell_command">make -f unix/Makefile prefix=$INSTALL_DIR install</action>
                 <action type="set_environment">

--- a/packages/package_vcflib_8a5602bf07/tool_dependencies.xml
+++ b/packages/package_vcflib_8a5602bf07/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="3f1d08c8d75cad7d8debdda63371e3358dd1d45a535e8cf1d5f8223ad75a7935">
-                        https://depot.galaxyproject.org/software/vcflib/vcflib_8a5602bf07_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="3f1d08c8d75cad7d8debdda63371e3358dd1d45a535e8cf1d5f8223ad75a7935">https://depot.galaxyproject.org/software/vcflib/vcflib_8a5602bf07_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR/bin</destination_directory>

--- a/packages/package_vcftools_0_1_12b/tool_dependencies.xml
+++ b/packages/package_vcftools_0_1_12b/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="vcftools" version="0.1.12b">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="9d2324512e9f1237d5cece74ba63965eb43643e9eada8685afe8217760a20a91">
-                    https://depot.galaxyproject.org/software/vcftools/vcftools_0.1.12b_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="9d2324512e9f1237d5cece74ba63965eb43643e9eada8685afe8217760a20a91">https://depot.galaxyproject.org/software/vcftools/vcftools_0.1.12b_src_all.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="shell_command">PREFIX="$INSTALL_DIR/vcftools" make install</action>
                 <!-- For some reason, the vcftools binary does not get installed using 'make install' above, so include manually. -->

--- a/packages/package_vienna_rna_1_8/tool_dependencies.xml
+++ b/packages/package_vienna_rna_1_8/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="vienna_rna" version="1.8.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="f4e2d94beaf77165e8321758e4ab0ad1c5d49879cefa12e48b07d09ed2d0ecf9">
-                    https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_1.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="f4e2d94beaf77165e8321758e4ab0ad1c5d49879cefa12e48b07d09ed2d0ecf9">https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_1.8_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_perl_5_18" owner="iuc">
                         <package name="perl" version="5.18.1" />

--- a/packages/package_vienna_rna_2_1/tool_dependencies.xml
+++ b/packages/package_vienna_rna_2_1/tool_dependencies.xml
@@ -7,18 +7,14 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_by_url" sha256sum="60eab3d236c44a1f2796cc7098a651384ca39c61754f4d589d3076ddbf110e23">
-                        https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_2.1_linux_x64.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="60eab3d236c44a1f2796cc7098a651384ca39c61754f4d589d3076ddbf110e23">https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_2.1_linux_x64.tar.gz</action>
                     <action type="move_directory_files">
                         <source_directory>.</source_directory>
                         <destination_directory>$INSTALL_DIR</destination_directory>
                     </action>
                 </actions>
                 <actions>
-                    <action type="download_by_url" sha256sum="37a0a0b7c8a167bcdab1a85d88bcb1025ad8e00a4b00a147bf36d45dc8ca7560">
-                        https://depot.galaxyproject.org/software/ViennaRNA/ViennaRNA_2.1.8_src_all.tar.gz
-                    </action>
+                    <action type="download_by_url" sha256sum="37a0a0b7c8a167bcdab1a85d88bcb1025ad8e00a4b00a147bf36d45dc8ca7560">https://depot.galaxyproject.org/software/ViennaRNA/ViennaRNA_2.1.8_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_perl_5_18" owner="iuc">
                             <package name="perl" version="5.18.1" />

--- a/packages/package_vienna_rna_2_1_5/tool_dependencies.xml
+++ b/packages/package_vienna_rna_2_1_5/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="vienna_rna" version="2.1.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2d02103b6a5d1536df26607ee00b8be364758f2cb796aeb010517c311e861d58">
-                    https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_2.1.5_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2d02103b6a5d1536df26607ee00b8be364758f2cb796aeb010517c311e861d58">https://depot.galaxyproject.org/software/vienna_rna/vienna_rna_2.1.5_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
                     <repository name="package_perl_5_18" owner="iuc">
                         <package name="perl" version="5.18.1" />

--- a/packages/package_vsearch_1_1_3/tool_dependencies.xml
+++ b/packages/package_vsearch_1_1_3/tool_dependencies.xml
@@ -4,9 +4,7 @@
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="darwin">
-                    <action type="download_file" sha256sum="109e70fef692c6114e707c453935c74bf312a897d642b0b4977e85f9b9c4f24b">
-                        https://depot.galaxyproject.org/software/vsearch/vsearch_1.1.3_darwin_x64
-                    </action>
+                    <action type="download_file" sha256sum="109e70fef692c6114e707c453935c74bf312a897d642b0b4977e85f9b9c4f24b">https://depot.galaxyproject.org/software/vsearch/vsearch_1.1.3_darwin_x64</action>
                     <action type="move_file" rename_to="vsearch">
                         <source>vsearch_1.1.3_darwin_x64</source>
                         <destination>$INSTALL_DIR/bin</destination>
@@ -14,9 +12,7 @@
                     <action type="shell_command">chmod +x $INSTALL_DIR/bin/vsearch</action>
                 </actions>
                 <actions architecture="x86_64" os="linux">
-                    <action type="download_file" sha256sum="4df3b4b4a31267cec9b7845aea2b68d61f6132762956048b26e4b93967eb5238">
-                        https://depot.galaxyproject.org/software/vsearch/vsearch_1.1.3_linux_x64
-                    </action>
+                    <action type="download_file" sha256sum="4df3b4b4a31267cec9b7845aea2b68d61f6132762956048b26e4b93967eb5238">https://depot.galaxyproject.org/software/vsearch/vsearch_1.1.3_linux_x64</action>
                     <action type="move_file" rename_to="vsearch">
                         <source>vsearch_1.1.3_linux_x64</source>
                         <destination>$INSTALL_DIR/bin</destination>

--- a/packages/package_weblogo_2_8_2/tool_dependencies.xml
+++ b/packages/package_weblogo_2_8_2/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="weblogo" version="2.8.2">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="2d3e0040c0c1e363c1dfd57f8b585387eb682ed08b2cc2fe2e4cc2a33ac52266">
-                    https://depot.galaxyproject.org/software/weblogo/weblogo_2.8.2_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="2d3e0040c0c1e363c1dfd57f8b585387eb682ed08b2cc2fe2e4cc2a33ac52266">https://depot.galaxyproject.org/software/weblogo/weblogo_2.8.2_src_all.tar.gz</action>
                 <action type="move_directory_files">
                     <source_directory>.</source_directory>
                     <destination_directory>$INSTALL_DIR/weblogo</destination_directory>

--- a/packages/package_weka_3_7_11/tool_dependencies.xml
+++ b/packages/package_weka_3_7_11/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="weka" version="3.7.11">
         <install version="1.0">
             <actions>
-                <action type="download_file" sha256sum="693073d518484d729c007024ee2c1fb85ab56232cd55daa6d76e7000907c1718">
-                    https://depot.galaxyproject.org/software/weka/weka_3.7.11_src_all.jar
-                </action>
+                <action type="download_file" sha256sum="693073d518484d729c007024ee2c1fb85ab56232cd55daa6d76e7000907c1718">https://depot.galaxyproject.org/software/weka/weka_3.7.11_src_all.jar</action>
                 <action type="shell_command">mv weka_3.7.11_src_all.jar $INSTALL_DIR/weka.jar</action>
                 <action type="set_environment">
                     <environment_variable name="WEKA_JAR_PATH" action="set_to">$INSTALL_DIR</environment_variable>

--- a/packages/package_xz_5_0_5/tool_dependencies.xml
+++ b/packages/package_xz_5_0_5/tool_dependencies.xml
@@ -6,9 +6,7 @@
     <package name="xz" version="5.0.5">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="166c48d2842519bc4f96333bff9e265f8cdda44d38e40594ef3f9bbb52890490">
-                    https://depot.galaxyproject.org/software/xz/xz_5.0.5_src_all.tar.bz2
-                </action>
+                <action type="download_by_url" sha256sum="166c48d2842519bc4f96333bff9e265f8cdda44d38e40594ef3f9bbb52890490">https://depot.galaxyproject.org/software/xz/xz_5.0.5_src_all.tar.bz2</action>
 
                 <action type="set_environment_for_install">
                     <repository name="package_bzlib_1_0" owner="iuc">

--- a/packages/package_zlib_1_2_8/tool_dependencies.xml
+++ b/packages/package_zlib_1_2_8/tool_dependencies.xml
@@ -3,9 +3,7 @@
     <package name="zlib" version="1.2.8">
         <install version="1.0">
             <actions>
-                <action type="download_by_url" sha256sum="36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d">
-                    https://depot.galaxyproject.org/software/zlib/zlib_1.2.8_src_all.tar.gz
-                </action>
+                <action type="download_by_url" sha256sum="36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d">https://depot.galaxyproject.org/software/zlib/zlib_1.2.8_src_all.tar.gz</action>
                 <action type="autoconf" />
                 <action type="set_environment">
                     <environment_variable name="ZLIB_ROOT_PATH" action="set_to">$INSTALL_DIR</environment_variable>


### PR DESCRIPTION
Also fixes `packages/package_bcftools_1_2/tool_dependencies.xml`.

Mainly done with:
```bash
find packages/ -name tool_dependencies.xml -exec perl -0777 -pi -e 's/<action type="download_by_url" sha256sum="(\w+)">\n\s*http(\S+)\n\s*<\/action>/<action type="download_by_url" sha256sum="\1">http\2<\/action>/g' {} \;
```