### PR TITLE
coreutils version 8.25

### DIFF
--- a/packages/package_gnu_coreutils_8_25/.shed.yml
+++ b/packages/package_gnu_coreutils_8_25/.shed.yml
@@ -1,0 +1,15 @@
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version
+  8.25 of the GNU coreutils.
+long_description: |
+  The GNU Core Utilities are the basic file, shell and text manipulation
+  utilities of the GNU operating system.
+
+  These are the core utilities which are expected to exist on every operating system.
+
+  http://www.gnu.org/software/coreutils/
+name: package_gnu_coreutils_8_25
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_gnu_coreutils_8_25
+type: tool_dependency_definition

--- a/packages/package_gnu_coreutils_8_25/tool_dependencies.xml
+++ b/packages/package_gnu_coreutils_8_25/tool_dependencies.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="gnu_coreutils" version="8.25">
+        <install version="1.0">
+            <actions>
+            <!--
+                repacked version of http://ftp.gnu.org/gnu/coreutils/coreutils-8.25.tar.xz,
+                because tarfile did not understand LZMA compression
+            -->
+                <action type="download_by_url" sha256sum="031a9842298864ed0d7ae87e008759465c8b4716ed4bf97d723fe8ced5145e94">
+                    https://depot.galaxyproject.org/software/coreutils/coreutils_8.25_src_all.tar.bz2
+                </action>
+                <action type="autoconf"/>
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>
+            Compiling GNU coreutils requires a C compiler.
+        </readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
It appears that this version doesn't hang on first compile on ubuntu 14.04, due to a newer nanosleep.c
The issue was mentioned here: http://dev.list.galaxyproject.org/JBrowse-on-dev-branch-progress-td4668897.html