### PR TITLE
rely on newer coreutils version

### DIFF
--- a/packages/package_perl_5_18/tool_dependencies.xml
+++ b/packages/package_perl_5_18/tool_dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="gnu_coreutils" version="8.22">
-        <repository name="package_gnu_coreutils_8_22" owner="iuc" prior_installation_required="True"></repository>
+    <package name="gnu_coreutils" version="8.25">
+        <repository name="package_gnu_coreutils_8_25" owner="iuc" prior_installation_required="True"></repository>
     </package>
     <package name="perl" version="5.18.1">
         <install version="1.0">


### PR DESCRIPTION
as mentioned before, due to a newer nanosleep.c in coreutils this should fix hangs during the ./configure on ubuntu trusty systems.