### PR TITLE
advance to stacks 1.37 with iuc dependency

### DIFF
--- a/tools/stacks/tool_dependencies.xml
+++ b/tools/stacks/tool_dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool_dependency>
-  <package name="stacks" version="1.35">
-      <repository name="package_stacks_1_35" owner="cmonjeau"/>
+  <package name="stacks" version="1.37">
+      <repository name="package_stacks_1_37" owner="iuc"/>
     </package>
     <package name="bwa" version="0.7.7">
       <repository name="package_bwa_0_7_7" owner="iuc"/>


### PR DESCRIPTION
Stacks 1.37 with iuc dependency.

IMPORTANT NOTE: This will only work if stacks is made available via iuc