### PR TITLE
Remove bcftools from the test blacklist

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -1,6 +1,5 @@
 tools/art
 tools/bam_to_scidx
-tools/bcftools
 tools/bioperl
 tools/blastxml_to_gapped_gff3
 tools/bwtool

--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -12,6 +12,8 @@
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="1.3">bcftools</requirement>
+      <!-- conda dependency for tabix -->
+      <requirement type="package" version="1.3">htslib</requirement>
       <requirement type="package" version="0.2.6">tabix</requirement>
     </requirements>
   </xml>


### PR DESCRIPTION
@jj-umn this will activate automatic travis testing for bcftools. We just need to fix the requirements.