### PR TITLE
fixed - @INPUT_BAMS@ to @BAM_INPUTS@

### DIFF
--- a/tools/gatk2/haplotype_caller.xml
+++ b/tools/gatk2/haplotype_caller.xml
@@ -8,7 +8,7 @@
   <command interpreter="python">
     gatk2_wrapper.py
     --stdout "${output_log}"
-    @INPUT_BAMS@
+    @BAM_INPUTS@
     -p '
     @JAR_PATH@
     -T "HaplotypeCaller"


### PR DESCRIPTION
Probably a typo, this fixes the Haplotype reference to the BAM files specified in the Macros.