### PR TITLE
Jbrowse v0.5

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -358,7 +358,7 @@ class JbrowseConnector(object):
     def add_blastxml(self, data, trackData, blastOpts, **kwargs):
         gff3 = self._blastxml_to_gff3(data, min_gap=blastOpts['min_gap'])
 
-        if 'parent' in blastOpts:
+        if 'parent' in blastOpts and blastOpts['parent'] != 'None':
             gff3_rebased = tempfile.NamedTemporaryFile(delete=False)
             cmd = ['python', os.path.join(INSTALLED_TO, 'gff3_rebase.py')]
             if blastOpts.get('protein', 'false') == 'true':

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -458,12 +458,13 @@ class JbrowseConnector(object):
         self._add_track_json(trackData)
 
     def add_features(self, data, format, trackData, gffOpts, **kwargs):
+        import pprint; pprint.pprint(gffOpts)
         cmd = [
             'perl', self._jbrowse_bin('flatfile-to-json.pl'),
             self.TN_TABLE.get(format, 'gff'),
             data,
             '--trackLabel', trackData['label'],
-            '--trackType', 'JBrowse/View/Track/CanvasFeatures',
+            # '--trackType', 'JBrowse/View/Track/CanvasFeatures',
             '--key', trackData['key']
         ]
 
@@ -476,8 +477,16 @@ class JbrowseConnector(object):
             cmd += ['--type', gffOpts['match']]
 
         cmd += ['--clientConfig', json.dumps(clientConfig),
-                '--trackType', 'JBrowse/View/Track/CanvasFeatures'
                 ]
+
+        if 'trackType' in gffOpts:
+            cmd += [
+                '--trackType', gffOpts['trackType']
+            ]
+        else:
+            cmd += [
+                '--trackType', 'JBrowse/View/Track/CanvasFeatures'
+            ]
 
         cmd.extend(['--config', json.dumps(config)])
 

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -318,7 +318,8 @@ class JbrowseConnector(object):
 
         # Generate name
         self.subprocess_check_call([
-            'perl', self._jbrowse_bin('generate-names.pl')
+            'perl', self._jbrowse_bin('generate-names.pl'),
+            '--hashBits', '16'
         ])
 
     def _add_json(self, json_data):

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -550,13 +550,13 @@ class JbrowseConnector(object):
     def add_final_data(self, data):
         viz_data = {}
         if len(data['visibility']['default_on']) > 0:
-            viz_data['defaultTracks'] = data['visibility']['default_on']
+            viz_data['defaultTracks'] = ','.join(data['visibility']['default_on'])
 
         if len(data['visibility']['always']) > 0:
-            viz_data['alwaysOnTracks'] = data['visibility']['always']
+            viz_data['alwaysOnTracks'] = ','.join(data['visibility']['always'])
 
         if len(data['visibility']['force']) > 0:
-            viz_data['forceTracks'] = data['visibility']['force']
+            viz_data['forceTracks'] = ','.join(data['visibility']['force'])
 
         generalData = {}
         if data['general']['aboutDescription'] is not None:

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -150,7 +150,7 @@ class ColorScaling(object):
         return '#%02x%02x%02x' % (r, g, b)
 
     def _get_colours(self):
-        r, g, b = self.BREWER_COLOUR_SCHEMES[self.brewer_colour_idx]
+        r, g, b = self.BREWER_COLOUR_SCHEMES[self.brewer_colour_idx % len(self.BREWER_COLOUR_SCHEMES)]
         self.brewer_colour_idx += 1
         return r, g, b
 

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -458,7 +458,6 @@ class JbrowseConnector(object):
         self._add_track_json(trackData)
 
     def add_features(self, data, format, trackData, gffOpts, **kwargs):
-        import pprint; pprint.pprint(gffOpts)
         cmd = [
             'perl', self._jbrowse_bin('flatfile-to-json.pl'),
             self.TN_TABLE.get(format, 'gff'),

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -558,6 +558,21 @@ class JbrowseConnector(object):
         if len(data['visibility']['force']) > 0:
             viz_data['forceTracks'] = data['visibility']['force']
 
+        generalData = {}
+        if data['general']['aboutDescription'] is not None:
+            generalData['aboutThisBrowser'] = {'description': data['general']['aboutDescription'].strip()}
+
+        generalData['view'] = {
+            'trackPadding': data['general']['trackPadding']
+        }
+        generalData['shareLink'] = (data['general']['shareLink'] == 'true')
+        generalData['show_tracklist'] = (data['general']['show_tracklist'] == 'true')
+        generalData['show_nav'] = (data['general']['show_nav'] == 'true')
+        generalData['show_overview'] = (data['general']['show_overview'] == 'true')
+        generalData['show_menu'] = (data['general']['show_menu'] == 'true')
+        generalData['hideGenomeOptions'] = (data['general']['hideGenomeOptions'] == 'true')
+
+        viz_data.update(generalData)
         self._add_json(viz_data)
 
     def clone_jbrowse(self, jbrowse_dir, destination):
@@ -605,6 +620,17 @@ if __name__ == '__main__':
             'default_off': [],
             'force': [],
             'always': [],
+        },
+        'general': {
+            'defaultLocation': root.find('metadata/general/defaultLocation').text,
+            'trackPadding': int(root.find('metadata/general/trackPadding').text),
+            'shareLink': root.find('metadata/general/shareLink').text,
+            'aboutDescription': root.find('metadata/general/aboutDescription').text,
+            'show_tracklist': root.find('metadata/general/show_tracklist').text,
+            'show_nav': root.find('metadata/general/show_nav').text,
+            'show_overview': root.find('metadata/general/show_overview').text,
+            'show_menu': root.find('metadata/general/show_menu').text,
+            'hideGenomeOptions': root.find('metadata/general/hideGenomeOptions').text,
         }
     }
     for track in root.findall('tracks/track'):

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -206,11 +206,11 @@ class ColorScaling(object):
                     min_val = 0
                     max_val = 1000
                     # Get min/max and build a scoring function since JBrowse doesn't
-                    if scales['type'] == 'automatic':
+                    if scales['type'] == 'automatic' or scales['type'] == '__auto__':
                         min_val, max_val = self.min_max_gff(gff3)
                     else:
-                        min_val = scales['min']
-                        max_val = scales['max']
+                        min_val = scales.get('min', 0)
+                        max_val = scales.get('max', 1000)
 
                     if scheme['color'] == '__auto__':
                         user_color = 'undefined'
@@ -315,6 +315,11 @@ class JbrowseConnector(object):
             self.subprocess_check_call([
                 'perl', self._jbrowse_bin('prepare-refseqs.pl'),
                 '--fasta', genome_path])
+
+        # Generate name
+        self.subprocess_check_call([
+            'perl', self._jbrowse_bin('generate-names.pl')
+        ])
 
     def _add_json(self, json_data):
         if len(json_data.keys()) == 0:

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -80,7 +80,7 @@ $trackxml;
     <tracks>
         #for $tg in $track_groups:
         #for $track in $tg.data_tracks:
-        <track cat="${tg.category}" format="${track.data_format.data_format_select}">
+        <track cat="${tg.category}" format="${track.data_format.data_format_select}" visibility="${track.data_format.track_visibility}">
             <files>
               #for $dataset in $track.data_format.annotation:
               <trackFile path="${dataset}" ext="${dataset.ext}" label="${dataset.element_identifier}" />
@@ -292,9 +292,11 @@ $trackxml;
                 <expand macro="color_selection"
                         token_scaling_lin_select="false"
                         token_scaling_log_select="true" />
+                <expand macro="track_display" />
             </when>
             <when value="vcf">
                 <expand macro="input_conditional" label="SNP Track Data" format="vcf" />
+                <expand macro="track_display" />
             </when>
             <when value="gene_calls">
                 <expand macro="input_conditional" label="GFF/GFF3/BED Track Data" format="gff,gff3,bed" />
@@ -320,6 +322,7 @@ $trackxml;
                 </param>
                 <expand macro="track_styling" />
                 <expand macro="color_selection" />
+                <expand macro="track_display" />
             </when>
             <when value="pileup">
                 <expand macro="input_conditional" label="BAM Track Data" format="bam" />
@@ -329,6 +332,7 @@ $trackxml;
                        name="auto_snp"
                        truevalue="true"
                        falsevalue="false" />
+                <expand macro="track_display" />
             </when>
             <when value="wiggle">
                 <expand macro="input_conditional" label="BigWig Track Data" format="bigwig" />
@@ -362,11 +366,13 @@ $trackxml;
                     </when>
                 </conditional>
                 <expand macro="color_selection_minmax" />
+                <expand macro="track_display" />
             </when>
             <when value="sparql">
                 <param type="text" label="SPARQL Server URL" name="url" />
                 <param type="text" label="Track Label" name="key" value="SPARQL Genes" />
                 <param type="text" label="SPARQL Query" name="query" area="true" />
+                <expand macro="track_display" />
             </when>
         </conditional>
     </repeat>

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -20,7 +20,13 @@ $trackxml
 #if str($standalone) == "Complete":
     --standalone
 #end if
---outdir $output.files_path;
+
+#if $action.action_select == "create":
+    --outdir $output.files_path;
+#else:
+    ## TODO: test
+    cp -Rv $action.update_jbrowse.extra_files_path/. $output.files_path
+#fi
 
 #if str($standalone) == "Complete":
     mv $output.files_path/index.html $output;
@@ -216,6 +222,20 @@ $trackxml
       <option value="24">24. Pterobranchia Mitochondrial Code</option>
       <option value="25">25. Candidate Division SR1 and Gracilibacteria Code</option>
    </param>
+
+    <conditional name="action" label="Action">
+        <param type="select" label="JBrowse-in-Galaxy Action" name="action_select">
+            <option value="create">New JBrowse Instance</option>
+            <option value="update">Update exising JBrowse Instance</option>
+        </param>
+        <when value="create" />
+        <when value="update">
+            <param label="Previous JBrowse Instance"
+                   name="update_jbrowse"
+                   type="data"
+                   format="html" />
+        </when>
+    </conditional>
 
     <repeat name="track_groups" title="Track Group">
         <param label="Track Category"

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -7,26 +7,27 @@
   <expand macro="stdio"/>
   <version_command>python jbrowse.py --version</version_command>
   <command><![CDATA[
-mkdir -p $output.files_path &&
+
+#if $action.action_select == "create":
+    mkdir -p $output.files_path;
+#else:
+    cp -R $action.update_jbrowse.extra_files_path $output.files_path;
+#end if
+
 ## Copy the XML file into the directory, mostly for debugging
 ## but nice if users want to reproduce locally
 cp $trackxml $output.files_path/galaxy.xml &&
 
 ## Once that's done, we run the python script to handle the real work
 python $__tool_directory__/jbrowse.py
-$trackxml
 
 --jbrowse \${JBROWSE_SOURCE_DIR}
 #if str($standalone) == "Complete":
     --standalone
 #end if
 
-#if $action.action_select == "create":
-    --outdir $output.files_path;
-#else:
-    ## TODO: test
-    cp -Rv $action.update_jbrowse.extra_files_path/. $output.files_path
-#fi
+--outdir $output.files_path
+$trackxml;
 
 #if str($standalone) == "Complete":
     mv $output.files_path/index.html $output;

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -180,6 +180,7 @@ $trackxml
                 </blast>
             #else if str($track.data_format.data_format_select) == "gene_calls":
                 <gff>
+                    <trackType>${track.data_format.track_class}</trackType>
                   #if $track.data_format.match_part.match_part_select:
                     <match>${track.data_format.match_part.name}</match>
                   #end if
@@ -312,6 +313,10 @@ $trackxml
                     </when>
                     <when value="false" />
                 </conditional>
+                <param type="select" label="JBrowse Track Type [Advanced]" name="track_class">
+                  <option value="JBrowse/View/Track/HTMLFeatures">HTML Features</option>
+                  <option value="JBrowse/View/Track/CanvasFeatures" selected="true">Canvas Features</option>
+                </param>
                 <expand macro="track_styling" />
                 <expand macro="color_selection" />
             </when>

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -184,6 +184,13 @@ $trackxml
                     <match>${track.data_format.match_part.name}</match>
                   #end if
                 </gff>
+            #else if str($track.data_format.data_format_select) == "sparql":
+                <sparql>
+                    <url>${track.data_format.url}</url>
+                    <label>${track.data_format.label}</label>
+                    <!-- This is going to be an absolutey nightmare -->
+                    <query>${track.data_format.query}</query>
+                </sparql>
             #end if
             </options>
         </track>
@@ -251,6 +258,7 @@ $trackxml
                 <option value="blast">Blast XML</option>
                 <option value="wiggle">BigWig XY</option>
                 <option value="vcf">VCF SNPs</option>
+                <option value="sparql">SPARQL</option>
             </param>
             <when value="blast">
                 <expand macro="input_conditional" label="BlastXML Track Data" format="blastxml" />
@@ -348,6 +356,11 @@ $trackxml
                     </when>
                 </conditional>
                 <expand macro="color_selection_minmax" />
+            </when>
+            <when value="sparql">
+                <param type="text" label="SPARQL Server URL" name="url" />
+                <param type="text" label="Track Label" name="key" value="SPARQL Genes" />
+                <param type="text" label="SPARQL Query" name="query" area="true" />
             </when>
         </conditional>
     </repeat>

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -76,6 +76,18 @@ $trackxml;
                 <genome>$genome</genome>
             #end for
         </genomes>
+        <general>
+            <defaultLocation>${jbgen.defaultLocation}</defaultLocation>
+            <trackPadding>${jbgen.trackPadding}</trackPadding>
+
+            <shareLink>${jbgen.shareLink}</shareLink>
+            <aboutDescription>${jbgen.aboutDescription}</aboutDescription>
+            <show_tracklist>${jbgen.show_tracklist}</show_tracklist>
+            <show_nav>${jbgen.show_nav}</show_nav>
+            <show_overview>${jbgen.show_overview}</show_overview>
+            <show_menu>${jbgen.show_menu}</show_menu>
+            <hideGenomeOptions>${jbgen.hideGenomeOptions}</hideGenomeOptions>
+        </general>
     </metadata>
     <tracks>
         #for $tg in $track_groups:
@@ -378,6 +390,7 @@ $trackxml;
     </repeat>
     </repeat>
 
+    <expand macro="general_options" />
     <param type="hidden" name="uglyTestingHack" value="" />
   </inputs>
   <outputs>

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -198,14 +198,14 @@ $trackxml;
                     <match>${track.data_format.match_part.name}</match>
                   #end if
                 </gff>
-            #else if str($track.data_format.data_format_select) == "sparql":
-                <sparql>
-                    <url>${track.data_format.url}</url>
-                    <label>${track.data_format.label}</label>
-                    <!-- This is going to be an absolutey nightmare -->
-                    <query>${track.data_format.query}</query>
-                </sparql>
-            #end if
+##            #else if str($track.data_format.data_format_select) == "sparql":
+##                <sparql>
+##                    <url>${track.data_format.url}</url>
+##                    <label>${track.data_format.label}</label>
+##                    <!-- This is going to be an absolutey nightmare -->
+##                    <query>${track.data_format.query}</query>
+##                </sparql>
+##            #end if
             </options>
         </track>
         #end for
@@ -272,7 +272,7 @@ $trackxml;
                 <option value="blast">Blast XML</option>
                 <option value="wiggle">BigWig XY</option>
                 <option value="vcf">VCF SNPs</option>
-                <option value="sparql">SPARQL</option>
+                <!--<option value="sparql">SPARQL</option>-->
             </param>
             <when value="blast">
                 <expand macro="input_conditional" label="BlastXML Track Data" format="blastxml" />
@@ -380,12 +380,14 @@ $trackxml;
                 <expand macro="color_selection_minmax" />
                 <expand macro="track_display" />
             </when>
+            <!--
             <when value="sparql">
                 <param type="text" label="SPARQL Server URL" name="url" />
                 <param type="text" label="Track Label" name="key" value="SPARQL Genes" />
                 <param type="text" label="SPARQL Query" name="query" area="true" />
                 <expand macro="track_display" />
             </when>
+            -->
         </conditional>
     </repeat>
     </repeat>

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -1,4 +1,4 @@
-<tool id="jbrowse" name="JBrowse" version="0.4">
+<tool id="jbrowse" name="JBrowse" version="0.5">
   <description>genome browser</description>
   <macros>
     <import>macros.xml</import>
@@ -205,7 +205,7 @@ $trackxml;
 ##                    <!-- This is going to be an absolutey nightmare -->
 ##                    <query>${track.data_format.query}</query>
 ##                </sparql>
-##            #end if
+            #end if
             </options>
         </track>
         #end for

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -119,7 +119,7 @@ This Galaxy tool relies on the JBrowse, maintained by the GMOD Community. The Ga
       <param label="Show Overview"   name="show_overview"  type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the overview bar"/>
       <param label="Show Menu"       name="show_menu"      type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the menu bar"/>
 
-      <param label="Show Genome Options" name="hideGenomeOptions" type="boolean" checked="True" truevalue="true" falsevalue="false" help="Show options for opening a sequence file"/>
+      <param label="Hide Genome Options" name="hideGenomeOptions" type="boolean" truevalue="true" falsevalue="false" help="Hide options for opening a sequence file"/>
     </section>
   </xml>
   <xml name="color_selection_minmax">

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -111,13 +111,13 @@ This Galaxy tool relies on the JBrowse, maintained by the GMOD Community. The Ga
       <param label="Default Location" type="text" name="defaultLocation" value="" help="Initial location to be shown for users who have never visited the browser before. Example: 'ctgA:1234..5678'"/>
       <param label="Track Padding" type="integer" value="20" name="trackPadding" help="Spacing between tracks in the genome view, in pixels." />
 
-      <param label="Enable Share Link" name="shareLink" type="boolean" checked="True" truevalue="true" falsevalue="false" />
+      <param label="Enable Share Link" name="shareLink" type="boolean" checked="true" truevalue="true" falsevalue="false" />
       <param label="About the Browser" type="text" name="aboutDescription" value="" help="Description of the browser to be used in the 'About' popup" />
 
-      <param label="Show Track List" name="show_tracklist" type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the track list"/>
-      <param label="Show Navigation" name="show_nav"       type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the navigation menu"/>
-      <param label="Show Overview"   name="show_overview"  type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the overview bar"/>
-      <param label="Show Menu"       name="show_menu"      type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the menu bar"/>
+      <param label="Show Track List" name="show_tracklist" type="boolean" checked="true" truevalue="true" falsevalue="false" help="Optionally hide the track list"/>
+      <param label="Show Navigation" name="show_nav"       type="boolean" checked="true" truevalue="true" falsevalue="false" help="Optionally hide the navigation menu"/>
+      <param label="Show Overview"   name="show_overview"  type="boolean" checked="true" truevalue="true" falsevalue="false" help="Optionally hide the overview bar"/>
+      <param label="Show Menu"       name="show_menu"      type="boolean" checked="true" truevalue="true" falsevalue="false" help="Optionally hide the menu bar"/>
 
       <param label="Hide Genome Options" name="hideGenomeOptions" type="boolean" truevalue="true" falsevalue="false" help="Hide options for opening a sequence file"/>
     </section>

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -106,6 +106,22 @@ This Galaxy tool relies on the JBrowse, maintained by the GMOD Community. The Ga
         <option value="Spectral">Spectral</option>
     </param>
   </xml>
+  <xml name="general_options">
+    <section name="jbgen" title="General JBrowse Options [Advanced]" expanded="false">
+      <param label="Default Location" type="text" name="defaultLocation" value="" help="Initial location to be shown for users who have never visited the browser before. Example: 'ctgA:1234..5678'"/>
+      <param label="Track Padding" type="integer" value="20" name="trackPadding" help="Spacing between tracks in the genome view, in pixels." />
+
+      <param label="Enable Share Link" name="shareLink" type="boolean" checked="True" truevalue="true" falsevalue="false" />
+      <param label="About the Browser" type="text" name="aboutDescription" value="" help="Description of the browser to be used in the 'About' popup" />
+
+      <param label="Show Track List" name="show_tracklist" type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the track list"/>
+      <param label="Show Navigation" name="show_nav"       type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the navigation menu"/>
+      <param label="Show Overview"   name="show_overview"  type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the overview bar"/>
+      <param label="Show Menu"       name="show_menu"      type="boolean" checked="True" truevalue="true" falsevalue="false" help="Optionally hide the menu bar"/>
+
+      <param label="Show Genome Options" name="hideGenomeOptions" type="boolean" checked="True" truevalue="true" falsevalue="false" help="Show options for opening a sequence file"/>
+    </section>
+  </xml>
   <xml name="color_selection_minmax">
     <section name="jbcolor" title="JBrowse Color Options [Advanced]" expanded="false">
       <!-- Abuse auto/manual for bicolor pivot. Means we'll have to handle the

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -48,6 +48,15 @@ This Galaxy tool relies on the JBrowse, maintained by the GMOD Community. The Ga
     </conditional>
   </xml>
 
+  <xml name="track_display">
+    <param type="select" label="Track Visibility" name="track_visibility">
+      <option value="default_off">Off for new users</option>
+      <option value="default_on">On for new users</option>
+      <option value="force">Force On</option>
+      <option value="always">Always On (ignores URL parameters)</option>
+    </param>
+  </xml>
+
   <xml name="jb_color"
       token_label="JBrowse style.color"
       token_name="style_color"

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -23,6 +23,7 @@
                     <height>100px</height>
                 </style>
                 <gff>
+                  <trackType>JBrowse/View/Track/HTMLFeatures</trackType>
                 </gff>
                 <scaling>
                     <method>ignore</method>

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -7,7 +7,7 @@
         </genomes>
     </metadata>
     <tracks>
-        <track cat="Auto Coloured" format="gene_calls">
+        <track cat="Auto Coloured" format="gene_calls" visibility="default_on">
             <files>
                 <trackFile path="test-data/gff3/1.gff" ext="gff3" label="A"/>
                 <trackFile path="test-data/gff3/1.gff" ext="gff3" label="B"/>

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -23,7 +23,6 @@
                     <height>100px</height>
                 </style>
                 <gff>
-                  <trackType>JBrowse/View/Track/HTMLFeatures</trackType>
                 </gff>
                 <scaling>
                     <method>ignore</method>

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -5,6 +5,17 @@
         <genomes>
             <genome>test-data/merlin.fa</genome>
         </genomes>
+        <general>
+            <defaultLocation></defaultLocation>
+            <trackPadding>40</trackPadding>
+            <shareLink>true</shareLink>
+            <aboutDescription></aboutDescription>
+            <show_tracklist>true</show_tracklist>
+            <show_nav>true</show_nav>
+            <show_overview>false</show_overview>
+            <show_menu>true</show_menu>
+            <hideGenomeOptions>false</hideGenomeOptions>
+        </general>
     </metadata>
     <tracks>
         <track cat="Auto Coloured" format="gene_calls" visibility="default_on">


### PR DESCRIPTION
This represents the v0.5 release of JBrowse-in-Galaxy. 

- The roadmap can be seen in #508, the features/issues for this version are copied from there.
- The branch should not be deleted post-merge, I'm continuing development on it.
- Review is welcome but this is a small release. I'm PRing it as that's our practice.
- SPARQL support has been moved back to the next release, so that code is commented out.

## Features

- [x] update existing jbrowse instances on disk (adding new tracks, also support pulling info from apollo) f4206bc58448bb39e5fae31942477c45642a9fca
- [x] generate-names.pl http://gmod.org/wiki/JBrowse_Configuration_Guide#Name_Searching_and_Autocompletion
- [x]  Allow forcing HTML rather than canvas ef1646fc375513143fd743841ac618720267dbc9
- [x] defaultTracks e6ef382e885381ab1606e44f397477014434aa82
- [x]  http://gmod.org/wiki/JBrowse_Configuration_Guide#General_configuration_options acb5b6696880d517bf76b790e70496b714dd46c3, f93e44ee9cc01d2f83ccbfe7151b408c12d4b333

## Bugfixes

- [x] >12 sequences would exceed brewer colour limit and crash. Now cycles back to start. https://github.com/galaxyproject/tools-iuc/commit/3dadcef329a8881837293e354b21880a6ecd3ca9
- [x] Incorrect XML could be generated, causing a crash for automatically coloured, automatically scored bigwig tracks 2fd44398452799138fa5c95fa78996814c72d386
- [x] BlastXML tracks without a gff3 feature parent would crash. 4be3385

## Screenshots

You can now update existing instances with new tracks. This is a useful feature as it will allow you to curate JBrowses over the course of a workflow, rather than having to create a single *gigantic* instance at the end.
 
![utvalg_649](https://cloud.githubusercontent.com/assets/458683/13991232/46c168ca-f10f-11e5-934e-e50d37adeb2b.png)

You are now allowed to select between Canvas and HTML features. This is not likely to be a well used feature for the time being, but there are some odd cases where we've needed HTML features so I'm supporting it as an option. (Specifically there are TMD regions we have tracks for which include some gff that shows the different regions. We have CSS to colour those regions appropriately so it's clear to end users that there's a TMD here.)

![utvalg_650](https://cloud.githubusercontent.com/assets/458683/13991233/46c2ff50-f10f-11e5-93dc-76efe03b3e9b.png)