### PR TITLE
Fix bioperl version in bp_genbank2gff3

### DIFF
--- a/tools/bioperl/macros.xml
+++ b/tools/bioperl/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="1.6">bioperl</requirement>
+            <requirement type="package" version="1.6.922">bioperl</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/bioperl/tool_dependencies.xml
+++ b/tools/bioperl/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="bioperl" version="1.6">
+    <package name="bioperl" version="1.6.922">
         <repository name="package_bioperl_1_6" owner="iuc" />
     </package>
 </tool_dependency>


### PR DESCRIPTION
bp_genbank2gff3 required bioperl 1.6, but the package_bioperl_1_6
actually provides version 1.6.922.