### PR TITLE
Add package_python_2_7_10_twobitreader_3_1_4

### DIFF
--- a/packages/package_python_2_7_10_twobitreader_3_1_4/.shed.yml
+++ b/packages/package_python_2_7_10_twobitreader_3_1_4/.shed.yml
@@ -1,0 +1,9 @@
+name: package_python_2_7_10_twobitreader_3_1_4
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and installs version 3.1.4 of twobitreader
+long_description: |
+  A fast python package for reading .2bit files (used by the UCSC genome browser)
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_python_2_7_10_twobitreader_3_1_4
+type: tool_dependency_definition

--- a/packages/package_python_2_7_10_twobitreader_3_1_4/tool_dependencies.xml
+++ b/packages/package_python_2_7_10_twobitreader_3_1_4/tool_dependencies.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="twobitreader" version="3.1.4">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <package md5sum="1672e7e515d057a93cc2dd6c8d487458">https://pypi.python.org/packages/4c/95/133326b21354b8592d1b6be6d594a17cebf1070325222075df2630d77da4/twobitreader-3.1.4.tar.gz</package>
+                </action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>Installs twobitreader, which is a fast python package for reading .2bit files.</readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
This will be used by the next version of deepTools. It's also an alternative to bx-python for anything that needs to handle .2bit files and work with both python2 and python3.