### PR TITLE
Trinity: fix dependency url

### DIFF
--- a/packages/package_trinity_2_1_1/tool_dependencies.xml
+++ b/packages/package_trinity_2_1_1/tool_dependencies.xml
@@ -110,7 +110,7 @@
                         https://depot.galaxyproject.org/software/ctc/ctc_1.44.0_src_all.tar.gz
                     </package>
                     <package sha256sum="f16b6316fdbd7ab0077644d41a3286a688b0b75cc34686383e10f139f0955ae1">
-                        https://depot.galaxyproject.org/software/biobase/biobase_2.30.0_src_all.tar.gz
+                        https://depot.galaxyproject.org/software/Biobase/Biobase_2.30.0_src_all.tar.gz
                     </package>
                 </action>
 


### PR DESCRIPTION
I thought everything was ok with trinity, but it turns out an url is wrong in tool_dependency.xml (my prod galaxy is not yet using conda)