### PR TITLE
Trinity: add missing dep for Biobase

### DIFF
--- a/packages/package_trinity_2_1_1/tool_dependencies.xml
+++ b/packages/package_trinity_2_1_1/tool_dependencies.xml
@@ -109,6 +109,9 @@
                     <package sha256sum="0f67391d3fd6bc970293b5eb11dcd14f15686b61bce1c6da03e16dc3a60e93f2">
                         https://depot.galaxyproject.org/software/ctc/ctc_1.44.0_src_all.tar.gz
                     </package>
+                    <package sha256sum="d16ad5910aee6247990a19745511a5d50e19fa8c236000cbf99395e06c73c9f8">
+                        https://depot.galaxyproject.org/software/BiocGenerics/BiocGenerics_0.14.0_src_all.tar.gz
+                    </package>
                     <package sha256sum="f16b6316fdbd7ab0077644d41a3286a688b0b75cc34686383e10f139f0955ae1">
                         https://depot.galaxyproject.org/software/Biobase/Biobase_2.30.0_src_all.tar.gz
                     </package>


### PR DESCRIPTION
Hum, another dependency problem with trinity. Sorry about that