### PR TITLE
package_numpy_1_9 update to explicitly specify ATLAS libs from toolshed

### DIFF
--- a/packages/package_numpy_1_9/tool_dependencies.xml
+++ b/packages/package_numpy_1_9/tool_dependencies.xml
@@ -9,7 +9,7 @@
         <package name="numpy" version="1.9">
             <install version="1.0">
                 <actions>
-                    <action type="download_by_url" sha256sum="2745b1d64445da3c29a34450320025c11897ae4af77475f861966e98b2cb1a0f">https://pypi.python.org/packages/source/n/numpy/numpy-1.9.0.tar.gz</action>
+                    <action type="download_by_url" sha256sum="9753003ab7c489968eb260e5460556fd7d533a8e11a9d5326e0995bd1aa21318">https://depot.galaxyproject.org/software/numpy/numpy_1.9p1_src_all.tar.gz</action>
                     <action type="make_directory">$INSTALL_DIR/lib/python</action>
                     <action type="set_environment_for_install">
                         <repository name="package_atlas_3_10" owner="iuc">


### PR DESCRIPTION
tl;dr:

This PR attempts to fix an issue with `package_numpy_1_9` and its dependency on `package_atlas_3_10`; essentially the former fails to use the ATLAS libraries provided by the latter when building `numpy`.

More details:

In cases where there is a pre-existing set of ATLAS libraries on the system, `package_numpy_1_9`  will compile against these and not the ones provided by `package_atlas_3_10`; this causes installation failures subsequently for other packages that depend on `package_numpy_1_9`. (This is what we're observing on our test server running Scientific Linux, when attempting to install e.g. `package_biopython_1_66`).

In cases where the system ATLAS is not picked up or doesn't exist, the installation failures may not be observed; however the toolshed ATLAS libs are not picked up either.

Essentially this is the same problem as that for `package_python_2_7_numpy_1_9` in PR #547; the fix implemented here is the same i.e. use the patched version of the `numpy` code from the Galaxy depot which explicitly includes the toolshed ATLAS.