### PR TITLE
Trinity: fix wrong sha256sum

### DIFF
--- a/packages/package_deseq2_1_10_0/tool_dependencies.xml
+++ b/packages/package_deseq2_1_10_0/tool_dependencies.xml
@@ -17,7 +17,7 @@
                     <repository name="package_libxml2_2_9_1" owner="iuc">
                         <package name="libxml2" version="2.9.1" />
                     </repository>
-                    <package sha256sum="d16ad5910aee6247990a19745511a5d50e19fa8c236000cbf99395e06c73c9f8">
+                    <package sha256sum="5e55e0f5c6577935d169f62268dc05a168a2f607b652d44a919cb16caca7952e">
                         https://depot.galaxyproject.org/software/BiocGenerics/BiocGenerics_0.14.0_src_all.tar.gz
                     </package>
                     <package sha256sum="25f82ea9278cfc93b8dadb70fe3b6d114719ea4247c28178d699fde8cacd68f0">

--- a/packages/package_trinity_2_1_1/tool_dependencies.xml
+++ b/packages/package_trinity_2_1_1/tool_dependencies.xml
@@ -109,7 +109,7 @@
                     <package sha256sum="0f67391d3fd6bc970293b5eb11dcd14f15686b61bce1c6da03e16dc3a60e93f2">
                         https://depot.galaxyproject.org/software/ctc/ctc_1.44.0_src_all.tar.gz
                     </package>
-                    <package sha256sum="d16ad5910aee6247990a19745511a5d50e19fa8c236000cbf99395e06c73c9f8">
+                    <package sha256sum="5e55e0f5c6577935d169f62268dc05a168a2f607b652d44a919cb16caca7952e">
                         https://depot.galaxyproject.org/software/BiocGenerics/BiocGenerics_0.14.0_src_all.tar.gz
                     </package>
                     <package sha256sum="f16b6316fdbd7ab0077644d41a3286a688b0b75cc34686383e10f139f0955ae1">


### PR DESCRIPTION
Ok, I should have checked the sha256sum before committing instead of just pasting it from package_deseq2_1_10_0 (I fixed it there too just in case)