### PR TITLE
package_python_2_7_pandas_0_16 needs to explicitly pull in Python 'six' module

### DIFF
--- a/packages/package_python_2_7_pandas_0_16/tool_dependencies.xml
+++ b/packages/package_python_2_7_pandas_0_16/tool_dependencies.xml
@@ -23,6 +23,7 @@
                     <package sha256sum="99266ef30a37e43932deec2b7ca73e83c8dbc3b9ff703ec73eca6b1dae6befea">
                         https://pypi.python.org/packages/source/p/pytz/pytz-2015.7.tar.gz
                     </package>
+                    <package sha256sum="105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a">https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz</package>
                     <package sha256sum="3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d">
                         https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.2.tar.gz
                     </package>


### PR DESCRIPTION
This PR explicitly pulls in `six` Python package, which is an implicit dependency of `pandas` as it's required by the `python-dateutils` package (see [this StackOverflow post](http://stackoverflow.com/a/21222511/579925), which refers to `matplotlib` not `pandas` but appears to be the same problem).

Without this patch I get the following error when running a tool that imports `pandas`:

    Fatal error: Exit code 1 ()
    Traceback (most recent call last):
      File "/XXXXXX/filter_summary_stats.py", line 5, in <module>
        import pandas as pd
      File "/XXXXXX/tool_dependencies/pandas/0.16/iuc/package_python_2_7_pandas_0_16/99747a5bdac1/lib/python/pandas/__init__.py", line 13, in <module>
        "extensions first.".format(module))
    ImportError: C extension: No module named six not built. If you want to import pandas from the source directory, you may need to run 'python setup.py build_ext --inplace' to build the C extensions first.