### PR TITLE
package_r_3_2_1 should 'prepend_to' R_LIBS to avoid clobbering existing value

### DIFF
--- a/packages/package_r_3_2_1/tool_dependencies.xml
+++ b/packages/package_r_3_2_1/tool_dependencies.xml
@@ -93,7 +93,7 @@
                     <environment_variable action="set_to" name="R_ROOT_DIR">$INSTALL_DIR</environment_variable>
                     <environment_variable action="set_to" name="R_HOME">$INSTALL_DIR/lib/R</environment_variable>
                     <environment_variable action="set_to" name="RHOME">$INSTALL_DIR/lib/R</environment_variable>
-                    <environment_variable action="set_to" name="R_LIBS">$INSTALL_DIR/lib/R/library</environment_variable>
+                    <environment_variable action="prepend_to" name="R_LIBS">$INSTALL_DIR/lib/R/library</environment_variable>
                     <environment_variable action="prepend_to" name="PKG_CONFIG_DIR">$INSTALL_DIR/lib/pkgconfig:$INSTALL_DIR/share/pkgconfig</environment_variable>
                     <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig:$INSTALL_DIR/share/pkgconfig</environment_variable>
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>


### PR DESCRIPTION
**tl;dr**

This PR tries to fix the setting of the `R_LIBS` env variable when requiring R 3.2.1 from `package_r_3_2_1` so that any previously included R libraries are still available. As it stands, the use of `set_to` on the `R_LIBS` environment variable clobbers any existing value; the proposed fix is to use `prepend_to` so the existing value is extended instead.

**More details:**

I'm working on a tool which uses R 3.2.1 plus a set of R libraries; these are defined in the `tool_dependencies.xml` file using the `setup_r_environment` action (https://wiki.galaxyproject.org/SetUpREnvironment), e.g.

    <package name="dplyr" version="0.4.3">
      ...
      <actions>
        <action type="setup_r_environment">
          <repository name="package_r_3_2_1" owner="iuc">
            <package name="R" version="3.2.1" />
          </repository>
          <package>https://cran.r-project.org/src/contrib/assertthat_0.1.tar.gz</package>
          ...more R dependencies...
          <package>https://cran.r-project.org/src/contrib/dplyr_0.4.3.tar.gz</package>
        </action>
      </actions>
      ...
    </package>

and then declared as requirements in `TOOL.xml` e.g.

    <requirement type="package" version="3.2.1">R</requirement>
    <requirement type="package" version="0.4.3">dplyr</requirement>
    <requirement type="package" version="2.3-1">coloc</requirement>
    ...

At run time the `env.sh` file for each R package sources the R 3.2.1 `env.sh` and then prepends the installation dir for the package to `R_LIBS`.

**However: as the R 3.2.1 `env.sh` effectively resets the value of `R_LIBS` each time, only the last package in the list of requirements ends up being included on the path.**

Changing R 3.2.1 to prepend rather than set the value of `R_LIBS` seems like the simplest solution.