### PR TITLE
Fix deps for deseq2 1.10.0

### DIFF
--- a/packages/package_deseq2_1_10_0/tool_dependencies.xml
+++ b/packages/package_deseq2_1_10_0/tool_dependencies.xml
@@ -17,14 +17,14 @@
                     <repository name="package_libxml2_2_9_1" owner="iuc">
                         <package name="libxml2" version="2.9.1" />
                     </repository>
-                    <package sha256sum="d16ad5910aee6247990a19745511a5d50e19fa8c236000cbf99395e06c73c9f8">
-                        https://depot.galaxyproject.org/software/BiocGenerics/BiocGenerics_0.14.0_src_all.tar.gz
+                    <package sha256sum="cb08191d70197c32d87441e22e393ea225b1706acf6b7f7e578691548e307154">
+                        https://bioarchive.galaxyproject.org/BiocGenerics_0.17.1.tar.gz
                     </package>
-                    <package sha256sum="25f82ea9278cfc93b8dadb70fe3b6d114719ea4247c28178d699fde8cacd68f0">
-                        https://depot.galaxyproject.org/software/S4Vectors/S4Vectors_0.6.5_src_all.tar.gz
+                    <package sha256sum="5d5e6e08130a262d047dc3ceba23a94b3b3954c5fc64968d65dfb1c96ba12c52">
+                        https://bioarchive.galaxyproject.org/S4Vectors_0.9.0.tar.gz
                     </package>
-                    <package sha256sum="0609e1887e17ab75f8fcabb40e7c5995a4033c2c6e764e73bda8d35350561861">
-                        https://depot.galaxyproject.org/software/IRanges/IRanges_2.2.7_src_all.tar.gz
+                    <package sha256sum="9fa61ea40074a98ee04fa6739f12ae6b56cfc87cc7ddae5be8ae68f1d3bfbbe9">
+                        https://bioarchive.galaxyproject.org/IRanges_2.5.0.tar.gz
                     </package>
                     <package sha256sum="3d4ff22c6a11192ee1e313042ff0da4703b18c72f2247be73a0590769328d05a">
                         https://depot.galaxyproject.org/software/GenomeInfoDb/GenomeInfoDb_1.4.2_src_all.tar.gz
@@ -32,8 +32,8 @@
                     <package sha256sum="64ca661349d7e25d8f2363901fa452b55d05780913025a5856a7b635166c1925">
                         https://depot.galaxyproject.org/software/XVector/XVector_0.8.0_src_all.tar.gz
                     </package>
-                    <package sha256sum="9d2bedd17a73864406d0284ddea2d28aef84c7c969b6924d8be2285d96f14e13">
-                        https://depot.galaxyproject.org/software/GenomicRanges/GenomicRanges_1.20.6_src_all.tar.gz
+                    <package sha256sum="7248c1113d799a2c37f73d0913e714ea443301bd95be664a1b799910145706c1">
+                        https://bioarchive.galaxyproject.org/GenomicRanges_1.23.0.tar.gz
                     </package>
                     <package sha256sum="68782050f5252c4246f1b5b335105eccf4c804d57a0cd41eb63a300f7e0241a0">
                         https://depot.galaxyproject.org/software/Rcpp/Rcpp_0.12.0_src_all.tar.gz
@@ -166,6 +166,9 @@
                     </package>
                     <package sha256sum="4edc3903da63e25d747f34c33abf3e4e9a1f250580bbbab39fb192469738a30d">
                         https://depot.galaxyproject.org/software/Hmisc/Hmisc_3.16-0_src_all.tar.gz
+                    </package>
+                    <package sha256sum="f60768da6c17e367510df1183753376ba0dd5d838ffe741c4cd6df4c17bd2ea0">
+                        https://bioarchive.galaxyproject.org/SummarizedExperiment_0.2.0.tar.gz
                     </package>
                     <package sha256sum="9a823489b05f043ed6831d2045efbbaaec74aa61c0692f77893e59b7c7f3941f">
                         https://bioarchive.galaxyproject.org/DESeq2_1.10.0.tar.gz


### PR DESCRIPTION
Here's a fix for a missing package for deseq2 1.10.0 installation (and I consequently had to update other packages)