### PR TITLE
Fix deseq2 1.10 broken dependency

### DIFF
--- a/packages/package_deseq2_1_10_0/tool_dependencies.xml
+++ b/packages/package_deseq2_1_10_0/tool_dependencies.xml
@@ -29,8 +29,11 @@
                     <package sha256sum="3d4ff22c6a11192ee1e313042ff0da4703b18c72f2247be73a0590769328d05a">
                         https://depot.galaxyproject.org/software/GenomeInfoDb/GenomeInfoDb_1.4.2_src_all.tar.gz
                     </package>
-                    <package sha256sum="64ca661349d7e25d8f2363901fa452b55d05780913025a5856a7b635166c1925">
-                        https://depot.galaxyproject.org/software/XVector/XVector_0.8.0_src_all.tar.gz
+                    <package sha256sum="a63298f7a2527204fe6014e1d68e54de6bc9738c94f2b51721a05fb6f2db7311">
+                        https://bioarchive.galaxyproject.org/zlibbioc_1.16.0.tar.gz
+                    </package>
+                    <package sha256sum="2d5ff65783d152a69825cb6f7dc37ad483e5186d60830f2254f20c0eaf282c7e">
+                        https://bioarchive.galaxyproject.org/XVector_0.10.0.tar.gz
                     </package>
                     <package sha256sum="7248c1113d799a2c37f73d0913e714ea443301bd95be664a1b799910145706c1">
                         https://bioarchive.galaxyproject.org/GenomicRanges_1.23.0.tar.gz


### PR DESCRIPTION
Another (last?) PR to fix a compilation error for a deseq2 1.10.0 dependency.
I switched to the same versions as in bioconda for the problematic packages