### PR TITLE
Allow fastq/fasta and sam/bam wrapper for bulk SRA download

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -22,7 +22,6 @@ tools/raxml
 tools/rglasso
 tools/rgrnastar
 tools/seqtk
-tools/sra-tools
 tools/taxonomy
 tools/taxonomy_krona_chart
 tools/tool_factory_2

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_dump" name="Extract reads" version="1.2.5">
+<tool id="fastq_dump" name="Extract reads" version="1.3.0">
     <description>in FASTQ/A format from NCBI SRA.</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -10,6 +10,18 @@
     <version_command>fastq-dump --version</version_command>
     <command>
         <![CDATA[
+
+    #if $input.input_select=="file_list":
+      for acc in `cat $input.file_list` ;
+      do
+    #elif $input.input_select=="accession_number":
+      acc="$input.accession" &&
+    #end if
+
+    #if $input.input_select=="file_list" or $input.input_select=="accession_number":
+          [ ""\$acc" =~ ^[E|S|D]RR[0-9]{1,}$" ] && (
+    #end if
+    
     ## Need to set the home directory to the current working directory,
     ## else the tool tries to write to home/.ncbi and fails when used 
     ## with a cluster manager. 
@@ -24,15 +36,16 @@
         #if ( str( $adv.region ) == "" ) and ( str( $adv.minID ) == "" ) and ( str( $adv.maxID ) == "" ):
             ASCP_PATH=`command -v ascp` &&
             ASCP_KEY=`dirname \$ASCP_PATH`/asperaweb_id_dsa.openssh || true &&
-            prefetch --ascp-path "\$ASCP_PATH|\$ASCP_KEY" $input.accession &&
+            prefetch --ascp-path "\$ASCP_PATH|\$ASCP_KEY" "\$acc" &&
             ## Duplicate vdb-config, in case settings changed between prefetch and
             ## dump command.
             vdb-config -s "/repository/user/main/public/root=\$PWD" &&
-            #end if
-        fastq-dump --accession "$input.accession"
+        #end if
+        fastq-dump --accession "\$acc"
+        --split-files
     #end if
     --defline-seq '@\$sn[_\$rn]/\$ri'
-    --stdout
+
     $adv.split
     #if str( $adv.alignments ) == "aligned":
         --aligned
@@ -63,14 +76,45 @@
     #end if
     $adv.clip
     $adv.skip_technical
+    
     #if str( $outputformat ) == "fasta":
         --fasta
     #end if
     #if $input.input_select=="file":
+        --stdout
         "$input.file" > "$output_file"
+    #elif $input.input_select=="file_list":
+        "\$acc"
     #else:
-        "$input.accession" > "$output_accession"
+         --stdout
+        "\$acc" > "$output_accession" )
     #end if
+
+    #if $input.input_select=="file_list":
+    ) ; done
+
+    ;
+
+
+    #if str( $outputformat ) == "fasta":
+    
+        for f in *_2.fasta ; do   mv "\$f" "`basename \$f _2.fasta`_reverse.fasta" ;  mv "`basename \$f _2.fasta`_1.fasta" "`basename \$f _2.fasta`_forward.fasta"  ; done &&
+        for f in *_1.fasta; do mv "\$f" "`basename \$f _1.fasta`__single.fasta"; done
+        
+    #else:
+
+        for f in *_2.fastq ; do   mv "\$f" "`basename \$f _2.fastq`_reverse.fastq" ;  mv "`basename \$f _2.fastq`_1.fastq" "`basename \$f _2.fastq`_forward.fastq"  ; done &&
+        for f in *_1.fastq; do mv "\$f" "`basename \$f _1.fastq`__single.fastq"; done
+        
+    #end if
+
+
+
+
+
+    #end if
+
+    
     ]]>
     </command>
     <inputs>
@@ -105,45 +149,60 @@
         </section>
     </inputs>
     <outputs>
-        <data format="fastq" name="output_accession" label="${input.accession}.${outputformat}">
-            <filter>input['input_select'] == "accession_number"</filter>
-            <change_format>
-                <when input="outputformat" value="fasta" format="fasta"/>
-            </change_format>
-        </data>
-        <data format="fastq" name="output_file" label="${input.file.name}.${outputformat}">
-            <filter>input['input_select'] == "file"</filter>
-            <change_format>
-                <when input="outputformat" value="fasta" format="fasta"/>
-            </change_format>
-        </data>
+      <collection name="list_paired" type="list:paired" label="Pair-end Fast(q|a)">
+        <filter>input['input_select'] == "file_list"</filter>
+        <!-- Use named regex group to grab pattern
+             <identifier_0>_<identifier_1>.fq. Here identifier_0 is the list
+             identifier in the nested collection and identifier_1 is either
+             forward or reverse (for instance samp1_forward.fq).
+        -->
+        <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fastq" ext="fastqsanger" visible="false" />
+        <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fasta" ext="fasta" visible="false" />
+      </collection>
+      <collection name="output_collection" type='list' label="Single-end Fast(q|a)">
+        <filter>input['input_select'] == "file_list"</filter>
+        <discover_datasets pattern="(?P&lt;designation&gt;.+)__single\.fastq" directory="." ext='fastqsanger'/>
+        <discover_datasets pattern="(?P&lt;designation&gt;.+)__single\.fasta" directory="." ext='fasta'/>
+      </collection>
+      <data format="fastq" name="output_accession" >
+        <filter>input['input_select'] == "accession_number"</filter>
+        <change_format>
+          <when input="outputformat" value="fasta" format="fasta"/>
+        </change_format>
+      </data>
+      <data format="fastq" name="output_file" label="${input.file.name}.${outputformat}">
+        <filter>input['input_select'] == "file"</filter>
+        <change_format>
+          <when input="outputformat" value="fasta" format="fasta"/>
+        </change_format>
+      </data>
     </outputs>
     <tests>
-        <test>
-            <param name="input_select" value="accession_number"/>
-            <param name="outputformat" value="fastqsanger"/>
-            <param name="accession" value="SRR044777"/>
-            <param name="skip_technical" value="True"/>
-            <output name="output_accession">
-                <assert_contents>
-                    <not_has_text text="rRNA_primer"/>
-                    <has_text text="F47USSH02GNP1D" />
-                </assert_contents>
-            </output>
-        </test>
-        <test>
-            <param name="input_select" value="accession_number"/>
-            <param name="outputformat" value="fastqsanger"/>
-            <param name="accession" value="SRR925743"/>
-            <param name="maxID" value="5"/>
-            <output name="output_accession" file="fastq_dump_result.fastq" ftype="fastq"/>
-        </test>
+      <test>
+        <param name="input_select" value="accession_number"/>
+        <param name="outputformat" value="fastqsanger"/>
+        <param name="accession" value="SRR044777"/>
+        <param name="skip_technical" value="True"/>
+        <output name="output_accession">
+          <assert_contents>
+            <not_has_text text="rRNA_primer"/>
+            <has_text text="F47USSH02GNP1D" />
+          </assert_contents>
+        </output>
+      </test>
+      <test>
+        <param name="input_select" value="accession_number"/>
+        <param name="outputformat" value="fastqsanger"/>
+        <param name="accession" value="SRR925743"/>
+        <param name="maxID" value="5"/>
+        <output name="output_accession" file="fastq_dump_result.fastq" ftype="fastq"/>
+      </test>
     </tests>
     <help>
-        This tool extracts reads from SRA archives using fastq-dump.
-        The fastq-dump program is developed at NCBI, and is available at
-        http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software.
-        @SRATOOLS_ATTRRIBUTION@
+      This tool extracts reads from SRA archives using fastq-dump.
+      The fastq-dump program is developed at NCBI, and is available at
+      http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software.
+      @SRATOOLS_ATTRRIBUTION@
     </help>
     <expand macro="citation"/>
-</tool>
+  </tool>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -199,10 +199,12 @@
       </test>
     </tests>
     <help>
-      This tool extracts reads from SRA archives using fastq-dump.
-      The fastq-dump program is developed at NCBI, and is available at
-      http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software.
-      @SRATOOLS_ATTRRIBUTION@
+        This tool extracts reads from SRA archives using fastq-dump.
+        The fastq-dump program is developed at NCBI, and is available at
+        http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software.
+        
+        NB: Single-end or pair-end collections may be empty if given SRRs LibraryLayout contains only either SINGLE or PAIRED respectively
+        @SRATOOLS_ATTRRIBUTION@
     </help>
     <expand macro="citation"/>
   </tool>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -164,13 +164,13 @@
         <discover_datasets pattern="(?P&lt;designation&gt;.+)__single\.fastq" directory="." ext='fastqsanger'/>
         <discover_datasets pattern="(?P&lt;designation&gt;.+)__single\.fasta" directory="." ext='fasta'/>
       </collection>
-      <data format="fastq" name="output_accession" >
+      <data format="fastqsanger" name="output_accession" >
         <filter>input['input_select'] == "accession_number"</filter>
         <change_format>
           <when input="outputformat" value="fasta" format="fasta"/>
         </change_format>
       </data>
-      <data format="fastq" name="output_file" label="${input.file.name}.${outputformat}">
+      <data format="fastqsanger" name="output_file" label="${input.file.name}.${outputformat}">
         <filter>input['input_select'] == "file"</filter>
         <change_format>
           <when input="outputformat" value="fasta" format="fasta"/>
@@ -195,7 +195,7 @@
         <param name="outputformat" value="fastqsanger"/>
         <param name="accession" value="SRR925743"/>
         <param name="maxID" value="5"/>
-        <output name="output_accession" file="fastq_dump_result.fastq" ftype="fastq"/>
+        <output name="output_accession" file="fastq_dump_result.fastq" ftype="fastqsanger"/>
       </test>
     </tests>
     <help>

--- a/tools/sra-tools/sam_dump.xml
+++ b/tools/sra-tools/sam_dump.xml
@@ -1,4 +1,4 @@
-<tool id="sam_dump" name="Extract reads" version="1.2.5">
+<tool id="sam_dump" name="Extract reads" version="1.3.0">
     <description>in SAM or BAM format from NCBI SRA.</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -7,6 +7,19 @@
     <version_command>sam-dump --version</version_command>
     <command>
         <![CDATA[
+    #if $input.input_select=="file_list":
+      for acc in `cat $input.file_list` ;
+      do
+    #elif $input.input_select=="accession_number":
+      acc="$input.accession" &&
+    #end if
+
+    #if $input.input_select=="file_list" or $input.input_select=="accession_number":
+          [ ""\$acc" =~ ^[E|S|D]RR[0-9]{1,}$" ] && (
+    #end if
+
+
+
         ## Need to set the home directory to the current working directory,
         ## else the tool tries to write to home/.ncbi and fails when used 
         ## with a cluster manager. 
@@ -18,7 +31,7 @@
         #if ( str( $adv.region ) == "" ):
             ASCP_PATH=`command -v ascp` &&
             ASCP_KEY=`dirname \$ASCP_PATH`/asperaweb_id_dsa.openssh || true &&
-            prefetch --ascp-path "\$ASCP_PATH|\$ASCP_KEY" "$input.accession" &&
+            prefetch --ascp-path "\$ASCP_PATH|\$ASCP_KEY" "\$acc" &&
             ## Duplicate vdb-config, in case settings changed between prefetch and
             ## dump command.
             vdb-config -s "/repository/user/main/public/root=\$PWD" &&
@@ -50,16 +63,30 @@
         #if $input.input_select == "file":
             "$input.file"
         #elif $input.input_select == "accession_number":
-            "$input.accession"
+            "\$acc"
+        #elif $input.input_select=="file_list":
+            "\$acc"
         #end if
+        
         #if str( $outputformat ) == "bam":
             | samtools view -Sb - 2> /dev/null
         #end if
         #if $input.input_select == "file":
             > "$output_file"
         #elif $input.input_select == "accession_number":
-            > "$output_accession"
+            > "$output_accession" )
         #end if
+
+        #if $input.input_select=="file_list":
+                 #if str( $outputformat ) == "bam":
+                      > "\$acc.bam"
+                 #elif str( $outputformat ) == "sam":
+                      > "\$acc.sam"
+                 #end if
+        ) ; done
+        #end if
+
+
         ]]>
     </command>
     <inputs>
@@ -86,6 +113,11 @@
         </section>
     </inputs>
     <outputs>
+        <collection name="output_collection" type='list'>
+          <filter>input['input_select'] == "file_list"</filter>
+          <discover_datasets pattern="(?P&lt;designation&gt;.+)\.bam" directory="." ext='bam'/>
+          <discover_datasets pattern="(?P&lt;designation&gt;.+)\.sam" directory="." ext='sam'/>
+        </collection>      
         <data name="output_accession" format="bam" label="${input.accession}.${outputformat}">
             <filter>input['input_select'] == "accession_number"</filter>
             <change_format>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -12,13 +12,17 @@
             <param name="input_select" type="select" label="select input type">
                 <option value="accession_number">SRR accession</option>
                 <option value="file">SRA archive in current history</option>
+                <option value="file_list">List of SRA accession, one per line</option>
             </param>
             <when value="accession_number">
-                <param name="accession" type="text" label="SRR accession" help="Must start with SRR, e.g. SRR925743"/>
+                <param name="accession" type="text" label="SRR accession" help="Must start with SRR or ERR, e.g. SRR925743 , ERR343809"/>
             </when>
             <when value="file">
                 <param format="sra" name="file" type="data" label="sra archive"/>
             </when>
+            <when value="file_list">
+                <param format="txt" name="file_list" type="data" label="sra accession list"/>
+            </when>            
         </conditional>
     </macro>
     <macro name="alignments">

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -15,7 +15,7 @@
                 <option value="file_list">List of SRA accession, one per line</option>
             </param>
             <when value="accession_number">
-                <param name="accession" type="text" label="SRR accession" help="Must start with SRR or ERR, e.g. SRR925743 , ERR343809"/>
+                <param name="accession" type="text" label="SRR accession" help="Must start with SRR,DRR or ERR, e.g. SRR925743 , ERR343809"/>
             </when>
             <when value="file">
                 <param format="sra" name="file" type="data" label="sra archive"/>
@@ -49,8 +49,16 @@
             <citation type="doi">10.1093/nar/gkq1019</citation>
         </citations>
     </macro>
-    <token name="@SRATOOLS_ATTRRIBUTION@">Browse the NCBI SRA for SRR accessions at http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies.
+    <token name="@SRATOOLS_ATTRRIBUTION@">
+        Browse the NCBI SRA for SRR accessions at http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies.
+        
         Galaxy tool wrapper originally written by Matt Shirley (mdshw5 at gmail.com).
+
+        Wrapper modified by Philip Mabon ( philip.mabon at phac-aspc.gc.ca ). 
+        
         Tool dependencies, clean-up and bug-fixes by Marius van den Beek (m.vandenbeek at gmail.com).
-        For support and bug reports contact Matt Shirley or Marius van den Beek or go to https://github.com/galaxyproject/tools-iuc.</token>
+        
+        For support and bug reports contact Matt Shirley or Marius van den Beek or go to https://github.com/galaxyproject/tools-iuc.
+        
+    </token>
 </macros>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -4,6 +4,7 @@
             <requirement type="package" version="1.2.3">ngs_sdk</requirement>
             <requirement type="package" version="2.6.2">ncbi_vdb</requirement>
             <requirement type="package" version="2.6.2">sra_toolkit</requirement>
+            <requirement type="package" version="2.6.2">sra-tools</requirement>
             <requirement type="package" version="5.18.1">perl</requirement>
         </requirements>
     </macro>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -1,9 +1,9 @@
 <macros>
     <macro name="requirements">
         <requirements>
-            <requirement type="package" version="1.1.3">ngs_sdk</requirement>
-            <requirement type="package" version="2.5.2">ncbi_vdb</requirement>
-            <requirement type="package" version="2.5.2">sra_toolkit</requirement>
+            <requirement type="package" version="1.2.3">ngs_sdk</requirement>
+            <requirement type="package" version="2.6.2">ncbi_vdb</requirement>
+            <requirement type="package" version="2.6.2">sra_toolkit</requirement>
             <requirement type="package" version="5.18.1">perl</requirement>
         </requirements>
     </macro>

--- a/tools/sra-tools/tool_dependencies.xml
+++ b/tools/sra-tools/tool_dependencies.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="ncbi_vdb" version="2.5.2">
-        <repository name="package_ncbi_vdb_2_5_2" owner="iuc" />
+    <package name="ncbi_vdb" version="2.6.2">
+        <repository name="package_ncbi_vdb_2_6_2" owner="iuc" />
     </package>
-    <package name="ngs_sdk" version="1.1.3">
-        <repository name="package_ngs_sdk_1_1_3" owner="iuc" />
+    <package name="ngs_sdk" version="1.2.3">
+        <repository name="package_ngs_sdk_1_2_3" owner="iuc" />
     </package>
-    <package name="sra_toolkit" version="2.5.2">
-        <repository name="package_sra_toolkit_2_5_2" owner="iuc" />
+    <package name="sra_toolkit" version="2.6.2">
+        <repository name="package_sra_toolkit_2_6_2" owner="iuc" />
     </package>
     <package name="perl" version="5.18.1">
         <repository name="package_perl_5_18" owner="iuc" />


### PR DESCRIPTION
Added ability to pass a text file where there is a single SRA per line to allow for serial bulk download. After download is complete, outputs will either be put into single end  or pair list collection. Each SRA entry is check to ensure no funny business and works in /bin/bash and /bin/sh environments.

All test pass.