### PR TITLE
Update travis' galaxy dependency to 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 2.7
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
-  - export GALAXY_RELEASE=release_16.01
+  - export GALAXY_RELEASE=release_16.04
   - export CONDA_PREFIX=$HOME/conda
 
 install:


### PR DESCRIPTION
Galaxy 16.04 was just released and I think it's important to start testing with the most recent stable version as well.