### PR TITLE
Added "../" back to patch command

### DIFF
--- a/packages/package_jbrowse_1_12_0/tool_dependencies.xml
+++ b/packages/package_jbrowse_1_12_0/tool_dependencies.xml
@@ -11,7 +11,7 @@
                 <action type="download_by_url" sha256sum="a8bb2a56f1ca0470df2d072811db1f90fd6756feed92d8656eba1e6f67f438d3">http://jbrowse.org/wordpress/wp-content/plugins/download-monitor/download.php?id=101&amp;fmt=.zip</action>
                 <action type="download_file" sha256sum="84dfdc81c8cae61ee61e03fe6be1b9d76813d933c268609a2c24dc85349b5840">https://gist.github.com/erasche/9cf020138d787eb47891/raw/e6ac8852be51c4869bd10d1977d2f68c731ffbc1/dojo.js.patch</action>
                 <action type="shell_command">
-                    patch -p1 &lt; dojo.js.patch
+                    patch -p1 &lt; ../dojo.js.patch
                 </action>
                 <action type="change_directory">..</action>
                 <action type="move_directory_files">


### PR DESCRIPTION
Last changeset removed the ../ in front of the dojo.js.patch file. This made it not work. I replaced it and it works for me now. See issue: #781 