### PR TITLE
Lapack: build shared lib too

### DIFF
--- a/packages/package_lapack_3_4/tool_dependencies.xml
+++ b/packages/package_lapack_3_4/tool_dependencies.xml
@@ -14,7 +14,7 @@
                     cd build &&
                     cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/lapack -DCMAKE_Fortran_FLAGS='-O2 -fPIC' &&
                     make &&
-                    make install
+                    make install &&
                     cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/lapack -DBUILD_SHARED_LIBS=ON -DCMAKE_Fortran_FLAGS='-O2 -fPIC' &&
                     make &&
                     make install

--- a/packages/package_lapack_3_4/tool_dependencies.xml
+++ b/packages/package_lapack_3_4/tool_dependencies.xml
@@ -8,21 +8,20 @@
             <actions>
                 <action type="download_by_url" sha256sum="60a65daaf16ec315034675942618a2230521ea7adf85eea788ee54841072faf0">https://depot.galaxyproject.org/software/lapack/lapack_3.4.2_src_all.tar.gz</action>
 
-                <action type="shell_command">mkdir build</action>
-                <action type="shell_command">
-                    cd build &amp;&amp;
-                    cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/lapack -DCMAKE_Fortran_FLAGS='-O2 -fPIC'
-                </action>
-
+                <!-- compile both static and shared library -->
                 <action type="shell_command"><![CDATA[
                     mkdir build &&
                     cd build &&
                     cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/lapack -DCMAKE_Fortran_FLAGS='-O2 -fPIC' &&
                     make &&
                     make install
+                    cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR/lapack -DBUILD_SHARED_LIBS=ON -DCMAKE_Fortran_FLAGS='-O2 -fPIC' &&
+                    make &&
+                    make install
                     ]]></action>
                 <action type="set_environment">
                     <environment_variable name="LAPACK_LIB_DIR" action="set_to">$INSTALL_DIR/lapack/lib</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lapack/lib</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
Hi,
This should fix #780: the lapack was only built in static mode, but shared libs are needed. I now compile both as many packages seem to depend on lapack, and I'm not sure if they expect static builds
Anthony (back to business!)