### PR TITLE
Meme 4.11.0 fixes

### DIFF
--- a/packages/package_meme_4_11_0/tool_dependencies.xml
+++ b/packages/package_meme_4_11_0/tool_dependencies.xml
@@ -18,9 +18,14 @@
                         <package name="perl_xml_parser_expat" version="2.41" />
                     </repository>
                 </action>
+                <action type="shell_command">
+                    # Handle this bug: https://groups.google.com/forum/#!topic/meme-suite/rHmLmSt2IiQ
+                    sed -i.bak -e 's|sprintf(evt_string, "%8g", dataset->evt)|sprintf(evt_string, "%g", dataset->evt)|' src/display.c
+                </action>
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="PERL5LIB" action="prepend_to">$ENV[PERL5LIB]</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
1. fix for this: https://groups.google.com/forum/#!topic/meme-suite/rHmLmSt2IiQ
2. add PERL5LIB path to meme runtime environment so it can find Perl dependencies