### PR TITLE
Add env values for required libxml2 to the environment for libxslt

### DIFF
--- a/packages/package_libxslt_1_1_28/tool_dependencies.xml
+++ b/packages/package_libxslt_1_1_28/tool_dependencies.xml
@@ -14,13 +14,20 @@
                 </action>
                 <action type="autoconf"></action>
                 <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$ENV[PKG_CONFIG_PATH]</environment_variable>
                     <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
+                    <environment_variable action="prepend_to" name="PATH">$ENV[PATH]</environment_variable>
                     <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
-                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
-                    <environment_variable name="DYLD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
-                    <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
-                    <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
-                    <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[LD_LIBRARY_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable action="prepend_to" name="DYLD_LIBRARY_PATH">$ENV[DYLD_LIBRARY_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="DYLD_LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable action="prepend_to" name="LIBRARY_PATH">$ENV[LIBRARY_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="LIBRARY_PATH">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$ENV[C_INCLUDE_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="C_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$ENV[CPLUS_INCLUDE_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="CPLUS_INCLUDE_PATH">$INSTALL_DIR/include</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
This should fix the following compile time error for package_meme_4_11_0 which has a dependency on package_libxslt_1_1_28:
```
./configure --prefix=/home/greg/work/ts_install/tool_dependency_dir/meme/4.11.0/iuc/package_meme_4_11_0/6ee2e1225125  && make && make install
STDERR
configure: WARNING: libxml2 library not found
/home/greg/work/ts_install/tool_dependency_dir/libxslt/1.1.28/iuc/package_libxslt_1_1_28/15c6da429d88/bin/xslt-config: line 94: xml2-config: command not found
/home/greg/work/ts_install/tool_dependency_dir/libxslt/1.1.28/iuc/package_libxslt_1_1_28/15c6da429d88/bin/xslt-config: line 94: xml2-config: command not found
configure: WARNING:

```