### PR TITLE
Propogate the Perl environment to the perl_xml_parser_expat recipe.

### DIFF
--- a/packages/package_perl_xml_parser_expat_2_41/tool_dependencies.xml
+++ b/packages/package_perl_xml_parser_expat_2_41/tool_dependencies.xml
@@ -62,6 +62,12 @@
                    </package>
 
                 </action>
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$ENV[PATH]</environment_variable>
+                    <environment_variable name="PERL5LIB" action="prepend_to">$ENV[PERL5LIB]</environment_variable>
+                    <environment_variable name="PERL_ROOT_DIR" action="prepend_to">$ENV[PERL_ROOT_DIR]</environment_variable>
+                    <environment_variable name="PERL_LOCALLIB_DIR" action="prepend_to">$ENV[PERL_LOCALLIB_DIR]</environment_variable>
+                </action>
             </actions>
         </install>
         <readme>


### PR DESCRIPTION
This will allow dependent packages to locate the Perl environment at compile time and / or runtime.