### PR TITLE
Trinity: add quotes to TRINITY_MEM_OPTIONS

### DIFF
--- a/tools/trinity/tool_dependencies.xml
+++ b/tools/trinity/tool_dependencies.xml
@@ -28,6 +28,6 @@
        <repository name="package_deseq2_1_10_0" owner="iuc" />
     </package>
     <set_environment version="1.0">
-        <environment_variable name="TRINITY_MEM_OPTIONS" action="set_to">"--max_memory 30G --bflyHeapSpaceMax 30G"</environment_variable>
+        <environment_variable name="TRINITY_MEM_OPTIONS" action="set_to">'--max_memory 30G --bflyHeapSpaceMax 30G'</environment_variable>
     </set_environment>
 </tool_dependency>

--- a/tools/trinity/tool_dependencies.xml
+++ b/tools/trinity/tool_dependencies.xml
@@ -28,6 +28,6 @@
        <repository name="package_deseq2_1_10_0" owner="iuc" />
     </package>
     <set_environment version="1.0">
-        <environment_variable name="TRINITY_MEM_OPTIONS" action="set_to">--max_memory 30G --bflyHeapSpaceMax 30G</environment_variable>
+        <environment_variable name="TRINITY_MEM_OPTIONS" action="set_to">"--max_memory 30G --bflyHeapSpaceMax 30G"</environment_variable>
     </set_environment>
 </tool_dependency>


### PR DESCRIPTION
We need quotes here or env.sh will fail to set TRINITY_MEM_OPTIONS variable (and trinity will use as much memory as it wants)