### PR TITLE
Revert "bioperl testing"

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -1,4 +1,5 @@
 tools/art
+tools/bioperl
 tools/blastxml_to_gapped_gff3
 tools/bwtool
 tools/deseq2

--- a/tools/bioperl/macros.xml
+++ b/tools/bioperl/macros.xml
@@ -2,8 +2,6 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="1.6.922">bioperl</requirement>
-            <!-- conda bioperl dependency -->
-            <requirement type="package" version="1.6.924">perl-bioperl</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/bioperl/test-data/seq.gb.0.gff
+++ b/tools/bioperl/test-data/seq.gb.0.gff
@@ -1,12 +1,10 @@
-# Input: /tmp/tmp1YCbBQ/files/000/dataset_1.dat
 ##gff-version 3
 ##sequence-region NC_014662 1 165540
 # conversion-by bp_genbank2gff3.pl
 # organism Enterobacteria phage CC31
 # Note Enterobacteria phage CC31, complete genome.
 # date 12-NOV-2010
-# working on contig:NC_014662, Enterobacteria phage CC31, Enterobacteria phage CC31, complete genome., 12-NOV-2010
-NC_014662	GenBank	contig	1	165540	.	+	1	ID=NC_014662;Dbxref=BioProject:PRJNA60119,taxon:709484;Name=NC_014662;Note=Enterobacteria phage CC31%2C complete genome.,PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;comment1=PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;date=12-NOV-2010;host=Escherichia coli;mol_type=genomic DNA;organism=Enterobacteria phage CC31
+NC_014662	GenBank	region	1	165540	.	+	1	ID=NC_014662;Dbxref=BioProject:PRJNA60119,taxon:709484;Name=NC_014662;Note=Enterobacteria phage CC31%2C complete genome.,PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;comment1=PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;date=12-NOV-2010;host=Escherichia coli;mol_type=genomic DNA;organism=Enterobacteria phage CC31
 NC_014662	GenBank	gene	1	2214	.	-	1	ID=CC31p001;Dbxref=GeneID:9926434;Name=rIIA;locus_tag=CC31p001
 NC_014662	GenBank	mRNA	1	2214	.	-	1	ID=CC31p001.t01;Parent=CC31p001
 NC_014662	GenBank	CDS	1	2214	.	-	1	ID=CC31p001.p01;Parent=CC31p001.t01;Dbxref=GI:311992993,GeneID:9926434;Name=rIIA;codon_start=1;locus_tag=CC31p001;product=membrane-associated affects host membrane ATPase;protein_id=YP_004009859.1;transl_table=11;translation=length.737
@@ -1147,7 +1145,6 @@ NC_014662	GenBank	gene	164610	165521	.	-	1	ID=CC31p279;Dbxref=GeneID:9926433;Nam
 NC_014662	GenBank	mRNA	164610	165521	.	-	1	ID=CC31p279.t01;Parent=CC31p279
 NC_014662	GenBank	CDS	164610	165521	.	-	1	ID=CC31p279.p01;Parent=CC31p279.t01;Dbxref=GI:311993271,GeneID:9926433;Name=rIIB;codon_start=1;locus_tag=CC31p279;product=protector from prophage-induced early lysis;protein_id=YP_004010137.1;transl_table=11;translation=length.303
 NC_014662	GenBank	exon	164610	165521	.	-	1	Parent=CC31p279.t01
-# GFF3 saved to stdout2829
 ##FASTA
 >NC_014662
 TTACTCATCTTCATCTTTACCTTTTAAGGAAGGAGCGCTTTCCAGCGCTCTCATAATACG

--- a/tools/bioperl/test-data/seq.gb.1.gff
+++ b/tools/bioperl/test-data/seq.gb.1.gff
@@ -1,4 +1,4 @@
-# Input: /tmp/tmp1YCbBQ/files/000/dataset_3.dat
+# Input: test-data/seq.gb
 ##gff-version 3
 ##sequence-region NC_014662 1 165540
 # conversion-by bp_genbank2gff3.pl
@@ -7,1147 +7,581 @@
 # date 12-NOV-2010
 # working on contig:NC_014662, Enterobacteria phage CC31, Enterobacteria phage CC31, complete genome., 12-NOV-2010
 NC_014662	GenBank	contig	1	165540	.	+	1	ID=NC_014662;Dbxref=BioProject:PRJNA60119,taxon:709484;Name=NC_014662;Note=Enterobacteria phage CC31%2C complete genome.,PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;comment1=PROVISIONAL REFSEQ: This record has not yet been subject to final NCBI review. The reference sequence is identical to GU323318. COMPLETENESS: full length. ;date=12-NOV-2010;host=Escherichia coli;mol_type=genomic DNA;organism=Enterobacteria phage CC31
-NC_014662	GenBank	gene	1	2214	.	-	1	ID=CC31p001;Dbxref=GeneID:9926434;Name=rIIA;locus_tag=CC31p001
-NC_014662	GenBank	mRNA	1	2214	.	-	1	ID=CC31p001.t01;Parent=CC31p001
-NC_014662	GenBank	CDS	1	2214	.	-	1	ID=CC31p001.p01;Parent=CC31p001.t01;Dbxref=GI:311992993,GeneID:9926434;Name=rIIA;codon_start=1;locus_tag=CC31p001;product=membrane-associated affects host membrane ATPase;protein_id=YP_004009859.1;transl_table=11;translation=length.737
-NC_014662	GenBank	exon	1	2214	.	-	1	Parent=CC31p001.t01
-NC_014662	GenBank	gene	2220	2426	.	-	1	ID=CC31p002;Dbxref=GeneID:9926148;Name=rIIA.1;locus_tag=CC31p002
-NC_014662	GenBank	mRNA	2220	2426	.	-	1	ID=CC31p002.t01;Parent=CC31p002
-NC_014662	GenBank	CDS	2220	2426	.	-	1	ID=CC31p002.p01;Parent=CC31p002.t01;Dbxref=GI:311992994,GeneID:9926148;Name=rIIA.1;codon_start=1;locus_tag=CC31p002;product=hypothetical protein;protein_id=YP_004009860.1;transl_table=11;translation=length.68
-NC_014662	GenBank	exon	2220	2426	.	-	1	Parent=CC31p002.t01
-NC_014662	GenBank	gene	2420	2704	.	-	1	ID=CC31p003;Dbxref=GeneID:9926149;Name=CC31p003
-NC_014662	GenBank	mRNA	2420	2704	.	-	1	ID=CC31p003.t01;Parent=CC31p003
-NC_014662	GenBank	CDS	2420	2704	.	-	1	ID=CC31p003.p01;Parent=CC31p003.t01;Dbxref=GI:311992995,GeneID:9926149;Name=CC31p003;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009861.1;transl_table=11;translation=length.94
-NC_014662	GenBank	exon	2420	2704	.	-	1	Parent=CC31p003.t01
-NC_014662	GenBank	gene	2750	2905	.	-	1	ID=CC31p004;Dbxref=GeneID:9926150;Name=CC31p004
-NC_014662	GenBank	mRNA	2750	2905	.	-	1	ID=CC31p004.t01;Parent=CC31p004
-NC_014662	GenBank	CDS	2750	2905	.	-	1	ID=CC31p004.p01;Parent=CC31p004.t01;Dbxref=GI:311992996,GeneID:9926150;Name=CC31p004;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009862.1;transl_table=11;translation=length.51
-NC_014662	GenBank	exon	2750	2905	.	-	1	Parent=CC31p004.t01
-NC_014662	GenBank	gene	2945	4789	.	-	1	ID=CC31p005;Dbxref=GeneID:9926151;Name=60plus39;locus_tag=CC31p005
-NC_014662	GenBank	mRNA	2945	4789	.	-	1	ID=CC31p005.t01;Parent=CC31p005
-NC_014662	GenBank	CDS	2945	4789	.	-	1	ID=CC31p005.p01;Parent=CC31p005.t01;Dbxref=GI:311992997,GeneID:9926151;Name=60plus39;codon_start=1;locus_tag=CC31p005;product=DNA topoisomerase subunit;protein_id=YP_004009863.1;transl_table=11;translation=length.614
-NC_014662	GenBank	exon	2945	4789	.	-	1	Parent=CC31p005.t01
-NC_014662	GenBank	gene	4835	5302	.	-	1	ID=CC31p006;Dbxref=GeneID:9926152;Name=CC31p006
-NC_014662	GenBank	mRNA	4835	5302	.	-	1	ID=CC31p006.t01;Parent=CC31p006
-NC_014662	GenBank	CDS	4835	5302	.	-	1	ID=CC31p006.p01;Parent=CC31p006.t01;Dbxref=GI:311992998,GeneID:9926152;Name=CC31p006;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009864.1;transl_table=11;translation=length.155
-NC_014662	GenBank	exon	4835	5302	.	-	1	Parent=CC31p006.t01
-NC_014662	GenBank	gene	5302	6837	.	-	1	ID=CC31p007;Dbxref=GeneID:9926153;Name=CC31p007
-NC_014662	GenBank	mRNA	5302	6837	.	-	1	ID=CC31p007.t01;Parent=CC31p007
-NC_014662	GenBank	CDS	5302	6837	.	-	1	ID=CC31p007.p01;Parent=CC31p007.t01;Dbxref=GI:311992999,GeneID:9926153;Name=CC31p007;Note=N-terminal part is similar to Hoc protein and C-terminal part is similar to lipolytic enzyme%2C G-D-S-L;codon_start=1;product=hypothetical protein;protein_id=YP_004009865.1;transl_table=11;translation=length.511
-NC_014662	GenBank	exon	5302	6837	.	-	1	Parent=CC31p007.t01
-NC_014662	GenBank	gene	6870	7130	.	-	1	ID=CC31p008;Dbxref=GeneID:9926154;Name=39.1;locus_tag=CC31p008
-NC_014662	GenBank	mRNA	6870	7130	.	-	1	ID=CC31p008.t01;Parent=CC31p008
-NC_014662	GenBank	CDS	6870	7130	.	-	1	ID=CC31p008.p01;Parent=CC31p008.t01;Dbxref=GI:311993000,GeneID:9926154;Name=39.1;codon_start=1;locus_tag=CC31p008;product=gp39.1 hypothetical protein;protein_id=YP_004009866.1;transl_table=11;translation=length.86
-NC_014662	GenBank	exon	6870	7130	.	-	1	Parent=CC31p008.t01
-NC_014662	GenBank	gene	7127	7222	.	-	1	ID=CC31p009;Dbxref=GeneID:9926155;Name=CC31p009
-NC_014662	GenBank	mRNA	7127	7222	.	-	1	ID=CC31p009.t01;Parent=CC31p009
-NC_014662	GenBank	CDS	7127	7222	.	-	1	ID=CC31p009.p01;Parent=CC31p009.t01;Dbxref=GI:311993001,GeneID:9926155;Name=CC31p009;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009867.1;transl_table=11;translation=length.31
-NC_014662	GenBank	exon	7127	7222	.	-	1	Parent=CC31p009.t01
-NC_014662	GenBank	gene	7222	7398	.	-	1	ID=CC31p010;Dbxref=GeneID:9926156;Name=CC31p010
-NC_014662	GenBank	mRNA	7222	7398	.	-	1	ID=CC31p010.t01;Parent=CC31p010
-NC_014662	GenBank	CDS	7222	7398	.	-	1	ID=CC31p010.p01;Parent=CC31p010.t01;Dbxref=GI:311993002,GeneID:9926156;Name=CC31p010;codon_start=1;product=conserved putative regulatory protein%2C FmdB family;protein_id=YP_004009868.1;transl_table=11;translation=length.58
-NC_014662	GenBank	exon	7222	7398	.	-	1	Parent=CC31p010.t01
-NC_014662	GenBank	gene	7385	7732	.	-	1	ID=CC31p011;Dbxref=GeneID:9926157;Name=CC31p011
-NC_014662	GenBank	mRNA	7385	7732	.	-	1	ID=CC31p011.t01;Parent=CC31p011
-NC_014662	GenBank	CDS	7385	7732	.	-	1	ID=CC31p011.p01;Parent=CC31p011.t01;Dbxref=GI:311993003,GeneID:9926157;Name=CC31p011;codon_start=1;product=hypothetical protein;protein_id=YP_004009869.1;transl_table=11;translation=length.115
-NC_014662	GenBank	exon	7385	7732	.	-	1	Parent=CC31p011.t01
-NC_014662	GenBank	gene	7720	8409	.	-	1	ID=CC31p012;Dbxref=GeneID:9926158;Name=CC31p012
-NC_014662	GenBank	mRNA	7720	8409	.	-	1	ID=CC31p012.t01;Parent=CC31p012
-NC_014662	GenBank	CDS	7720	8409	.	-	1	ID=CC31p012.p01;Parent=CC31p012.t01;Dbxref=GI:311993004,GeneID:9926158;Name=CC31p012;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009870.1;transl_table=11;translation=length.229
-NC_014662	GenBank	exon	7720	8409	.	-	1	Parent=CC31p012.t01
-NC_014662	GenBank	gene	8402	8626	.	-	1	ID=CC31p013;Dbxref=GeneID:9926159;Name=cef;locus_tag=CC31p013
-NC_014662	GenBank	mRNA	8402	8626	.	-	1	ID=CC31p013.t01;Parent=CC31p013
-NC_014662	GenBank	CDS	8402	8626	.	-	1	ID=CC31p013.p01;Parent=CC31p013.t01;Dbxref=GI:311993005,GeneID:9926159;Name=cef;codon_start=1;locus_tag=CC31p013;product=modifier of suppressor tRNAs;protein_id=YP_004009871.1;transl_table=11;translation=length.74
-NC_014662	GenBank	exon	8402	8626	.	-	1	Parent=CC31p013.t01
-NC_014662	GenBank	gene	8693	9130	.	-	1	ID=CC31p014;Dbxref=GeneID:9926160;Name=CC31p014
-NC_014662	GenBank	mRNA	8693	9130	.	-	1	ID=CC31p014.t01;Parent=CC31p014
-NC_014662	GenBank	CDS	8693	9130	.	-	1	ID=CC31p014.p01;Parent=CC31p014.t01;Dbxref=GI:311993006,GeneID:9926160;Name=CC31p014;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009872.1;transl_table=11;translation=length.145
-NC_014662	GenBank	exon	8693	9130	.	-	1	Parent=CC31p014.t01
-NC_014662	GenBank	gene	9186	9875	.	-	1	ID=CC31p015;Dbxref=GeneID:9926161;Name=dexA;locus_tag=CC31p015
-NC_014662	GenBank	mRNA	9186	9875	.	-	1	ID=CC31p015.t01;Parent=CC31p015
-NC_014662	GenBank	CDS	9186	9875	.	-	1	ID=CC31p015.p01;Parent=CC31p015.t01;Dbxref=GI:311993007,GeneID:9926161;Name=dexA;Note=DexA;codon_start=1;locus_tag=CC31p015;product=exonuclease A;protein_id=YP_004009873.1;transl_table=11;translation=length.229
-NC_014662	GenBank	exon	9186	9875	.	-	1	Parent=CC31p015.t01
-NC_014662	GenBank	gene	9872	10114	.	-	1	ID=CC31p016;Dbxref=GeneID:9926162;Name=CC31p016
-NC_014662	GenBank	mRNA	9872	10114	.	-	1	ID=CC31p016.t01;Parent=CC31p016
-NC_014662	GenBank	CDS	9872	10114	.	-	1	ID=CC31p016.p01;Parent=CC31p016.t01;Dbxref=GI:311993008,GeneID:9926162;Name=CC31p016;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009874.1;transl_table=11;translation=length.80
-NC_014662	GenBank	exon	9872	10114	.	-	1	Parent=CC31p016.t01
-NC_014662	GenBank	gene	10120	11433	.	-	1	ID=CC31p017;Dbxref=GeneID:9926163;Name=dda;locus_tag=CC31p017
-NC_014662	GenBank	mRNA	10120	11433	.	-	1	ID=CC31p017.t01;Parent=CC31p017
-NC_014662	GenBank	CDS	10120	11433	.	-	1	ID=CC31p017.p01;Parent=CC31p017.t01;Dbxref=GI:311993009,GeneID:9926163;Name=dda;Note=Dda;codon_start=1;locus_tag=CC31p017;product=DNA helicase;protein_id=YP_004009875.1;transl_table=11;translation=length.437
-NC_014662	GenBank	exon	10120	11433	.	-	1	Parent=CC31p017.t01
-NC_014662	GenBank	gene	11460	11774	.	-	1	ID=CC31p018;Dbxref=GeneID:9926164;Name=CC31p018
-NC_014662	GenBank	mRNA	11460	11774	.	-	1	ID=CC31p018.t01;Parent=CC31p018
-NC_014662	GenBank	CDS	11460	11774	.	-	1	ID=CC31p018.p01;Parent=CC31p018.t01;Dbxref=GI:311993010,GeneID:9926164;Name=CC31p018;codon_start=1;product=hypothetical protein;protein_id=YP_004009876.1;transl_table=11;translation=length.104
-NC_014662	GenBank	exon	11460	11774	.	-	1	Parent=CC31p018.t01
-NC_014662	GenBank	gene	11774	12526	.	-	1	ID=CC31p019;Dbxref=GeneID:9926165;Name=srd;locus_tag=CC31p019
-NC_014662	GenBank	mRNA	11774	12526	.	-	1	ID=CC31p019.t01;Parent=CC31p019
-NC_014662	GenBank	CDS	11774	12526	.	-	1	ID=CC31p019.p01;Parent=CC31p019.t01;Dbxref=GI:311993011,GeneID:9926165;Name=srd;Note=Srd;codon_start=1;locus_tag=CC31p019;product=anti-sigma factor%2C putative;protein_id=YP_004009877.1;transl_table=11;translation=length.250
-NC_014662	GenBank	exon	11774	12526	.	-	1	Parent=CC31p019.t01
-NC_014662	GenBank	gene	12682	13290	.	-	1	ID=CC31p020;Dbxref=GeneID:9926166;Name=modA;locus_tag=CC31p020
-NC_014662	GenBank	mRNA	12682	13290	.	-	1	ID=CC31p020.t01;Parent=CC31p020
-NC_014662	GenBank	CDS	12682	13290	.	-	1	ID=CC31p020.p01;Parent=CC31p020.t01;Dbxref=GI:311993012,GeneID:9926166;Name=modA;Note=ModA;codon_start=1;locus_tag=CC31p020;product=RNA polymerase ADP-ribosylase;protein_id=YP_004009878.1;transl_table=11;translation=length.202
-NC_014662	GenBank	exon	12682	13290	.	-	1	Parent=CC31p020.t01
-NC_014662	GenBank	gene	13351	13542	.	-	1	ID=CC31p021;Dbxref=GeneID:9926167;Name=modA.2;locus_tag=CC31p021
-NC_014662	GenBank	mRNA	13351	13542	.	-	1	ID=CC31p021.t01;Parent=CC31p021
-NC_014662	GenBank	CDS	13351	13542	.	-	1	ID=CC31p021.p01;Parent=CC31p021.t01;Dbxref=GI:311993013,GeneID:9926167;Name=modA.2;codon_start=1;locus_tag=CC31p021;product=hypothetical protein;protein_id=YP_004009879.1;transl_table=11;translation=length.63
-NC_014662	GenBank	exon	13351	13542	.	-	1	Parent=CC31p021.t01
-NC_014662	GenBank	gene	13557	14069	.	-	1	ID=CC31p022;Dbxref=GeneID:9926168;Name=CC31p022
-NC_014662	GenBank	mRNA	13557	14069	.	-	1	ID=CC31p022.t01;Parent=CC31p022
-NC_014662	GenBank	CDS	13557	14069	.	-	1	ID=CC31p022.p01;Parent=CC31p022.t01;Dbxref=GI:311993014,GeneID:9926168;Name=CC31p022;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009880.1;transl_table=11;translation=length.170
-NC_014662	GenBank	exon	13557	14069	.	-	1	Parent=CC31p022.t01
-NC_014662	GenBank	gene	14062	14454	.	-	1	ID=CC31p023;Dbxref=GeneID:9926169;Name=CC31p023
-NC_014662	GenBank	mRNA	14062	14454	.	-	1	ID=CC31p023.t01;Parent=CC31p023
-NC_014662	GenBank	CDS	14062	14454	.	-	1	ID=CC31p023.p01;Parent=CC31p023.t01;Dbxref=GI:311993015,GeneID:9926169;Name=CC31p023;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009881.1;transl_table=11;translation=length.130
-NC_014662	GenBank	exon	14062	14454	.	-	1	Parent=CC31p023.t01
-NC_014662	GenBank	gene	14454	14732	.	-	1	ID=CC31p024;Dbxref=GeneID:9926170;Name=CC31p024
-NC_014662	GenBank	mRNA	14454	14732	.	-	1	ID=CC31p024.t01;Parent=CC31p024
-NC_014662	GenBank	CDS	14454	14732	.	-	1	ID=CC31p024.p01;Parent=CC31p024.t01;Dbxref=GI:311993016,GeneID:9926170;Name=CC31p024;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009882.1;transl_table=11;translation=length.92
-NC_014662	GenBank	exon	14454	14732	.	-	1	Parent=CC31p024.t01
-NC_014662	GenBank	gene	14786	15025	.	-	1	ID=CC31p025;Dbxref=GeneID:9926171;Name=soc;locus_tag=CC31p025
-NC_014662	GenBank	mRNA	14786	15025	.	-	1	ID=CC31p025.t01;Parent=CC31p025
-NC_014662	GenBank	CDS	14786	15025	.	-	1	ID=CC31p025.p01;Parent=CC31p025.t01;Dbxref=GI:311993017,GeneID:9926171;Name=soc;Note=Soc;codon_start=1;locus_tag=CC31p025;product=small outer capsid protein;protein_id=YP_004009883.1;transl_table=11;translation=length.79
-NC_014662	GenBank	exon	14786	15025	.	-	1	Parent=CC31p025.t01
-NC_014662	GenBank	gene	15053	15256	.	-	1	ID=CC31p026;Dbxref=GeneID:9926172;Name=soc.1;locus_tag=CC31p026
-NC_014662	GenBank	mRNA	15053	15256	.	-	1	ID=CC31p026.t01;Parent=CC31p026
-NC_014662	GenBank	CDS	15053	15256	.	-	1	ID=CC31p026.p01;Parent=CC31p026.t01;Dbxref=GI:311993018,GeneID:9926172;Name=soc.1;codon_start=1;locus_tag=CC31p026;product=hypothetical protein;protein_id=YP_004009884.1;transl_table=11;translation=length.67
-NC_014662	GenBank	exon	15053	15256	.	-	1	Parent=CC31p026.t01
-NC_014662	GenBank	gene	15256	15774	.	-	1	ID=CC31p027;Dbxref=GeneID:9926173;Name=56;locus_tag=CC31p027
-NC_014662	GenBank	mRNA	15256	15774	.	-	1	ID=CC31p027.t01;Parent=CC31p027
-NC_014662	GenBank	CDS	15256	15774	.	-	1	ID=CC31p027.p01;Parent=CC31p027.t01;Dbxref=GI:311993019,GeneID:9926173;Name=56;codon_start=1;locus_tag=CC31p027;product=gp56 dCTPase%2C dUTPase%2C dCDPase%2C dUDPase;protein_id=YP_004009885.1;transl_table=11;translation=length.172
-NC_014662	GenBank	exon	15256	15774	.	-	1	Parent=CC31p027.t01
-NC_014662	GenBank	gene	15820	16104	.	-	1	ID=CC31p028;Dbxref=GeneID:9926174;Name=CC31p028
-NC_014662	GenBank	mRNA	15820	16104	.	-	1	ID=CC31p028.t01;Parent=CC31p028
-NC_014662	GenBank	CDS	15820	16104	.	-	1	ID=CC31p028.p01;Parent=CC31p028.t01;Dbxref=GI:311993020,GeneID:9926174;Name=CC31p028;codon_start=1;product=hypothetical protein;protein_id=YP_004009886.1;transl_table=11;translation=length.94
-NC_014662	GenBank	exon	15820	16104	.	-	1	Parent=CC31p028.t01
-NC_014662	GenBank	gene	16101	17126	.	-	1	ID=CC31p029;Dbxref=GeneID:9926175;Name=61;locus_tag=CC31p029
-NC_014662	GenBank	mRNA	16101	17126	.	-	1	ID=CC31p029.t01;Parent=CC31p029
-NC_014662	GenBank	CDS	16101	17126	.	-	1	ID=CC31p029.p01;Parent=CC31p029.t01;Dbxref=GI:311993021,GeneID:9926175;Name=61;codon_start=1;locus_tag=CC31p029;product=gp61 DNA primase subunit;protein_id=YP_004009887.1;transl_table=11;translation=length.341
-NC_014662	GenBank	exon	16101	17126	.	-	1	Parent=CC31p029.t01
-NC_014662	GenBank	gene	17166	17630	.	-	1	ID=CC31p030;Dbxref=GeneID:9926176;Name=61.1;locus_tag=CC31p030
-NC_014662	GenBank	mRNA	17166	17630	.	-	1	ID=CC31p030.t01;Parent=CC31p030
-NC_014662	GenBank	CDS	17166	17630	.	-	1	ID=CC31p030.p01;Parent=CC31p030.t01;Dbxref=GI:311993022,GeneID:9926176;Name=61.1;codon_start=1;locus_tag=CC31p030;product=hypothetical protein;protein_id=YP_004009888.1;transl_table=11;translation=length.154
-NC_014662	GenBank	exon	17166	17630	.	-	1	Parent=CC31p030.t01
-NC_014662	GenBank	gene	17646	17834	.	-	1	ID=CC31p031;Dbxref=GeneID:9926177;Name=CC31p031
-NC_014662	GenBank	mRNA	17646	17834	.	-	1	ID=CC31p031.t01;Parent=CC31p031
-NC_014662	GenBank	CDS	17646	17834	.	-	1	ID=CC31p031.p01;Parent=CC31p031.t01;Dbxref=GI:311993023,GeneID:9926177;Name=CC31p031;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009889.1;transl_table=11;translation=length.62
-NC_014662	GenBank	exon	17646	17834	.	-	1	Parent=CC31p031.t01
-NC_014662	GenBank	gene	17831	18166	.	-	1	ID=CC31p032;Dbxref=GeneID:9926178;Name=CC31p032
-NC_014662	GenBank	mRNA	17831	18166	.	-	1	ID=CC31p032.t01;Parent=CC31p032
-NC_014662	GenBank	CDS	17831	18166	.	-	1	ID=CC31p032.p01;Parent=CC31p032.t01;Dbxref=GI:311993024,GeneID:9926178;Name=CC31p032;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009890.1;transl_table=11;translation=length.111
-NC_014662	GenBank	exon	17831	18166	.	-	1	Parent=CC31p032.t01
-NC_014662	GenBank	gene	18154	18345	.	-	1	ID=CC31p033;Dbxref=GeneID:9926179;Name=CC31p033
-NC_014662	GenBank	mRNA	18154	18345	.	-	1	ID=CC31p033.t01;Parent=CC31p033
-NC_014662	GenBank	CDS	18154	18345	.	-	1	ID=CC31p033.p01;Parent=CC31p033.t01;Dbxref=GI:311993025,GeneID:9926179;Name=CC31p033;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009891.1;transl_table=11;translation=length.63
-NC_014662	GenBank	exon	18154	18345	.	-	1	Parent=CC31p033.t01
-NC_014662	GenBank	gene	18342	18623	.	-	1	ID=CC31p034;Dbxref=GeneID:9926180;Name=CC31p034
-NC_014662	GenBank	mRNA	18342	18623	.	-	1	ID=CC31p034.t01;Parent=CC31p034
-NC_014662	GenBank	CDS	18342	18623	.	-	1	ID=CC31p034.p01;Parent=CC31p034.t01;Dbxref=GI:311993026,GeneID:9926180;Name=CC31p034;Note=N-terminal similarity to T4 Sp (spackle periplasmic) protein;codon_start=1;product=hypothetical protein;protein_id=YP_004009892.1;transl_table=11;translation=length.93
-NC_014662	GenBank	exon	18342	18623	.	-	1	Parent=CC31p034.t01
-NC_014662	GenBank	gene	18633	18914	.	-	1	ID=CC31p035;Dbxref=GeneID:9926181;Name=CC31p035
-NC_014662	GenBank	mRNA	18633	18914	.	-	1	ID=CC31p035.t01;Parent=CC31p035
-NC_014662	GenBank	CDS	18633	18914	.	-	1	ID=CC31p035.p01;Parent=CC31p035.t01;Dbxref=GI:311993027,GeneID:9926181;Name=CC31p035;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009893.1;transl_table=11;translation=length.93
-NC_014662	GenBank	exon	18633	18914	.	-	1	Parent=CC31p035.t01
-NC_014662	GenBank	gene	18976	20352	.	-	1	ID=CC31p036;Dbxref=GeneID:9926182;Name=41;locus_tag=CC31p036
-NC_014662	GenBank	mRNA	18976	20352	.	-	1	ID=CC31p036.t01;Parent=CC31p036
-NC_014662	GenBank	CDS	18976	20352	.	-	1	ID=CC31p036.p01;Parent=CC31p036.t01;Dbxref=GI:311993028,GeneID:9926182;Name=41;codon_start=1;locus_tag=CC31p036;product=gp41 DNA primase-helicase subunit;protein_id=YP_004009894.1;transl_table=11;translation=length.458
-NC_014662	GenBank	exon	18976	20352	.	-	1	Parent=CC31p036.t01
-NC_014662	GenBank	gene	20429	20818	.	-	1	ID=CC31p037;Dbxref=GeneID:9926183;Name=40;locus_tag=CC31p037
-NC_014662	GenBank	mRNA	20429	20818	.	-	1	ID=CC31p037.t01;Parent=CC31p037
-NC_014662	GenBank	CDS	20429	20818	.	-	1	ID=CC31p037.p01;Parent=CC31p037.t01;Dbxref=GI:311993029,GeneID:9926183;Name=40;codon_start=1;locus_tag=CC31p037;product=gp40 head vertex assembly chaperone;protein_id=YP_004009895.1;transl_table=11;translation=length.129
-NC_014662	GenBank	exon	20429	20818	.	-	1	Parent=CC31p037.t01
-NC_014662	GenBank	gene	20787	21953	.	-	1	ID=CC31p038;Dbxref=GeneID:9926184;Name=uvsX;locus_tag=CC31p038
-NC_014662	GenBank	mRNA	20787	21953	.	-	1	ID=CC31p038.t01;Parent=CC31p038
-NC_014662	GenBank	CDS	20787	21953	.	-	1	ID=CC31p038.p01;Parent=CC31p038.t01;Dbxref=GI:311993030,GeneID:9926184;Name=uvsX;Note=UvsX;codon_start=1;locus_tag=CC31p038;product=RecA-like recombination protein;protein_id=YP_004009896.1;transl_table=11;translation=length.388
-NC_014662	GenBank	exon	20787	21953	.	-	1	Parent=CC31p038.t01
-NC_014662	GenBank	gene	22117	23193	.	-	1	ID=CC31p039;Dbxref=GeneID:9926185;Name=b-gt;locus_tag=CC31p039
-NC_014662	GenBank	mRNA	22117	23193	.	-	1	ID=CC31p039.t01;Parent=CC31p039
-NC_014662	GenBank	CDS	22117	23193	.	-	1	ID=CC31p039.p01;Parent=CC31p039.t01;Dbxref=GI:311993031,GeneID:9926185;Name=b-gt;codon_start=1;locus_tag=CC31p039;product=beta glucosyl transferase;protein_id=YP_004009897.1;transl_table=11;translation=length.358
-NC_014662	GenBank	exon	22117	23193	.	-	1	Parent=CC31p039.t01
-NC_014662	GenBank	gene	23190	24026	.	-	1	ID=CC31p040;Dbxref=GeneID:9926186;Name=CC31p040
-NC_014662	GenBank	mRNA	23190	24026	.	-	1	ID=CC31p040.t01;Parent=CC31p040
-NC_014662	GenBank	CDS	23190	24026	.	-	1	ID=CC31p040.p01;Parent=CC31p040.t01;Dbxref=GI:311993032,GeneID:9926186;Name=CC31p040;Note=similar to T2%2C T6 beta-glucosyl-HMC-alpha-glucosyl-transferase;codon_start=1;product=hypothetical protein;protein_id=YP_004009898.1;transl_table=11;translation=length.278
-NC_014662	GenBank	exon	23190	24026	.	-	1	Parent=CC31p040.t01
-NC_014662	GenBank	gene	24017	24754	.	-	1	ID=CC31p041;Dbxref=GeneID:9926187;Name=42;locus_tag=CC31p041
-NC_014662	GenBank	mRNA	24017	24754	.	-	1	ID=CC31p041.t01;Parent=CC31p041
-NC_014662	GenBank	CDS	24017	24754	.	-	1	ID=CC31p041.p01;Parent=CC31p041.t01;Dbxref=GI:311993033,GeneID:9926187;Name=42;codon_start=1;locus_tag=CC31p041;product=gp42 dCMP hydroxymethylase;protein_id=YP_004009899.1;transl_table=11;translation=length.245
-NC_014662	GenBank	exon	24017	24754	.	-	1	Parent=CC31p041.t01
-NC_014662	GenBank	gene	24751	25191	.	-	1	ID=CC31p042;Dbxref=GeneID:9926188;Name=CC31p042
-NC_014662	GenBank	mRNA	24751	25191	.	-	1	ID=CC31p042.t01;Parent=CC31p042
-NC_014662	GenBank	CDS	24751	25191	.	-	1	ID=CC31p042.p01;Parent=CC31p042.t01;Dbxref=GI:311993034,GeneID:9926188;Name=CC31p042;codon_start=1;product=hypothetical protein;protein_id=YP_004009900.1;transl_table=11;translation=length.146
-NC_014662	GenBank	exon	24751	25191	.	-	1	Parent=CC31p042.t01
-NC_014662	GenBank	gene	25255	27963	.	-	1	ID=CC31p043;Dbxref=GeneID:9926189;Name=43;locus_tag=CC31p043
-NC_014662	GenBank	mRNA	25255	27963	.	-	1	ID=CC31p043.t01;Parent=CC31p043
-NC_014662	GenBank	CDS	25255	27963	.	-	1	ID=CC31p043.p01;Parent=CC31p043.t01;Dbxref=GI:311993035,GeneID:9926189;Name=43;codon_start=1;locus_tag=CC31p043;product=gp43 DNA polymerase;protein_id=YP_004009901.1;transl_table=11;translation=length.902
-NC_014662	GenBank	exon	25255	27963	.	-	1	Parent=CC31p043.t01
-NC_014662	GenBank	gene	28061	28222	.	-	1	ID=CC31p044;Dbxref=GeneID:9926190;Name=43.1;locus_tag=CC31p044
-NC_014662	GenBank	mRNA	28061	28222	.	-	1	ID=CC31p044.t01;Parent=CC31p044
-NC_014662	GenBank	CDS	28061	28222	.	-	1	ID=CC31p044.p01;Parent=CC31p044.t01;Dbxref=GI:311993036,GeneID:9926190;Name=43.1;codon_start=1;locus_tag=CC31p044;product=gp43.1 hypothetical protein;protein_id=YP_004009902.1;transl_table=11;translation=length.53
-NC_014662	GenBank	exon	28061	28222	.	-	1	Parent=CC31p044.t01
-NC_014662	GenBank	gene	28222	28587	.	-	1	ID=CC31p045;Dbxref=GeneID:9926191;Name=regA;locus_tag=CC31p045
-NC_014662	GenBank	mRNA	28222	28587	.	-	1	ID=CC31p045.t01;Parent=CC31p045
-NC_014662	GenBank	CDS	28222	28587	.	-	1	ID=CC31p045.p01;Parent=CC31p045.t01;Dbxref=GI:311993037,GeneID:9926191;Name=regA;Note=RegA;codon_start=1;locus_tag=CC31p045;product=translational repressor protein;protein_id=YP_004009903.1;transl_table=11;translation=length.121
-NC_014662	GenBank	exon	28222	28587	.	-	1	Parent=CC31p045.t01
-NC_014662	GenBank	gene	28589	29152	.	-	1	ID=CC31p046;Dbxref=GeneID:9926192;Name=62;locus_tag=CC31p046
-NC_014662	GenBank	mRNA	28589	29152	.	-	1	ID=CC31p046.t01;Parent=CC31p046
-NC_014662	GenBank	CDS	28589	29152	.	-	1	ID=CC31p046.p01;Parent=CC31p046.t01;Dbxref=GI:311993038,GeneID:9926192;Name=62;codon_start=1;locus_tag=CC31p046;product=gp62 clamp loader subunit%2C DNA polymerase accessory protein;protein_id=YP_004009904.1;transl_table=11;translation=length.187
-NC_014662	GenBank	exon	28589	29152	.	-	1	Parent=CC31p046.t01
-NC_014662	GenBank	gene	29149	30108	.	-	1	ID=CC31p047;Dbxref=GeneID:9926193;Name=44;locus_tag=CC31p047
-NC_014662	GenBank	mRNA	29149	30108	.	-	1	ID=CC31p047.t01;Parent=CC31p047
-NC_014662	GenBank	CDS	29149	30108	.	-	1	ID=CC31p047.p01;Parent=CC31p047.t01;Dbxref=GI:311993039,GeneID:9926193;Name=44;codon_start=1;locus_tag=CC31p047;product=gp44 clamp loader subunit%2C DNA polymerase accessory protein;protein_id=YP_004009905.1;transl_table=11;translation=length.319
-NC_014662	GenBank	exon	29149	30108	.	-	1	Parent=CC31p047.t01
-NC_014662	GenBank	gene	30168	30854	.	-	1	ID=CC31p048;Dbxref=GeneID:9926194;Name=45;locus_tag=CC31p048
-NC_014662	GenBank	mRNA	30168	30854	.	-	1	ID=CC31p048.t01;Parent=CC31p048
-NC_014662	GenBank	CDS	30168	30854	.	-	1	ID=CC31p048.p01;Parent=CC31p048.t01;Dbxref=GI:311993040,GeneID:9926194;Name=45;codon_start=1;locus_tag=CC31p048;product=gp45 sliding clamp%2C DNA polymerase accessory protein;protein_id=YP_004009906.1;transl_table=11;translation=length.228
-NC_014662	GenBank	exon	30168	30854	.	-	1	Parent=CC31p048.t01
-NC_014662	GenBank	gene	30863	31288	.	-	1	ID=CC31p049;Dbxref=GeneID:9926195;Name=rpbA;locus_tag=CC31p049
-NC_014662	GenBank	mRNA	30863	31288	.	-	1	ID=CC31p049.t01;Parent=CC31p049
-NC_014662	GenBank	CDS	30863	31288	.	-	1	ID=CC31p049.p01;Parent=CC31p049.t01;Dbxref=GI:311993041,GeneID:9926195;Name=rpbA;Note=RpbA;codon_start=1;locus_tag=CC31p049;product=RNA polymerase binding protein;protein_id=YP_004009907.1;transl_table=11;translation=length.141
-NC_014662	GenBank	exon	30863	31288	.	-	1	Parent=CC31p049.t01
-NC_014662	GenBank	gene	31300	31491	.	-	1	ID=CC31p050;Dbxref=GeneID:9926196;Name=45.1;locus_tag=CC31p050
-NC_014662	GenBank	mRNA	31300	31491	.	-	1	ID=CC31p050.t01;Parent=CC31p050
-NC_014662	GenBank	CDS	31300	31491	.	-	1	ID=CC31p050.p01;Parent=CC31p050.t01;Dbxref=GI:311993042,GeneID:9926196;Name=45.1;codon_start=1;locus_tag=CC31p050;product=hypothetical protein;protein_id=YP_004009908.1;transl_table=11;translation=length.63
-NC_014662	GenBank	exon	31300	31491	.	-	1	Parent=CC31p050.t01
-NC_014662	GenBank	gene	31488	33176	.	-	1	ID=CC31p051;Dbxref=GeneID:9926197;Name=46;locus_tag=CC31p051
-NC_014662	GenBank	mRNA	31488	33176	.	-	1	ID=CC31p051.t01;Parent=CC31p051
-NC_014662	GenBank	CDS	31488	33176	.	-	1	ID=CC31p051.p01;Parent=CC31p051.t01;Dbxref=GI:311993043,GeneID:9926197;Name=46;codon_start=1;locus_tag=CC31p051;product=gp46 recombination endonuclease subunit;protein_id=YP_004009909.1;transl_table=11;translation=length.562
-NC_014662	GenBank	exon	31488	33176	.	-	1	Parent=CC31p051.t01
-NC_014662	GenBank	gene	33173	34195	.	-	1	ID=CC31p052;Dbxref=GeneID:9926198;Name=47;locus_tag=CC31p052
-NC_014662	GenBank	mRNA	33173	34195	.	-	1	ID=CC31p052.t01;Parent=CC31p052
-NC_014662	GenBank	CDS	33173	34195	.	-	1	ID=CC31p052.p01;Parent=CC31p052.t01;Dbxref=GI:311993044,GeneID:9926198;Name=47;codon_start=1;locus_tag=CC31p052;product=gp47 recombination endonuclease subunit;protein_id=YP_004009910.1;transl_table=11;translation=length.340
-NC_014662	GenBank	exon	33173	34195	.	-	1	Parent=CC31p052.t01
-NC_014662	GenBank	gene	34303	34551	.	-	1	ID=CC31p053;Dbxref=GeneID:9926199;Name=CC31p053
-NC_014662	GenBank	mRNA	34303	34551	.	-	1	ID=CC31p053.t01;Parent=CC31p053
-NC_014662	GenBank	CDS	34303	34551	.	-	1	ID=CC31p053.p01;Parent=CC31p053.t01;Dbxref=GI:311993045,GeneID:9926199;Name=CC31p053;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009911.1;transl_table=11;translation=length.82
-NC_014662	GenBank	exon	34303	34551	.	-	1	Parent=CC31p053.t01
-NC_014662	GenBank	gene	34551	34748	.	-	1	ID=CC31p054;Dbxref=GeneID:9926200;Name=a-gt.3;locus_tag=CC31p054
-NC_014662	GenBank	mRNA	34551	34748	.	-	1	ID=CC31p054.t01;Parent=CC31p054
-NC_014662	GenBank	CDS	34551	34748	.	-	1	ID=CC31p054.p01;Parent=CC31p054.t01;Dbxref=GI:311993046,GeneID:9926200;Name=a-gt.3;codon_start=1;locus_tag=CC31p054;product=hypothetical protein;protein_id=YP_004009912.1;transl_table=11;translation=length.65
-NC_014662	GenBank	exon	34551	34748	.	-	1	Parent=CC31p054.t01
-NC_014662	GenBank	gene	34726	35052	.	-	1	ID=CC31p055;Dbxref=GeneID:9926201;Name=a-gt.4;locus_tag=CC31p055
-NC_014662	GenBank	mRNA	34726	35052	.	-	1	ID=CC31p055.t01;Parent=CC31p055
-NC_014662	GenBank	CDS	34726	35052	.	-	1	ID=CC31p055.p01;Parent=CC31p055.t01;Dbxref=GI:311993047,GeneID:9926201;Name=a-gt.4;codon_start=1;locus_tag=CC31p055;product=hypothetical protein;protein_id=YP_004009913.1;transl_table=11;translation=length.108
-NC_014662	GenBank	exon	34726	35052	.	-	1	Parent=CC31p055.t01
-NC_014662	GenBank	gene	35058	35285	.	-	1	ID=CC31p056;Dbxref=GeneID:9926202;Name=a-gt.5;locus_tag=CC31p056
-NC_014662	GenBank	mRNA	35058	35285	.	-	1	ID=CC31p056.t01;Parent=CC31p056
-NC_014662	GenBank	CDS	35058	35285	.	-	1	ID=CC31p056.p01;Parent=CC31p056.t01;Dbxref=GI:311993048,GeneID:9926202;Name=a-gt.5;codon_start=1;locus_tag=CC31p056;product=hypothetical protein;protein_id=YP_004009914.1;transl_table=11;translation=length.75
-NC_014662	GenBank	exon	35058	35285	.	-	1	Parent=CC31p056.t01
-NC_014662	GenBank	gene	35269	35802	.	-	1	ID=CC31p057;Dbxref=GeneID:9926203;Name=55;locus_tag=CC31p057
-NC_014662	GenBank	mRNA	35269	35802	.	-	1	ID=CC31p057.t01;Parent=CC31p057
-NC_014662	GenBank	CDS	35269	35802	.	-	1	ID=CC31p057.p01;Parent=CC31p057.t01;Dbxref=GI:311993049,GeneID:9926203;Name=55;codon_start=1;locus_tag=CC31p057;product=gp55 sigma factor for T4 late transcription;protein_id=YP_004009915.1;transl_table=11;translation=length.177
-NC_014662	GenBank	exon	35269	35802	.	-	1	Parent=CC31p057.t01
-NC_014662	GenBank	gene	35869	36165	.	-	1	ID=CC31p058;Dbxref=GeneID:9926204;Name=CC31p058
-NC_014662	GenBank	mRNA	35869	36165	.	-	1	ID=CC31p058.t01;Parent=CC31p058
-NC_014662	GenBank	CDS	35869	36165	.	-	1	ID=CC31p058.p01;Parent=CC31p058.t01;Dbxref=GI:311993050,GeneID:9926204;Name=CC31p058;codon_start=1;product=hypothetical protein;protein_id=YP_004009916.1;transl_table=11;translation=length.98
-NC_014662	GenBank	exon	35869	36165	.	-	1	Parent=CC31p058.t01
-NC_014662	GenBank	gene	36162	36413	.	-	1	ID=CC31p059;Dbxref=GeneID:9926205;Name=CC31p059
-NC_014662	GenBank	mRNA	36162	36413	.	-	1	ID=CC31p059.t01;Parent=CC31p059
-NC_014662	GenBank	CDS	36162	36413	.	-	1	ID=CC31p059.p01;Parent=CC31p059.t01;Dbxref=GI:311993051,GeneID:9926205;Name=CC31p059;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009917.1;transl_table=11;translation=length.83
-NC_014662	GenBank	exon	36162	36413	.	-	1	Parent=CC31p059.t01
-NC_014662	GenBank	gene	36410	36637	.	-	1	ID=CC31p060;Dbxref=GeneID:9926206;Name=55.1;locus_tag=CC31p060
-NC_014662	GenBank	mRNA	36410	36637	.	-	1	ID=CC31p060.t01;Parent=CC31p060
-NC_014662	GenBank	CDS	36410	36637	.	-	1	ID=CC31p060.p01;Parent=CC31p060.t01;Dbxref=GI:311993052,GeneID:9926206;Name=55.1;codon_start=1;locus_tag=CC31p060;product=hypothetical protein;protein_id=YP_004009918.1;transl_table=11;translation=length.75
-NC_014662	GenBank	exon	36410	36637	.	-	1	Parent=CC31p060.t01
-NC_014662	GenBank	gene	36630	36893	.	-	1	ID=CC31p061;Dbxref=GeneID:9926207;Name=CC31p061
-NC_014662	GenBank	mRNA	36630	36893	.	-	1	ID=CC31p061.t01;Parent=CC31p061
-NC_014662	GenBank	CDS	36630	36893	.	-	1	ID=CC31p061.p01;Parent=CC31p061.t01;Dbxref=GI:311993053,GeneID:9926207;Name=CC31p061;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009919.1;transl_table=11;translation=length.87
-NC_014662	GenBank	exon	36630	36893	.	-	1	Parent=CC31p061.t01
-NC_014662	GenBank	gene	36890	37204	.	-	1	ID=CC31p062;Dbxref=GeneID:9926208;Name=CC31p062
-NC_014662	GenBank	mRNA	36890	37204	.	-	1	ID=CC31p062.t01;Parent=CC31p062
-NC_014662	GenBank	CDS	36890	37204	.	-	1	ID=CC31p062.p01;Parent=CC31p062.t01;Dbxref=GI:311993054,GeneID:9926208;Name=CC31p062;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009920.1;transl_table=11;translation=length.104
-NC_014662	GenBank	exon	36890	37204	.	-	1	Parent=CC31p062.t01
-NC_014662	GenBank	gene	37201	37539	.	-	1	ID=CC31p063;Dbxref=GeneID:9926209;Name=55.2;locus_tag=CC31p063
-NC_014662	GenBank	mRNA	37201	37539	.	-	1	ID=CC31p063.t01;Parent=CC31p063
-NC_014662	GenBank	CDS	37201	37539	.	-	1	ID=CC31p063.p01;Parent=CC31p063.t01;Dbxref=GI:311993055,GeneID:9926209;Name=55.2;codon_start=1;locus_tag=CC31p063;product=hypothetical protein;protein_id=YP_004009921.1;transl_table=11;translation=length.112
-NC_014662	GenBank	exon	37201	37539	.	-	1	Parent=CC31p063.t01
-NC_014662	GenBank	gene	37605	37871	.	-	1	ID=CC31p064;Dbxref=GeneID:9926210;Name=CC31p064
-NC_014662	GenBank	mRNA	37605	37871	.	-	1	ID=CC31p064.t01;Parent=CC31p064
-NC_014662	GenBank	CDS	37605	37871	.	-	1	ID=CC31p064.p01;Parent=CC31p064.t01;Dbxref=GI:311993056,GeneID:9926210;Name=CC31p064;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009922.1;transl_table=11;translation=length.88
-NC_014662	GenBank	exon	37605	37871	.	-	1	Parent=CC31p064.t01
-NC_014662	GenBank	gene	38018	38332	.	-	1	ID=CC31p065;Dbxref=GeneID:9926211;Name=nrdH;locus_tag=CC31p065
-NC_014662	GenBank	mRNA	38018	38332	.	-	1	ID=CC31p065.t01;Parent=CC31p065
-NC_014662	GenBank	CDS	38018	38332	.	-	1	ID=CC31p065.p01;Parent=CC31p065.t01;Dbxref=GI:311993057,GeneID:9926211;Name=nrdH;Note=NrdH;codon_start=1;locus_tag=CC31p065;product=glutaredoxin;protein_id=YP_004009923.1;transl_table=11;translation=length.104
-NC_014662	GenBank	exon	38018	38332	.	-	1	Parent=CC31p065.t01
-NC_014662	GenBank	gene	38307	38582	.	-	1	ID=CC31p066;Dbxref=GeneID:9926212;Name=CC31p066
-NC_014662	GenBank	mRNA	38307	38582	.	-	1	ID=CC31p066.t01;Parent=CC31p066
-NC_014662	GenBank	CDS	38307	38582	.	-	1	ID=CC31p066.p01;Parent=CC31p066.t01;Dbxref=GI:311993058,GeneID:9926212;Name=CC31p066;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009924.1;transl_table=11;translation=length.91
-NC_014662	GenBank	exon	38307	38582	.	-	1	Parent=CC31p066.t01
-NC_014662	GenBank	gene	38591	38698	.	-	1	ID=CC31p067;Dbxref=GeneID:9926213;Name=CC31p067
-NC_014662	GenBank	mRNA	38591	38698	.	-	1	ID=CC31p067.t01;Parent=CC31p067
-NC_014662	GenBank	CDS	38591	38698	.	-	1	ID=CC31p067.p01;Parent=CC31p067.t01;Dbxref=GI:311993059,GeneID:9926213;Name=CC31p067;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009925.1;transl_table=11;translation=length.35
-NC_014662	GenBank	exon	38591	38698	.	-	1	Parent=CC31p067.t01
-NC_014662	GenBank	gene	38682	39167	.	-	1	ID=CC31p068;Dbxref=GeneID:9926214;Name=nrdG;locus_tag=CC31p068
-NC_014662	GenBank	mRNA	38682	39167	.	-	1	ID=CC31p068.t01;Parent=CC31p068
-NC_014662	GenBank	CDS	38682	39167	.	-	1	ID=CC31p068.p01;Parent=CC31p068.t01;Dbxref=GI:311993060,GeneID:9926214;Name=nrdG;Note=NrdG;codon_start=1;locus_tag=CC31p068;product=anaerobic NTP reductase%2C small subunit;protein_id=YP_004009926.1;transl_table=11;translation=length.161
-NC_014662	GenBank	exon	38682	39167	.	-	1	Parent=CC31p068.t01
-NC_014662	GenBank	gene	39157	40986	.	-	1	ID=CC31p069;Dbxref=GeneID:9926215;Name=nrdD;locus_tag=CC31p069
-NC_014662	GenBank	mRNA	39157	40986	.	-	1	ID=CC31p069.t01;Parent=CC31p069
-NC_014662	GenBank	CDS	39157	40986	.	-	1	ID=CC31p069.p01;Parent=CC31p069.t01;Dbxref=GI:311993061,GeneID:9926215;Name=nrdD;Note=NrdD;codon_start=1;locus_tag=CC31p069;product=anaerobic NTP reductase%2C large subunit;protein_id=YP_004009927.1;transl_table=11;translation=length.609
-NC_014662	GenBank	exon	39157	40986	.	-	1	Parent=CC31p069.t01
-NC_014662	GenBank	gene	40983	41456	.	-	1	ID=CC31p070;Dbxref=GeneID:9926216;Name=49;locus_tag=CC31p070
-NC_014662	GenBank	mRNA	40983	41456	.	-	1	ID=CC31p070.t01;Parent=CC31p070
-NC_014662	GenBank	CDS	40983	41456	.	-	1	ID=CC31p070.p01;Parent=CC31p070.t01;Dbxref=GI:311993062,GeneID:9926216;Name=49;codon_start=1;locus_tag=CC31p070;product=gp49 recombinase endonuclease VII;protein_id=YP_004009928.1;transl_table=11;translation=length.157
-NC_014662	GenBank	exon	40983	41456	.	-	1	Parent=CC31p070.t01
-NC_014662	GenBank	gene	41491	41958	.	-	1	ID=CC31p071;Dbxref=GeneID:9926217;Name=pin;locus_tag=CC31p071
-NC_014662	GenBank	mRNA	41491	41958	.	-	1	ID=CC31p071.t01;Parent=CC31p071
-NC_014662	GenBank	CDS	41491	41958	.	-	1	ID=CC31p071.p01;Parent=CC31p071.t01;Dbxref=GI:311993063,GeneID:9926217;Name=pin;Note=Pin;codon_start=1;locus_tag=CC31p071;product=inhibitor of host Lon protease;protein_id=YP_004009929.1;transl_table=11;translation=length.155
-NC_014662	GenBank	exon	41491	41958	.	-	1	Parent=CC31p071.t01
-NC_014662	GenBank	gene	41942	42088	.	-	1	ID=CC31p072;Dbxref=GeneID:9926218;Name=49.1;locus_tag=CC31p072
-NC_014662	GenBank	mRNA	41942	42088	.	-	1	ID=CC31p072.t01;Parent=CC31p072
-NC_014662	GenBank	CDS	41942	42088	.	-	1	ID=CC31p072.p01;Parent=CC31p072.t01;Dbxref=GI:311993064,GeneID:9926218;Name=49.1;codon_start=1;locus_tag=CC31p072;product=hypothetical protein;protein_id=YP_004009930.1;transl_table=11;translation=length.48
-NC_014662	GenBank	exon	41942	42088	.	-	1	Parent=CC31p072.t01
-NC_014662	GenBank	gene	42073	42384	.	-	1	ID=CC31p073;Dbxref=GeneID:9926219;Name=49.2;locus_tag=CC31p073
-NC_014662	GenBank	mRNA	42073	42384	.	-	1	ID=CC31p073.t01;Parent=CC31p073
-NC_014662	GenBank	CDS	42073	42384	.	-	1	ID=CC31p073.p01;Parent=CC31p073.t01;Dbxref=GI:311993065,GeneID:9926219;Name=49.2;codon_start=1;locus_tag=CC31p073;product=hypothetical protein;protein_id=YP_004009931.1;transl_table=11;translation=length.103
-NC_014662	GenBank	exon	42073	42384	.	-	1	Parent=CC31p073.t01
-NC_014662	GenBank	gene	42384	42557	.	-	1	ID=CC31p074;Dbxref=GeneID:9926220;Name=CC31p074
-NC_014662	GenBank	mRNA	42384	42557	.	-	1	ID=CC31p074.t01;Parent=CC31p074
-NC_014662	GenBank	CDS	42384	42557	.	-	1	ID=CC31p074.p01;Parent=CC31p074.t01;Dbxref=GI:311993066,GeneID:9926220;Name=CC31p074;codon_start=1;product=hypothetical protein;protein_id=YP_004009932.1;transl_table=11;translation=length.57
-NC_014662	GenBank	exon	42384	42557	.	-	1	Parent=CC31p074.t01
-NC_014662	GenBank	gene	42554	42835	.	-	1	ID=CC31p075;Dbxref=GeneID:9926221;Name=nrdC;locus_tag=CC31p075
-NC_014662	GenBank	mRNA	42554	42835	.	-	1	ID=CC31p075.t01;Parent=CC31p075
-NC_014662	GenBank	CDS	42554	42835	.	-	1	ID=CC31p075.p01;Parent=CC31p075.t01;Dbxref=GI:311993067,GeneID:9926221;Name=nrdC;Note=NrdC;codon_start=1;locus_tag=CC31p075;product=thioredoxin;protein_id=YP_004009933.1;transl_table=11;translation=length.93
-NC_014662	GenBank	exon	42554	42835	.	-	1	Parent=CC31p075.t01
-NC_014662	GenBank	gene	42795	43088	.	-	1	ID=CC31p076;Dbxref=GeneID:9926222;Name=nrdC.1;locus_tag=CC31p076
-NC_014662	GenBank	mRNA	42795	43088	.	-	1	ID=CC31p076.t01;Parent=CC31p076
-NC_014662	GenBank	CDS	42795	43088	.	-	1	ID=CC31p076.p01;Parent=CC31p076.t01;Dbxref=GI:311993068,GeneID:9926222;Name=nrdC.1;codon_start=1;locus_tag=CC31p076;product=hypothetical protein;protein_id=YP_004009934.1;transl_table=11;translation=length.97
-NC_014662	GenBank	exon	42795	43088	.	-	1	Parent=CC31p076.t01
-NC_014662	GenBank	gene	43085	43378	.	-	1	ID=CC31p077;Dbxref=GeneID:9926223;Name=CC31p077
-NC_014662	GenBank	mRNA	43085	43378	.	-	1	ID=CC31p077.t01;Parent=CC31p077
-NC_014662	GenBank	CDS	43085	43378	.	-	1	ID=CC31p077.p01;Parent=CC31p077.t01;Dbxref=GI:311993069,GeneID:9926223;Name=CC31p077;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009935.1;transl_table=11;translation=length.97
-NC_014662	GenBank	exon	43085	43378	.	-	1	Parent=CC31p077.t01
-NC_014662	GenBank	gene	43375	43710	.	-	1	ID=CC31p078;Dbxref=GeneID:9926224;Name=CC31p078
-NC_014662	GenBank	mRNA	43375	43710	.	-	1	ID=CC31p078.t01;Parent=CC31p078
-NC_014662	GenBank	CDS	43375	43710	.	-	1	ID=CC31p078.p01;Parent=CC31p078.t01;Dbxref=GI:311993070,GeneID:9926224;Name=CC31p078;codon_start=1;product=hypothetical protein;protein_id=YP_004009936.1;transl_table=11;translation=length.111
-NC_014662	GenBank	exon	43375	43710	.	-	1	Parent=CC31p078.t01
-NC_014662	GenBank	gene	43707	44222	.	-	1	ID=CC31p079;Dbxref=GeneID:9926225;Name=CC31p079
-NC_014662	GenBank	mRNA	43707	44222	.	-	1	ID=CC31p079.t01;Parent=CC31p079
-NC_014662	GenBank	CDS	43707	44222	.	-	1	ID=CC31p079.p01;Parent=CC31p079.t01;Dbxref=GI:311993071,GeneID:9926225;Name=CC31p079;codon_start=1;product=hypothetical protein;protein_id=YP_004009937.1;transl_table=11;translation=length.171
-NC_014662	GenBank	exon	43707	44222	.	-	1	Parent=CC31p079.t01
-NC_014662	GenBank	gene	44235	44663	.	-	1	ID=CC31p080;Dbxref=GeneID:9926226;Name=nrdC.7;locus_tag=CC31p080
-NC_014662	GenBank	mRNA	44235	44663	.	-	1	ID=CC31p080.t01;Parent=CC31p080
-NC_014662	GenBank	CDS	44235	44663	.	-	1	ID=CC31p080.p01;Parent=CC31p080.t01;Dbxref=GI:311993072,GeneID:9926226;Name=nrdC.7;codon_start=1;locus_tag=CC31p080;product=predicted membrane protein;protein_id=YP_004009938.1;transl_table=11;translation=length.142
-NC_014662	GenBank	exon	44235	44663	.	-	1	Parent=CC31p080.t01
-NC_014662	GenBank	gene	44660	44917	.	-	1	ID=CC31p081;Dbxref=GeneID:9926227;Name=nrdC.2;locus_tag=CC31p081
-NC_014662	GenBank	mRNA	44660	44917	.	-	1	ID=CC31p081.t01;Parent=CC31p081
-NC_014662	GenBank	CDS	44660	44917	.	-	1	ID=CC31p081.p01;Parent=CC31p081.t01;Dbxref=GI:311993073,GeneID:9926227;Name=nrdC.2;codon_start=1;locus_tag=CC31p081;product=hypothetical protein;protein_id=YP_004009939.1;transl_table=11;translation=length.85
-NC_014662	GenBank	exon	44660	44917	.	-	1	Parent=CC31p081.t01
-NC_014662	GenBank	gene	44914	45912	.	-	1	ID=CC31p082;Dbxref=GeneID:9926228;Name=CC31p082
-NC_014662	GenBank	mRNA	44914	45912	.	-	1	ID=CC31p082.t01;Parent=CC31p082
-NC_014662	GenBank	CDS	44914	45912	.	-	1	ID=CC31p082.p01;Parent=CC31p082.t01;Dbxref=GI:311993074,GeneID:9926228;Name=CC31p082;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009940.1;transl_table=11;translation=length.332
-NC_014662	GenBank	exon	44914	45912	.	-	1	Parent=CC31p082.t01
-NC_014662	GenBank	gene	45988	46194	.	-	1	ID=CC31p083;Dbxref=GeneID:9926229;Name=CC31p083
-NC_014662	GenBank	mRNA	45988	46194	.	-	1	ID=CC31p083.t01;Parent=CC31p083
-NC_014662	GenBank	CDS	45988	46194	.	-	1	ID=CC31p083.p01;Parent=CC31p083.t01;Dbxref=GI:311993075,GeneID:9926229;Name=CC31p083;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009941.1;transl_table=11;translation=length.68
-NC_014662	GenBank	exon	45988	46194	.	-	1	Parent=CC31p083.t01
-NC_014662	GenBank	gene	46182	46619	.	-	1	ID=CC31p084;Dbxref=GeneID:9926230;Name=CC31p084
-NC_014662	GenBank	mRNA	46182	46619	.	-	1	ID=CC31p084.t01;Parent=CC31p084
-NC_014662	GenBank	CDS	46182	46619	.	-	1	ID=CC31p084.p01;Parent=CC31p084.t01;Dbxref=GI:311993076,GeneID:9926230;Name=CC31p084;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009942.1;transl_table=11;translation=length.145
-NC_014662	GenBank	exon	46182	46619	.	-	1	Parent=CC31p084.t01
-NC_014662	GenBank	gene	46613	47389	.	-	1	ID=CC31p085;Dbxref=GeneID:9926231;Name=CC31p085
-NC_014662	GenBank	mRNA	46613	47389	.	-	1	ID=CC31p085.t01;Parent=CC31p085
-NC_014662	GenBank	CDS	46613	47389	.	-	1	ID=CC31p085.p01;Parent=CC31p085.t01;Dbxref=GI:311993077,GeneID:9926231;Name=CC31p085;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009943.1;transl_table=11;translation=length.258
-NC_014662	GenBank	exon	46613	47389	.	-	1	Parent=CC31p085.t01
-NC_014662	GenBank	gene	47555	47896	.	-	1	ID=CC31p086;Dbxref=GeneID:9926232;Name=CC31p086
-NC_014662	GenBank	mRNA	47555	47896	.	-	1	ID=CC31p086.t01;Parent=CC31p086
-NC_014662	GenBank	CDS	47555	47896	.	-	1	ID=CC31p086.p01;Parent=CC31p086.t01;Dbxref=GI:311993078,GeneID:9926232;Name=CC31p086;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009944.1;transl_table=11;translation=length.113
-NC_014662	GenBank	exon	47555	47896	.	-	1	Parent=CC31p086.t01
-NC_014662	GenBank	gene	47920	48336	.	-	1	ID=CC31p087;Dbxref=GeneID:9926233;Name=CC31p087
-NC_014662	GenBank	mRNA	47920	48336	.	-	1	ID=CC31p087.t01;Parent=CC31p087
-NC_014662	GenBank	CDS	47920	48336	.	-	1	ID=CC31p087.p01;Parent=CC31p087.t01;Dbxref=GI:311993079,GeneID:9926233;Name=CC31p087;codon_start=1;product=hypothetical protein;protein_id=YP_004009945.1;transl_table=11;translation=length.138
-NC_014662	GenBank	exon	47920	48336	.	-	1	Parent=CC31p087.t01
-NC_014662	GenBank	gene	48336	48551	.	-	1	ID=CC31p088;Dbxref=GeneID:9926234;Name=CC31p088
-NC_014662	GenBank	mRNA	48336	48551	.	-	1	ID=CC31p088.t01;Parent=CC31p088
-NC_014662	GenBank	CDS	48336	48551	.	-	1	ID=CC31p088.p01;Parent=CC31p088.t01;Dbxref=GI:311993080,GeneID:9926234;Name=CC31p088;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009946.1;transl_table=11;translation=length.71
-NC_014662	GenBank	exon	48336	48551	.	-	1	Parent=CC31p088.t01
-NC_014662	GenBank	gene	48545	48730	.	-	1	ID=CC31p089;Dbxref=GeneID:9926235;Name=CC31p089
-NC_014662	GenBank	mRNA	48545	48730	.	-	1	ID=CC31p089.t01;Parent=CC31p089
-NC_014662	GenBank	CDS	48545	48730	.	-	1	ID=CC31p089.p01;Parent=CC31p089.t01;Dbxref=GI:311993081,GeneID:9926235;Name=CC31p089;codon_start=1;product=hypothetical protein;protein_id=YP_004009947.1;transl_table=11;translation=length.61
-NC_014662	GenBank	exon	48545	48730	.	-	1	Parent=CC31p089.t01
-NC_014662	GenBank	gene	48727	49230	.	-	1	ID=CC31p090;Dbxref=GeneID:9926236;Name=CC31p090
-NC_014662	GenBank	mRNA	48727	49230	.	-	1	ID=CC31p090.t01;Parent=CC31p090
-NC_014662	GenBank	CDS	48727	49230	.	-	1	ID=CC31p090.p01;Parent=CC31p090.t01;Dbxref=GI:311993082,GeneID:9926236;Name=CC31p090;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009948.1;transl_table=11;translation=length.167
-NC_014662	GenBank	exon	48727	49230	.	-	1	Parent=CC31p090.t01
-NC_014662	GenBank	gene	49241	49582	.	-	1	ID=CC31p091;Dbxref=GeneID:9926237;Name=CC31p091
-NC_014662	GenBank	mRNA	49241	49582	.	-	1	ID=CC31p091.t01;Parent=CC31p091
-NC_014662	GenBank	CDS	49241	49582	.	-	1	ID=CC31p091.p01;Parent=CC31p091.t01;Dbxref=GI:311993083,GeneID:9926237;Name=CC31p091;codon_start=1;product=hypothetical protein;protein_id=YP_004009949.1;transl_table=11;translation=length.113
-NC_014662	GenBank	exon	49241	49582	.	-	1	Parent=CC31p091.t01
-NC_014662	GenBank	gene	49621	50598	.	-	1	ID=CC31p092;Dbxref=GeneID:9926238;Name=nrdC.10;locus_tag=CC31p092
-NC_014662	GenBank	mRNA	49621	50598	.	-	1	ID=CC31p092.t01;Parent=CC31p092
-NC_014662	GenBank	CDS	49621	50598	.	-	1	ID=CC31p092.p01;Parent=CC31p092.t01;Dbxref=GI:311993084,GeneID:9926238;Name=nrdC.10;codon_start=1;locus_tag=CC31p092;product=hypothetical protein;protein_id=YP_004009950.1;transl_table=11;translation=length.325
-NC_014662	GenBank	exon	49621	50598	.	-	1	Parent=CC31p092.t01
-NC_014662	GenBank	gene	50670	50933	.	-	1	ID=CC31p093;Dbxref=GeneID:9926239;Name=CC31p093
-NC_014662	GenBank	mRNA	50670	50933	.	-	1	ID=CC31p093.t01;Parent=CC31p093
-NC_014662	GenBank	CDS	50670	50933	.	-	1	ID=CC31p093.p01;Parent=CC31p093.t01;Dbxref=GI:311993085,GeneID:9926239;Name=CC31p093;codon_start=1;product=hypothetical protein;protein_id=YP_004009951.1;transl_table=11;translation=length.87
-NC_014662	GenBank	exon	50670	50933	.	-	1	Parent=CC31p093.t01
-NC_014662	GenBank	gene	50930	51079	.	-	1	ID=CC31p094;Dbxref=GeneID:9926240;Name=CC31p094
-NC_014662	GenBank	mRNA	50930	51079	.	-	1	ID=CC31p094.t01;Parent=CC31p094
-NC_014662	GenBank	CDS	50930	51079	.	-	1	ID=CC31p094.p01;Parent=CC31p094.t01;Dbxref=GI:311993086,GeneID:9926240;Name=CC31p094;codon_start=1;product=hypothetical protein;protein_id=YP_004009952.1;transl_table=11;translation=length.49
-NC_014662	GenBank	exon	50930	51079	.	-	1	Parent=CC31p094.t01
-NC_014662	GenBank	gene	51079	51351	.	-	1	ID=CC31p095;Dbxref=GeneID:9926241;Name=CC31p095
-NC_014662	GenBank	mRNA	51079	51351	.	-	1	ID=CC31p095.t01;Parent=CC31p095
-NC_014662	GenBank	CDS	51079	51351	.	-	1	ID=CC31p095.p01;Parent=CC31p095.t01;Dbxref=GI:311993087,GeneID:9926241;Name=CC31p095;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009953.1;transl_table=11;translation=length.90
-NC_014662	GenBank	exon	51079	51351	.	-	1	Parent=CC31p095.t01
-NC_014662	GenBank	gene	51357	51641	.	-	1	ID=CC31p096;Dbxref=GeneID:9926242;Name=CC31p096
-NC_014662	GenBank	mRNA	51357	51641	.	-	1	ID=CC31p096.t01;Parent=CC31p096
-NC_014662	GenBank	CDS	51357	51641	.	-	1	ID=CC31p096.p01;Parent=CC31p096.t01;Dbxref=GI:311993088,GeneID:9926242;Name=CC31p096;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009954.1;transl_table=11;translation=length.94
-NC_014662	GenBank	exon	51357	51641	.	-	1	Parent=CC31p096.t01
-NC_014662	GenBank	gene	51760	52014	.	-	1	ID=CC31p097;Dbxref=GeneID:9926243;Name=CC31p097
-NC_014662	GenBank	mRNA	51760	52014	.	-	1	ID=CC31p097.t01;Parent=CC31p097
-NC_014662	GenBank	CDS	51760	52014	.	-	1	ID=CC31p097.p01;Parent=CC31p097.t01;Dbxref=GI:311993089,GeneID:9926243;Name=CC31p097;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009955.1;transl_table=11;translation=length.84
-NC_014662	GenBank	exon	51760	52014	.	-	1	Parent=CC31p097.t01
-NC_014662	GenBank	gene	52017	53027	.	-	1	ID=CC31p098;Dbxref=GeneID:9926244;Name=nrdC.11;locus_tag=CC31p098
-NC_014662	GenBank	mRNA	52017	53027	.	-	1	ID=CC31p098.t01;Parent=CC31p098
-NC_014662	GenBank	CDS	52017	53027	.	-	1	ID=CC31p098.p01;Parent=CC31p098.t01;Dbxref=GI:311993090,GeneID:9926244;Name=nrdC.11;Note=predicted nucleotidyltransferase motif;codon_start=1;locus_tag=CC31p098;product=hypothetical protein;protein_id=YP_004009956.1;transl_table=11;translation=length.336
-NC_014662	GenBank	exon	52017	53027	.	-	1	Parent=CC31p098.t01
-NC_014662	GenBank	gene	53024	53449	.	-	1	ID=CC31p099;Dbxref=GeneID:9926245;Name=CC31p099
-NC_014662	GenBank	mRNA	53024	53449	.	-	1	ID=CC31p099.t01;Parent=CC31p099
-NC_014662	GenBank	CDS	53024	53449	.	-	1	ID=CC31p099.p01;Parent=CC31p099.t01;Dbxref=GI:311993091,GeneID:9926245;Name=CC31p099;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009957.1;transl_table=11;translation=length.141
-NC_014662	GenBank	exon	53024	53449	.	-	1	Parent=CC31p099.t01
-NC_014662	GenBank	gene	53446	54000	.	-	1	ID=CC31p100;Dbxref=GeneID:9926246;Name=CC31p100
-NC_014662	GenBank	mRNA	53446	54000	.	-	1	ID=CC31p100.t01;Parent=CC31p100
-NC_014662	GenBank	CDS	53446	54000	.	-	1	ID=CC31p100.p01;Parent=CC31p100.t01;Dbxref=GI:311993092,GeneID:9926246;Name=CC31p100;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009958.1;transl_table=11;translation=length.184
-NC_014662	GenBank	exon	53446	54000	.	-	1	Parent=CC31p100.t01
-NC_014662	GenBank	gene	54010	54231	.	-	1	ID=CC31p101;Dbxref=GeneID:9926247;Name=CC31p101
-NC_014662	GenBank	mRNA	54010	54231	.	-	1	ID=CC31p101.t01;Parent=CC31p101
-NC_014662	GenBank	CDS	54010	54231	.	-	1	ID=CC31p101.p01;Parent=CC31p101.t01;Dbxref=GI:311993093,GeneID:9926247;Name=CC31p101;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009959.1;transl_table=11;translation=length.73
-NC_014662	GenBank	exon	54010	54231	.	-	1	Parent=CC31p101.t01
-NC_014662	GenBank	gene	54231	54683	.	-	1	ID=CC31p102;Dbxref=GeneID:9926248;Name=CC31p102
-NC_014662	GenBank	mRNA	54231	54683	.	-	1	ID=CC31p102.t01;Parent=CC31p102
-NC_014662	GenBank	CDS	54231	54683	.	-	1	ID=CC31p102.p01;Parent=CC31p102.t01;Dbxref=GI:311993094,GeneID:9926248;Name=CC31p102;codon_start=1;product=hypothetical protein;protein_id=YP_004009960.1;transl_table=11;translation=length.150
-NC_014662	GenBank	exon	54231	54683	.	-	1	Parent=CC31p102.t01
-NC_014662	GenBank	gene	54705	54950	.	-	1	ID=CC31p103;Dbxref=GeneID:9926249;Name=CC31p103
-NC_014662	GenBank	mRNA	54705	54950	.	-	1	ID=CC31p103.t01;Parent=CC31p103
-NC_014662	GenBank	CDS	54705	54950	.	-	1	ID=CC31p103.p01;Parent=CC31p103.t01;Dbxref=GI:311993095,GeneID:9926249;Name=CC31p103;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009961.1;transl_table=11;translation=length.81
-NC_014662	GenBank	exon	54705	54950	.	-	1	Parent=CC31p103.t01
-NC_014662	GenBank	gene	54943	55218	.	-	1	ID=CC31p104;Dbxref=GeneID:9926250;Name=CC31p104
-NC_014662	GenBank	mRNA	54943	55218	.	-	1	ID=CC31p104.t01;Parent=CC31p104
-NC_014662	GenBank	CDS	54943	55218	.	-	1	ID=CC31p104.p01;Parent=CC31p104.t01;Dbxref=GI:311993096,GeneID:9926250;Name=CC31p104;codon_start=1;product=hypothetical protein;protein_id=YP_004009962.1;transl_table=11;translation=length.91
-NC_014662	GenBank	exon	54943	55218	.	-	1	Parent=CC31p104.t01
-NC_014662	GenBank	gene	55202	55408	.	-	1	ID=CC31p105;Dbxref=GeneID:9926251;Name=CC31p105
-NC_014662	GenBank	mRNA	55202	55408	.	-	1	ID=CC31p105.t01;Parent=CC31p105
-NC_014662	GenBank	CDS	55202	55408	.	-	1	ID=CC31p105.p01;Parent=CC31p105.t01;Dbxref=GI:311993097,GeneID:9926251;Name=CC31p105;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009963.1;transl_table=11;translation=length.68
-NC_014662	GenBank	exon	55202	55408	.	-	1	Parent=CC31p105.t01
-NC_014662	GenBank	gene	55405	55692	.	-	1	ID=CC31p106;Dbxref=GeneID:9926252;Name=CC31p106
-NC_014662	GenBank	mRNA	55405	55692	.	-	1	ID=CC31p106.t01;Parent=CC31p106
-NC_014662	GenBank	CDS	55405	55692	.	-	1	ID=CC31p106.p01;Parent=CC31p106.t01;Dbxref=GI:311993098,GeneID:9926252;Name=CC31p106;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009964.1;transl_table=11;translation=length.95
-NC_014662	GenBank	exon	55405	55692	.	-	1	Parent=CC31p106.t01
-NC_014662	GenBank	gene	55695	55964	.	-	1	ID=CC31p107;Dbxref=GeneID:9926253;Name=CC31p107
-NC_014662	GenBank	mRNA	55695	55964	.	-	1	ID=CC31p107.t01;Parent=CC31p107
-NC_014662	GenBank	CDS	55695	55964	.	-	1	ID=CC31p107.p01;Parent=CC31p107.t01;Dbxref=GI:311993099,GeneID:9926253;Name=CC31p107;Note=predicted DksA/TraR family%2C C4-type zinc finger motif;codon_start=1;product=conserved hypothetical bacterial protein;protein_id=YP_004009965.1;transl_table=11;translation=length.89
-NC_014662	GenBank	exon	55695	55964	.	-	1	Parent=CC31p107.t01
-NC_014662	GenBank	gene	56099	56530	.	-	1	ID=CC31p108;Dbxref=GeneID:9926254;Name=CC31p108
-NC_014662	GenBank	mRNA	56099	56530	.	-	1	ID=CC31p108.t01;Parent=CC31p108
-NC_014662	GenBank	CDS	56099	56530	.	-	1	ID=CC31p108.p01;Parent=CC31p108.t01;Dbxref=GI:311993100,GeneID:9926254;Name=CC31p108;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009966.1;transl_table=11;translation=length.143
-NC_014662	GenBank	exon	56099	56530	.	-	1	Parent=CC31p108.t01
-NC_014662	GenBank	gene	56637	57029	.	-	1	ID=CC31p109;Dbxref=GeneID:9926255;Name=mobD.6;locus_tag=CC31p109
-NC_014662	GenBank	mRNA	56637	57029	.	-	1	ID=CC31p109.t01;Parent=CC31p109
-NC_014662	GenBank	CDS	56637	57029	.	-	1	ID=CC31p109.p01;Parent=CC31p109.t01;Dbxref=GI:311993101,GeneID:9926255;Name=mobD.6;codon_start=1;locus_tag=CC31p109;product=hypothetical protein;protein_id=YP_004009967.1;transl_table=11;translation=length.130
-NC_014662	GenBank	exon	56637	57029	.	-	1	Parent=CC31p109.t01
-NC_014662	GenBank	gene	57013	57288	.	-	1	ID=CC31p110;Dbxref=GeneID:9926256;Name=rI;locus_tag=CC31p110
-NC_014662	GenBank	mRNA	57013	57288	.	-	1	ID=CC31p110.t01;Parent=CC31p110
-NC_014662	GenBank	CDS	57013	57288	.	-	1	ID=CC31p110.p01;Parent=CC31p110.t01;Dbxref=GI:311993102,GeneID:9926256;Name=rI;codon_start=1;locus_tag=CC31p110;product=lysis inhibition regulator membrane protein;protein_id=YP_004009968.1;transl_table=11;translation=length.91
-NC_014662	GenBank	exon	57013	57288	.	-	1	Parent=CC31p110.t01
-NC_014662	GenBank	gene	57296	57508	.	-	1	ID=CC31p111;Dbxref=GeneID:9926257;Name=rI.1;locus_tag=CC31p111
-NC_014662	GenBank	mRNA	57296	57508	.	-	1	ID=CC31p111.t01;Parent=CC31p111
-NC_014662	GenBank	CDS	57296	57508	.	-	1	ID=CC31p111.p01;Parent=CC31p111.t01;Dbxref=GI:311993103,GeneID:9926257;Name=rI.1;codon_start=1;locus_tag=CC31p111;product=hypothetical protein;protein_id=YP_004009969.1;transl_table=11;translation=length.70
-NC_014662	GenBank	exon	57296	57508	.	-	1	Parent=CC31p111.t01
-NC_014662	GenBank	gene	57568	57951	.	-	1	ID=CC31p112;Dbxref=GeneID:9926258;Name=CC31p112
-NC_014662	GenBank	mRNA	57568	57951	.	-	1	ID=CC31p112.t01;Parent=CC31p112
-NC_014662	GenBank	CDS	57568	57951	.	-	1	ID=CC31p112.p01;Parent=CC31p112.t01;Dbxref=GI:311993104,GeneID:9926258;Name=CC31p112;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009970.1;transl_table=11;translation=length.127
-NC_014662	GenBank	exon	57568	57951	.	-	1	Parent=CC31p112.t01
-NC_014662	GenBank	gene	58008	58118	.	-	1	ID=CC31p113;Dbxref=GeneID:9926259;Name=CC31p113
-NC_014662	GenBank	mRNA	58008	58118	.	-	1	ID=CC31p113.t01;Parent=CC31p113
-NC_014662	GenBank	CDS	58008	58118	.	-	1	ID=CC31p113.p01;Parent=CC31p113.t01;Dbxref=GI:311993105,GeneID:9926259;Name=CC31p113;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009971.1;transl_table=11;translation=length.36
-NC_014662	GenBank	exon	58008	58118	.	-	1	Parent=CC31p113.t01
-NC_014662	GenBank	gene	58115	58246	.	-	1	ID=CC31p114;Dbxref=GeneID:9926260;Name=CC31p114
-NC_014662	GenBank	mRNA	58115	58246	.	-	1	ID=CC31p114.t01;Parent=CC31p114
-NC_014662	GenBank	CDS	58115	58246	.	-	1	ID=CC31p114.p01;Parent=CC31p114.t01;Dbxref=GI:311993106,GeneID:9926260;Name=CC31p114;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009972.1;transl_table=11;translation=length.43
-NC_014662	GenBank	exon	58115	58246	.	-	1	Parent=CC31p114.t01
-NC_014662	GenBank	gene	58243	58407	.	-	1	ID=CC31p115;Dbxref=GeneID:9926261;Name=CC31p115
-NC_014662	GenBank	mRNA	58243	58407	.	-	1	ID=CC31p115.t01;Parent=CC31p115
-NC_014662	GenBank	CDS	58243	58407	.	-	1	ID=CC31p115.p01;Parent=CC31p115.t01;Dbxref=GI:311993107,GeneID:9926261;Name=CC31p115;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009973.1;transl_table=11;translation=length.54
-NC_014662	GenBank	exon	58243	58407	.	-	1	Parent=CC31p115.t01
-NC_014662	GenBank	gene	58404	58616	.	-	1	ID=CC31p116;Dbxref=GeneID:9926262;Name=CC31p116
-NC_014662	GenBank	mRNA	58404	58616	.	-	1	ID=CC31p116.t01;Parent=CC31p116
-NC_014662	GenBank	CDS	58404	58616	.	-	1	ID=CC31p116.p01;Parent=CC31p116.t01;Dbxref=GI:311993108,GeneID:9926262;Name=CC31p116;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009974.1;transl_table=11;translation=length.70
-NC_014662	GenBank	exon	58404	58616	.	-	1	Parent=CC31p116.t01
-NC_014662	GenBank	gene	58609	59193	.	-	1	ID=CC31p117;Dbxref=GeneID:9926263;Name=tk;locus_tag=CC31p117
-NC_014662	GenBank	mRNA	58609	59193	.	-	1	ID=CC31p117.t01;Parent=CC31p117
-NC_014662	GenBank	CDS	58609	59193	.	-	1	ID=CC31p117.p01;Parent=CC31p117.t01;Dbxref=GI:311993109,GeneID:9926263;Name=tk;Note=Tk;codon_start=1;locus_tag=CC31p117;product=thymidine kinase;protein_id=YP_004009975.1;transl_table=11;translation=length.194
-NC_014662	GenBank	exon	58609	59193	.	-	1	Parent=CC31p117.t01
-NC_014662	GenBank	gene	59193	59648	.	-	1	ID=CC31p118;Dbxref=GeneID:9926264;Name=tk.4;locus_tag=CC31p118
-NC_014662	GenBank	mRNA	59193	59648	.	-	1	ID=CC31p118.t01;Parent=CC31p118
-NC_014662	GenBank	CDS	59193	59648	.	-	1	ID=CC31p118.p01;Parent=CC31p118.t01;Dbxref=GI:311993110,GeneID:9926264;Name=tk.4;codon_start=1;locus_tag=CC31p118;product=hypothetical protein;protein_id=YP_004009976.1;transl_table=11;translation=length.151
-NC_014662	GenBank	exon	59193	59648	.	-	1	Parent=CC31p118.t01
-NC_014662	GenBank	gene	59645	60064	.	-	1	ID=CC31p119;Dbxref=GeneID:9926265;Name=CC31p119
-NC_014662	GenBank	mRNA	59645	60064	.	-	1	ID=CC31p119.t01;Parent=CC31p119
-NC_014662	GenBank	CDS	59645	60064	.	-	1	ID=CC31p119.p01;Parent=CC31p119.t01;Dbxref=GI:311993111,GeneID:9926265;Name=CC31p119;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009977.1;transl_table=11;translation=length.139
-NC_014662	GenBank	exon	59645	60064	.	-	1	Parent=CC31p119.t01
-NC_014662	GenBank	gene	60061	60387	.	-	1	ID=CC31p120;Dbxref=GeneID:9926266;Name=vs;locus_tag=CC31p120
-NC_014662	GenBank	mRNA	60061	60387	.	-	1	ID=CC31p120.t01;Parent=CC31p120
-NC_014662	GenBank	CDS	60061	60387	.	-	1	ID=CC31p120.p01;Parent=CC31p120.t01;Dbxref=GI:311993112,GeneID:9926266;Name=vs;Note=Vs;codon_start=1;locus_tag=CC31p120;product=valyl-tRNA synthetase modifier;protein_id=YP_004009978.1;transl_table=11;translation=length.108
-NC_014662	GenBank	exon	60061	60387	.	-	1	Parent=CC31p120.t01
-NC_014662	GenBank	gene	60387	60935	.	-	1	ID=CC31p121;Dbxref=GeneID:9926267;Name=vs.1;locus_tag=CC31p121
-NC_014662	GenBank	mRNA	60387	60935	.	-	1	ID=CC31p121.t01;Parent=CC31p121
-NC_014662	GenBank	CDS	60387	60935	.	-	1	ID=CC31p121.p01;Parent=CC31p121.t01;Dbxref=GI:311993113,GeneID:9926267;Name=vs.1;Note=predicted endoribonuclease RegB motif;codon_start=1;locus_tag=CC31p121;product=hypothetical protein;protein_id=YP_004009979.1;transl_table=11;translation=length.182
-NC_014662	GenBank	exon	60387	60935	.	-	1	Parent=CC31p121.t01
-NC_014662	GenBank	gene	60958	61422	.	-	1	ID=CC31p122;Dbxref=GeneID:9926268;Name=regB;locus_tag=CC31p122
-NC_014662	GenBank	mRNA	60958	61422	.	-	1	ID=CC31p122.t01;Parent=CC31p122
-NC_014662	GenBank	CDS	60958	61422	.	-	1	ID=CC31p122.p01;Parent=CC31p122.t01;Dbxref=GI:311993114,GeneID:9926268;Name=regB;Note=RegB;codon_start=1;locus_tag=CC31p122;product=site-specific RNA endonuclease;protein_id=YP_004009980.1;transl_table=11;translation=length.154
-NC_014662	GenBank	exon	60958	61422	.	-	1	Parent=CC31p122.t01
-NC_014662	GenBank	gene	61478	61708	.	-	1	ID=CC31p123;Dbxref=GeneID:9926269;Name=CC31p123
-NC_014662	GenBank	mRNA	61478	61708	.	-	1	ID=CC31p123.t01;Parent=CC31p123
-NC_014662	GenBank	CDS	61478	61708	.	-	1	ID=CC31p123.p01;Parent=CC31p123.t01;Dbxref=GI:311993115,GeneID:9926269;Name=CC31p123;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009981.1;transl_table=11;translation=length.76
-NC_014662	GenBank	exon	61478	61708	.	-	1	Parent=CC31p123.t01
-NC_014662	GenBank	gene	61708	61989	.	-	1	ID=CC31p124;Dbxref=GeneID:9926270;Name=vs.4;locus_tag=CC31p124
-NC_014662	GenBank	mRNA	61708	61989	.	-	1	ID=CC31p124.t01;Parent=CC31p124
-NC_014662	GenBank	CDS	61708	61989	.	-	1	ID=CC31p124.p01;Parent=CC31p124.t01;Dbxref=GI:311993116,GeneID:9926270;Name=vs.4;Note=PRP8%3B U5 snRNP spliceosome subunit%3B predicted RNA processing and modification motif;codon_start=1;locus_tag=CC31p124;product=hypothetical protein;protein_id=YP_004009982.1;transl_table=11;translation=length.93
-NC_014662	GenBank	exon	61708	61989	.	-	1	Parent=CC31p124.t01
-NC_014662	GenBank	gene	61989	62351	.	-	1	ID=CC31p125;Dbxref=GeneID:9926271;Name=vs.6;locus_tag=CC31p125
-NC_014662	GenBank	mRNA	61989	62351	.	-	1	ID=CC31p125.t01;Parent=CC31p125
-NC_014662	GenBank	CDS	61989	62351	.	-	1	ID=CC31p125.p01;Parent=CC31p125.t01;Dbxref=GI:311993117,GeneID:9926271;Name=vs.6;Note=predicted Gly radical superfamily motif;codon_start=1;locus_tag=CC31p125;product=hypothetical protein;protein_id=YP_004009983.1;transl_table=11;translation=length.120
-NC_014662	GenBank	exon	61989	62351	.	-	1	Parent=CC31p125.t01
-NC_014662	GenBank	gene	62361	62513	.	-	1	ID=CC31p126;Dbxref=GeneID:9926272;Name=vs.5;locus_tag=CC31p126
-NC_014662	GenBank	mRNA	62361	62513	.	-	1	ID=CC31p126.t01;Parent=CC31p126
-NC_014662	GenBank	CDS	62361	62513	.	-	1	ID=CC31p126.p01;Parent=CC31p126.t01;Dbxref=GI:311993118,GeneID:9926272;Name=vs.5;codon_start=1;locus_tag=CC31p126;product=hypothetical protein;protein_id=YP_004009984.1;transl_table=11;translation=length.50
-NC_014662	GenBank	exon	62361	62513	.	-	1	Parent=CC31p126.t01
-NC_014662	GenBank	gene	62513	62932	.	-	1	ID=CC31p127;Dbxref=GeneID:9926273;Name=vs.7;locus_tag=CC31p127
-NC_014662	GenBank	mRNA	62513	62932	.	-	1	ID=CC31p127.t01;Parent=CC31p127
-NC_014662	GenBank	CDS	62513	62932	.	-	1	ID=CC31p127.p01;Parent=CC31p127.t01;Dbxref=GI:311993119,GeneID:9926273;Name=vs.7;codon_start=1;locus_tag=CC31p127;product=hypothetical protein;protein_id=YP_004009985.1;transl_table=11;translation=length.139
-NC_014662	GenBank	exon	62513	62932	.	-	1	Parent=CC31p127.t01
-NC_014662	GenBank	gene	62929	63528	.	-	1	ID=CC31p128;Dbxref=GeneID:9926274;Name=vs.8;locus_tag=CC31p128
-NC_014662	GenBank	mRNA	62929	63528	.	-	1	ID=CC31p128.t01;Parent=CC31p128
-NC_014662	GenBank	CDS	62929	63528	.	-	1	ID=CC31p128.p01;Parent=CC31p128.t01;Dbxref=GI:311993120,GeneID:9926274;Name=vs.8;codon_start=1;locus_tag=CC31p128;product=hypothetical protein;protein_id=YP_004009986.1;transl_table=11;translation=length.199
-NC_014662	GenBank	exon	62929	63528	.	-	1	Parent=CC31p128.t01
-NC_014662	GenBank	gene	63671	63967	.	-	1	ID=CC31p129;Dbxref=GeneID:9926275;Name=CC31p129
-NC_014662	GenBank	mRNA	63671	63967	.	-	1	ID=CC31p129.t01;Parent=CC31p129
-NC_014662	GenBank	CDS	63671	63967	.	-	1	ID=CC31p129.p01;Parent=CC31p129.t01;Dbxref=GI:311993121,GeneID:9926275;Name=CC31p129;codon_start=1;product=hypothetical protein;protein_id=YP_004009987.1;transl_table=11;translation=length.98
-NC_014662	GenBank	exon	63671	63967	.	-	1	Parent=CC31p129.t01
-NC_014662	GenBank	gene	63976	64392	.	-	1	ID=CC31p130;Dbxref=GeneID:9926276;Name=denV;locus_tag=CC31p130
-NC_014662	GenBank	mRNA	63976	64392	.	-	1	ID=CC31p130.t01;Parent=CC31p130
-NC_014662	GenBank	CDS	63976	64392	.	-	1	ID=CC31p130.p01;Parent=CC31p130.t01;Dbxref=GI:311993122,GeneID:9926276;Name=denV;Note=DenV;codon_start=1;locus_tag=CC31p130;product=endonuclease V%2C N-glycosylase UV repair enzyme;protein_id=YP_004009988.1;transl_table=11;translation=length.138
-NC_014662	GenBank	exon	63976	64392	.	-	1	Parent=CC31p130.t01
-NC_014662	GenBank	gene	64452	64742	.	-	1	ID=CC31p131;Dbxref=GeneID:9926277;Name=CC31p131
-NC_014662	GenBank	mRNA	64452	64742	.	-	1	ID=CC31p131.t01;Parent=CC31p131
-NC_014662	GenBank	CDS	64452	64742	.	-	1	ID=CC31p131.p01;Parent=CC31p131.t01;Dbxref=GI:311993123,GeneID:9926277;Name=CC31p131;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009989.1;transl_table=11;translation=length.96
-NC_014662	GenBank	exon	64452	64742	.	-	1	Parent=CC31p131.t01
-NC_014662	GenBank	gene	64729	65223	.	-	1	ID=CC31p132;Dbxref=GeneID:9926278;Name=e;locus_tag=CC31p132
-NC_014662	GenBank	mRNA	64729	65223	.	-	1	ID=CC31p132.t01;Parent=CC31p132
-NC_014662	GenBank	CDS	64729	65223	.	-	1	ID=CC31p132.p01;Parent=CC31p132.t01;Dbxref=GI:311993124,GeneID:9926278;Name=e;codon_start=1;locus_tag=CC31p132;product=lysozyme murein hydrolase;protein_id=YP_004009990.1;transl_table=11;translation=length.164
-NC_014662	GenBank	exon	64729	65223	.	-	1	Parent=CC31p132.t01
-NC_014662	GenBank	gene	65257	65736	.	-	1	ID=CC31p133;Dbxref=GeneID:9926279;Name=nudE;locus_tag=CC31p133
-NC_014662	GenBank	mRNA	65257	65736	.	-	1	ID=CC31p133.t01;Parent=CC31p133
-NC_014662	GenBank	CDS	65257	65736	.	-	1	ID=CC31p133.p01;Parent=CC31p133.t01;Dbxref=GI:311993125,GeneID:9926279;Name=nudE;Note=NudE;codon_start=1;locus_tag=CC31p133;product=nudix hydrolase;protein_id=YP_004009991.1;transl_table=11;translation=length.159
-NC_014662	GenBank	exon	65257	65736	.	-	1	Parent=CC31p133.t01
-NC_014662	GenBank	gene	65733	65963	.	-	1	ID=CC31p134;Dbxref=GeneID:9926280;Name=CC31p134
-NC_014662	GenBank	mRNA	65733	65963	.	-	1	ID=CC31p134.t01;Parent=CC31p134
-NC_014662	GenBank	CDS	65733	65963	.	-	1	ID=CC31p134.p01;Parent=CC31p134.t01;Dbxref=GI:311993126,GeneID:9926280;Name=CC31p134;codon_start=1;product=hypothetical protein;protein_id=YP_004009992.1;transl_table=11;translation=length.76
-NC_014662	GenBank	exon	65733	65963	.	-	1	Parent=CC31p134.t01
-NC_014662	GenBank	gene	65960	66271	.	-	1	ID=CC31p135;Dbxref=GeneID:9926281;Name=CC31p135
-NC_014662	GenBank	mRNA	65960	66271	.	-	1	ID=CC31p135.t01;Parent=CC31p135
-NC_014662	GenBank	CDS	65960	66271	.	-	1	ID=CC31p135.p01;Parent=CC31p135.t01;Dbxref=GI:311993127,GeneID:9926281;Name=CC31p135;codon_start=1;product=hypothetical protein;protein_id=YP_004009993.1;transl_table=11;translation=length.103
-NC_014662	GenBank	exon	65960	66271	.	-	1	Parent=CC31p135.t01
-NC_014662	GenBank	gene	66268	66630	.	-	1	ID=CC31p136;Dbxref=GeneID:9926282;Name=CC31p136
-NC_014662	GenBank	mRNA	66268	66630	.	-	1	ID=CC31p136.t01;Parent=CC31p136
-NC_014662	GenBank	CDS	66268	66630	.	-	1	ID=CC31p136.p01;Parent=CC31p136.t01;Dbxref=GI:311993128,GeneID:9926282;Name=CC31p136;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009994.1;transl_table=11;translation=length.120
-NC_014662	GenBank	exon	66268	66630	.	-	1	Parent=CC31p136.t01
-NC_014662	GenBank	gene	66627	66965	.	-	1	ID=CC31p137;Dbxref=GeneID:9926283;Name=CC31p137
-NC_014662	GenBank	mRNA	66627	66965	.	-	1	ID=CC31p137.t01;Parent=CC31p137
-NC_014662	GenBank	CDS	66627	66965	.	-	1	ID=CC31p137.p01;Parent=CC31p137.t01;Dbxref=GI:311993129,GeneID:9926283;Name=CC31p137;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009995.1;transl_table=11;translation=length.112
-NC_014662	GenBank	exon	66627	66965	.	-	1	Parent=CC31p137.t01
-NC_014662	GenBank	gene	66949	67302	.	-	1	ID=CC31p138;Dbxref=GeneID:9926284;Name=CC31p138
-NC_014662	GenBank	mRNA	66949	67302	.	-	1	ID=CC31p138.t01;Parent=CC31p138
-NC_014662	GenBank	CDS	66949	67302	.	-	1	ID=CC31p138.p01;Parent=CC31p138.t01;Dbxref=GI:311993130,GeneID:9926284;Name=CC31p138;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009996.1;transl_table=11;translation=length.117
-NC_014662	GenBank	exon	66949	67302	.	-	1	Parent=CC31p138.t01
-NC_014662	GenBank	gene	67305	67679	.	-	1	ID=CC31p139;Dbxref=GeneID:9926285;Name=CC31p139
-NC_014662	GenBank	mRNA	67305	67679	.	-	1	ID=CC31p139.t01;Parent=CC31p139
-NC_014662	GenBank	CDS	67305	67679	.	-	1	ID=CC31p139.p01;Parent=CC31p139.t01;Dbxref=GI:311993131,GeneID:9926285;Name=CC31p139;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009997.1;transl_table=11;translation=length.124
-NC_014662	GenBank	exon	67305	67679	.	-	1	Parent=CC31p139.t01
-NC_014662	GenBank	gene	67713	68630	.	-	1	ID=CC31p140;Dbxref=GeneID:9926286;Name=CC31p140
-NC_014662	GenBank	mRNA	67713	68630	.	-	1	ID=CC31p140.t01;Parent=CC31p140
-NC_014662	GenBank	CDS	67713	68630	.	-	1	ID=CC31p140.p01;Parent=CC31p140.t01;Dbxref=GI:311993132,GeneID:9926286;Name=CC31p140;codon_start=1;product=hypothetical protein;protein_id=YP_004009998.1;transl_table=11;translation=length.305
-NC_014662	GenBank	exon	67713	68630	.	-	1	Parent=CC31p140.t01
-NC_014662	GenBank	gene	68660	69001	.	-	1	ID=CC31p141;Dbxref=GeneID:9926287;Name=CC31p141
-NC_014662	GenBank	mRNA	68660	69001	.	-	1	ID=CC31p141.t01;Parent=CC31p141
-NC_014662	GenBank	CDS	68660	69001	.	-	1	ID=CC31p141.p01;Parent=CC31p141.t01;Dbxref=GI:311993133,GeneID:9926287;Name=CC31p141;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009999.1;transl_table=11;translation=length.113
-NC_014662	GenBank	exon	68660	69001	.	-	1	Parent=CC31p141.t01
+NC_014662	GenBank	CDS	1	2214	.	-	1	ID=CC31p001;Dbxref=GI:311992993,GeneID:9926434;Name=rIIA;codon_start=1;locus_tag=CC31p001;product=membrane-associated affects host membrane ATPase;protein_id=YP_004009859.1;transl_table=11;translation=length.737
+NC_014662	GenBank	gene	1	2214	.	-	1	ID=CC31p001.gene;Alias=CC31p001;Dbxref=GeneID:9926434;Name=rIIA;locus_tag=CC31p001
+NC_014662	GenBank	CDS	2220	2426	.	-	1	ID=CC31p002;Dbxref=GI:311992994,GeneID:9926148;Name=rIIA.1;codon_start=1;locus_tag=CC31p002;product=hypothetical protein;protein_id=YP_004009860.1;transl_table=11;translation=length.68
+NC_014662	GenBank	gene	2220	2426	.	-	1	ID=CC31p002.gene;Alias=CC31p002;Dbxref=GeneID:9926148;Name=rIIA.1;locus_tag=CC31p002
+NC_014662	GenBank	CDS	2420	2704	.	-	1	ID=CC31p003;Dbxref=GI:311992995,GeneID:9926149;Name=CC31p003;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009861.1;transl_table=11;translation=length.94
+NC_014662	GenBank	gene	2420	2704	.	-	1	ID=CC31p003.gene;Alias=CC31p003;Dbxref=GeneID:9926149;Name=CC31p003
+NC_014662	GenBank	CDS	2750	2905	.	-	1	ID=CC31p004;Dbxref=GI:311992996,GeneID:9926150;Name=CC31p004;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009862.1;transl_table=11;translation=length.51
+NC_014662	GenBank	gene	2750	2905	.	-	1	ID=CC31p004.gene;Alias=CC31p004;Dbxref=GeneID:9926150;Name=CC31p004
+NC_014662	GenBank	CDS	2945	4789	.	-	1	ID=CC31p005;Dbxref=GI:311992997,GeneID:9926151;Name=60plus39;codon_start=1;locus_tag=CC31p005;product=DNA topoisomerase subunit;protein_id=YP_004009863.1;transl_table=11;translation=length.614
+NC_014662	GenBank	gene	2945	4789	.	-	1	ID=CC31p005.gene;Alias=CC31p005;Dbxref=GeneID:9926151;Name=60plus39;locus_tag=CC31p005
+NC_014662	GenBank	CDS	4835	5302	.	-	1	ID=CC31p006;Dbxref=GI:311992998,GeneID:9926152;Name=CC31p006;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009864.1;transl_table=11;translation=length.155
+NC_014662	GenBank	gene	4835	5302	.	-	1	ID=CC31p006.gene;Alias=CC31p006;Dbxref=GeneID:9926152;Name=CC31p006
+NC_014662	GenBank	CDS	5302	6837	.	-	1	ID=CC31p007;Dbxref=GI:311992999,GeneID:9926153;Name=CC31p007;Note=N-terminal part is similar to Hoc protein and C-terminal part is similar to lipolytic enzyme%2C G-D-S-L;codon_start=1;product=hypothetical protein;protein_id=YP_004009865.1;transl_table=11;translation=length.511
+NC_014662	GenBank	gene	5302	6837	.	-	1	ID=CC31p007.gene;Alias=CC31p007;Dbxref=GeneID:9926153;Name=CC31p007
+NC_014662	GenBank	CDS	6870	7130	.	-	1	ID=CC31p008;Dbxref=GI:311993000,GeneID:9926154;Name=39.1;codon_start=1;locus_tag=CC31p008;product=gp39.1 hypothetical protein;protein_id=YP_004009866.1;transl_table=11;translation=length.86
+NC_014662	GenBank	gene	6870	7130	.	-	1	ID=CC31p008.gene;Alias=CC31p008;Dbxref=GeneID:9926154;Name=39.1;locus_tag=CC31p008
+NC_014662	GenBank	CDS	7127	7222	.	-	1	ID=CC31p009;Dbxref=GI:311993001,GeneID:9926155;Name=CC31p009;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009867.1;transl_table=11;translation=length.31
+NC_014662	GenBank	gene	7127	7222	.	-	1	ID=CC31p009.gene;Alias=CC31p009;Dbxref=GeneID:9926155;Name=CC31p009
+NC_014662	GenBank	CDS	7222	7398	.	-	1	ID=CC31p010;Dbxref=GI:311993002,GeneID:9926156;Name=CC31p010;codon_start=1;product=conserved putative regulatory protein%2C FmdB family;protein_id=YP_004009868.1;transl_table=11;translation=length.58
+NC_014662	GenBank	gene	7222	7398	.	-	1	ID=CC31p010.gene;Alias=CC31p010;Dbxref=GeneID:9926156;Name=CC31p010
+NC_014662	GenBank	CDS	7385	7732	.	-	1	ID=CC31p011;Dbxref=GI:311993003,GeneID:9926157;Name=CC31p011;codon_start=1;product=hypothetical protein;protein_id=YP_004009869.1;transl_table=11;translation=length.115
+NC_014662	GenBank	gene	7385	7732	.	-	1	ID=CC31p011.gene;Alias=CC31p011;Dbxref=GeneID:9926157;Name=CC31p011
+NC_014662	GenBank	CDS	7720	8409	.	-	1	ID=CC31p012;Dbxref=GI:311993004,GeneID:9926158;Name=CC31p012;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009870.1;transl_table=11;translation=length.229
+NC_014662	GenBank	gene	7720	8409	.	-	1	ID=CC31p012.gene;Alias=CC31p012;Dbxref=GeneID:9926158;Name=CC31p012
+NC_014662	GenBank	CDS	8402	8626	.	-	1	ID=CC31p013;Dbxref=GI:311993005,GeneID:9926159;Name=cef;codon_start=1;locus_tag=CC31p013;product=modifier of suppressor tRNAs;protein_id=YP_004009871.1;transl_table=11;translation=length.74
+NC_014662	GenBank	gene	8402	8626	.	-	1	ID=CC31p013.gene;Alias=CC31p013;Dbxref=GeneID:9926159;Name=cef;locus_tag=CC31p013
+NC_014662	GenBank	CDS	8693	9130	.	-	1	ID=CC31p014;Dbxref=GI:311993006,GeneID:9926160;Name=CC31p014;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009872.1;transl_table=11;translation=length.145
+NC_014662	GenBank	gene	8693	9130	.	-	1	ID=CC31p014.gene;Alias=CC31p014;Dbxref=GeneID:9926160;Name=CC31p014
+NC_014662	GenBank	CDS	9186	9875	.	-	1	ID=CC31p015;Dbxref=GI:311993007,GeneID:9926161;Name=dexA;Note=DexA;codon_start=1;locus_tag=CC31p015;product=exonuclease A;protein_id=YP_004009873.1;transl_table=11;translation=length.229
+NC_014662	GenBank	gene	9186	9875	.	-	1	ID=CC31p015.gene;Alias=CC31p015;Dbxref=GeneID:9926161;Name=dexA;locus_tag=CC31p015
+NC_014662	GenBank	CDS	9872	10114	.	-	1	ID=CC31p016;Dbxref=GI:311993008,GeneID:9926162;Name=CC31p016;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009874.1;transl_table=11;translation=length.80
+NC_014662	GenBank	gene	9872	10114	.	-	1	ID=CC31p016.gene;Alias=CC31p016;Dbxref=GeneID:9926162;Name=CC31p016
+NC_014662	GenBank	CDS	10120	11433	.	-	1	ID=CC31p017;Dbxref=GI:311993009,GeneID:9926163;Name=dda;Note=Dda;codon_start=1;locus_tag=CC31p017;product=DNA helicase;protein_id=YP_004009875.1;transl_table=11;translation=length.437
+NC_014662	GenBank	gene	10120	11433	.	-	1	ID=CC31p017.gene;Alias=CC31p017;Dbxref=GeneID:9926163;Name=dda;locus_tag=CC31p017
+NC_014662	GenBank	CDS	11460	11774	.	-	1	ID=CC31p018;Dbxref=GI:311993010,GeneID:9926164;Name=CC31p018;codon_start=1;product=hypothetical protein;protein_id=YP_004009876.1;transl_table=11;translation=length.104
+NC_014662	GenBank	gene	11460	11774	.	-	1	ID=CC31p018.gene;Alias=CC31p018;Dbxref=GeneID:9926164;Name=CC31p018
+NC_014662	GenBank	CDS	11774	12526	.	-	1	ID=CC31p019;Dbxref=GI:311993011,GeneID:9926165;Name=srd;Note=Srd;codon_start=1;locus_tag=CC31p019;product=anti-sigma factor%2C putative;protein_id=YP_004009877.1;transl_table=11;translation=length.250
+NC_014662	GenBank	gene	11774	12526	.	-	1	ID=CC31p019.gene;Alias=CC31p019;Dbxref=GeneID:9926165;Name=srd;locus_tag=CC31p019
+NC_014662	GenBank	CDS	12682	13290	.	-	1	ID=CC31p020;Dbxref=GI:311993012,GeneID:9926166;Name=modA;Note=ModA;codon_start=1;locus_tag=CC31p020;product=RNA polymerase ADP-ribosylase;protein_id=YP_004009878.1;transl_table=11;translation=length.202
+NC_014662	GenBank	gene	12682	13290	.	-	1	ID=CC31p020.gene;Alias=CC31p020;Dbxref=GeneID:9926166;Name=modA;locus_tag=CC31p020
+NC_014662	GenBank	CDS	13351	13542	.	-	1	ID=CC31p021;Dbxref=GI:311993013,GeneID:9926167;Name=modA.2;codon_start=1;locus_tag=CC31p021;product=hypothetical protein;protein_id=YP_004009879.1;transl_table=11;translation=length.63
+NC_014662	GenBank	gene	13351	13542	.	-	1	ID=CC31p021.gene;Alias=CC31p021;Dbxref=GeneID:9926167;Name=modA.2;locus_tag=CC31p021
+NC_014662	GenBank	CDS	13557	14069	.	-	1	ID=CC31p022;Dbxref=GI:311993014,GeneID:9926168;Name=CC31p022;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009880.1;transl_table=11;translation=length.170
+NC_014662	GenBank	gene	13557	14069	.	-	1	ID=CC31p022.gene;Alias=CC31p022;Dbxref=GeneID:9926168;Name=CC31p022
+NC_014662	GenBank	CDS	14062	14454	.	-	1	ID=CC31p023;Dbxref=GI:311993015,GeneID:9926169;Name=CC31p023;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009881.1;transl_table=11;translation=length.130
+NC_014662	GenBank	gene	14062	14454	.	-	1	ID=CC31p023.gene;Alias=CC31p023;Dbxref=GeneID:9926169;Name=CC31p023
+NC_014662	GenBank	CDS	14454	14732	.	-	1	ID=CC31p024;Dbxref=GI:311993016,GeneID:9926170;Name=CC31p024;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009882.1;transl_table=11;translation=length.92
+NC_014662	GenBank	gene	14454	14732	.	-	1	ID=CC31p024.gene;Alias=CC31p024;Dbxref=GeneID:9926170;Name=CC31p024
+NC_014662	GenBank	CDS	14786	15025	.	-	1	ID=CC31p025;Dbxref=GI:311993017,GeneID:9926171;Name=soc;Note=Soc;codon_start=1;locus_tag=CC31p025;product=small outer capsid protein;protein_id=YP_004009883.1;transl_table=11;translation=length.79
+NC_014662	GenBank	gene	14786	15025	.	-	1	ID=CC31p025.gene;Alias=CC31p025;Dbxref=GeneID:9926171;Name=soc;locus_tag=CC31p025
+NC_014662	GenBank	CDS	15053	15256	.	-	1	ID=CC31p026;Dbxref=GI:311993018,GeneID:9926172;Name=soc.1;codon_start=1;locus_tag=CC31p026;product=hypothetical protein;protein_id=YP_004009884.1;transl_table=11;translation=length.67
+NC_014662	GenBank	gene	15053	15256	.	-	1	ID=CC31p026.gene;Alias=CC31p026;Dbxref=GeneID:9926172;Name=soc.1;locus_tag=CC31p026
+NC_014662	GenBank	CDS	15256	15774	.	-	1	ID=CC31p027;Dbxref=GI:311993019,GeneID:9926173;Name=56;codon_start=1;locus_tag=CC31p027;product=gp56 dCTPase%2C dUTPase%2C dCDPase%2C dUDPase;protein_id=YP_004009885.1;transl_table=11;translation=length.172
+NC_014662	GenBank	gene	15256	15774	.	-	1	ID=CC31p027.gene;Alias=CC31p027;Dbxref=GeneID:9926173;Name=56;locus_tag=CC31p027
+NC_014662	GenBank	CDS	15820	16104	.	-	1	ID=CC31p028;Dbxref=GI:311993020,GeneID:9926174;Name=CC31p028;codon_start=1;product=hypothetical protein;protein_id=YP_004009886.1;transl_table=11;translation=length.94
+NC_014662	GenBank	gene	15820	16104	.	-	1	ID=CC31p028.gene;Alias=CC31p028;Dbxref=GeneID:9926174;Name=CC31p028
+NC_014662	GenBank	CDS	16101	17126	.	-	1	ID=CC31p029;Dbxref=GI:311993021,GeneID:9926175;Name=61;codon_start=1;locus_tag=CC31p029;product=gp61 DNA primase subunit;protein_id=YP_004009887.1;transl_table=11;translation=length.341
+NC_014662	GenBank	gene	16101	17126	.	-	1	ID=CC31p029.gene;Alias=CC31p029;Dbxref=GeneID:9926175;Name=61;locus_tag=CC31p029
+NC_014662	GenBank	CDS	17166	17630	.	-	1	ID=CC31p030;Dbxref=GI:311993022,GeneID:9926176;Name=61.1;codon_start=1;locus_tag=CC31p030;product=hypothetical protein;protein_id=YP_004009888.1;transl_table=11;translation=length.154
+NC_014662	GenBank	gene	17166	17630	.	-	1	ID=CC31p030.gene;Alias=CC31p030;Dbxref=GeneID:9926176;Name=61.1;locus_tag=CC31p030
+NC_014662	GenBank	CDS	17646	17834	.	-	1	ID=CC31p031;Dbxref=GI:311993023,GeneID:9926177;Name=CC31p031;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009889.1;transl_table=11;translation=length.62
+NC_014662	GenBank	gene	17646	17834	.	-	1	ID=CC31p031.gene;Alias=CC31p031;Dbxref=GeneID:9926177;Name=CC31p031
+NC_014662	GenBank	CDS	17831	18166	.	-	1	ID=CC31p032;Dbxref=GI:311993024,GeneID:9926178;Name=CC31p032;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009890.1;transl_table=11;translation=length.111
+NC_014662	GenBank	gene	17831	18166	.	-	1	ID=CC31p032.gene;Alias=CC31p032;Dbxref=GeneID:9926178;Name=CC31p032
+NC_014662	GenBank	CDS	18154	18345	.	-	1	ID=CC31p033;Dbxref=GI:311993025,GeneID:9926179;Name=CC31p033;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009891.1;transl_table=11;translation=length.63
+NC_014662	GenBank	gene	18154	18345	.	-	1	ID=CC31p033.gene;Alias=CC31p033;Dbxref=GeneID:9926179;Name=CC31p033
+NC_014662	GenBank	CDS	18342	18623	.	-	1	ID=CC31p034;Dbxref=GI:311993026,GeneID:9926180;Name=CC31p034;Note=N-terminal similarity to T4 Sp (spackle periplasmic) protein;codon_start=1;product=hypothetical protein;protein_id=YP_004009892.1;transl_table=11;translation=length.93
+NC_014662	GenBank	gene	18342	18623	.	-	1	ID=CC31p034.gene;Alias=CC31p034;Dbxref=GeneID:9926180;Name=CC31p034
+NC_014662	GenBank	CDS	18633	18914	.	-	1	ID=CC31p035;Dbxref=GI:311993027,GeneID:9926181;Name=CC31p035;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009893.1;transl_table=11;translation=length.93
+NC_014662	GenBank	gene	18633	18914	.	-	1	ID=CC31p035.gene;Alias=CC31p035;Dbxref=GeneID:9926181;Name=CC31p035
+NC_014662	GenBank	CDS	18976	20352	.	-	1	ID=CC31p036;Dbxref=GI:311993028,GeneID:9926182;Name=41;codon_start=1;locus_tag=CC31p036;product=gp41 DNA primase-helicase subunit;protein_id=YP_004009894.1;transl_table=11;translation=length.458
+NC_014662	GenBank	gene	18976	20352	.	-	1	ID=CC31p036.gene;Alias=CC31p036;Dbxref=GeneID:9926182;Name=41;locus_tag=CC31p036
+NC_014662	GenBank	CDS	20429	20818	.	-	1	ID=CC31p037;Dbxref=GI:311993029,GeneID:9926183;Name=40;codon_start=1;locus_tag=CC31p037;product=gp40 head vertex assembly chaperone;protein_id=YP_004009895.1;transl_table=11;translation=length.129
+NC_014662	GenBank	gene	20429	20818	.	-	1	ID=CC31p037.gene;Alias=CC31p037;Dbxref=GeneID:9926183;Name=40;locus_tag=CC31p037
+NC_014662	GenBank	CDS	20787	21953	.	-	1	ID=CC31p038;Dbxref=GI:311993030,GeneID:9926184;Name=uvsX;Note=UvsX;codon_start=1;locus_tag=CC31p038;product=RecA-like recombination protein;protein_id=YP_004009896.1;transl_table=11;translation=length.388
+NC_014662	GenBank	gene	20787	21953	.	-	1	ID=CC31p038.gene;Alias=CC31p038;Dbxref=GeneID:9926184;Name=uvsX;locus_tag=CC31p038
+NC_014662	GenBank	CDS	22117	23193	.	-	1	ID=CC31p039;Dbxref=GI:311993031,GeneID:9926185;Name=b-gt;codon_start=1;locus_tag=CC31p039;product=beta glucosyl transferase;protein_id=YP_004009897.1;transl_table=11;translation=length.358
+NC_014662	GenBank	gene	22117	23193	.	-	1	ID=CC31p039.gene;Alias=CC31p039;Dbxref=GeneID:9926185;Name=b-gt;locus_tag=CC31p039
+NC_014662	GenBank	CDS	23190	24026	.	-	1	ID=CC31p040;Dbxref=GI:311993032,GeneID:9926186;Name=CC31p040;Note=similar to T2%2C T6 beta-glucosyl-HMC-alpha-glucosyl-transferase;codon_start=1;product=hypothetical protein;protein_id=YP_004009898.1;transl_table=11;translation=length.278
+NC_014662	GenBank	gene	23190	24026	.	-	1	ID=CC31p040.gene;Alias=CC31p040;Dbxref=GeneID:9926186;Name=CC31p040
+NC_014662	GenBank	CDS	24017	24754	.	-	1	ID=CC31p041;Dbxref=GI:311993033,GeneID:9926187;Name=42;codon_start=1;locus_tag=CC31p041;product=gp42 dCMP hydroxymethylase;protein_id=YP_004009899.1;transl_table=11;translation=length.245
+NC_014662	GenBank	gene	24017	24754	.	-	1	ID=CC31p041.gene;Alias=CC31p041;Dbxref=GeneID:9926187;Name=42;locus_tag=CC31p041
+NC_014662	GenBank	CDS	24751	25191	.	-	1	ID=CC31p042;Dbxref=GI:311993034,GeneID:9926188;Name=CC31p042;codon_start=1;product=hypothetical protein;protein_id=YP_004009900.1;transl_table=11;translation=length.146
+NC_014662	GenBank	gene	24751	25191	.	-	1	ID=CC31p042.gene;Alias=CC31p042;Dbxref=GeneID:9926188;Name=CC31p042
+NC_014662	GenBank	CDS	25255	27963	.	-	1	ID=CC31p043;Dbxref=GI:311993035,GeneID:9926189;Name=43;codon_start=1;locus_tag=CC31p043;product=gp43 DNA polymerase;protein_id=YP_004009901.1;transl_table=11;translation=length.902
+NC_014662	GenBank	gene	25255	27963	.	-	1	ID=CC31p043.gene;Alias=CC31p043;Dbxref=GeneID:9926189;Name=43;locus_tag=CC31p043
+NC_014662	GenBank	CDS	28061	28222	.	-	1	ID=CC31p044;Dbxref=GI:311993036,GeneID:9926190;Name=43.1;codon_start=1;locus_tag=CC31p044;product=gp43.1 hypothetical protein;protein_id=YP_004009902.1;transl_table=11;translation=length.53
+NC_014662	GenBank	gene	28061	28222	.	-	1	ID=CC31p044.gene;Alias=CC31p044;Dbxref=GeneID:9926190;Name=43.1;locus_tag=CC31p044
+NC_014662	GenBank	CDS	28222	28587	.	-	1	ID=CC31p045;Dbxref=GI:311993037,GeneID:9926191;Name=regA;Note=RegA;codon_start=1;locus_tag=CC31p045;product=translational repressor protein;protein_id=YP_004009903.1;transl_table=11;translation=length.121
+NC_014662	GenBank	gene	28222	28587	.	-	1	ID=CC31p045.gene;Alias=CC31p045;Dbxref=GeneID:9926191;Name=regA;locus_tag=CC31p045
+NC_014662	GenBank	CDS	28589	29152	.	-	1	ID=CC31p046;Dbxref=GI:311993038,GeneID:9926192;Name=62;codon_start=1;locus_tag=CC31p046;product=gp62 clamp loader subunit%2C DNA polymerase accessory protein;protein_id=YP_004009904.1;transl_table=11;translation=length.187
+NC_014662	GenBank	gene	28589	29152	.	-	1	ID=CC31p046.gene;Alias=CC31p046;Dbxref=GeneID:9926192;Name=62;locus_tag=CC31p046
+NC_014662	GenBank	CDS	29149	30108	.	-	1	ID=CC31p047;Dbxref=GI:311993039,GeneID:9926193;Name=44;codon_start=1;locus_tag=CC31p047;product=gp44 clamp loader subunit%2C DNA polymerase accessory protein;protein_id=YP_004009905.1;transl_table=11;translation=length.319
+NC_014662	GenBank	gene	29149	30108	.	-	1	ID=CC31p047.gene;Alias=CC31p047;Dbxref=GeneID:9926193;Name=44;locus_tag=CC31p047
+NC_014662	GenBank	CDS	30168	30854	.	-	1	ID=CC31p048;Dbxref=GI:311993040,GeneID:9926194;Name=45;codon_start=1;locus_tag=CC31p048;product=gp45 sliding clamp%2C DNA polymerase accessory protein;protein_id=YP_004009906.1;transl_table=11;translation=length.228
+NC_014662	GenBank	gene	30168	30854	.	-	1	ID=CC31p048.gene;Alias=CC31p048;Dbxref=GeneID:9926194;Name=45;locus_tag=CC31p048
+NC_014662	GenBank	CDS	30863	31288	.	-	1	ID=CC31p049;Dbxref=GI:311993041,GeneID:9926195;Name=rpbA;Note=RpbA;codon_start=1;locus_tag=CC31p049;product=RNA polymerase binding protein;protein_id=YP_004009907.1;transl_table=11;translation=length.141
+NC_014662	GenBank	gene	30863	31288	.	-	1	ID=CC31p049.gene;Alias=CC31p049;Dbxref=GeneID:9926195;Name=rpbA;locus_tag=CC31p049
+NC_014662	GenBank	CDS	31300	31491	.	-	1	ID=CC31p050;Dbxref=GI:311993042,GeneID:9926196;Name=45.1;codon_start=1;locus_tag=CC31p050;product=hypothetical protein;protein_id=YP_004009908.1;transl_table=11;translation=length.63
+NC_014662	GenBank	gene	31300	31491	.	-	1	ID=CC31p050.gene;Alias=CC31p050;Dbxref=GeneID:9926196;Name=45.1;locus_tag=CC31p050
+NC_014662	GenBank	CDS	31488	33176	.	-	1	ID=CC31p051;Dbxref=GI:311993043,GeneID:9926197;Name=46;codon_start=1;locus_tag=CC31p051;product=gp46 recombination endonuclease subunit;protein_id=YP_004009909.1;transl_table=11;translation=length.562
+NC_014662	GenBank	gene	31488	33176	.	-	1	ID=CC31p051.gene;Alias=CC31p051;Dbxref=GeneID:9926197;Name=46;locus_tag=CC31p051
+NC_014662	GenBank	CDS	33173	34195	.	-	1	ID=CC31p052;Dbxref=GI:311993044,GeneID:9926198;Name=47;codon_start=1;locus_tag=CC31p052;product=gp47 recombination endonuclease subunit;protein_id=YP_004009910.1;transl_table=11;translation=length.340
+NC_014662	GenBank	gene	33173	34195	.	-	1	ID=CC31p052.gene;Alias=CC31p052;Dbxref=GeneID:9926198;Name=47;locus_tag=CC31p052
+NC_014662	GenBank	CDS	34303	34551	.	-	1	ID=CC31p053;Dbxref=GI:311993045,GeneID:9926199;Name=CC31p053;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009911.1;transl_table=11;translation=length.82
+NC_014662	GenBank	gene	34303	34551	.	-	1	ID=CC31p053.gene;Alias=CC31p053;Dbxref=GeneID:9926199;Name=CC31p053
+NC_014662	GenBank	CDS	34551	34748	.	-	1	ID=CC31p054;Dbxref=GI:311993046,GeneID:9926200;Name=a-gt.3;codon_start=1;locus_tag=CC31p054;product=hypothetical protein;protein_id=YP_004009912.1;transl_table=11;translation=length.65
+NC_014662	GenBank	gene	34551	34748	.	-	1	ID=CC31p054.gene;Alias=CC31p054;Dbxref=GeneID:9926200;Name=a-gt.3;locus_tag=CC31p054
+NC_014662	GenBank	CDS	34726	35052	.	-	1	ID=CC31p055;Dbxref=GI:311993047,GeneID:9926201;Name=a-gt.4;codon_start=1;locus_tag=CC31p055;product=hypothetical protein;protein_id=YP_004009913.1;transl_table=11;translation=length.108
+NC_014662	GenBank	gene	34726	35052	.	-	1	ID=CC31p055.gene;Alias=CC31p055;Dbxref=GeneID:9926201;Name=a-gt.4;locus_tag=CC31p055
+NC_014662	GenBank	CDS	35058	35285	.	-	1	ID=CC31p056;Dbxref=GI:311993048,GeneID:9926202;Name=a-gt.5;codon_start=1;locus_tag=CC31p056;product=hypothetical protein;protein_id=YP_004009914.1;transl_table=11;translation=length.75
+NC_014662	GenBank	gene	35058	35285	.	-	1	ID=CC31p056.gene;Alias=CC31p056;Dbxref=GeneID:9926202;Name=a-gt.5;locus_tag=CC31p056
+NC_014662	GenBank	CDS	35269	35802	.	-	1	ID=CC31p057;Dbxref=GI:311993049,GeneID:9926203;Name=55;codon_start=1;locus_tag=CC31p057;product=gp55 sigma factor for T4 late transcription;protein_id=YP_004009915.1;transl_table=11;translation=length.177
+NC_014662	GenBank	gene	35269	35802	.	-	1	ID=CC31p057.gene;Alias=CC31p057;Dbxref=GeneID:9926203;Name=55;locus_tag=CC31p057
+NC_014662	GenBank	CDS	35869	36165	.	-	1	ID=CC31p058;Dbxref=GI:311993050,GeneID:9926204;Name=CC31p058;codon_start=1;product=hypothetical protein;protein_id=YP_004009916.1;transl_table=11;translation=length.98
+NC_014662	GenBank	gene	35869	36165	.	-	1	ID=CC31p058.gene;Alias=CC31p058;Dbxref=GeneID:9926204;Name=CC31p058
+NC_014662	GenBank	CDS	36162	36413	.	-	1	ID=CC31p059;Dbxref=GI:311993051,GeneID:9926205;Name=CC31p059;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009917.1;transl_table=11;translation=length.83
+NC_014662	GenBank	gene	36162	36413	.	-	1	ID=CC31p059.gene;Alias=CC31p059;Dbxref=GeneID:9926205;Name=CC31p059
+NC_014662	GenBank	CDS	36410	36637	.	-	1	ID=CC31p060;Dbxref=GI:311993052,GeneID:9926206;Name=55.1;codon_start=1;locus_tag=CC31p060;product=hypothetical protein;protein_id=YP_004009918.1;transl_table=11;translation=length.75
+NC_014662	GenBank	gene	36410	36637	.	-	1	ID=CC31p060.gene;Alias=CC31p060;Dbxref=GeneID:9926206;Name=55.1;locus_tag=CC31p060
+NC_014662	GenBank	CDS	36630	36893	.	-	1	ID=CC31p061;Dbxref=GI:311993053,GeneID:9926207;Name=CC31p061;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009919.1;transl_table=11;translation=length.87
+NC_014662	GenBank	gene	36630	36893	.	-	1	ID=CC31p061.gene;Alias=CC31p061;Dbxref=GeneID:9926207;Name=CC31p061
+NC_014662	GenBank	CDS	36890	37204	.	-	1	ID=CC31p062;Dbxref=GI:311993054,GeneID:9926208;Name=CC31p062;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009920.1;transl_table=11;translation=length.104
+NC_014662	GenBank	gene	36890	37204	.	-	1	ID=CC31p062.gene;Alias=CC31p062;Dbxref=GeneID:9926208;Name=CC31p062
+NC_014662	GenBank	CDS	37201	37539	.	-	1	ID=CC31p063;Dbxref=GI:311993055,GeneID:9926209;Name=55.2;codon_start=1;locus_tag=CC31p063;product=hypothetical protein;protein_id=YP_004009921.1;transl_table=11;translation=length.112
+NC_014662	GenBank	gene	37201	37539	.	-	1	ID=CC31p063.gene;Alias=CC31p063;Dbxref=GeneID:9926209;Name=55.2;locus_tag=CC31p063
+NC_014662	GenBank	CDS	37605	37871	.	-	1	ID=CC31p064;Dbxref=GI:311993056,GeneID:9926210;Name=CC31p064;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009922.1;transl_table=11;translation=length.88
+NC_014662	GenBank	gene	37605	37871	.	-	1	ID=CC31p064.gene;Alias=CC31p064;Dbxref=GeneID:9926210;Name=CC31p064
+NC_014662	GenBank	CDS	38018	38332	.	-	1	ID=CC31p065;Dbxref=GI:311993057,GeneID:9926211;Name=nrdH;Note=NrdH;codon_start=1;locus_tag=CC31p065;product=glutaredoxin;protein_id=YP_004009923.1;transl_table=11;translation=length.104
+NC_014662	GenBank	gene	38018	38332	.	-	1	ID=CC31p065.gene;Alias=CC31p065;Dbxref=GeneID:9926211;Name=nrdH;locus_tag=CC31p065
+NC_014662	GenBank	CDS	38307	38582	.	-	1	ID=CC31p066;Dbxref=GI:311993058,GeneID:9926212;Name=CC31p066;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009924.1;transl_table=11;translation=length.91
+NC_014662	GenBank	gene	38307	38582	.	-	1	ID=CC31p066.gene;Alias=CC31p066;Dbxref=GeneID:9926212;Name=CC31p066
+NC_014662	GenBank	CDS	38591	38698	.	-	1	ID=CC31p067;Dbxref=GI:311993059,GeneID:9926213;Name=CC31p067;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009925.1;transl_table=11;translation=length.35
+NC_014662	GenBank	gene	38591	38698	.	-	1	ID=CC31p067.gene;Alias=CC31p067;Dbxref=GeneID:9926213;Name=CC31p067
+NC_014662	GenBank	CDS	38682	39167	.	-	1	ID=CC31p068;Dbxref=GI:311993060,GeneID:9926214;Name=nrdG;Note=NrdG;codon_start=1;locus_tag=CC31p068;product=anaerobic NTP reductase%2C small subunit;protein_id=YP_004009926.1;transl_table=11;translation=length.161
+NC_014662	GenBank	gene	38682	39167	.	-	1	ID=CC31p068.gene;Alias=CC31p068;Dbxref=GeneID:9926214;Name=nrdG;locus_tag=CC31p068
+NC_014662	GenBank	CDS	39157	40986	.	-	1	ID=CC31p069;Dbxref=GI:311993061,GeneID:9926215;Name=nrdD;Note=NrdD;codon_start=1;locus_tag=CC31p069;product=anaerobic NTP reductase%2C large subunit;protein_id=YP_004009927.1;transl_table=11;translation=length.609
+NC_014662	GenBank	gene	39157	40986	.	-	1	ID=CC31p069.gene;Alias=CC31p069;Dbxref=GeneID:9926215;Name=nrdD;locus_tag=CC31p069
+NC_014662	GenBank	CDS	40983	41456	.	-	1	ID=CC31p070;Dbxref=GI:311993062,GeneID:9926216;Name=49;codon_start=1;locus_tag=CC31p070;product=gp49 recombinase endonuclease VII;protein_id=YP_004009928.1;transl_table=11;translation=length.157
+NC_014662	GenBank	gene	40983	41456	.	-	1	ID=CC31p070.gene;Alias=CC31p070;Dbxref=GeneID:9926216;Name=49;locus_tag=CC31p070
+NC_014662	GenBank	CDS	41491	41958	.	-	1	ID=CC31p071;Dbxref=GI:311993063,GeneID:9926217;Name=pin;Note=Pin;codon_start=1;locus_tag=CC31p071;product=inhibitor of host Lon protease;protein_id=YP_004009929.1;transl_table=11;translation=length.155
+NC_014662	GenBank	gene	41491	41958	.	-	1	ID=CC31p071.gene;Alias=CC31p071;Dbxref=GeneID:9926217;Name=pin;locus_tag=CC31p071
+NC_014662	GenBank	CDS	41942	42088	.	-	1	ID=CC31p072;Dbxref=GI:311993064,GeneID:9926218;Name=49.1;codon_start=1;locus_tag=CC31p072;product=hypothetical protein;protein_id=YP_004009930.1;transl_table=11;translation=length.48
+NC_014662	GenBank	gene	41942	42088	.	-	1	ID=CC31p072.gene;Alias=CC31p072;Dbxref=GeneID:9926218;Name=49.1;locus_tag=CC31p072
+NC_014662	GenBank	CDS	42073	42384	.	-	1	ID=CC31p073;Dbxref=GI:311993065,GeneID:9926219;Name=49.2;codon_start=1;locus_tag=CC31p073;product=hypothetical protein;protein_id=YP_004009931.1;transl_table=11;translation=length.103
+NC_014662	GenBank	gene	42073	42384	.	-	1	ID=CC31p073.gene;Alias=CC31p073;Dbxref=GeneID:9926219;Name=49.2;locus_tag=CC31p073
+NC_014662	GenBank	CDS	42384	42557	.	-	1	ID=CC31p074;Dbxref=GI:311993066,GeneID:9926220;Name=CC31p074;codon_start=1;product=hypothetical protein;protein_id=YP_004009932.1;transl_table=11;translation=length.57
+NC_014662	GenBank	gene	42384	42557	.	-	1	ID=CC31p074.gene;Alias=CC31p074;Dbxref=GeneID:9926220;Name=CC31p074
+NC_014662	GenBank	CDS	42554	42835	.	-	1	ID=CC31p075;Dbxref=GI:311993067,GeneID:9926221;Name=nrdC;Note=NrdC;codon_start=1;locus_tag=CC31p075;product=thioredoxin;protein_id=YP_004009933.1;transl_table=11;translation=length.93
+NC_014662	GenBank	gene	42554	42835	.	-	1	ID=CC31p075.gene;Alias=CC31p075;Dbxref=GeneID:9926221;Name=nrdC;locus_tag=CC31p075
+NC_014662	GenBank	CDS	42795	43088	.	-	1	ID=CC31p076;Dbxref=GI:311993068,GeneID:9926222;Name=nrdC.1;codon_start=1;locus_tag=CC31p076;product=hypothetical protein;protein_id=YP_004009934.1;transl_table=11;translation=length.97
+NC_014662	GenBank	gene	42795	43088	.	-	1	ID=CC31p076.gene;Alias=CC31p076;Dbxref=GeneID:9926222;Name=nrdC.1;locus_tag=CC31p076
+NC_014662	GenBank	CDS	43085	43378	.	-	1	ID=CC31p077;Dbxref=GI:311993069,GeneID:9926223;Name=CC31p077;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009935.1;transl_table=11;translation=length.97
+NC_014662	GenBank	gene	43085	43378	.	-	1	ID=CC31p077.gene;Alias=CC31p077;Dbxref=GeneID:9926223;Name=CC31p077
+NC_014662	GenBank	CDS	43375	43710	.	-	1	ID=CC31p078;Dbxref=GI:311993070,GeneID:9926224;Name=CC31p078;codon_start=1;product=hypothetical protein;protein_id=YP_004009936.1;transl_table=11;translation=length.111
+NC_014662	GenBank	gene	43375	43710	.	-	1	ID=CC31p078.gene;Alias=CC31p078;Dbxref=GeneID:9926224;Name=CC31p078
+NC_014662	GenBank	CDS	43707	44222	.	-	1	ID=CC31p079;Dbxref=GI:311993071,GeneID:9926225;Name=CC31p079;codon_start=1;product=hypothetical protein;protein_id=YP_004009937.1;transl_table=11;translation=length.171
+NC_014662	GenBank	gene	43707	44222	.	-	1	ID=CC31p079.gene;Alias=CC31p079;Dbxref=GeneID:9926225;Name=CC31p079
+NC_014662	GenBank	CDS	44235	44663	.	-	1	ID=CC31p080;Dbxref=GI:311993072,GeneID:9926226;Name=nrdC.7;codon_start=1;locus_tag=CC31p080;product=predicted membrane protein;protein_id=YP_004009938.1;transl_table=11;translation=length.142
+NC_014662	GenBank	gene	44235	44663	.	-	1	ID=CC31p080.gene;Alias=CC31p080;Dbxref=GeneID:9926226;Name=nrdC.7;locus_tag=CC31p080
+NC_014662	GenBank	CDS	44660	44917	.	-	1	ID=CC31p081;Dbxref=GI:311993073,GeneID:9926227;Name=nrdC.2;codon_start=1;locus_tag=CC31p081;product=hypothetical protein;protein_id=YP_004009939.1;transl_table=11;translation=length.85
+NC_014662	GenBank	gene	44660	44917	.	-	1	ID=CC31p081.gene;Alias=CC31p081;Dbxref=GeneID:9926227;Name=nrdC.2;locus_tag=CC31p081
+NC_014662	GenBank	CDS	44914	45912	.	-	1	ID=CC31p082;Dbxref=GI:311993074,GeneID:9926228;Name=CC31p082;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009940.1;transl_table=11;translation=length.332
+NC_014662	GenBank	gene	44914	45912	.	-	1	ID=CC31p082.gene;Alias=CC31p082;Dbxref=GeneID:9926228;Name=CC31p082
+NC_014662	GenBank	CDS	45988	46194	.	-	1	ID=CC31p083;Dbxref=GI:311993075,GeneID:9926229;Name=CC31p083;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009941.1;transl_table=11;translation=length.68
+NC_014662	GenBank	gene	45988	46194	.	-	1	ID=CC31p083.gene;Alias=CC31p083;Dbxref=GeneID:9926229;Name=CC31p083
+NC_014662	GenBank	CDS	46182	46619	.	-	1	ID=CC31p084;Dbxref=GI:311993076,GeneID:9926230;Name=CC31p084;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009942.1;transl_table=11;translation=length.145
+NC_014662	GenBank	gene	46182	46619	.	-	1	ID=CC31p084.gene;Alias=CC31p084;Dbxref=GeneID:9926230;Name=CC31p084
+NC_014662	GenBank	CDS	46613	47389	.	-	1	ID=CC31p085;Dbxref=GI:311993077,GeneID:9926231;Name=CC31p085;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009943.1;transl_table=11;translation=length.258
+NC_014662	GenBank	gene	46613	47389	.	-	1	ID=CC31p085.gene;Alias=CC31p085;Dbxref=GeneID:9926231;Name=CC31p085
+NC_014662	GenBank	CDS	47555	47896	.	-	1	ID=CC31p086;Dbxref=GI:311993078,GeneID:9926232;Name=CC31p086;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009944.1;transl_table=11;translation=length.113
+NC_014662	GenBank	gene	47555	47896	.	-	1	ID=CC31p086.gene;Alias=CC31p086;Dbxref=GeneID:9926232;Name=CC31p086
+NC_014662	GenBank	CDS	47920	48336	.	-	1	ID=CC31p087;Dbxref=GI:311993079,GeneID:9926233;Name=CC31p087;codon_start=1;product=hypothetical protein;protein_id=YP_004009945.1;transl_table=11;translation=length.138
+NC_014662	GenBank	gene	47920	48336	.	-	1	ID=CC31p087.gene;Alias=CC31p087;Dbxref=GeneID:9926233;Name=CC31p087
+NC_014662	GenBank	CDS	48336	48551	.	-	1	ID=CC31p088;Dbxref=GI:311993080,GeneID:9926234;Name=CC31p088;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009946.1;transl_table=11;translation=length.71
+NC_014662	GenBank	gene	48336	48551	.	-	1	ID=CC31p088.gene;Alias=CC31p088;Dbxref=GeneID:9926234;Name=CC31p088
+NC_014662	GenBank	CDS	48545	48730	.	-	1	ID=CC31p089;Dbxref=GI:311993081,GeneID:9926235;Name=CC31p089;codon_start=1;product=hypothetical protein;protein_id=YP_004009947.1;transl_table=11;translation=length.61
+NC_014662	GenBank	gene	48545	48730	.	-	1	ID=CC31p089.gene;Alias=CC31p089;Dbxref=GeneID:9926235;Name=CC31p089
+NC_014662	GenBank	CDS	48727	49230	.	-	1	ID=CC31p090;Dbxref=GI:311993082,GeneID:9926236;Name=CC31p090;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009948.1;transl_table=11;translation=length.167
+NC_014662	GenBank	gene	48727	49230	.	-	1	ID=CC31p090.gene;Alias=CC31p090;Dbxref=GeneID:9926236;Name=CC31p090
+NC_014662	GenBank	CDS	49241	49582	.	-	1	ID=CC31p091;Dbxref=GI:311993083,GeneID:9926237;Name=CC31p091;codon_start=1;product=hypothetical protein;protein_id=YP_004009949.1;transl_table=11;translation=length.113
+NC_014662	GenBank	gene	49241	49582	.	-	1	ID=CC31p091.gene;Alias=CC31p091;Dbxref=GeneID:9926237;Name=CC31p091
+NC_014662	GenBank	CDS	49621	50598	.	-	1	ID=CC31p092;Dbxref=GI:311993084,GeneID:9926238;Name=nrdC.10;codon_start=1;locus_tag=CC31p092;product=hypothetical protein;protein_id=YP_004009950.1;transl_table=11;translation=length.325
+NC_014662	GenBank	gene	49621	50598	.	-	1	ID=CC31p092.gene;Alias=CC31p092;Dbxref=GeneID:9926238;Name=nrdC.10;locus_tag=CC31p092
+NC_014662	GenBank	CDS	50670	50933	.	-	1	ID=CC31p093;Dbxref=GI:311993085,GeneID:9926239;Name=CC31p093;codon_start=1;product=hypothetical protein;protein_id=YP_004009951.1;transl_table=11;translation=length.87
+NC_014662	GenBank	gene	50670	50933	.	-	1	ID=CC31p093.gene;Alias=CC31p093;Dbxref=GeneID:9926239;Name=CC31p093
+NC_014662	GenBank	CDS	50930	51079	.	-	1	ID=CC31p094;Dbxref=GI:311993086,GeneID:9926240;Name=CC31p094;codon_start=1;product=hypothetical protein;protein_id=YP_004009952.1;transl_table=11;translation=length.49
+NC_014662	GenBank	gene	50930	51079	.	-	1	ID=CC31p094.gene;Alias=CC31p094;Dbxref=GeneID:9926240;Name=CC31p094
+NC_014662	GenBank	CDS	51079	51351	.	-	1	ID=CC31p095;Dbxref=GI:311993087,GeneID:9926241;Name=CC31p095;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009953.1;transl_table=11;translation=length.90
+NC_014662	GenBank	gene	51079	51351	.	-	1	ID=CC31p095.gene;Alias=CC31p095;Dbxref=GeneID:9926241;Name=CC31p095
+NC_014662	GenBank	CDS	51357	51641	.	-	1	ID=CC31p096;Dbxref=GI:311993088,GeneID:9926242;Name=CC31p096;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009954.1;transl_table=11;translation=length.94
+NC_014662	GenBank	gene	51357	51641	.	-	1	ID=CC31p096.gene;Alias=CC31p096;Dbxref=GeneID:9926242;Name=CC31p096
+NC_014662	GenBank	CDS	51760	52014	.	-	1	ID=CC31p097;Dbxref=GI:311993089,GeneID:9926243;Name=CC31p097;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009955.1;transl_table=11;translation=length.84
+NC_014662	GenBank	gene	51760	52014	.	-	1	ID=CC31p097.gene;Alias=CC31p097;Dbxref=GeneID:9926243;Name=CC31p097
+NC_014662	GenBank	CDS	52017	53027	.	-	1	ID=CC31p098;Dbxref=GI:311993090,GeneID:9926244;Name=nrdC.11;Note=predicted nucleotidyltransferase motif;codon_start=1;locus_tag=CC31p098;product=hypothetical protein;protein_id=YP_004009956.1;transl_table=11;translation=length.336
+NC_014662	GenBank	gene	52017	53027	.	-	1	ID=CC31p098.gene;Alias=CC31p098;Dbxref=GeneID:9926244;Name=nrdC.11;locus_tag=CC31p098
+NC_014662	GenBank	CDS	53024	53449	.	-	1	ID=CC31p099;Dbxref=GI:311993091,GeneID:9926245;Name=CC31p099;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009957.1;transl_table=11;translation=length.141
+NC_014662	GenBank	gene	53024	53449	.	-	1	ID=CC31p099.gene;Alias=CC31p099;Dbxref=GeneID:9926245;Name=CC31p099
+NC_014662	GenBank	CDS	53446	54000	.	-	1	ID=CC31p100;Dbxref=GI:311993092,GeneID:9926246;Name=CC31p100;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009958.1;transl_table=11;translation=length.184
+NC_014662	GenBank	gene	53446	54000	.	-	1	ID=CC31p100.gene;Alias=CC31p100;Dbxref=GeneID:9926246;Name=CC31p100
+NC_014662	GenBank	CDS	54010	54231	.	-	1	ID=CC31p101;Dbxref=GI:311993093,GeneID:9926247;Name=CC31p101;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009959.1;transl_table=11;translation=length.73
+NC_014662	GenBank	gene	54010	54231	.	-	1	ID=CC31p101.gene;Alias=CC31p101;Dbxref=GeneID:9926247;Name=CC31p101
+NC_014662	GenBank	CDS	54231	54683	.	-	1	ID=CC31p102;Dbxref=GI:311993094,GeneID:9926248;Name=CC31p102;codon_start=1;product=hypothetical protein;protein_id=YP_004009960.1;transl_table=11;translation=length.150
+NC_014662	GenBank	gene	54231	54683	.	-	1	ID=CC31p102.gene;Alias=CC31p102;Dbxref=GeneID:9926248;Name=CC31p102
+NC_014662	GenBank	CDS	54705	54950	.	-	1	ID=CC31p103;Dbxref=GI:311993095,GeneID:9926249;Name=CC31p103;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009961.1;transl_table=11;translation=length.81
+NC_014662	GenBank	gene	54705	54950	.	-	1	ID=CC31p103.gene;Alias=CC31p103;Dbxref=GeneID:9926249;Name=CC31p103
+NC_014662	GenBank	CDS	54943	55218	.	-	1	ID=CC31p104;Dbxref=GI:311993096,GeneID:9926250;Name=CC31p104;codon_start=1;product=hypothetical protein;protein_id=YP_004009962.1;transl_table=11;translation=length.91
+NC_014662	GenBank	gene	54943	55218	.	-	1	ID=CC31p104.gene;Alias=CC31p104;Dbxref=GeneID:9926250;Name=CC31p104
+NC_014662	GenBank	CDS	55202	55408	.	-	1	ID=CC31p105;Dbxref=GI:311993097,GeneID:9926251;Name=CC31p105;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009963.1;transl_table=11;translation=length.68
+NC_014662	GenBank	gene	55202	55408	.	-	1	ID=CC31p105.gene;Alias=CC31p105;Dbxref=GeneID:9926251;Name=CC31p105
+NC_014662	GenBank	CDS	55405	55692	.	-	1	ID=CC31p106;Dbxref=GI:311993098,GeneID:9926252;Name=CC31p106;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009964.1;transl_table=11;translation=length.95
+NC_014662	GenBank	gene	55405	55692	.	-	1	ID=CC31p106.gene;Alias=CC31p106;Dbxref=GeneID:9926252;Name=CC31p106
+NC_014662	GenBank	CDS	55695	55964	.	-	1	ID=CC31p107;Dbxref=GI:311993099,GeneID:9926253;Name=CC31p107;Note=predicted DksA/TraR family%2C C4-type zinc finger motif;codon_start=1;product=conserved hypothetical bacterial protein;protein_id=YP_004009965.1;transl_table=11;translation=length.89
+NC_014662	GenBank	gene	55695	55964	.	-	1	ID=CC31p107.gene;Alias=CC31p107;Dbxref=GeneID:9926253;Name=CC31p107
+NC_014662	GenBank	CDS	56099	56530	.	-	1	ID=CC31p108;Dbxref=GI:311993100,GeneID:9926254;Name=CC31p108;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009966.1;transl_table=11;translation=length.143
+NC_014662	GenBank	gene	56099	56530	.	-	1	ID=CC31p108.gene;Alias=CC31p108;Dbxref=GeneID:9926254;Name=CC31p108
+NC_014662	GenBank	CDS	56637	57029	.	-	1	ID=CC31p109;Dbxref=GI:311993101,GeneID:9926255;Name=mobD.6;codon_start=1;locus_tag=CC31p109;product=hypothetical protein;protein_id=YP_004009967.1;transl_table=11;translation=length.130
+NC_014662	GenBank	gene	56637	57029	.	-	1	ID=CC31p109.gene;Alias=CC31p109;Dbxref=GeneID:9926255;Name=mobD.6;locus_tag=CC31p109
+NC_014662	GenBank	CDS	57013	57288	.	-	1	ID=CC31p110;Dbxref=GI:311993102,GeneID:9926256;Name=rI;codon_start=1;locus_tag=CC31p110;product=lysis inhibition regulator membrane protein;protein_id=YP_004009968.1;transl_table=11;translation=length.91
+NC_014662	GenBank	gene	57013	57288	.	-	1	ID=CC31p110.gene;Alias=CC31p110;Dbxref=GeneID:9926256;Name=rI;locus_tag=CC31p110
+NC_014662	GenBank	CDS	57296	57508	.	-	1	ID=CC31p111;Dbxref=GI:311993103,GeneID:9926257;Name=rI.1;codon_start=1;locus_tag=CC31p111;product=hypothetical protein;protein_id=YP_004009969.1;transl_table=11;translation=length.70
+NC_014662	GenBank	gene	57296	57508	.	-	1	ID=CC31p111.gene;Alias=CC31p111;Dbxref=GeneID:9926257;Name=rI.1;locus_tag=CC31p111
+NC_014662	GenBank	CDS	57568	57951	.	-	1	ID=CC31p112;Dbxref=GI:311993104,GeneID:9926258;Name=CC31p112;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009970.1;transl_table=11;translation=length.127
+NC_014662	GenBank	gene	57568	57951	.	-	1	ID=CC31p112.gene;Alias=CC31p112;Dbxref=GeneID:9926258;Name=CC31p112
+NC_014662	GenBank	CDS	58008	58118	.	-	1	ID=CC31p113;Dbxref=GI:311993105,GeneID:9926259;Name=CC31p113;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009971.1;transl_table=11;translation=length.36
+NC_014662	GenBank	gene	58008	58118	.	-	1	ID=CC31p113.gene;Alias=CC31p113;Dbxref=GeneID:9926259;Name=CC31p113
+NC_014662	GenBank	CDS	58115	58246	.	-	1	ID=CC31p114;Dbxref=GI:311993106,GeneID:9926260;Name=CC31p114;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009972.1;transl_table=11;translation=length.43
+NC_014662	GenBank	gene	58115	58246	.	-	1	ID=CC31p114.gene;Alias=CC31p114;Dbxref=GeneID:9926260;Name=CC31p114
+NC_014662	GenBank	CDS	58243	58407	.	-	1	ID=CC31p115;Dbxref=GI:311993107,GeneID:9926261;Name=CC31p115;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009973.1;transl_table=11;translation=length.54
+NC_014662	GenBank	gene	58243	58407	.	-	1	ID=CC31p115.gene;Alias=CC31p115;Dbxref=GeneID:9926261;Name=CC31p115
+NC_014662	GenBank	CDS	58404	58616	.	-	1	ID=CC31p116;Dbxref=GI:311993108,GeneID:9926262;Name=CC31p116;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009974.1;transl_table=11;translation=length.70
+NC_014662	GenBank	gene	58404	58616	.	-	1	ID=CC31p116.gene;Alias=CC31p116;Dbxref=GeneID:9926262;Name=CC31p116
+NC_014662	GenBank	CDS	58609	59193	.	-	1	ID=CC31p117;Dbxref=GI:311993109,GeneID:9926263;Name=tk;Note=Tk;codon_start=1;locus_tag=CC31p117;product=thymidine kinase;protein_id=YP_004009975.1;transl_table=11;translation=length.194
+NC_014662	GenBank	gene	58609	59193	.	-	1	ID=CC31p117.gene;Alias=CC31p117;Dbxref=GeneID:9926263;Name=tk;locus_tag=CC31p117
+NC_014662	GenBank	CDS	59193	59648	.	-	1	ID=CC31p118;Dbxref=GI:311993110,GeneID:9926264;Name=tk.4;codon_start=1;locus_tag=CC31p118;product=hypothetical protein;protein_id=YP_004009976.1;transl_table=11;translation=length.151
+NC_014662	GenBank	gene	59193	59648	.	-	1	ID=CC31p118.gene;Alias=CC31p118;Dbxref=GeneID:9926264;Name=tk.4;locus_tag=CC31p118
+NC_014662	GenBank	CDS	59645	60064	.	-	1	ID=CC31p119;Dbxref=GI:311993111,GeneID:9926265;Name=CC31p119;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009977.1;transl_table=11;translation=length.139
+NC_014662	GenBank	gene	59645	60064	.	-	1	ID=CC31p119.gene;Alias=CC31p119;Dbxref=GeneID:9926265;Name=CC31p119
+NC_014662	GenBank	CDS	60061	60387	.	-	1	ID=CC31p120;Dbxref=GI:311993112,GeneID:9926266;Name=vs;Note=Vs;codon_start=1;locus_tag=CC31p120;product=valyl-tRNA synthetase modifier;protein_id=YP_004009978.1;transl_table=11;translation=length.108
+NC_014662	GenBank	gene	60061	60387	.	-	1	ID=CC31p120.gene;Alias=CC31p120;Dbxref=GeneID:9926266;Name=vs;locus_tag=CC31p120
+NC_014662	GenBank	CDS	60387	60935	.	-	1	ID=CC31p121;Dbxref=GI:311993113,GeneID:9926267;Name=vs.1;Note=predicted endoribonuclease RegB motif;codon_start=1;locus_tag=CC31p121;product=hypothetical protein;protein_id=YP_004009979.1;transl_table=11;translation=length.182
+NC_014662	GenBank	gene	60387	60935	.	-	1	ID=CC31p121.gene;Alias=CC31p121;Dbxref=GeneID:9926267;Name=vs.1;locus_tag=CC31p121
+NC_014662	GenBank	CDS	60958	61422	.	-	1	ID=CC31p122;Dbxref=GI:311993114,GeneID:9926268;Name=regB;Note=RegB;codon_start=1;locus_tag=CC31p122;product=site-specific RNA endonuclease;protein_id=YP_004009980.1;transl_table=11;translation=length.154
+NC_014662	GenBank	gene	60958	61422	.	-	1	ID=CC31p122.gene;Alias=CC31p122;Dbxref=GeneID:9926268;Name=regB;locus_tag=CC31p122
+NC_014662	GenBank	CDS	61478	61708	.	-	1	ID=CC31p123;Dbxref=GI:311993115,GeneID:9926269;Name=CC31p123;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009981.1;transl_table=11;translation=length.76
+NC_014662	GenBank	gene	61478	61708	.	-	1	ID=CC31p123.gene;Alias=CC31p123;Dbxref=GeneID:9926269;Name=CC31p123
+NC_014662	GenBank	CDS	61708	61989	.	-	1	ID=CC31p124;Dbxref=GI:311993116,GeneID:9926270;Name=vs.4;Note=PRP8%3B U5 snRNP spliceosome subunit%3B predicted RNA processing and modification motif;codon_start=1;locus_tag=CC31p124;product=hypothetical protein;protein_id=YP_004009982.1;transl_table=11;translation=length.93
+NC_014662	GenBank	gene	61708	61989	.	-	1	ID=CC31p124.gene;Alias=CC31p124;Dbxref=GeneID:9926270;Name=vs.4;locus_tag=CC31p124
+NC_014662	GenBank	CDS	61989	62351	.	-	1	ID=CC31p125;Dbxref=GI:311993117,GeneID:9926271;Name=vs.6;Note=predicted Gly radical superfamily motif;codon_start=1;locus_tag=CC31p125;product=hypothetical protein;protein_id=YP_004009983.1;transl_table=11;translation=length.120
+NC_014662	GenBank	gene	61989	62351	.	-	1	ID=CC31p125.gene;Alias=CC31p125;Dbxref=GeneID:9926271;Name=vs.6;locus_tag=CC31p125
+NC_014662	GenBank	CDS	62361	62513	.	-	1	ID=CC31p126;Dbxref=GI:311993118,GeneID:9926272;Name=vs.5;codon_start=1;locus_tag=CC31p126;product=hypothetical protein;protein_id=YP_004009984.1;transl_table=11;translation=length.50
+NC_014662	GenBank	gene	62361	62513	.	-	1	ID=CC31p126.gene;Alias=CC31p126;Dbxref=GeneID:9926272;Name=vs.5;locus_tag=CC31p126
+NC_014662	GenBank	CDS	62513	62932	.	-	1	ID=CC31p127;Dbxref=GI:311993119,GeneID:9926273;Name=vs.7;codon_start=1;locus_tag=CC31p127;product=hypothetical protein;protein_id=YP_004009985.1;transl_table=11;translation=length.139
+NC_014662	GenBank	gene	62513	62932	.	-	1	ID=CC31p127.gene;Alias=CC31p127;Dbxref=GeneID:9926273;Name=vs.7;locus_tag=CC31p127
+NC_014662	GenBank	CDS	62929	63528	.	-	1	ID=CC31p128;Dbxref=GI:311993120,GeneID:9926274;Name=vs.8;codon_start=1;locus_tag=CC31p128;product=hypothetical protein;protein_id=YP_004009986.1;transl_table=11;translation=length.199
+NC_014662	GenBank	gene	62929	63528	.	-	1	ID=CC31p128.gene;Alias=CC31p128;Dbxref=GeneID:9926274;Name=vs.8;locus_tag=CC31p128
+NC_014662	GenBank	CDS	63671	63967	.	-	1	ID=CC31p129;Dbxref=GI:311993121,GeneID:9926275;Name=CC31p129;codon_start=1;product=hypothetical protein;protein_id=YP_004009987.1;transl_table=11;translation=length.98
+NC_014662	GenBank	gene	63671	63967	.	-	1	ID=CC31p129.gene;Alias=CC31p129;Dbxref=GeneID:9926275;Name=CC31p129
+NC_014662	GenBank	CDS	63976	64392	.	-	1	ID=CC31p130;Dbxref=GI:311993122,GeneID:9926276;Name=denV;Note=DenV;codon_start=1;locus_tag=CC31p130;product=endonuclease V%2C N-glycosylase UV repair enzyme;protein_id=YP_004009988.1;transl_table=11;translation=length.138
+NC_014662	GenBank	gene	63976	64392	.	-	1	ID=CC31p130.gene;Alias=CC31p130;Dbxref=GeneID:9926276;Name=denV;locus_tag=CC31p130
+NC_014662	GenBank	CDS	64452	64742	.	-	1	ID=CC31p131;Dbxref=GI:311993123,GeneID:9926277;Name=CC31p131;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009989.1;transl_table=11;translation=length.96
+NC_014662	GenBank	gene	64452	64742	.	-	1	ID=CC31p131.gene;Alias=CC31p131;Dbxref=GeneID:9926277;Name=CC31p131
+NC_014662	GenBank	CDS	64729	65223	.	-	1	ID=CC31p132;Dbxref=GI:311993124,GeneID:9926278;Name=e;codon_start=1;locus_tag=CC31p132;product=lysozyme murein hydrolase;protein_id=YP_004009990.1;transl_table=11;translation=length.164
+NC_014662	GenBank	gene	64729	65223	.	-	1	ID=CC31p132.gene;Alias=CC31p132;Dbxref=GeneID:9926278;Name=e;locus_tag=CC31p132
+NC_014662	GenBank	CDS	65257	65736	.	-	1	ID=CC31p133;Dbxref=GI:311993125,GeneID:9926279;Name=nudE;Note=NudE;codon_start=1;locus_tag=CC31p133;product=nudix hydrolase;protein_id=YP_004009991.1;transl_table=11;translation=length.159
+NC_014662	GenBank	gene	65257	65736	.	-	1	ID=CC31p133.gene;Alias=CC31p133;Dbxref=GeneID:9926279;Name=nudE;locus_tag=CC31p133
+NC_014662	GenBank	CDS	65733	65963	.	-	1	ID=CC31p134;Dbxref=GI:311993126,GeneID:9926280;Name=CC31p134;codon_start=1;product=hypothetical protein;protein_id=YP_004009992.1;transl_table=11;translation=length.76
+NC_014662	GenBank	gene	65733	65963	.	-	1	ID=CC31p134.gene;Alias=CC31p134;Dbxref=GeneID:9926280;Name=CC31p134
+NC_014662	GenBank	CDS	65960	66271	.	-	1	ID=CC31p135;Dbxref=GI:311993127,GeneID:9926281;Name=CC31p135;codon_start=1;product=hypothetical protein;protein_id=YP_004009993.1;transl_table=11;translation=length.103
+NC_014662	GenBank	gene	65960	66271	.	-	1	ID=CC31p135.gene;Alias=CC31p135;Dbxref=GeneID:9926281;Name=CC31p135
+NC_014662	GenBank	CDS	66268	66630	.	-	1	ID=CC31p136;Dbxref=GI:311993128,GeneID:9926282;Name=CC31p136;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009994.1;transl_table=11;translation=length.120
+NC_014662	GenBank	gene	66268	66630	.	-	1	ID=CC31p136.gene;Alias=CC31p136;Dbxref=GeneID:9926282;Name=CC31p136
+NC_014662	GenBank	CDS	66627	66965	.	-	1	ID=CC31p137;Dbxref=GI:311993129,GeneID:9926283;Name=CC31p137;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009995.1;transl_table=11;translation=length.112
+NC_014662	GenBank	gene	66627	66965	.	-	1	ID=CC31p137.gene;Alias=CC31p137;Dbxref=GeneID:9926283;Name=CC31p137
+NC_014662	GenBank	CDS	66949	67302	.	-	1	ID=CC31p138;Dbxref=GI:311993130,GeneID:9926284;Name=CC31p138;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009996.1;transl_table=11;translation=length.117
+NC_014662	GenBank	gene	66949	67302	.	-	1	ID=CC31p138.gene;Alias=CC31p138;Dbxref=GeneID:9926284;Name=CC31p138
+NC_014662	GenBank	CDS	67305	67679	.	-	1	ID=CC31p139;Dbxref=GI:311993131,GeneID:9926285;Name=CC31p139;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009997.1;transl_table=11;translation=length.124
+NC_014662	GenBank	gene	67305	67679	.	-	1	ID=CC31p139.gene;Alias=CC31p139;Dbxref=GeneID:9926285;Name=CC31p139
+NC_014662	GenBank	CDS	67713	68630	.	-	1	ID=CC31p140;Dbxref=GI:311993132,GeneID:9926286;Name=CC31p140;codon_start=1;product=hypothetical protein;protein_id=YP_004009998.1;transl_table=11;translation=length.305
+NC_014662	GenBank	gene	67713	68630	.	-	1	ID=CC31p140.gene;Alias=CC31p140;Dbxref=GeneID:9926286;Name=CC31p140
+NC_014662	GenBank	CDS	68660	69001	.	-	1	ID=CC31p141;Dbxref=GI:311993133,GeneID:9926287;Name=CC31p141;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004009999.1;transl_table=11;translation=length.113
+NC_014662	GenBank	gene	68660	69001	.	-	1	ID=CC31p141.gene;Alias=CC31p141;Dbxref=GeneID:9926287;Name=CC31p141
 NC_014662	GenBank	gene	69066	69138	.	-	1	ID=CC31t001;Dbxref=GeneID:9926288;Name=CC31t001
 NC_014662	GenBank	tRNA	69066	69138	.	-	1	ID=CC31t001.r01;Parent=CC31t001;Dbxref=GeneID:9926288;Name=CC31t001;product=tRNA-Gln
-NC_014662	GenBank	exon	69066	69138	.	-	1	Parent=CC31t001.r01;Name=CC31t001
 NC_014662	GenBank	gene	69148	69221	.	-	1	ID=CC31t002;Dbxref=GeneID:9926292;Name=CC31t002
 NC_014662	GenBank	tRNA	69148	69221	.	-	1	ID=CC31t002.r01;Parent=CC31t002;Dbxref=GeneID:9926292;Name=CC31t002;product=tRNA-Met
-NC_014662	GenBank	exon	69148	69221	.	-	1	Parent=CC31t002.r01;Name=CC31t002
 NC_014662	GenBank	gene	69345	69417	.	-	1	ID=CC31t003;Dbxref=GeneID:9926293;Name=CC31t003
 NC_014662	GenBank	tRNA	69345	69417	.	-	1	ID=CC31t003.r01;Parent=CC31t003;Dbxref=GeneID:9926293;Name=CC31t003;product=tRNA-Asp
-NC_014662	GenBank	exon	69345	69417	.	-	1	Parent=CC31t003.r01;Name=CC31t003
 NC_014662	GenBank	gene	69663	69744	.	-	1	ID=CC31t004;Dbxref=GeneID:9926294;Name=CC31t004
 NC_014662	GenBank	tRNA	69663	69744	.	-	1	ID=CC31t004.r01;Parent=CC31t004;Dbxref=GeneID:9926294;Name=CC31t004;product=tRNA-Asn
-NC_014662	GenBank	exon	69663	69744	.	-	1	Parent=CC31t004.r01;Name=CC31t004
 NC_014662	GenBank	gene	69753	69824	.	-	1	ID=CC31t005;Dbxref=GeneID:9926295;Name=CC31t005
 NC_014662	GenBank	tRNA	69753	69824	.	-	1	ID=CC31t005.r01;Parent=CC31t005;Dbxref=GeneID:9926295;Name=CC31t005;product=tRNA-Glu
-NC_014662	GenBank	exon	69753	69824	.	-	1	Parent=CC31t005.r01;Name=CC31t005
 NC_014662	GenBank	gene	69829	69903	.	-	1	ID=CC31t006;Dbxref=GeneID:9926296;Name=CC31t006
 NC_014662	GenBank	tRNA	69829	69903	.	-	1	ID=CC31t006.r01;Parent=CC31t006;Dbxref=GeneID:9926296;Name=CC31t006;product=tRNA-Lys
-NC_014662	GenBank	exon	69829	69903	.	-	1	Parent=CC31t006.r01;Name=CC31t006
 NC_014662	GenBank	gene	69945	70017	.	-	1	ID=CC31t007;Dbxref=GeneID:9926297;Name=CC31t007
 NC_014662	GenBank	tRNA	69945	70017	.	-	1	ID=CC31t007.r01;Parent=CC31t007;Dbxref=GeneID:9926297;Name=CC31t007;product=tRNA-Ile
-NC_014662	GenBank	exon	69945	70017	.	-	1	Parent=CC31t007.r01;Name=CC31t007
 NC_014662	GenBank	gene	70027	70111	.	-	1	ID=CC31t008;Dbxref=GeneID:9926298;Name=CC31t008
 NC_014662	GenBank	tRNA	70027	70111	.	-	1	ID=CC31t008.r01;Parent=CC31t008;Dbxref=GeneID:9926298;Name=CC31t008;product=tRNA-Tyr
-NC_014662	GenBank	exon	70027	70111	.	-	1	Parent=CC31t008.r01;Name=CC31t008
-NC_014662	GenBank	gene	70116	70475	.	-	1	ID=CC31p142;Dbxref=GeneID:9926299;Name=CC31p142
-NC_014662	GenBank	mRNA	70116	70475	.	-	1	ID=CC31p142.t01;Parent=CC31p142
-NC_014662	GenBank	CDS	70116	70475	.	-	1	ID=CC31p142.p01;Parent=CC31p142.t01;Dbxref=GI:311993134,GeneID:9926299;Name=CC31p142;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010000.1;transl_table=11;translation=length.119
-NC_014662	GenBank	exon	70116	70475	.	-	1	Parent=CC31p142.t01
-NC_014662	GenBank	gene	70462	70674	.	-	1	ID=CC31p143;Dbxref=GeneID:9926289;Name=CC31p143
-NC_014662	GenBank	mRNA	70462	70674	.	-	1	ID=CC31p143.t01;Parent=CC31p143
-NC_014662	GenBank	CDS	70462	70674	.	-	1	ID=CC31p143.p01;Parent=CC31p143.t01;Dbxref=GI:311993135,GeneID:9926289;Name=CC31p143;codon_start=1;product=hypothetical protein;protein_id=YP_004010001.1;transl_table=11;translation=length.70
-NC_014662	GenBank	exon	70462	70674	.	-	1	Parent=CC31p143.t01
-NC_014662	GenBank	gene	70718	70915	.	-	1	ID=CC31p144;Dbxref=GeneID:9926290;Name=CC31p144
-NC_014662	GenBank	mRNA	70718	70915	.	-	1	ID=CC31p144.t01;Parent=CC31p144
-NC_014662	GenBank	CDS	70718	70915	.	-	1	ID=CC31p144.p01;Parent=CC31p144.t01;Dbxref=GI:311993136,GeneID:9926290;Name=CC31p144;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010002.1;transl_table=11;translation=length.65
-NC_014662	GenBank	exon	70718	70915	.	-	1	Parent=CC31p144.t01
-NC_014662	GenBank	gene	70902	71081	.	-	1	ID=CC31p145;Dbxref=GeneID:9926291;Name=tRNA.4;locus_tag=CC31p145
-NC_014662	GenBank	mRNA	70902	71081	.	-	1	ID=CC31p145.t01;Parent=CC31p145
-NC_014662	GenBank	CDS	70902	71081	.	-	1	ID=CC31p145.p01;Parent=CC31p145.t01;Dbxref=GI:311993137,GeneID:9926291;Name=tRNA.4;codon_start=1;locus_tag=CC31p145;product=predicted membrane protein;protein_id=YP_004010003.1;transl_table=11;translation=length.59
-NC_014662	GenBank	exon	70902	71081	.	-	1	Parent=CC31p145.t01
-NC_014662	GenBank	gene	71147	71455	.	-	1	ID=CC31p146;Dbxref=GeneID:9926300;Name=ip7;locus_tag=CC31p146
-NC_014662	GenBank	mRNA	71147	71455	.	-	1	ID=CC31p146.t01;Parent=CC31p146
-NC_014662	GenBank	CDS	71147	71455	.	-	1	ID=CC31p146.p01;Parent=CC31p146.t01;Dbxref=GI:311993138,GeneID:9926300;Name=ip7;codon_start=1;locus_tag=CC31p146;product=Ip7 protein;protein_id=YP_004010004.1;transl_table=11;translation=length.102
-NC_014662	GenBank	exon	71147	71455	.	-	1	Parent=CC31p146.t01
-NC_014662	GenBank	gene	71452	71910	.	-	1	ID=CC31p147;Dbxref=GeneID:9926301;Name=57B;locus_tag=CC31p147
-NC_014662	GenBank	mRNA	71452	71910	.	-	1	ID=CC31p147.t01;Parent=CC31p147
-NC_014662	GenBank	CDS	71452	71910	.	-	1	ID=CC31p147.p01;Parent=CC31p147.t01;Dbxref=GI:311993139,GeneID:9926301;Name=57B;codon_start=1;locus_tag=CC31p147;product=hypothetical protein;protein_id=YP_004010005.1;transl_table=11;translation=length.152
-NC_014662	GenBank	exon	71452	71910	.	-	1	Parent=CC31p147.t01
-NC_014662	GenBank	gene	71907	72161	.	-	1	ID=CC31p148;Dbxref=GeneID:9926303;Name=57A;locus_tag=CC31p148
-NC_014662	GenBank	mRNA	71907	72161	.	-	1	ID=CC31p148.t01;Parent=CC31p148
-NC_014662	GenBank	CDS	71907	72161	.	-	1	ID=CC31p148.p01;Parent=CC31p148.t01;Dbxref=GI:311993140,GeneID:9926303;Name=57A;codon_start=1;locus_tag=CC31p148;product=gp57A chaperone for tail fiber formation;protein_id=YP_004010006.1;transl_table=11;translation=length.84
-NC_014662	GenBank	exon	71907	72161	.	-	1	Parent=CC31p148.t01
-NC_014662	GenBank	gene	72158	72886	.	-	1	ID=CC31p149;Dbxref=GeneID:9926302;Name=1;locus_tag=CC31p149
-NC_014662	GenBank	mRNA	72158	72886	.	-	1	ID=CC31p149.t01;Parent=CC31p149
-NC_014662	GenBank	CDS	72158	72886	.	-	1	ID=CC31p149.p01;Parent=CC31p149.t01;Dbxref=GI:311993141,GeneID:9926302;Name=1;codon_start=1;locus_tag=CC31p149;product=gp1 dNMP kinase;protein_id=YP_004010007.1;transl_table=11;translation=length.242
-NC_014662	GenBank	exon	72158	72886	.	-	1	Parent=CC31p149.t01
-NC_014662	GenBank	gene	72888	73478	.	-	1	ID=CC31p150;Dbxref=GeneID:9926304;Name=3;locus_tag=CC31p150
-NC_014662	GenBank	mRNA	72888	73478	.	-	1	ID=CC31p150.t01;Parent=CC31p150
-NC_014662	GenBank	CDS	72888	73478	.	-	1	ID=CC31p150.p01;Parent=CC31p150.t01;Dbxref=GI:311993142,GeneID:9926304;Name=3;codon_start=1;locus_tag=CC31p150;product=gp3 tail completion and sheath stabilizer protein;protein_id=YP_004010008.1;transl_table=11;translation=length.196
-NC_014662	GenBank	exon	72888	73478	.	-	1	Parent=CC31p150.t01
-NC_014662	GenBank	gene	73560	74390	.	-	1	ID=CC31p151;Dbxref=GeneID:9926305;Name=2;locus_tag=CC31p151
-NC_014662	GenBank	mRNA	73560	74390	.	-	1	ID=CC31p151.t01;Parent=CC31p151
-NC_014662	GenBank	CDS	73560	74390	.	-	1	ID=CC31p151.p01;Parent=CC31p151.t01;Dbxref=GI:311993143,GeneID:9926305;Name=2;codon_start=1;locus_tag=CC31p151;product=gp2 DNA end protector protein;protein_id=YP_004010009.1;transl_table=11;translation=length.276
-NC_014662	GenBank	exon	73560	74390	.	-	1	Parent=CC31p151.t01
-NC_014662	GenBank	gene	74390	74839	.	-	1	ID=CC31p152;Dbxref=GeneID:9926306;Name=4;locus_tag=CC31p152
-NC_014662	GenBank	mRNA	74390	74839	.	-	1	ID=CC31p152.t01;Parent=CC31p152
-NC_014662	GenBank	CDS	74390	74839	.	-	1	ID=CC31p152.p01;Parent=CC31p152.t01;Dbxref=GI:311993144,GeneID:9926306;Name=4;codon_start=1;locus_tag=CC31p152;product=gp4 head completion protein;protein_id=YP_004010010.1;transl_table=11;translation=length.149
-NC_014662	GenBank	exon	74390	74839	.	-	1	Parent=CC31p152.t01
-NC_014662	GenBank	gene	74889	75464	.	+	1	ID=CC31p153;Dbxref=GeneID:9926307;Name=53;locus_tag=CC31p153
-NC_014662	GenBank	mRNA	74889	75464	.	+	1	ID=CC31p153.t01;Parent=CC31p153
-NC_014662	GenBank	CDS	74889	75464	.	+	1	ID=CC31p153.p01;Parent=CC31p153.t01;Dbxref=GI:311993145,GeneID:9926307;Name=53;codon_start=1;locus_tag=CC31p153;product=gp53 base plate wedge completion;protein_id=YP_004010011.1;transl_table=11;translation=length.191
-NC_014662	GenBank	exon	74889	75464	.	+	1	Parent=CC31p153.t01
-NC_014662	GenBank	gene	75464	77197	.	+	1	ID=CC31p154;Dbxref=GeneID:9926308;Name=5;locus_tag=CC31p154
-NC_014662	GenBank	mRNA	75464	77197	.	+	1	ID=CC31p154.t01;Parent=CC31p154
-NC_014662	GenBank	CDS	75464	77197	.	+	1	ID=CC31p154.p01;Parent=CC31p154.t01;Dbxref=GI:311993146,GeneID:9926308;Name=5;codon_start=1;locus_tag=CC31p154;product=gp5 base plate hub subunit and tail lysozyme;protein_id=YP_004010012.1;transl_table=11;translation=length.577
-NC_014662	GenBank	exon	75464	77197	.	+	1	Parent=CC31p154.t01
-NC_014662	GenBank	gene	77205	77708	.	+	1	ID=CC31p155;Dbxref=GeneID:9926309;Name=5.1;locus_tag=CC31p155
-NC_014662	GenBank	mRNA	77205	77708	.	+	1	ID=CC31p155.t01;Parent=CC31p155
-NC_014662	GenBank	CDS	77205	77708	.	+	1	ID=CC31p155.p01;Parent=CC31p155.t01;Dbxref=GI:311993147,GeneID:9926309;Name=5.1;codon_start=1;locus_tag=CC31p155;product=hypothetical protein;protein_id=YP_004010013.1;transl_table=11;translation=length.167
-NC_014662	GenBank	exon	77205	77708	.	+	1	Parent=CC31p155.t01
-NC_014662	GenBank	gene	77709	78005	.	+	1	ID=CC31p156;Dbxref=GeneID:9926310;Name=5.4;locus_tag=CC31p156
-NC_014662	GenBank	mRNA	77709	78005	.	+	1	ID=CC31p156.t01;Parent=CC31p156
-NC_014662	GenBank	CDS	77709	78005	.	+	1	ID=CC31p156.p01;Parent=CC31p156.t01;Dbxref=GI:311993148,GeneID:9926310;Name=5.4;codon_start=1;locus_tag=CC31p156;product=hypothetical protein;protein_id=YP_004010014.1;transl_table=11;translation=length.98
-NC_014662	GenBank	exon	77709	78005	.	+	1	Parent=CC31p156.t01
-NC_014662	GenBank	gene	78010	79956	.	+	1	ID=CC31p157;Dbxref=GeneID:9926311;Name=6;locus_tag=CC31p157
-NC_014662	GenBank	mRNA	78010	79956	.	+	1	ID=CC31p157.t01;Parent=CC31p157
-NC_014662	GenBank	CDS	78010	79956	.	+	1	ID=CC31p157.p01;Parent=CC31p157.t01;Dbxref=GI:311993149,GeneID:9926311;Name=6;codon_start=1;locus_tag=CC31p157;product=gp6 base plate wedge;protein_id=YP_004010015.1;transl_table=11;translation=length.648
-NC_014662	GenBank	exon	78010	79956	.	+	1	Parent=CC31p157.t01
-NC_014662	GenBank	gene	79953	83051	.	+	1	ID=CC31p158;Dbxref=GeneID:9926312;Name=7;locus_tag=CC31p158
-NC_014662	GenBank	mRNA	79953	83051	.	+	1	ID=CC31p158.t01;Parent=CC31p158
-NC_014662	GenBank	CDS	79953	83051	.	+	1	ID=CC31p158.p01;Parent=CC31p158.t01;Dbxref=GI:311993150,GeneID:9926312;Name=7;codon_start=1;locus_tag=CC31p158;product=gp7 base plate wedge initiator;protein_id=YP_004010016.1;transl_table=11;translation=length.1032
-NC_014662	GenBank	exon	79953	83051	.	+	1	Parent=CC31p158.t01
-NC_014662	GenBank	gene	83044	84054	.	+	1	ID=CC31p159;Dbxref=GeneID:9926313;Name=8;locus_tag=CC31p159
-NC_014662	GenBank	mRNA	83044	84054	.	+	1	ID=CC31p159.t01;Parent=CC31p159
-NC_014662	GenBank	CDS	83044	84054	.	+	1	ID=CC31p159.p01;Parent=CC31p159.t01;Dbxref=GI:311993151,GeneID:9926313;Name=8;codon_start=1;locus_tag=CC31p159;product=gp8 base plate wedge;protein_id=YP_004010017.1;transl_table=11;translation=length.336
-NC_014662	GenBank	exon	83044	84054	.	+	1	Parent=CC31p159.t01
-NC_014662	GenBank	gene	84115	85023	.	+	1	ID=CC31p160;Dbxref=GeneID:9926314;Name=9;locus_tag=CC31p160
-NC_014662	GenBank	mRNA	84115	85023	.	+	1	ID=CC31p160.t01;Parent=CC31p160
-NC_014662	GenBank	CDS	84115	85023	.	+	1	ID=CC31p160.p01;Parent=CC31p160.t01;Dbxref=GI:311993152,GeneID:9926314;Name=9;codon_start=1;locus_tag=CC31p160;product=gp9 base plate wedge completion tail fiber socket;protein_id=YP_004010018.1;transl_table=11;translation=length.302
-NC_014662	GenBank	exon	84115	85023	.	+	1	Parent=CC31p160.t01
-NC_014662	GenBank	gene	85020	86828	.	+	1	ID=CC31p161;Dbxref=GeneID:9926315;Name=10;locus_tag=CC31p161
-NC_014662	GenBank	mRNA	85020	86828	.	+	1	ID=CC31p161.t01;Parent=CC31p161
-NC_014662	GenBank	CDS	85020	86828	.	+	1	ID=CC31p161.p01;Parent=CC31p161.t01;Dbxref=GI:311993153,GeneID:9926315;Name=10;codon_start=1;locus_tag=CC31p161;product=gp10 base plate wedge subunit and tail pin;protein_id=YP_004010019.1;transl_table=11;translation=length.602
-NC_014662	GenBank	exon	85020	86828	.	+	1	Parent=CC31p161.t01
-NC_014662	GenBank	gene	86828	87490	.	+	1	ID=CC31p162;Dbxref=GeneID:9926316;Name=11;locus_tag=CC31p162
-NC_014662	GenBank	mRNA	86828	87490	.	+	1	ID=CC31p162.t01;Parent=CC31p162
-NC_014662	GenBank	CDS	86828	87490	.	+	1	ID=CC31p162.p01;Parent=CC31p162.t01;Dbxref=GI:311993154,GeneID:9926316;Name=11;codon_start=1;locus_tag=CC31p162;product=gp11 base plate wedge completion tail pin;protein_id=YP_004010020.1;transl_table=11;translation=length.220
-NC_014662	GenBank	exon	86828	87490	.	+	1	Parent=CC31p162.t01
-NC_014662	GenBank	gene	87490	89040	.	+	1	ID=CC31p163;Dbxref=GeneID:9926317;Name=12;locus_tag=CC31p163
-NC_014662	GenBank	mRNA	87490	89040	.	+	1	ID=CC31p163.t01;Parent=CC31p163
-NC_014662	GenBank	CDS	87490	89040	.	+	1	ID=CC31p163.p01;Parent=CC31p163.t01;Dbxref=GI:311993155,GeneID:9926317;Name=12;codon_start=1;locus_tag=CC31p163;product=gp12 short tail fiber protein;protein_id=YP_004010021.1;transl_table=11;translation=length.516
-NC_014662	GenBank	exon	87490	89040	.	+	1	Parent=CC31p163.t01
-NC_014662	GenBank	gene	89049	90461	.	+	1	ID=CC31p164;Dbxref=GeneID:9926318;Name=wac;locus_tag=CC31p164
-NC_014662	GenBank	mRNA	89049	90461	.	+	1	ID=CC31p164.t01;Parent=CC31p164
-NC_014662	GenBank	CDS	89049	90461	.	+	1	ID=CC31p164.p01;Parent=CC31p164.t01;Dbxref=GI:311993156,GeneID:9926318;Name=wac;codon_start=1;locus_tag=CC31p164;product=fibritin neck whisker protein;protein_id=YP_004010022.1;transl_table=11;translation=length.470
-NC_014662	GenBank	exon	89049	90461	.	+	1	Parent=CC31p164.t01
-NC_014662	GenBank	gene	90492	91430	.	+	1	ID=CC31p165;Dbxref=GeneID:9926319;Name=13;locus_tag=CC31p165
-NC_014662	GenBank	mRNA	90492	91430	.	+	1	ID=CC31p165.t01;Parent=CC31p165
-NC_014662	GenBank	CDS	90492	91430	.	+	1	ID=CC31p165.p01;Parent=CC31p165.t01;Dbxref=GI:311993157,GeneID:9926319;Name=13;codon_start=1;locus_tag=CC31p165;product=gp13 neck protein;protein_id=YP_004010023.1;transl_table=11;translation=length.312
-NC_014662	GenBank	exon	90492	91430	.	+	1	Parent=CC31p165.t01
-NC_014662	GenBank	gene	91427	92227	.	+	1	ID=CC31p166;Dbxref=GeneID:9926320;Name=14;locus_tag=CC31p166
-NC_014662	GenBank	mRNA	91427	92227	.	+	1	ID=CC31p166.t01;Parent=CC31p166
-NC_014662	GenBank	CDS	91427	92227	.	+	1	ID=CC31p166.p01;Parent=CC31p166.t01;Dbxref=GI:311993158,GeneID:9926320;Name=14;codon_start=1;locus_tag=CC31p166;product=gp14 neck protein;protein_id=YP_004010024.1;transl_table=11;translation=length.266
-NC_014662	GenBank	exon	91427	92227	.	+	1	Parent=CC31p166.t01
-NC_014662	GenBank	gene	92318	93103	.	+	1	ID=CC31p167;Dbxref=GeneID:9926321;Name=15;locus_tag=CC31p167
-NC_014662	GenBank	mRNA	92318	93103	.	+	1	ID=CC31p167.t01;Parent=CC31p167
-NC_014662	GenBank	CDS	92318	93103	.	+	1	ID=CC31p167.p01;Parent=CC31p167.t01;Dbxref=GI:311993159,GeneID:9926321;Name=15;codon_start=1;locus_tag=CC31p167;product=gp15 tail sheath stabilizer and completion protein;protein_id=YP_004010025.1;transl_table=11;translation=length.261
-NC_014662	GenBank	exon	92318	93103	.	+	1	Parent=CC31p167.t01
-NC_014662	GenBank	gene	93103	93600	.	+	1	ID=CC31p168;Dbxref=GeneID:9926322;Name=16;locus_tag=CC31p168
-NC_014662	GenBank	mRNA	93103	93600	.	+	1	ID=CC31p168.t01;Parent=CC31p168
-NC_014662	GenBank	CDS	93103	93600	.	+	1	ID=CC31p168.p01;Parent=CC31p168.t01;Dbxref=GI:311993160,GeneID:9926322;Name=16;codon_start=1;locus_tag=CC31p168;product=gp16 terminase DNA packaging enzyme%2C small subunit;protein_id=YP_004010026.1;transl_table=11;translation=length.165
-NC_014662	GenBank	exon	93103	93600	.	+	1	Parent=CC31p168.t01
-NC_014662	GenBank	gene	93584	95416	.	+	1	ID=CC31p169;Dbxref=GeneID:9926323;Name=17;locus_tag=CC31p169
-NC_014662	GenBank	mRNA	93584	95416	.	+	1	ID=CC31p169.t01;Parent=CC31p169
-NC_014662	GenBank	CDS	93584	95416	.	+	1	ID=CC31p169.p01;Parent=CC31p169.t01;Dbxref=GI:311993161,GeneID:9926323;Name=17;codon_start=1;locus_tag=CC31p169;product=gp17 terminase DNA packaging enzyme%2C large subunit;protein_id=YP_004010027.1;transl_table=11;translation=length.610
-NC_014662	GenBank	exon	93584	95416	.	+	1	Parent=CC31p169.t01
-NC_014662	GenBank	gene	95450	97432	.	+	1	ID=CC31p170;Dbxref=GeneID:9926324;Name=18;locus_tag=CC31p170
-NC_014662	GenBank	mRNA	95450	97432	.	+	1	ID=CC31p170.t01;Parent=CC31p170
-NC_014662	GenBank	CDS	95450	97432	.	+	1	ID=CC31p170.p01;Parent=CC31p170.t01;Dbxref=GI:311993162,GeneID:9926324;Name=18;codon_start=1;locus_tag=CC31p170;product=gp18 tail sheath protein;protein_id=YP_004010028.1;transl_table=11;translation=length.660
-NC_014662	GenBank	exon	95450	97432	.	+	1	Parent=CC31p170.t01
-NC_014662	GenBank	gene	97550	98041	.	+	1	ID=CC31p171;Dbxref=GeneID:9926325;Name=19;locus_tag=CC31p171
-NC_014662	GenBank	mRNA	97550	98041	.	+	1	ID=CC31p171.t01;Parent=CC31p171
-NC_014662	GenBank	CDS	97550	98041	.	+	1	ID=CC31p171.p01;Parent=CC31p171.t01;Dbxref=GI:311993163,GeneID:9926325;Name=19;codon_start=1;locus_tag=CC31p171;product=gp19 tail tube protein;protein_id=YP_004010029.1;transl_table=11;translation=length.163
-NC_014662	GenBank	exon	97550	98041	.	+	1	Parent=CC31p171.t01
-NC_014662	GenBank	gene	98102	99670	.	+	1	ID=CC31p172;Dbxref=GeneID:9926326;Name=20;locus_tag=CC31p172
-NC_014662	GenBank	mRNA	98102	99670	.	+	1	ID=CC31p172.t01;Parent=CC31p172
-NC_014662	GenBank	CDS	98102	99670	.	+	1	ID=CC31p172.p01;Parent=CC31p172.t01;Dbxref=GI:311993164,GeneID:9926326;Name=20;codon_start=1;locus_tag=CC31p172;product=gp20 portal vertex protein of head;protein_id=YP_004010030.1;transl_table=11;translation=length.522
-NC_014662	GenBank	exon	98102	99670	.	+	1	Parent=CC31p172.t01
-NC_014662	GenBank	gene	99670	99912	.	+	1	ID=CC31p173;Dbxref=GeneID:9926327;Name=67;locus_tag=CC31p173
-NC_014662	GenBank	mRNA	99670	99912	.	+	1	ID=CC31p173.t01;Parent=CC31p173
-NC_014662	GenBank	CDS	99670	99912	.	+	1	ID=CC31p173.p01;Parent=CC31p173.t01;Dbxref=GI:311993165,GeneID:9926327;Name=67;codon_start=1;locus_tag=CC31p173;product=gp67 prohead core protein;protein_id=YP_004010031.1;transl_table=11;translation=length.80
-NC_014662	GenBank	exon	99670	99912	.	+	1	Parent=CC31p173.t01
-NC_014662	GenBank	gene	99928	100353	.	+	1	ID=CC31p174;Dbxref=GeneID:9926328;Name=68;locus_tag=CC31p174
-NC_014662	GenBank	mRNA	99928	100353	.	+	1	ID=CC31p174.t01;Parent=CC31p174
-NC_014662	GenBank	CDS	99928	100353	.	+	1	ID=CC31p174.p01;Parent=CC31p174.t01;Dbxref=GI:311993166,GeneID:9926328;Name=68;codon_start=1;locus_tag=CC31p174;product=gp68 prohead core protein;protein_id=YP_004010032.1;transl_table=11;translation=length.141
-NC_014662	GenBank	exon	99928	100353	.	+	1	Parent=CC31p174.t01
-NC_014662	GenBank	gene	100353	100994	.	+	1	ID=CC31p175;Dbxref=GeneID:9926329;Name=21;locus_tag=CC31p175
-NC_014662	GenBank	mRNA	100353	100994	.	+	1	ID=CC31p175.t01;Parent=CC31p175
-NC_014662	GenBank	CDS	100353	100994	.	+	1	ID=CC31p175.p01;Parent=CC31p175.t01;Dbxref=GI:311993167,GeneID:9926329;Name=21;codon_start=1;locus_tag=CC31p175;product=gp21 prohead core scaffold protein and protease;protein_id=YP_004010033.1;transl_table=11;translation=length.213
-NC_014662	GenBank	exon	100353	100994	.	+	1	Parent=CC31p175.t01
-NC_014662	GenBank	gene	101028	101843	.	+	1	ID=CC31p176;Dbxref=GeneID:9926330;Name=22;locus_tag=CC31p176
-NC_014662	GenBank	mRNA	101028	101843	.	+	1	ID=CC31p176.t01;Parent=CC31p176
-NC_014662	GenBank	CDS	101028	101843	.	+	1	ID=CC31p176.p01;Parent=CC31p176.t01;Dbxref=GI:311993168,GeneID:9926330;Name=22;codon_start=1;locus_tag=CC31p176;product=gp22 prohead core scaffold protein;protein_id=YP_004010034.1;transl_table=11;translation=length.271
-NC_014662	GenBank	exon	101028	101843	.	+	1	Parent=CC31p176.t01
-NC_014662	GenBank	gene	101866	103428	.	+	1	ID=CC31p177;Dbxref=GeneID:9926331;Name=23;locus_tag=CC31p177
-NC_014662	GenBank	mRNA	101866	103428	.	+	1	ID=CC31p177.t01;Parent=CC31p177
-NC_014662	GenBank	CDS	101866	103428	.	+	1	ID=CC31p177.p01;Parent=CC31p177.t01;Dbxref=GI:311993169,GeneID:9926331;Name=23;codon_start=1;locus_tag=CC31p177;product=gp23 major head protein;protein_id=YP_004010035.1;transl_table=11;translation=length.520
-NC_014662	GenBank	exon	101866	103428	.	+	1	Parent=CC31p177.t01
-NC_014662	GenBank	gene	103514	104797	.	+	1	ID=CC31p178;Dbxref=GeneID:9926332;Name=24;locus_tag=CC31p178
-NC_014662	GenBank	mRNA	103514	104797	.	+	1	ID=CC31p178.t01;Parent=CC31p178
-NC_014662	GenBank	CDS	103514	104797	.	+	1	ID=CC31p178.p01;Parent=CC31p178.t01;Dbxref=GI:311993170,GeneID:9926332;Name=24;codon_start=1;locus_tag=CC31p178;product=gp24 head vertex protein;protein_id=YP_004010036.1;transl_table=11;translation=length.427
-NC_014662	GenBank	exon	103514	104797	.	+	1	Parent=CC31p178.t01
-NC_014662	GenBank	gene	104830	105375	.	-	1	ID=CC31p179;Dbxref=GeneID:9926333;Name=CC31p179
-NC_014662	GenBank	mRNA	104830	105375	.	-	1	ID=CC31p179.t01;Parent=CC31p179
-NC_014662	GenBank	CDS	104830	105375	.	-	1	ID=CC31p179.p01;Parent=CC31p179.t01;Dbxref=GI:311993171,GeneID:9926333;Name=CC31p179;codon_start=1;product=hypothetical protein;protein_id=YP_004010037.1;transl_table=11;translation=length.181
-NC_014662	GenBank	exon	104830	105375	.	-	1	Parent=CC31p179.t01
-NC_014662	GenBank	gene	105375	106379	.	-	1	ID=CC31p180;Dbxref=GeneID:9926334;Name=rnlB;locus_tag=CC31p180
-NC_014662	GenBank	mRNA	105375	106379	.	-	1	ID=CC31p180.t01;Parent=CC31p180
-NC_014662	GenBank	CDS	105375	106379	.	-	1	ID=CC31p180.p01;Parent=CC31p180.t01;Dbxref=GI:311993172,GeneID:9926334;Name=rnlB;Note=RnlB;codon_start=1;locus_tag=CC31p180;product=RNA ligase 2;protein_id=YP_004010038.1;transl_table=11;translation=length.334
-NC_014662	GenBank	exon	105375	106379	.	-	1	Parent=CC31p180.t01
-NC_014662	GenBank	gene	106388	106609	.	-	1	ID=CC31p181;Dbxref=GeneID:9926335;Name=CC31p181
-NC_014662	GenBank	mRNA	106388	106609	.	-	1	ID=CC31p181.t01;Parent=CC31p181
-NC_014662	GenBank	CDS	106388	106609	.	-	1	ID=CC31p181.p01;Parent=CC31p181.t01;Dbxref=GI:311993173,GeneID:9926335;Name=CC31p181;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010039.1;transl_table=11;translation=length.73
-NC_014662	GenBank	exon	106388	106609	.	-	1	Parent=CC31p181.t01
-NC_014662	GenBank	gene	106751	107332	.	-	1	ID=CC31p182;Dbxref=GeneID:9926336;Name=24.3;locus_tag=CC31p182
-NC_014662	GenBank	mRNA	106751	107332	.	-	1	ID=CC31p182.t01;Parent=CC31p182
-NC_014662	GenBank	CDS	106751	107332	.	-	1	ID=CC31p182.p01;Parent=CC31p182.t01;Dbxref=GI:311993174,GeneID:9926336;Name=24.3;codon_start=1;locus_tag=CC31p182;product=hypothetical protein;protein_id=YP_004010040.1;transl_table=11;translation=length.193
-NC_014662	GenBank	exon	106751	107332	.	-	1	Parent=CC31p182.t01
-NC_014662	GenBank	gene	107408	108106	.	-	1	ID=CC31p183;Dbxref=GeneID:9926337;Name=hoc-B;locus_tag=CC31p183
-NC_014662	GenBank	mRNA	107408	108106	.	-	1	ID=CC31p183.t01;Parent=CC31p183
-NC_014662	GenBank	CDS	107408	108106	.	-	1	ID=CC31p183.p01;Parent=CC31p183.t01;Dbxref=GI:311993175,GeneID:9926337;Name=hoc-B;codon_start=1;locus_tag=CC31p183;product=head outer capsid protein;protein_id=YP_004010041.1;transl_table=11;translation=length.232
-NC_014662	GenBank	exon	107408	108106	.	-	1	Parent=CC31p183.t01
-NC_014662	GenBank	gene	108097	108219	.	-	1	ID=CC31p184;Dbxref=GeneID:9926338;Name=hoc-A;locus_tag=CC31p184
-NC_014662	GenBank	mRNA	108097	108219	.	-	1	ID=CC31p184.t01;Parent=CC31p184
-NC_014662	GenBank	CDS	108097	108219	.	-	1	ID=CC31p184.p01;Parent=CC31p184.t01;Dbxref=GI:311993176,GeneID:9926338;Name=hoc-A;codon_start=1;locus_tag=CC31p184;product=head outer capsid protein;protein_id=YP_004010042.1;transl_table=11;translation=length.40
-NC_014662	GenBank	exon	108097	108219	.	-	1	Parent=CC31p184.t01
-NC_014662	GenBank	gene	108253	109008	.	-	1	ID=CC31p185;Dbxref=GeneID:9926339;Name=inh;locus_tag=CC31p185
-NC_014662	GenBank	mRNA	108253	109008	.	-	1	ID=CC31p185.t01;Parent=CC31p185
-NC_014662	GenBank	CDS	108253	109008	.	-	1	ID=CC31p185.p01;Parent=CC31p185.t01;Dbxref=GI:311993177,GeneID:9926339;Name=inh;codon_start=1;locus_tag=CC31p185;product=inhibitor of prohead protease gp21;protein_id=YP_004010043.1;transl_table=11;translation=length.251
-NC_014662	GenBank	exon	108253	109008	.	-	1	Parent=CC31p185.t01
-NC_014662	GenBank	gene	109061	110563	.	+	1	ID=CC31p186;Dbxref=GeneID:9926340;Name=uvsW;locus_tag=CC31p186
-NC_014662	GenBank	mRNA	109061	110563	.	+	1	ID=CC31p186.t01;Parent=CC31p186
-NC_014662	GenBank	CDS	109061	110563	.	+	1	ID=CC31p186.p01;Parent=CC31p186.t01;Dbxref=GI:311993178,GeneID:9926340;Name=uvsW;codon_start=1;locus_tag=CC31p186;product=RNA-DNA and DNA-DNA helicase%2C ATPase;protein_id=YP_004010044.1;transl_table=11;translation=length.500
-NC_014662	GenBank	exon	109061	110563	.	+	1	Parent=CC31p186.t01
-NC_014662	GenBank	gene	110571	110801	.	+	1	ID=CC31p187;Dbxref=GeneID:9926341;Name=uvsW.1;locus_tag=CC31p187
-NC_014662	GenBank	mRNA	110571	110801	.	+	1	ID=CC31p187.t01;Parent=CC31p187
-NC_014662	GenBank	CDS	110571	110801	.	+	1	ID=CC31p187.p01;Parent=CC31p187.t01;Dbxref=GI:311993179,GeneID:9926341;Name=uvsW.1;codon_start=1;locus_tag=CC31p187;product=hypothetical protein;protein_id=YP_004010045.1;transl_table=11;translation=length.76
-NC_014662	GenBank	exon	110571	110801	.	+	1	Parent=CC31p187.t01
-NC_014662	GenBank	gene	110855	111022	.	-	1	ID=CC31p188;Dbxref=GeneID:9926342;Name=uvsY.-2;locus_tag=CC31p188
-NC_014662	GenBank	mRNA	110855	111022	.	-	1	ID=CC31p188.t01;Parent=CC31p188
-NC_014662	GenBank	CDS	110855	111022	.	-	1	ID=CC31p188.p01;Parent=CC31p188.t01;Dbxref=GI:311993180,GeneID:9926342;Name=uvsY.-2;codon_start=1;locus_tag=CC31p188;product=hypothetical protein;protein_id=YP_004010046.1;transl_table=11;translation=length.55
-NC_014662	GenBank	exon	110855	111022	.	-	1	Parent=CC31p188.t01
-NC_014662	GenBank	gene	111056	111469	.	-	1	ID=CC31p189;Dbxref=GeneID:9926343;Name=uvsY;locus_tag=CC31p189
-NC_014662	GenBank	mRNA	111056	111469	.	-	1	ID=CC31p189.t01;Parent=CC31p189
-NC_014662	GenBank	CDS	111056	111469	.	-	1	ID=CC31p189.p01;Parent=CC31p189.t01;Dbxref=GI:311993181,GeneID:9926343;Name=uvsY;Note=UvsY;codon_start=1;locus_tag=CC31p189;product=recombination%2C repair and ssDNA binding protein;protein_id=YP_004010047.1;transl_table=11;translation=length.137
-NC_014662	GenBank	exon	111056	111469	.	-	1	Parent=CC31p189.t01
-NC_014662	GenBank	gene	111546	111944	.	-	1	ID=CC31p190;Dbxref=GeneID:9926344;Name=25;locus_tag=CC31p190
-NC_014662	GenBank	mRNA	111546	111944	.	-	1	ID=CC31p190.t01;Parent=CC31p190
-NC_014662	GenBank	CDS	111546	111944	.	-	1	ID=CC31p190.p01;Parent=CC31p190.t01;Dbxref=GI:311993182,GeneID:9926344;Name=25;codon_start=1;locus_tag=CC31p190;product=gp25 base plate wedge subunit;protein_id=YP_004010048.1;transl_table=11;translation=length.132
-NC_014662	GenBank	exon	111546	111944	.	-	1	Parent=CC31p190.t01
-NC_014662	GenBank	gene	111944	112573	.	-	1	ID=CC31p191;Dbxref=GeneID:9926345;Name=26;locus_tag=CC31p191
-NC_014662	GenBank	mRNA	111944	112573	.	-	1	ID=CC31p191.t01;Parent=CC31p191
-NC_014662	GenBank	CDS	111944	112573	.	-	1	ID=CC31p191.p01;Parent=CC31p191.t01;Dbxref=GI:311993183,GeneID:9926345;Name=26;codon_start=1;locus_tag=CC31p191;product=gp26 base plate hub subunit;protein_id=YP_004010049.1;transl_table=11;translation=length.209
-NC_014662	GenBank	exon	111944	112573	.	-	1	Parent=CC31p191.t01
-NC_014662	GenBank	gene	112722	113375	.	+	1	ID=CC31p192;Dbxref=GeneID:9926346;Name=51;locus_tag=CC31p192
-NC_014662	GenBank	mRNA	112722	113375	.	+	1	ID=CC31p192.t01;Parent=CC31p192
-NC_014662	GenBank	CDS	112722	113375	.	+	1	ID=CC31p192.p01;Parent=CC31p192.t01;Dbxref=GI:311993184,GeneID:9926346;Name=51;codon_start=1;locus_tag=CC31p192;product=gp51 base plate hub assembly catalyst;protein_id=YP_004010050.1;transl_table=11;translation=length.217
-NC_014662	GenBank	exon	112722	113375	.	+	1	Parent=CC31p192.t01
-NC_014662	GenBank	gene	113372	114556	.	+	1	ID=CC31p193;Dbxref=GeneID:9926347;Name=27;locus_tag=CC31p193
-NC_014662	GenBank	mRNA	113372	114556	.	+	1	ID=CC31p193.t01;Parent=CC31p193
-NC_014662	GenBank	CDS	113372	114556	.	+	1	ID=CC31p193.p01;Parent=CC31p193.t01;Dbxref=GI:311993185,GeneID:9926347;Name=27;codon_start=1;locus_tag=CC31p193;product=gp27 base plate hub subunit;protein_id=YP_004010051.1;transl_table=11;translation=length.394
-NC_014662	GenBank	exon	113372	114556	.	+	1	Parent=CC31p193.t01
-NC_014662	GenBank	gene	114513	115016	.	+	1	ID=CC31p194;Dbxref=GeneID:9926348;Name=28;locus_tag=CC31p194
-NC_014662	GenBank	mRNA	114513	115016	.	+	1	ID=CC31p194.t01;Parent=CC31p194
-NC_014662	GenBank	CDS	114513	115016	.	+	1	ID=CC31p194.p01;Parent=CC31p194.t01;Dbxref=GI:311993186,GeneID:9926348;Name=28;codon_start=1;locus_tag=CC31p194;product=gp28 base plate distal hub subunit;protein_id=YP_004010052.1;transl_table=11;translation=length.167
-NC_014662	GenBank	exon	114513	115016	.	+	1	Parent=CC31p194.t01
-NC_014662	GenBank	gene	115013	116773	.	+	1	ID=CC31p195;Dbxref=GeneID:9926349;Name=29;locus_tag=CC31p195
-NC_014662	GenBank	mRNA	115013	116773	.	+	1	ID=CC31p195.t01;Parent=CC31p195
-NC_014662	GenBank	CDS	115013	116773	.	+	1	ID=CC31p195.p01;Parent=CC31p195.t01;Dbxref=GI:311993187,GeneID:9926349;Name=29;codon_start=1;locus_tag=CC31p195;product=gp29 base plate hub subunit%2C tail length determinator;protein_id=YP_004010053.1;transl_table=11;translation=length.586
-NC_014662	GenBank	exon	115013	116773	.	+	1	Parent=CC31p195.t01
-NC_014662	GenBank	gene	116783	117832	.	+	1	ID=CC31p196;Dbxref=GeneID:9926350;Name=48;locus_tag=CC31p196
-NC_014662	GenBank	mRNA	116783	117832	.	+	1	ID=CC31p196.t01;Parent=CC31p196
-NC_014662	GenBank	CDS	116783	117832	.	+	1	ID=CC31p196.p01;Parent=CC31p196.t01;Dbxref=GI:311993188,GeneID:9926350;Name=48;codon_start=1;locus_tag=CC31p196;product=gp48 base plate tail tube cap;protein_id=YP_004010054.1;transl_table=11;translation=length.349
-NC_014662	GenBank	exon	116783	117832	.	+	1	Parent=CC31p196.t01
-NC_014662	GenBank	gene	117832	118794	.	+	1	ID=CC31p197;Dbxref=GeneID:9926351;Name=54;locus_tag=CC31p197
-NC_014662	GenBank	mRNA	117832	118794	.	+	1	ID=CC31p197.t01;Parent=CC31p197
-NC_014662	GenBank	CDS	117832	118794	.	+	1	ID=CC31p197.p01;Parent=CC31p197.t01;Dbxref=GI:311993189,GeneID:9926351;Name=54;codon_start=1;locus_tag=CC31p197;product=gp54 base plate tail tube initiator;protein_id=YP_004010055.1;transl_table=11;translation=length.320
-NC_014662	GenBank	exon	117832	118794	.	+	1	Parent=CC31p197.t01
-NC_014662	GenBank	gene	118824	119114	.	-	1	ID=CC31p198;Dbxref=GeneID:9926352;Name=alt.-3;locus_tag=CC31p198
-NC_014662	GenBank	mRNA	118824	119114	.	-	1	ID=CC31p198.t01;Parent=CC31p198
-NC_014662	GenBank	CDS	118824	119114	.	-	1	ID=CC31p198.p01;Parent=CC31p198.t01;Dbxref=GI:311993190,GeneID:9926352;Name=alt.-3;codon_start=1;locus_tag=CC31p198;product=hypothetical protein;protein_id=YP_004010056.1;transl_table=11;translation=length.96
-NC_014662	GenBank	exon	118824	119114	.	-	1	Parent=CC31p198.t01
-NC_014662	GenBank	gene	119174	121309	.	-	1	ID=CC31p199;Dbxref=GeneID:9926353;Name=alt;locus_tag=CC31p199
-NC_014662	GenBank	mRNA	119174	121309	.	-	1	ID=CC31p199.t01;Parent=CC31p199
-NC_014662	GenBank	CDS	119174	121309	.	-	1	ID=CC31p199.p01;Parent=CC31p199.t01;Dbxref=GI:311993191,GeneID:9926353;Name=alt;codon_start=1;locus_tag=CC31p199;product=RNA polymerase ADP-ribosylase;protein_id=YP_004010057.1;transl_table=11;translation=length.711
-NC_014662	GenBank	exon	119174	121309	.	-	1	Parent=CC31p199.t01
-NC_014662	GenBank	gene	121364	121582	.	-	1	ID=CC31p200;Dbxref=GeneID:9926354;Name=CC31p200
-NC_014662	GenBank	mRNA	121364	121582	.	-	1	ID=CC31p200.t01;Parent=CC31p200
-NC_014662	GenBank	CDS	121364	121582	.	-	1	ID=CC31p200.p01;Parent=CC31p200.t01;Dbxref=GI:311993192,GeneID:9926354;Name=CC31p200;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010058.1;transl_table=11;translation=length.72
-NC_014662	GenBank	exon	121364	121582	.	-	1	Parent=CC31p200.t01
-NC_014662	GenBank	gene	121579	123027	.	-	1	ID=CC31p201;Dbxref=GeneID:9926355;Name=30;locus_tag=CC31p201
-NC_014662	GenBank	mRNA	121579	123027	.	-	1	ID=CC31p201.t01;Parent=CC31p201
-NC_014662	GenBank	CDS	121579	123027	.	-	1	ID=CC31p201.p01;Parent=CC31p201.t01;Dbxref=GI:311993193,GeneID:9926355;Name=30;codon_start=1;locus_tag=CC31p201;product=gp30 DNA ligase;protein_id=YP_004010059.1;transl_table=11;translation=length.482
-NC_014662	GenBank	exon	121579	123027	.	-	1	Parent=CC31p201.t01
-NC_014662	GenBank	gene	123086	123316	.	-	1	ID=CC31p202;Dbxref=GeneID:9926356;Name=CC31p202
-NC_014662	GenBank	mRNA	123086	123316	.	-	1	ID=CC31p202.t01;Parent=CC31p202
-NC_014662	GenBank	CDS	123086	123316	.	-	1	ID=CC31p202.p01;Parent=CC31p202.t01;Dbxref=GI:311993194,GeneID:9926356;Name=CC31p202;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010060.1;transl_table=11;translation=length.76
-NC_014662	GenBank	exon	123086	123316	.	-	1	Parent=CC31p202.t01
-NC_014662	GenBank	gene	123313	124182	.	-	1	ID=CC31p203;Dbxref=GeneID:9926357;Name=30.2;locus_tag=CC31p203
-NC_014662	GenBank	mRNA	123313	124182	.	-	1	ID=CC31p203.t01;Parent=CC31p203
-NC_014662	GenBank	CDS	123313	124182	.	-	1	ID=CC31p203.p01;Parent=CC31p203.t01;Dbxref=GI:311993195,GeneID:9926357;Name=30.2;codon_start=1;locus_tag=CC31p203;product=hypothetical protein;protein_id=YP_004010061.1;transl_table=11;translation=length.289
-NC_014662	GenBank	exon	123313	124182	.	-	1	Parent=CC31p203.t01
-NC_014662	GenBank	gene	124172	124348	.	-	1	ID=CC31p204;Dbxref=GeneID:9926358;Name=CC31p204
-NC_014662	GenBank	mRNA	124172	124348	.	-	1	ID=CC31p204.t01;Parent=CC31p204
-NC_014662	GenBank	CDS	124172	124348	.	-	1	ID=CC31p204.p01;Parent=CC31p204.t01;Dbxref=GI:311993196,GeneID:9926358;Name=CC31p204;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010062.1;transl_table=11;translation=length.58
-NC_014662	GenBank	exon	124172	124348	.	-	1	Parent=CC31p204.t01
-NC_014662	GenBank	gene	124496	124699	.	-	1	ID=CC31p205;Dbxref=GeneID:9926359;Name=30.5;locus_tag=CC31p205
-NC_014662	GenBank	mRNA	124496	124699	.	-	1	ID=CC31p205.t01;Parent=CC31p205
-NC_014662	GenBank	CDS	124496	124699	.	-	1	ID=CC31p205.p01;Parent=CC31p205.t01;Dbxref=GI:311993197,GeneID:9926359;Name=30.5;codon_start=1;locus_tag=CC31p205;product=hypothetical protein;protein_id=YP_004010063.1;transl_table=11;translation=length.67
-NC_014662	GenBank	exon	124496	124699	.	-	1	Parent=CC31p205.t01
-NC_014662	GenBank	gene	124696	124863	.	-	1	ID=CC31p206;Dbxref=GeneID:9926360;Name=CC31p206
-NC_014662	GenBank	mRNA	124696	124863	.	-	1	ID=CC31p206.t01;Parent=CC31p206
-NC_014662	GenBank	CDS	124696	124863	.	-	1	ID=CC31p206.p01;Parent=CC31p206.t01;Dbxref=GI:311993198,GeneID:9926360;Name=CC31p206;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010064.1;transl_table=11;translation=length.55
-NC_014662	GenBank	exon	124696	124863	.	-	1	Parent=CC31p206.t01
-NC_014662	GenBank	gene	124863	125330	.	-	1	ID=CC31p207;Dbxref=GeneID:9926361;Name=CC31p207
-NC_014662	GenBank	mRNA	124863	125330	.	-	1	ID=CC31p207.t01;Parent=CC31p207
-NC_014662	GenBank	CDS	124863	125330	.	-	1	ID=CC31p207.p01;Parent=CC31p207.t01;Dbxref=GI:311993199,GeneID:9926361;Name=CC31p207;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010065.1;transl_table=11;translation=length.155
-NC_014662	GenBank	exon	124863	125330	.	-	1	Parent=CC31p207.t01
-NC_014662	GenBank	gene	125370	125732	.	-	1	ID=CC31p208;Dbxref=GeneID:9926362;Name=30.7;locus_tag=CC31p208
-NC_014662	GenBank	mRNA	125370	125732	.	-	1	ID=CC31p208.t01;Parent=CC31p208
-NC_014662	GenBank	CDS	125370	125732	.	-	1	ID=CC31p208.p01;Parent=CC31p208.t01;Dbxref=GI:311993200,GeneID:9926362;Name=30.7;codon_start=1;locus_tag=CC31p208;product=hypothetical protein;protein_id=YP_004010066.1;transl_table=11;translation=length.120
-NC_014662	GenBank	exon	125370	125732	.	-	1	Parent=CC31p208.t01
-NC_014662	GenBank	gene	125803	126324	.	-	1	ID=CC31p209;Dbxref=GeneID:9926363;Name=CC31p209
-NC_014662	GenBank	mRNA	125803	126324	.	-	1	ID=CC31p209.t01;Parent=CC31p209
-NC_014662	GenBank	CDS	125803	126324	.	-	1	ID=CC31p209.p01;Parent=CC31p209.t01;Dbxref=GI:311993201,GeneID:9926363;Name=CC31p209;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010067.1;transl_table=11;translation=length.173
-NC_014662	GenBank	exon	125803	126324	.	-	1	Parent=CC31p209.t01
-NC_014662	GenBank	gene	126349	126741	.	-	1	ID=CC31p210;Dbxref=GeneID:9926364;Name=30.8;locus_tag=CC31p210
-NC_014662	GenBank	mRNA	126349	126741	.	-	1	ID=CC31p210.t01;Parent=CC31p210
-NC_014662	GenBank	CDS	126349	126741	.	-	1	ID=CC31p210.p01;Parent=CC31p210.t01;Dbxref=GI:311993202,GeneID:9926364;Name=30.8;codon_start=1;locus_tag=CC31p210;product=hypothetical protein;protein_id=YP_004010068.1;transl_table=11;translation=length.130
-NC_014662	GenBank	exon	126349	126741	.	-	1	Parent=CC31p210.t01
-NC_014662	GenBank	gene	126792	126995	.	-	1	ID=CC31p211;Dbxref=GeneID:9926365;Name=CC31p211
-NC_014662	GenBank	mRNA	126792	126995	.	-	1	ID=CC31p211.t01;Parent=CC31p211
-NC_014662	GenBank	CDS	126792	126995	.	-	1	ID=CC31p211.p01;Parent=CC31p211.t01;Dbxref=GI:311993203,GeneID:9926365;Name=CC31p211;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010069.1;transl_table=11;translation=length.67
-NC_014662	GenBank	exon	126792	126995	.	-	1	Parent=CC31p211.t01
-NC_014662	GenBank	gene	127048	127227	.	-	1	ID=CC31p212;Dbxref=GeneID:9926366;Name=30.9;locus_tag=CC31p212
-NC_014662	GenBank	mRNA	127048	127227	.	-	1	ID=CC31p212.t01;Parent=CC31p212
-NC_014662	GenBank	CDS	127048	127227	.	-	1	ID=CC31p212.p01;Parent=CC31p212.t01;Dbxref=GI:311993204,GeneID:9926366;Name=30.9;codon_start=1;locus_tag=CC31p212;product=hypothetical protein;protein_id=YP_004010070.1;transl_table=11;translation=length.59
-NC_014662	GenBank	exon	127048	127227	.	-	1	Parent=CC31p212.t01
-NC_014662	GenBank	gene	127376	127630	.	-	1	ID=CC31p213;Dbxref=GeneID:9926367;Name=rIII;locus_tag=CC31p213
-NC_014662	GenBank	mRNA	127376	127630	.	-	1	ID=CC31p213.t01;Parent=CC31p213
-NC_014662	GenBank	CDS	127376	127630	.	-	1	ID=CC31p213.p01;Parent=CC31p213.t01;Dbxref=GI:311993205,GeneID:9926367;Name=rIII;codon_start=1;locus_tag=CC31p213;product=lysis inhibition accessory protein%2C rapid lysis phenotype;protein_id=YP_004010071.1;transl_table=11;translation=length.84
-NC_014662	GenBank	exon	127376	127630	.	-	1	Parent=CC31p213.t01
-NC_014662	GenBank	gene	127756	128103	.	-	1	ID=CC31p214;Dbxref=GeneID:9926368;Name=31;locus_tag=CC31p214
-NC_014662	GenBank	mRNA	127756	128103	.	-	1	ID=CC31p214.t01;Parent=CC31p214
-NC_014662	GenBank	CDS	127756	128103	.	-	1	ID=CC31p214.p01;Parent=CC31p214.t01;Dbxref=GI:311993206,GeneID:9926368;Name=31;codon_start=1;locus_tag=CC31p214;product=gp31 head assembly cochaperone with GroEL;protein_id=YP_004010072.1;transl_table=11;translation=length.115
-NC_014662	GenBank	exon	127756	128103	.	-	1	Parent=CC31p214.t01
-NC_014662	GenBank	gene	128136	128465	.	-	1	ID=CC31p215;Dbxref=GeneID:9926369;Name=31.1;locus_tag=CC31p215
-NC_014662	GenBank	mRNA	128136	128465	.	-	1	ID=CC31p215.t01;Parent=CC31p215
-NC_014662	GenBank	CDS	128136	128465	.	-	1	ID=CC31p215.p01;Parent=CC31p215.t01;Dbxref=GI:311993207,GeneID:9926369;Name=31.1;codon_start=1;locus_tag=CC31p215;product=hypothetical protein;protein_id=YP_004010073.1;transl_table=11;translation=length.109
-NC_014662	GenBank	exon	128136	128465	.	-	1	Parent=CC31p215.t01
-NC_014662	GenBank	gene	128458	128772	.	-	1	ID=CC31p216;Dbxref=GeneID:9926370;Name=CC31p216
-NC_014662	GenBank	mRNA	128458	128772	.	-	1	ID=CC31p216.t01;Parent=CC31p216
-NC_014662	GenBank	CDS	128458	128772	.	-	1	ID=CC31p216.p01;Parent=CC31p216.t01;Dbxref=GI:311993208,GeneID:9926370;Name=CC31p216;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010074.1;transl_table=11;translation=length.104
-NC_014662	GenBank	exon	128458	128772	.	-	1	Parent=CC31p216.t01
-NC_014662	GenBank	gene	128765	129331	.	-	1	ID=CC31p217;Dbxref=GeneID:9926371;Name=cd;locus_tag=CC31p217
-NC_014662	GenBank	mRNA	128765	129331	.	-	1	ID=CC31p217.t01;Parent=CC31p217
-NC_014662	GenBank	CDS	128765	129331	.	-	1	ID=CC31p217.p01;Parent=CC31p217.t01;Dbxref=GI:311993209,GeneID:9926371;Name=cd;Note=Cd;codon_start=1;locus_tag=CC31p217;product=dCMP deaminase;protein_id=YP_004010075.1;transl_table=11;translation=length.188
-NC_014662	GenBank	exon	128765	129331	.	-	1	Parent=CC31p217.t01
-NC_014662	GenBank	gene	129331	129675	.	-	1	ID=CC31p218;Dbxref=GeneID:9926372;Name=cd.1;locus_tag=CC31p218
-NC_014662	GenBank	mRNA	129331	129675	.	-	1	ID=CC31p218.t01;Parent=CC31p218
-NC_014662	GenBank	CDS	129331	129675	.	-	1	ID=CC31p218.p01;Parent=CC31p218.t01;Dbxref=GI:311993210,GeneID:9926372;Name=cd.1;codon_start=1;locus_tag=CC31p218;product=hypothetical protein;protein_id=YP_004010076.1;transl_table=11;translation=length.114
-NC_014662	GenBank	exon	129331	129675	.	-	1	Parent=CC31p218.t01
-NC_014662	GenBank	gene	129675	129905	.	-	1	ID=CC31p219;Dbxref=GeneID:9926373;Name=CC31p219
-NC_014662	GenBank	mRNA	129675	129905	.	-	1	ID=CC31p219.t01;Parent=CC31p219
-NC_014662	GenBank	CDS	129675	129905	.	-	1	ID=CC31p219.p01;Parent=CC31p219.t01;Dbxref=GI:311993211,GeneID:9926373;Name=CC31p219;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010077.1;transl_table=11;translation=length.76
-NC_014662	GenBank	exon	129675	129905	.	-	1	Parent=CC31p219.t01
-NC_014662	GenBank	gene	129895	130188	.	-	1	ID=CC31p220;Dbxref=GeneID:9926374;Name=CC31p220
-NC_014662	GenBank	mRNA	129895	130188	.	-	1	ID=CC31p220.t01;Parent=CC31p220
-NC_014662	GenBank	CDS	129895	130188	.	-	1	ID=CC31p220.p01;Parent=CC31p220.t01;Dbxref=GI:311993212,GeneID:9926374;Name=CC31p220;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010078.1;transl_table=11;translation=length.97
-NC_014662	GenBank	exon	129895	130188	.	-	1	Parent=CC31p220.t01
-NC_014662	GenBank	gene	130188	130406	.	-	1	ID=CC31p221;Dbxref=GeneID:9926375;Name=CC31p221
-NC_014662	GenBank	mRNA	130188	130406	.	-	1	ID=CC31p221.t01;Parent=CC31p221
-NC_014662	GenBank	CDS	130188	130406	.	-	1	ID=CC31p221.p01;Parent=CC31p221.t01;Dbxref=GI:311993213,GeneID:9926375;Name=CC31p221;codon_start=1;product=hypothetical protein;protein_id=YP_004010079.1;transl_table=11;translation=length.72
-NC_014662	GenBank	exon	130188	130406	.	-	1	Parent=CC31p221.t01
-NC_014662	GenBank	gene	130420	130611	.	-	1	ID=CC31p222;Dbxref=GeneID:9926376;Name=cd.5;locus_tag=CC31p222
-NC_014662	GenBank	mRNA	130420	130611	.	-	1	ID=CC31p222.t01;Parent=CC31p222
-NC_014662	GenBank	CDS	130420	130611	.	-	1	ID=CC31p222.p01;Parent=CC31p222.t01;Dbxref=GI:311993214,GeneID:9926376;Name=cd.5;codon_start=1;locus_tag=CC31p222;product=hypothetical protein;protein_id=YP_004010080.1;transl_table=11;translation=length.63
-NC_014662	GenBank	exon	130420	130611	.	-	1	Parent=CC31p222.t01
-NC_014662	GenBank	gene	130611	131498	.	-	1	ID=CC31p223;Dbxref=GeneID:9926377;Name=pseT;locus_tag=CC31p223
-NC_014662	GenBank	mRNA	130611	131498	.	-	1	ID=CC31p223.t01;Parent=CC31p223
-NC_014662	GenBank	CDS	130611	131498	.	-	1	ID=CC31p223.p01;Parent=CC31p223.t01;Dbxref=GI:311993215,GeneID:9926377;Name=pseT;Note=PseT;codon_start=1;locus_tag=CC31p223;product=polynucleotide 5'-kinase and 3'-phosphatase;protein_id=YP_004010081.1;transl_table=11;translation=length.295
-NC_014662	GenBank	exon	130611	131498	.	-	1	Parent=CC31p223.t01
-NC_014662	GenBank	gene	131495	131833	.	-	1	ID=CC31p224;Dbxref=GeneID:9926378;Name=CC31p224
-NC_014662	GenBank	mRNA	131495	131833	.	-	1	ID=CC31p224.t01;Parent=CC31p224
-NC_014662	GenBank	CDS	131495	131833	.	-	1	ID=CC31p224.p01;Parent=CC31p224.t01;Dbxref=GI:311993216,GeneID:9926378;Name=CC31p224;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010082.1;transl_table=11;translation=length.112
-NC_014662	GenBank	exon	131495	131833	.	-	1	Parent=CC31p224.t01
-NC_014662	GenBank	gene	131823	132038	.	-	1	ID=CC31p225;Dbxref=GeneID:9926379;Name=CC31p225
-NC_014662	GenBank	mRNA	131823	132038	.	-	1	ID=CC31p225.t01;Parent=CC31p225
-NC_014662	GenBank	CDS	131823	132038	.	-	1	ID=CC31p225.p01;Parent=CC31p225.t01;Dbxref=GI:311993217,GeneID:9926379;Name=CC31p225;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010083.1;transl_table=11;translation=length.71
-NC_014662	GenBank	exon	131823	132038	.	-	1	Parent=CC31p225.t01
-NC_014662	GenBank	gene	132035	132514	.	-	1	ID=CC31p226;Dbxref=GeneID:9926380;Name=CC31p226
-NC_014662	GenBank	mRNA	132035	132514	.	-	1	ID=CC31p226.t01;Parent=CC31p226
-NC_014662	GenBank	CDS	132035	132514	.	-	1	ID=CC31p226.p01;Parent=CC31p226.t01;Dbxref=GI:311993218,GeneID:9926380;Name=CC31p226;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010084.1;transl_table=11;translation=length.159
-NC_014662	GenBank	exon	132035	132514	.	-	1	Parent=CC31p226.t01
-NC_014662	GenBank	gene	132563	132661	.	-	1	ID=CC31p227;Dbxref=GeneID:9926381;Name=CC31p227
-NC_014662	GenBank	mRNA	132563	132661	.	-	1	ID=CC31p227.t01;Parent=CC31p227
-NC_014662	GenBank	CDS	132563	132661	.	-	1	ID=CC31p227.p01;Parent=CC31p227.t01;Dbxref=GI:311993219,GeneID:9926381;Name=CC31p227;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010085.1;transl_table=11;translation=length.32
-NC_014662	GenBank	exon	132563	132661	.	-	1	Parent=CC31p227.t01
-NC_014662	GenBank	gene	132643	132858	.	-	1	ID=CC31p228;Dbxref=GeneID:9926382;Name=pseT.2;locus_tag=CC31p228
-NC_014662	GenBank	mRNA	132643	132858	.	-	1	ID=CC31p228.t01;Parent=CC31p228
-NC_014662	GenBank	CDS	132643	132858	.	-	1	ID=CC31p228.p01;Parent=CC31p228.t01;Dbxref=GI:311993220,GeneID:9926382;Name=pseT.2;codon_start=1;locus_tag=CC31p228;product=hypothetical protein;protein_id=YP_004010086.1;transl_table=11;translation=length.71
-NC_014662	GenBank	exon	132643	132858	.	-	1	Parent=CC31p228.t01
-NC_014662	GenBank	gene	132942	133298	.	-	1	ID=CC31p229;Dbxref=GeneID:9926383;Name=pseT.3;locus_tag=CC31p229
-NC_014662	GenBank	mRNA	132942	133298	.	-	1	ID=CC31p229.t01;Parent=CC31p229
-NC_014662	GenBank	CDS	132942	133298	.	-	1	ID=CC31p229.p01;Parent=CC31p229.t01;Dbxref=GI:311993221,GeneID:9926383;Name=pseT.3;codon_start=1;locus_tag=CC31p229;product=predicted membrane protein;protein_id=YP_004010087.1;transl_table=11;translation=length.118
-NC_014662	GenBank	exon	132942	133298	.	-	1	Parent=CC31p229.t01
-NC_014662	GenBank	gene	133286	133792	.	-	1	ID=CC31p230;Dbxref=GeneID:9926384;Name=alc;locus_tag=CC31p230
-NC_014662	GenBank	mRNA	133286	133792	.	-	1	ID=CC31p230.t01;Parent=CC31p230
-NC_014662	GenBank	CDS	133286	133792	.	-	1	ID=CC31p230.p01;Parent=CC31p230.t01;Dbxref=GI:311993222,GeneID:9926384;Name=alc;Note=Alc;codon_start=1;locus_tag=CC31p230;product=inhibitor of host transcription;protein_id=YP_004010088.1;transl_table=11;translation=length.168
-NC_014662	GenBank	exon	133286	133792	.	-	1	Parent=CC31p230.t01
-NC_014662	GenBank	gene	133856	134962	.	-	1	ID=CC31p231;Dbxref=GeneID:9926385;Name=rnlA;locus_tag=CC31p231
-NC_014662	GenBank	mRNA	133856	134962	.	-	1	ID=CC31p231.t01;Parent=CC31p231
-NC_014662	GenBank	CDS	133856	134962	.	-	1	ID=CC31p231.p01;Parent=CC31p231.t01;Dbxref=GI:311993223,GeneID:9926385;Name=rnlA;Note=RnlA;codon_start=1;locus_tag=CC31p231;product=RNA ligase 1 and tail fiber attachment catalyst;protein_id=YP_004010089.1;transl_table=11;translation=length.368
-NC_014662	GenBank	exon	133856	134962	.	-	1	Parent=CC31p231.t01
-NC_014662	GenBank	gene	134983	135396	.	-	1	ID=CC31p232;Dbxref=GeneID:9926386;Name=denA;locus_tag=CC31p232
-NC_014662	GenBank	mRNA	134983	135396	.	-	1	ID=CC31p232.t01;Parent=CC31p232
-NC_014662	GenBank	CDS	134983	135396	.	-	1	ID=CC31p232.p01;Parent=CC31p232.t01;Dbxref=GI:311993224,GeneID:9926386;Name=denA;Note=DenA;codon_start=1;locus_tag=CC31p232;product=endonuclease II;protein_id=YP_004010090.1;transl_table=11;translation=length.137
-NC_014662	GenBank	exon	134983	135396	.	-	1	Parent=CC31p232.t01
-NC_014662	GenBank	gene	135423	136562	.	-	1	ID=CC31p233;Dbxref=GeneID:9926387;Name=nrdB;locus_tag=CC31p233
-NC_014662	GenBank	mRNA	135423	136562	.	-	1	ID=CC31p233.t01;Parent=CC31p233
-NC_014662	GenBank	CDS	135423	136562	.	-	1	ID=CC31p233.p01;Parent=CC31p233.t01;Dbxref=GI:311993225,GeneID:9926387;Name=nrdB;Note=NrdB;codon_start=1;locus_tag=CC31p233;product=aerobic NDP reductase%2C small subunit;protein_id=YP_004010091.1;transl_table=11;translation=length.379
-NC_014662	GenBank	exon	135423	136562	.	-	1	Parent=CC31p233.t01
-NC_014662	GenBank	gene	136646	138901	.	-	1	ID=CC31p234;Dbxref=GeneID:9926388;Name=nrdA;locus_tag=CC31p234
-NC_014662	GenBank	mRNA	136646	138901	.	-	1	ID=CC31p234.t01;Parent=CC31p234
-NC_014662	GenBank	CDS	136646	138901	.	-	1	ID=CC31p234.p01;Parent=CC31p234.t01;Dbxref=GI:311993226,GeneID:9926388;Name=nrdA;Note=NrdA;codon_start=1;locus_tag=CC31p234;product=aerobic NDP reductase%2C large subunit;protein_id=YP_004010092.1;transl_table=11;translation=length.751
-NC_014662	GenBank	exon	136646	138901	.	-	1	Parent=CC31p234.t01
-NC_014662	GenBank	gene	138888	139199	.	-	1	ID=CC31p235;Dbxref=GeneID:9926389;Name=nrdA.1;locus_tag=CC31p235
-NC_014662	GenBank	mRNA	138888	139199	.	-	1	ID=CC31p235.t01;Parent=CC31p235
-NC_014662	GenBank	CDS	138888	139199	.	-	1	ID=CC31p235.p01;Parent=CC31p235.t01;Dbxref=GI:311993227,GeneID:9926389;Name=nrdA.1;codon_start=1;locus_tag=CC31p235;product=hypothetical protein;protein_id=YP_004010093.1;transl_table=11;translation=length.103
-NC_014662	GenBank	exon	138888	139199	.	-	1	Parent=CC31p235.t01
-NC_014662	GenBank	gene	139196	139429	.	-	1	ID=CC31p236;Dbxref=GeneID:9926390;Name=CC31p236
-NC_014662	GenBank	mRNA	139196	139429	.	-	1	ID=CC31p236.t01;Parent=CC31p236
-NC_014662	GenBank	CDS	139196	139429	.	-	1	ID=CC31p236.p01;Parent=CC31p236.t01;Dbxref=GI:311993228,GeneID:9926390;Name=CC31p236;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010094.1;transl_table=11;translation=length.77
-NC_014662	GenBank	exon	139196	139429	.	-	1	Parent=CC31p236.t01
-NC_014662	GenBank	gene	139429	140475	.	-	1	ID=CC31p237;Dbxref=GeneID:9926391;Name=td;locus_tag=CC31p237
-NC_014662	GenBank	mRNA	139429	140475	.	-	1	ID=CC31p237.t01;Parent=CC31p237
-NC_014662	GenBank	CDS	139429	140475	.	-	1	ID=CC31p237.p01;Parent=CC31p237.t01;Dbxref=GI:311993229,GeneID:9926391;Name=td;codon_start=1;locus_tag=CC31p237;product=dTMP thymidylate synthase;protein_id=YP_004010095.1;transl_table=11;translation=length.348
-NC_014662	GenBank	exon	139429	140475	.	-	1	Parent=CC31p237.t01
-NC_014662	GenBank	gene	140472	140822	.	-	1	ID=CC31p238;Dbxref=GeneID:9926392;Name=CC31p238
-NC_014662	GenBank	mRNA	140472	140822	.	-	1	ID=CC31p238.t01;Parent=CC31p238
-NC_014662	GenBank	CDS	140472	140822	.	-	1	ID=CC31p238.p01;Parent=CC31p238.t01;Dbxref=GI:311993230,GeneID:9926392;Name=CC31p238;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010096.1;transl_table=11;translation=length.116
-NC_014662	GenBank	exon	140472	140822	.	-	1	Parent=CC31p238.t01
-NC_014662	GenBank	gene	140809	141129	.	-	1	ID=CC31p239;Dbxref=GeneID:9926393;Name=CC31p239
-NC_014662	GenBank	mRNA	140809	141129	.	-	1	ID=CC31p239.t01;Parent=CC31p239
-NC_014662	GenBank	CDS	140809	141129	.	-	1	ID=CC31p239.p01;Parent=CC31p239.t01;Dbxref=GI:311993231,GeneID:9926393;Name=CC31p239;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010097.1;transl_table=11;translation=length.106
-NC_014662	GenBank	exon	140809	141129	.	-	1	Parent=CC31p239.t01
-NC_014662	GenBank	gene	141116	141709	.	-	1	ID=CC31p240;Dbxref=GeneID:9926394;Name=frd;locus_tag=CC31p240
-NC_014662	GenBank	mRNA	141116	141709	.	-	1	ID=CC31p240.t01;Parent=CC31p240
-NC_014662	GenBank	CDS	141116	141709	.	-	1	ID=CC31p240.p01;Parent=CC31p240.t01;Dbxref=GI:311993232,GeneID:9926394;Name=frd;Note=Frd;codon_start=1;locus_tag=CC31p240;product=dihydrofolate reductase;protein_id=YP_004010098.1;transl_table=11;translation=length.197
-NC_014662	GenBank	exon	141116	141709	.	-	1	Parent=CC31p240.t01
-NC_014662	GenBank	gene	141709	141921	.	-	1	ID=CC31p241;Dbxref=GeneID:9926395;Name=CC31p241
-NC_014662	GenBank	mRNA	141709	141921	.	-	1	ID=CC31p241.t01;Parent=CC31p241
-NC_014662	GenBank	CDS	141709	141921	.	-	1	ID=CC31p241.p01;Parent=CC31p241.t01;Dbxref=GI:311993233,GeneID:9926395;Name=CC31p241;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010099.1;transl_table=11;translation=length.70
-NC_014662	GenBank	exon	141709	141921	.	-	1	Parent=CC31p241.t01
-NC_014662	GenBank	gene	141921	142160	.	-	1	ID=CC31p242;Dbxref=GeneID:9926396;Name=CC31p242
-NC_014662	GenBank	mRNA	141921	142160	.	-	1	ID=CC31p242.t01;Parent=CC31p242
-NC_014662	GenBank	CDS	141921	142160	.	-	1	ID=CC31p242.p01;Parent=CC31p242.t01;Dbxref=GI:311993234,GeneID:9926396;Name=CC31p242;codon_start=1;product=hypothetical protein;protein_id=YP_004010100.1;transl_table=11;translation=length.79
-NC_014662	GenBank	exon	141921	142160	.	-	1	Parent=CC31p242.t01
-NC_014662	GenBank	gene	142160	142402	.	-	1	ID=CC31p243;Dbxref=GeneID:9926397;Name=CC31p243
-NC_014662	GenBank	mRNA	142160	142402	.	-	1	ID=CC31p243.t01;Parent=CC31p243
-NC_014662	GenBank	CDS	142160	142402	.	-	1	ID=CC31p243.p01;Parent=CC31p243.t01;Dbxref=GI:311993235,GeneID:9926397;Name=CC31p243;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010101.1;transl_table=11;translation=length.80
-NC_014662	GenBank	exon	142160	142402	.	-	1	Parent=CC31p243.t01
-NC_014662	GenBank	gene	142481	142804	.	-	1	ID=CC31p244;Dbxref=GeneID:9926398;Name=CC31p244
-NC_014662	GenBank	mRNA	142481	142804	.	-	1	ID=CC31p244.t01;Parent=CC31p244
-NC_014662	GenBank	CDS	142481	142804	.	-	1	ID=CC31p244.p01;Parent=CC31p244.t01;Dbxref=GI:311993236,GeneID:9926398;Name=CC31p244;codon_start=1;product=hypothetical protein;protein_id=YP_004010102.1;transl_table=11;translation=length.107
-NC_014662	GenBank	exon	142481	142804	.	-	1	Parent=CC31p244.t01
-NC_014662	GenBank	gene	142804	143088	.	-	1	ID=CC31p245;Dbxref=GeneID:9926399;Name=frd.1;locus_tag=CC31p245
-NC_014662	GenBank	mRNA	142804	143088	.	-	1	ID=CC31p245.t01;Parent=CC31p245
-NC_014662	GenBank	CDS	142804	143088	.	-	1	ID=CC31p245.p01;Parent=CC31p245.t01;Dbxref=GI:311993237,GeneID:9926399;Name=frd.1;codon_start=1;locus_tag=CC31p245;product=hypothetical protein;protein_id=YP_004010103.1;transl_table=11;translation=length.94
-NC_014662	GenBank	exon	142804	143088	.	-	1	Parent=CC31p245.t01
-NC_014662	GenBank	gene	143148	143396	.	-	1	ID=CC31p246;Dbxref=GeneID:9926400;Name=CC31p246
-NC_014662	GenBank	mRNA	143148	143396	.	-	1	ID=CC31p246.t01;Parent=CC31p246
-NC_014662	GenBank	CDS	143148	143396	.	-	1	ID=CC31p246.p01;Parent=CC31p246.t01;Dbxref=GI:311993238,GeneID:9926400;Name=CC31p246;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010104.1;transl_table=11;translation=length.82
-NC_014662	GenBank	exon	143148	143396	.	-	1	Parent=CC31p246.t01
-NC_014662	GenBank	gene	143429	143701	.	-	1	ID=CC31p247;Dbxref=GeneID:9926401;Name=CC31p247
-NC_014662	GenBank	mRNA	143429	143701	.	-	1	ID=CC31p247.t01;Parent=CC31p247
-NC_014662	GenBank	CDS	143429	143701	.	-	1	ID=CC31p247.p01;Parent=CC31p247.t01;Dbxref=GI:311993239,GeneID:9926401;Name=CC31p247;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010105.1;transl_table=11;translation=length.90
-NC_014662	GenBank	exon	143429	143701	.	-	1	Parent=CC31p247.t01
-NC_014662	GenBank	gene	143766	143990	.	-	1	ID=CC31p248;Dbxref=GeneID:9926402;Name=CC31p248
-NC_014662	GenBank	mRNA	143766	143990	.	-	1	ID=CC31p248.t01;Parent=CC31p248
-NC_014662	GenBank	CDS	143766	143990	.	-	1	ID=CC31p248.p01;Parent=CC31p248.t01;Dbxref=GI:311993240,GeneID:9926402;Name=CC31p248;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010106.1;transl_table=11;translation=length.74
-NC_014662	GenBank	exon	143766	143990	.	-	1	Parent=CC31p248.t01
-NC_014662	GenBank	gene	144165	145085	.	-	1	ID=CC31p249;Dbxref=GeneID:9926403;Name=32;locus_tag=CC31p249
-NC_014662	GenBank	mRNA	144165	145085	.	-	1	ID=CC31p249.t01;Parent=CC31p249
-NC_014662	GenBank	CDS	144165	145085	.	-	1	ID=CC31p249.p01;Parent=CC31p249.t01;Dbxref=GI:311993241,GeneID:9926403;Name=32;codon_start=1;locus_tag=CC31p249;product=gp32 single-stranded DNA binding protein;protein_id=YP_004010107.1;transl_table=11;translation=length.306
-NC_014662	GenBank	exon	144165	145085	.	-	1	Parent=CC31p249.t01
-NC_014662	GenBank	gene	145096	145749	.	-	1	ID=CC31p250;Dbxref=GeneID:9926404;Name=59;locus_tag=CC31p250
-NC_014662	GenBank	mRNA	145096	145749	.	-	1	ID=CC31p250.t01;Parent=CC31p250
-NC_014662	GenBank	CDS	145096	145749	.	-	1	ID=CC31p250.p01;Parent=CC31p250.t01;Dbxref=GI:311993242,GeneID:9926404;Name=59;codon_start=1;locus_tag=CC31p250;product=gp59 loader of gp41 DNA helicase;protein_id=YP_004010108.1;transl_table=11;translation=length.217
-NC_014662	GenBank	exon	145096	145749	.	-	1	Parent=CC31p250.t01
-NC_014662	GenBank	gene	145746	146045	.	-	1	ID=CC31p251;Dbxref=GeneID:9926405;Name=33;locus_tag=CC31p251
-NC_014662	GenBank	mRNA	145746	146045	.	-	1	ID=CC31p251.t01;Parent=CC31p251
-NC_014662	GenBank	CDS	145746	146045	.	-	1	ID=CC31p251.p01;Parent=CC31p251.t01;Dbxref=GI:311993243,GeneID:9926405;Name=33;codon_start=1;locus_tag=CC31p251;product=gp33 late promoter transcription accessory protein;protein_id=YP_004010109.1;transl_table=11;translation=length.99
-NC_014662	GenBank	exon	145746	146045	.	-	1	Parent=CC31p251.t01
-NC_014662	GenBank	gene	146023	146298	.	-	1	ID=CC31p252;Dbxref=GeneID:9926406;Name=dsbA;locus_tag=CC31p252
-NC_014662	GenBank	mRNA	146023	146298	.	-	1	ID=CC31p252.t01;Parent=CC31p252
-NC_014662	GenBank	CDS	146023	146298	.	-	1	ID=CC31p252.p01;Parent=CC31p252.t01;Dbxref=GI:311993244,GeneID:9926406;Name=dsbA;Note=DsbA;codon_start=1;locus_tag=CC31p252;product=dsDNA binding protein%2C late transcription;protein_id=YP_004010110.1;transl_table=11;translation=length.91
-NC_014662	GenBank	exon	146023	146298	.	-	1	Parent=CC31p252.t01
-NC_014662	GenBank	gene	146306	147229	.	-	1	ID=CC31p253;Dbxref=GeneID:9926407;Name=rnh;locus_tag=CC31p253
-NC_014662	GenBank	mRNA	146306	147229	.	-	1	ID=CC31p253.t01;Parent=CC31p253
-NC_014662	GenBank	CDS	146306	147229	.	-	1	ID=CC31p253.p01;Parent=CC31p253.t01;Dbxref=GI:311993245,GeneID:9926407;Name=rnh;codon_start=1;locus_tag=CC31p253;product=RNaseH ribonuclease;protein_id=YP_004010111.1;transl_table=11;translation=length.307
-NC_014662	GenBank	exon	146306	147229	.	-	1	Parent=CC31p253.t01
-NC_014662	GenBank	gene	147299	151093	.	+	1	ID=CC31p254;Dbxref=GeneID:9926408;Name=34;locus_tag=CC31p254
-NC_014662	GenBank	mRNA	147299	151093	.	+	1	ID=CC31p254.t01;Parent=CC31p254
-NC_014662	GenBank	CDS	147299	151093	.	+	1	ID=CC31p254.p01;Parent=CC31p254.t01;Dbxref=GI:311993246,GeneID:9926408;Name=34;codon_start=1;locus_tag=CC31p254;product=gp34 long tail fiber%2C proximal subunit;protein_id=YP_004010112.1;transl_table=11;translation=length.1264
-NC_014662	GenBank	exon	147299	151093	.	+	1	Parent=CC31p254.t01
-NC_014662	GenBank	gene	151093	152241	.	+	1	ID=CC31p255;Dbxref=GeneID:9926409;Name=35;locus_tag=CC31p255
-NC_014662	GenBank	mRNA	151093	152241	.	+	1	ID=CC31p255.t01;Parent=CC31p255
-NC_014662	GenBank	CDS	151093	152241	.	+	1	ID=CC31p255.p01;Parent=CC31p255.t01;Dbxref=GI:311993247,GeneID:9926409;Name=35;codon_start=1;locus_tag=CC31p255;product=gp35 hinge connector of long tail fiber%2C proximal connector;protein_id=YP_004010113.1;transl_table=11;translation=length.382
-NC_014662	GenBank	exon	151093	152241	.	+	1	Parent=CC31p255.t01
-NC_014662	GenBank	gene	152301	152954	.	+	1	ID=CC31p256;Dbxref=GeneID:9926410;Name=36;locus_tag=CC31p256
-NC_014662	GenBank	mRNA	152301	152954	.	+	1	ID=CC31p256.t01;Parent=CC31p256
-NC_014662	GenBank	CDS	152301	152954	.	+	1	ID=CC31p256.p01;Parent=CC31p256.t01;Dbxref=GI:311993248,GeneID:9926410;Name=36;codon_start=1;locus_tag=CC31p256;product=gp36 hinge connector of long tail fiber distal connector;protein_id=YP_004010114.1;transl_table=11;translation=length.217
-NC_014662	GenBank	exon	152301	152954	.	+	1	Parent=CC31p256.t01
-NC_014662	GenBank	gene	152962	155574	.	+	1	ID=CC31p257;Dbxref=GeneID:9926411;Name=37;locus_tag=CC31p257
-NC_014662	GenBank	mRNA	152962	155574	.	+	1	ID=CC31p257.t01;Parent=CC31p257
-NC_014662	GenBank	CDS	152962	155574	.	+	1	ID=CC31p257.p01;Parent=CC31p257.t01;Dbxref=GI:311993249,GeneID:9926411;Name=37;codon_start=1;locus_tag=CC31p257;product=gp37 long tail fiber%2C distal subunit;protein_id=YP_004010115.1;transl_table=11;translation=length.870
-NC_014662	GenBank	exon	152962	155574	.	+	1	Parent=CC31p257.t01
-NC_014662	GenBank	gene	155608	156393	.	+	1	ID=CC31p258;Dbxref=GeneID:9926412;Name=38;locus_tag=CC31p258
-NC_014662	GenBank	mRNA	155608	156393	.	+	1	ID=CC31p258.t01;Parent=CC31p258
-NC_014662	GenBank	CDS	155608	156393	.	+	1	ID=CC31p258.p01;Parent=CC31p258.t01;Dbxref=GI:311993250,GeneID:9926412;Name=38;codon_start=1;locus_tag=CC31p258;product=gp38 distal long tail fiber assembly catalyst;protein_id=YP_004010116.1;transl_table=11;translation=length.261
-NC_014662	GenBank	exon	155608	156393	.	+	1	Parent=CC31p258.t01
-NC_014662	GenBank	gene	156422	157078	.	+	1	ID=CC31p259;Dbxref=GeneID:9926413;Name=t;locus_tag=CC31p259
-NC_014662	GenBank	mRNA	156422	157078	.	+	1	ID=CC31p259.t01;Parent=CC31p259
-NC_014662	GenBank	CDS	156422	157078	.	+	1	ID=CC31p259.p01;Parent=CC31p259.t01;Dbxref=GI:311993251,GeneID:9926413;Name=t;codon_start=1;locus_tag=CC31p259;product=holin lysis mediator;protein_id=YP_004010117.1;transl_table=11;translation=length.218
-NC_014662	GenBank	exon	156422	157078	.	+	1	Parent=CC31p259.t01
-NC_014662	GenBank	gene	157087	157359	.	-	1	ID=CC31p260;Dbxref=GeneID:9926414;Name=asiA;locus_tag=CC31p260
-NC_014662	GenBank	mRNA	157087	157359	.	-	1	ID=CC31p260.t01;Parent=CC31p260
-NC_014662	GenBank	CDS	157087	157359	.	-	1	ID=CC31p260.p01;Parent=CC31p260.t01;Dbxref=GI:311993252,GeneID:9926414;Name=asiA;Note=AsiA;codon_start=1;locus_tag=CC31p260;product=anti-sigma 70 protein;protein_id=YP_004010118.1;transl_table=11;translation=length.90
-NC_014662	GenBank	exon	157087	157359	.	-	1	Parent=CC31p260.t01
-NC_014662	GenBank	gene	157427	157684	.	-	1	ID=CC31p261;Dbxref=GeneID:9926415;Name=CC31p261
-NC_014662	GenBank	mRNA	157427	157684	.	-	1	ID=CC31p261.t01;Parent=CC31p261
-NC_014662	GenBank	CDS	157427	157684	.	-	1	ID=CC31p261.p01;Parent=CC31p261.t01;Dbxref=GI:311993253,GeneID:9926415;Name=CC31p261;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010119.1;transl_table=11;translation=length.85
-NC_014662	GenBank	exon	157427	157684	.	-	1	Parent=CC31p261.t01
-NC_014662	GenBank	gene	157684	158034	.	-	1	ID=CC31p262;Dbxref=GeneID:9926416;Name=CC31p262
-NC_014662	GenBank	mRNA	157684	158034	.	-	1	ID=CC31p262.t01;Parent=CC31p262
-NC_014662	GenBank	CDS	157684	158034	.	-	1	ID=CC31p262.p01;Parent=CC31p262.t01;Dbxref=GI:311993254,GeneID:9926416;Name=CC31p262;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010120.1;transl_table=11;translation=length.116
-NC_014662	GenBank	exon	157684	158034	.	-	1	Parent=CC31p262.t01
-NC_014662	GenBank	gene	158027	158305	.	-	1	ID=CC31p263;Dbxref=GeneID:9926417;Name=CC31p263
-NC_014662	GenBank	mRNA	158027	158305	.	-	1	ID=CC31p263.t01;Parent=CC31p263
-NC_014662	GenBank	CDS	158027	158305	.	-	1	ID=CC31p263.p01;Parent=CC31p263.t01;Dbxref=GI:311993255,GeneID:9926417;Name=CC31p263;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010121.1;transl_table=11;translation=length.92
-NC_014662	GenBank	exon	158027	158305	.	-	1	Parent=CC31p263.t01
-NC_014662	GenBank	gene	158292	158414	.	-	1	ID=CC31p264;Dbxref=GeneID:9926418;Name=CC31p264
-NC_014662	GenBank	mRNA	158292	158414	.	-	1	ID=CC31p264.t01;Parent=CC31p264
-NC_014662	GenBank	CDS	158292	158414	.	-	1	ID=CC31p264.p01;Parent=CC31p264.t01;Dbxref=GI:311993256,GeneID:9926418;Name=CC31p264;codon_start=1;product=hypothetical protein;protein_id=YP_004010122.1;transl_table=11;translation=length.40
-NC_014662	GenBank	exon	158292	158414	.	-	1	Parent=CC31p264.t01
-NC_014662	GenBank	gene	158579	158890	.	-	1	ID=CC31p265;Dbxref=GeneID:9926420;Name=arn.2;locus_tag=CC31p265
-NC_014662	GenBank	mRNA	158579	158890	.	-	1	ID=CC31p265.t01;Parent=CC31p265
-NC_014662	GenBank	CDS	158579	158890	.	-	1	ID=CC31p265.p01;Parent=CC31p265.t01;Dbxref=GI:311993257,GeneID:9926420;Name=arn.2;codon_start=1;locus_tag=CC31p265;product=hypothetical protein;protein_id=YP_004010123.1;transl_table=11;translation=length.103
-NC_014662	GenBank	exon	158579	158890	.	-	1	Parent=CC31p265.t01
-NC_014662	GenBank	gene	158890	159273	.	-	1	ID=CC31p266;Dbxref=GeneID:9926419;Name=arn.3;locus_tag=CC31p266
-NC_014662	GenBank	mRNA	158890	159273	.	-	1	ID=CC31p266.t01;Parent=CC31p266
-NC_014662	GenBank	CDS	158890	159273	.	-	1	ID=CC31p266.p01;Parent=CC31p266.t01;Dbxref=GI:311993258,GeneID:9926419;Name=arn.3;codon_start=1;locus_tag=CC31p266;product=hypothetical protein;protein_id=YP_004010124.1;transl_table=11;translation=length.127
-NC_014662	GenBank	exon	158890	159273	.	-	1	Parent=CC31p266.t01
-NC_014662	GenBank	gene	159270	159680	.	-	1	ID=CC31p267;Dbxref=GeneID:9926421;Name=arn.4;locus_tag=CC31p267
-NC_014662	GenBank	mRNA	159270	159680	.	-	1	ID=CC31p267.t01;Parent=CC31p267
-NC_014662	GenBank	CDS	159270	159680	.	-	1	ID=CC31p267.p01;Parent=CC31p267.t01;Dbxref=GI:311993259,GeneID:9926421;Name=arn.4;codon_start=1;locus_tag=CC31p267;product=hypothetical protein;protein_id=YP_004010125.1;transl_table=11;translation=length.136
-NC_014662	GenBank	exon	159270	159680	.	-	1	Parent=CC31p267.t01
-NC_014662	GenBank	gene	159695	160339	.	-	1	ID=CC31p268;Dbxref=GeneID:9926422;Name=motA;locus_tag=CC31p268
-NC_014662	GenBank	mRNA	159695	160339	.	-	1	ID=CC31p268.t01;Parent=CC31p268
-NC_014662	GenBank	CDS	159695	160339	.	-	1	ID=CC31p268.p01;Parent=CC31p268.t01;Dbxref=GI:311993260,GeneID:9926422;Name=motA;Note=MotA;codon_start=1;locus_tag=CC31p268;product=activator of middle period transcription;protein_id=YP_004010126.1;transl_table=11;translation=length.214
-NC_014662	GenBank	exon	159695	160339	.	-	1	Parent=CC31p268.t01
-NC_014662	GenBank	gene	160449	160721	.	-	1	ID=CC31p269;Dbxref=GeneID:9926423;Name=CC31p269
-NC_014662	GenBank	mRNA	160449	160721	.	-	1	ID=CC31p269.t01;Parent=CC31p269
-NC_014662	GenBank	CDS	160449	160721	.	-	1	ID=CC31p269.p01;Parent=CC31p269.t01;Dbxref=GI:311993261,GeneID:9926423;Name=CC31p269;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010127.1;transl_table=11;translation=length.90
-NC_014662	GenBank	exon	160449	160721	.	-	1	Parent=CC31p269.t01
-NC_014662	GenBank	gene	160729	160992	.	-	1	ID=CC31p270;Dbxref=GeneID:9926424;Name=CC31p270
-NC_014662	GenBank	mRNA	160729	160992	.	-	1	ID=CC31p270.t01;Parent=CC31p270
-NC_014662	GenBank	CDS	160729	160992	.	-	1	ID=CC31p270.p01;Parent=CC31p270.t01;Dbxref=GI:311993262,GeneID:9926424;Name=CC31p270;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010128.1;transl_table=11;translation=length.87
-NC_014662	GenBank	exon	160729	160992	.	-	1	Parent=CC31p270.t01
-NC_014662	GenBank	gene	161180	162562	.	-	1	ID=CC31p271;Dbxref=GeneID:9926425;Name=52;locus_tag=CC31p271
-NC_014662	GenBank	mRNA	161180	162562	.	-	1	ID=CC31p271.t01;Parent=CC31p271
-NC_014662	GenBank	CDS	161180	162562	.	-	1	ID=CC31p271.p01;Parent=CC31p271.t01;Dbxref=GI:311993263,GeneID:9926425;Name=52;codon_start=1;locus_tag=CC31p271;product=gp52 topoisomerase II%2C medium subunit;protein_id=YP_004010129.1;transl_table=11;translation=length.460
-NC_014662	GenBank	exon	161180	162562	.	-	1	Parent=CC31p271.t01
-NC_014662	GenBank	gene	162569	162703	.	-	1	ID=CC31p272;Dbxref=GeneID:9926426;Name=CC31p272
-NC_014662	GenBank	mRNA	162569	162703	.	-	1	ID=CC31p272.t01;Parent=CC31p272
-NC_014662	GenBank	CDS	162569	162703	.	-	1	ID=CC31p272.p01;Parent=CC31p272.t01;Dbxref=GI:311993264,GeneID:9926426;Name=CC31p272;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010130.1;transl_table=11;translation=length.44
-NC_014662	GenBank	exon	162569	162703	.	-	1	Parent=CC31p272.t01
-NC_014662	GenBank	gene	162700	162882	.	-	1	ID=CC31p273;Dbxref=GeneID:9926427;Name=CC31p273
-NC_014662	GenBank	mRNA	162700	162882	.	-	1	ID=CC31p273.t01;Parent=CC31p273
-NC_014662	GenBank	CDS	162700	162882	.	-	1	ID=CC31p273.p01;Parent=CC31p273.t01;Dbxref=GI:311993265,GeneID:9926427;Name=CC31p273;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010131.1;transl_table=11;translation=length.60
-NC_014662	GenBank	exon	162700	162882	.	-	1	Parent=CC31p273.t01
-NC_014662	GenBank	gene	162884	163330	.	-	1	ID=CC31p274;Dbxref=GeneID:9926428;Name=ndd;locus_tag=CC31p274
-NC_014662	GenBank	mRNA	162884	163330	.	-	1	ID=CC31p274.t01;Parent=CC31p274
-NC_014662	GenBank	CDS	162884	163330	.	-	1	ID=CC31p274.p01;Parent=CC31p274.t01;Dbxref=GI:311993266,GeneID:9926428;Name=ndd;Note=Ndd;codon_start=1;locus_tag=CC31p274;product=nucleoid disruption protein;protein_id=YP_004010132.1;transl_table=11;translation=length.148
-NC_014662	GenBank	exon	162884	163330	.	-	1	Parent=CC31p274.t01
-NC_014662	GenBank	gene	163386	163592	.	-	1	ID=CC31p275;Dbxref=GeneID:9926429;Name=CC31p275
-NC_014662	GenBank	mRNA	163386	163592	.	-	1	ID=CC31p275.t01;Parent=CC31p275
-NC_014662	GenBank	CDS	163386	163592	.	-	1	ID=CC31p275.p01;Parent=CC31p275.t01;Dbxref=GI:311993267,GeneID:9926429;Name=CC31p275;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010133.1;transl_table=11;translation=length.68
-NC_014662	GenBank	exon	163386	163592	.	-	1	Parent=CC31p275.t01
-NC_014662	GenBank	gene	163603	163722	.	-	1	ID=CC31p276;Dbxref=GeneID:9926430;Name=CC31p276
-NC_014662	GenBank	mRNA	163603	163722	.	-	1	ID=CC31p276.t01;Parent=CC31p276
-NC_014662	GenBank	CDS	163603	163722	.	-	1	ID=CC31p276.p01;Parent=CC31p276.t01;Dbxref=GI:311993268,GeneID:9926430;Name=CC31p276;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010134.1;transl_table=11;translation=length.39
-NC_014662	GenBank	exon	163603	163722	.	-	1	Parent=CC31p276.t01
-NC_014662	GenBank	gene	163789	164316	.	-	1	ID=CC31p277;Dbxref=GeneID:9926431;Name=denB;locus_tag=CC31p277
-NC_014662	GenBank	mRNA	163789	164316	.	-	1	ID=CC31p277.t01;Parent=CC31p277
-NC_014662	GenBank	CDS	163789	164316	.	-	1	ID=CC31p277.p01;Parent=CC31p277.t01;Dbxref=GI:311993269,GeneID:9926431;Name=denB;Note=DenB;codon_start=1;locus_tag=CC31p277;product=DNA endonuclease IV;protein_id=YP_004010135.1;transl_table=11;translation=length.175
-NC_014662	GenBank	exon	163789	164316	.	-	1	Parent=CC31p277.t01
-NC_014662	GenBank	gene	164279	164569	.	-	1	ID=CC31p278;Dbxref=GeneID:9926432;Name=CC31p278
-NC_014662	GenBank	mRNA	164279	164569	.	-	1	ID=CC31p278.t01;Parent=CC31p278
-NC_014662	GenBank	CDS	164279	164569	.	-	1	ID=CC31p278.p01;Parent=CC31p278.t01;Dbxref=GI:311993270,GeneID:9926432;Name=CC31p278;codon_start=1;product=hypothetical protein;protein_id=YP_004010136.1;transl_table=11;translation=length.96
-NC_014662	GenBank	exon	164279	164569	.	-	1	Parent=CC31p278.t01
-NC_014662	GenBank	gene	164610	165521	.	-	1	ID=CC31p279;Dbxref=GeneID:9926433;Name=rIIB;locus_tag=CC31p279
-NC_014662	GenBank	mRNA	164610	165521	.	-	1	ID=CC31p279.t01;Parent=CC31p279
-NC_014662	GenBank	CDS	164610	165521	.	-	1	ID=CC31p279.p01;Parent=CC31p279.t01;Dbxref=GI:311993271,GeneID:9926433;Name=rIIB;codon_start=1;locus_tag=CC31p279;product=protector from prophage-induced early lysis;protein_id=YP_004010137.1;transl_table=11;translation=length.303
-NC_014662	GenBank	exon	164610	165521	.	-	1	Parent=CC31p279.t01
-# GFF3 saved to stdout3418
+NC_014662	GenBank	CDS	70116	70475	.	-	1	ID=CC31p142;Dbxref=GI:311993134,GeneID:9926299;Name=CC31p142;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010000.1;transl_table=11;translation=length.119
+NC_014662	GenBank	gene	70116	70475	.	-	1	ID=CC31p142.gene;Alias=CC31p142;Dbxref=GeneID:9926299;Name=CC31p142
+NC_014662	GenBank	CDS	70462	70674	.	-	1	ID=CC31p143;Dbxref=GI:311993135,GeneID:9926289;Name=CC31p143;codon_start=1;product=hypothetical protein;protein_id=YP_004010001.1;transl_table=11;translation=length.70
+NC_014662	GenBank	gene	70462	70674	.	-	1	ID=CC31p143.gene;Alias=CC31p143;Dbxref=GeneID:9926289;Name=CC31p143
+NC_014662	GenBank	CDS	70718	70915	.	-	1	ID=CC31p144;Dbxref=GI:311993136,GeneID:9926290;Name=CC31p144;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010002.1;transl_table=11;translation=length.65
+NC_014662	GenBank	gene	70718	70915	.	-	1	ID=CC31p144.gene;Alias=CC31p144;Dbxref=GeneID:9926290;Name=CC31p144
+NC_014662	GenBank	CDS	70902	71081	.	-	1	ID=CC31p145;Dbxref=GI:311993137,GeneID:9926291;Name=tRNA.4;codon_start=1;locus_tag=CC31p145;product=predicted membrane protein;protein_id=YP_004010003.1;transl_table=11;translation=length.59
+NC_014662	GenBank	gene	70902	71081	.	-	1	ID=CC31p145.gene;Alias=CC31p145;Dbxref=GeneID:9926291;Name=tRNA.4;locus_tag=CC31p145
+NC_014662	GenBank	CDS	71147	71455	.	-	1	ID=CC31p146;Dbxref=GI:311993138,GeneID:9926300;Name=ip7;codon_start=1;locus_tag=CC31p146;product=Ip7 protein;protein_id=YP_004010004.1;transl_table=11;translation=length.102
+NC_014662	GenBank	gene	71147	71455	.	-	1	ID=CC31p146.gene;Alias=CC31p146;Dbxref=GeneID:9926300;Name=ip7;locus_tag=CC31p146
+NC_014662	GenBank	CDS	71452	71910	.	-	1	ID=CC31p147;Dbxref=GI:311993139,GeneID:9926301;Name=57B;codon_start=1;locus_tag=CC31p147;product=hypothetical protein;protein_id=YP_004010005.1;transl_table=11;translation=length.152
+NC_014662	GenBank	gene	71452	71910	.	-	1	ID=CC31p147.gene;Alias=CC31p147;Dbxref=GeneID:9926301;Name=57B;locus_tag=CC31p147
+NC_014662	GenBank	CDS	71907	72161	.	-	1	ID=CC31p148;Dbxref=GI:311993140,GeneID:9926303;Name=57A;codon_start=1;locus_tag=CC31p148;product=gp57A chaperone for tail fiber formation;protein_id=YP_004010006.1;transl_table=11;translation=length.84
+NC_014662	GenBank	gene	71907	72161	.	-	1	ID=CC31p148.gene;Alias=CC31p148;Dbxref=GeneID:9926303;Name=57A;locus_tag=CC31p148
+NC_014662	GenBank	CDS	72158	72886	.	-	1	ID=CC31p149;Dbxref=GI:311993141,GeneID:9926302;Name=1;codon_start=1;locus_tag=CC31p149;product=gp1 dNMP kinase;protein_id=YP_004010007.1;transl_table=11;translation=length.242
+NC_014662	GenBank	gene	72158	72886	.	-	1	ID=CC31p149.gene;Alias=CC31p149;Dbxref=GeneID:9926302;Name=1;locus_tag=CC31p149
+NC_014662	GenBank	CDS	72888	73478	.	-	1	ID=CC31p150;Dbxref=GI:311993142,GeneID:9926304;Name=3;codon_start=1;locus_tag=CC31p150;product=gp3 tail completion and sheath stabilizer protein;protein_id=YP_004010008.1;transl_table=11;translation=length.196
+NC_014662	GenBank	gene	72888	73478	.	-	1	ID=CC31p150.gene;Alias=CC31p150;Dbxref=GeneID:9926304;Name=3;locus_tag=CC31p150
+NC_014662	GenBank	CDS	73560	74390	.	-	1	ID=CC31p151;Dbxref=GI:311993143,GeneID:9926305;Name=2;codon_start=1;locus_tag=CC31p151;product=gp2 DNA end protector protein;protein_id=YP_004010009.1;transl_table=11;translation=length.276
+NC_014662	GenBank	gene	73560	74390	.	-	1	ID=CC31p151.gene;Alias=CC31p151;Dbxref=GeneID:9926305;Name=2;locus_tag=CC31p151
+NC_014662	GenBank	CDS	74390	74839	.	-	1	ID=CC31p152;Dbxref=GI:311993144,GeneID:9926306;Name=4;codon_start=1;locus_tag=CC31p152;product=gp4 head completion protein;protein_id=YP_004010010.1;transl_table=11;translation=length.149
+NC_014662	GenBank	gene	74390	74839	.	-	1	ID=CC31p152.gene;Alias=CC31p152;Dbxref=GeneID:9926306;Name=4;locus_tag=CC31p152
+NC_014662	GenBank	CDS	74889	75464	.	+	1	ID=CC31p153;Dbxref=GI:311993145,GeneID:9926307;Name=53;codon_start=1;locus_tag=CC31p153;product=gp53 base plate wedge completion;protein_id=YP_004010011.1;transl_table=11;translation=length.191
+NC_014662	GenBank	gene	74889	75464	.	+	1	ID=CC31p153.gene;Alias=CC31p153;Dbxref=GeneID:9926307;Name=53;locus_tag=CC31p153
+NC_014662	GenBank	CDS	75464	77197	.	+	1	ID=CC31p154;Dbxref=GI:311993146,GeneID:9926308;Name=5;codon_start=1;locus_tag=CC31p154;product=gp5 base plate hub subunit and tail lysozyme;protein_id=YP_004010012.1;transl_table=11;translation=length.577
+NC_014662	GenBank	gene	75464	77197	.	+	1	ID=CC31p154.gene;Alias=CC31p154;Dbxref=GeneID:9926308;Name=5;locus_tag=CC31p154
+NC_014662	GenBank	CDS	77205	77708	.	+	1	ID=CC31p155;Dbxref=GI:311993147,GeneID:9926309;Name=5.1;codon_start=1;locus_tag=CC31p155;product=hypothetical protein;protein_id=YP_004010013.1;transl_table=11;translation=length.167
+NC_014662	GenBank	gene	77205	77708	.	+	1	ID=CC31p155.gene;Alias=CC31p155;Dbxref=GeneID:9926309;Name=5.1;locus_tag=CC31p155
+NC_014662	GenBank	CDS	77709	78005	.	+	1	ID=CC31p156;Dbxref=GI:311993148,GeneID:9926310;Name=5.4;codon_start=1;locus_tag=CC31p156;product=hypothetical protein;protein_id=YP_004010014.1;transl_table=11;translation=length.98
+NC_014662	GenBank	gene	77709	78005	.	+	1	ID=CC31p156.gene;Alias=CC31p156;Dbxref=GeneID:9926310;Name=5.4;locus_tag=CC31p156
+NC_014662	GenBank	CDS	78010	79956	.	+	1	ID=CC31p157;Dbxref=GI:311993149,GeneID:9926311;Name=6;codon_start=1;locus_tag=CC31p157;product=gp6 base plate wedge;protein_id=YP_004010015.1;transl_table=11;translation=length.648
+NC_014662	GenBank	gene	78010	79956	.	+	1	ID=CC31p157.gene;Alias=CC31p157;Dbxref=GeneID:9926311;Name=6;locus_tag=CC31p157
+NC_014662	GenBank	CDS	79953	83051	.	+	1	ID=CC31p158;Dbxref=GI:311993150,GeneID:9926312;Name=7;codon_start=1;locus_tag=CC31p158;product=gp7 base plate wedge initiator;protein_id=YP_004010016.1;transl_table=11;translation=length.1032
+NC_014662	GenBank	gene	79953	83051	.	+	1	ID=CC31p158.gene;Alias=CC31p158;Dbxref=GeneID:9926312;Name=7;locus_tag=CC31p158
+NC_014662	GenBank	CDS	83044	84054	.	+	1	ID=CC31p159;Dbxref=GI:311993151,GeneID:9926313;Name=8;codon_start=1;locus_tag=CC31p159;product=gp8 base plate wedge;protein_id=YP_004010017.1;transl_table=11;translation=length.336
+NC_014662	GenBank	gene	83044	84054	.	+	1	ID=CC31p159.gene;Alias=CC31p159;Dbxref=GeneID:9926313;Name=8;locus_tag=CC31p159
+NC_014662	GenBank	CDS	84115	85023	.	+	1	ID=CC31p160;Dbxref=GI:311993152,GeneID:9926314;Name=9;codon_start=1;locus_tag=CC31p160;product=gp9 base plate wedge completion tail fiber socket;protein_id=YP_004010018.1;transl_table=11;translation=length.302
+NC_014662	GenBank	gene	84115	85023	.	+	1	ID=CC31p160.gene;Alias=CC31p160;Dbxref=GeneID:9926314;Name=9;locus_tag=CC31p160
+NC_014662	GenBank	CDS	85020	86828	.	+	1	ID=CC31p161;Dbxref=GI:311993153,GeneID:9926315;Name=10;codon_start=1;locus_tag=CC31p161;product=gp10 base plate wedge subunit and tail pin;protein_id=YP_004010019.1;transl_table=11;translation=length.602
+NC_014662	GenBank	gene	85020	86828	.	+	1	ID=CC31p161.gene;Alias=CC31p161;Dbxref=GeneID:9926315;Name=10;locus_tag=CC31p161
+NC_014662	GenBank	CDS	86828	87490	.	+	1	ID=CC31p162;Dbxref=GI:311993154,GeneID:9926316;Name=11;codon_start=1;locus_tag=CC31p162;product=gp11 base plate wedge completion tail pin;protein_id=YP_004010020.1;transl_table=11;translation=length.220
+NC_014662	GenBank	gene	86828	87490	.	+	1	ID=CC31p162.gene;Alias=CC31p162;Dbxref=GeneID:9926316;Name=11;locus_tag=CC31p162
+NC_014662	GenBank	CDS	87490	89040	.	+	1	ID=CC31p163;Dbxref=GI:311993155,GeneID:9926317;Name=12;codon_start=1;locus_tag=CC31p163;product=gp12 short tail fiber protein;protein_id=YP_004010021.1;transl_table=11;translation=length.516
+NC_014662	GenBank	gene	87490	89040	.	+	1	ID=CC31p163.gene;Alias=CC31p163;Dbxref=GeneID:9926317;Name=12;locus_tag=CC31p163
+NC_014662	GenBank	CDS	89049	90461	.	+	1	ID=CC31p164;Dbxref=GI:311993156,GeneID:9926318;Name=wac;codon_start=1;locus_tag=CC31p164;product=fibritin neck whisker protein;protein_id=YP_004010022.1;transl_table=11;translation=length.470
+NC_014662	GenBank	gene	89049	90461	.	+	1	ID=CC31p164.gene;Alias=CC31p164;Dbxref=GeneID:9926318;Name=wac;locus_tag=CC31p164
+NC_014662	GenBank	CDS	90492	91430	.	+	1	ID=CC31p165;Dbxref=GI:311993157,GeneID:9926319;Name=13;codon_start=1;locus_tag=CC31p165;product=gp13 neck protein;protein_id=YP_004010023.1;transl_table=11;translation=length.312
+NC_014662	GenBank	gene	90492	91430	.	+	1	ID=CC31p165.gene;Alias=CC31p165;Dbxref=GeneID:9926319;Name=13;locus_tag=CC31p165
+NC_014662	GenBank	CDS	91427	92227	.	+	1	ID=CC31p166;Dbxref=GI:311993158,GeneID:9926320;Name=14;codon_start=1;locus_tag=CC31p166;product=gp14 neck protein;protein_id=YP_004010024.1;transl_table=11;translation=length.266
+NC_014662	GenBank	gene	91427	92227	.	+	1	ID=CC31p166.gene;Alias=CC31p166;Dbxref=GeneID:9926320;Name=14;locus_tag=CC31p166
+NC_014662	GenBank	CDS	92318	93103	.	+	1	ID=CC31p167;Dbxref=GI:311993159,GeneID:9926321;Name=15;codon_start=1;locus_tag=CC31p167;product=gp15 tail sheath stabilizer and completion protein;protein_id=YP_004010025.1;transl_table=11;translation=length.261
+NC_014662	GenBank	gene	92318	93103	.	+	1	ID=CC31p167.gene;Alias=CC31p167;Dbxref=GeneID:9926321;Name=15;locus_tag=CC31p167
+NC_014662	GenBank	CDS	93103	93600	.	+	1	ID=CC31p168;Dbxref=GI:311993160,GeneID:9926322;Name=16;codon_start=1;locus_tag=CC31p168;product=gp16 terminase DNA packaging enzyme%2C small subunit;protein_id=YP_004010026.1;transl_table=11;translation=length.165
+NC_014662	GenBank	gene	93103	93600	.	+	1	ID=CC31p168.gene;Alias=CC31p168;Dbxref=GeneID:9926322;Name=16;locus_tag=CC31p168
+NC_014662	GenBank	CDS	93584	95416	.	+	1	ID=CC31p169;Dbxref=GI:311993161,GeneID:9926323;Name=17;codon_start=1;locus_tag=CC31p169;product=gp17 terminase DNA packaging enzyme%2C large subunit;protein_id=YP_004010027.1;transl_table=11;translation=length.610
+NC_014662	GenBank	gene	93584	95416	.	+	1	ID=CC31p169.gene;Alias=CC31p169;Dbxref=GeneID:9926323;Name=17;locus_tag=CC31p169
+NC_014662	GenBank	CDS	95450	97432	.	+	1	ID=CC31p170;Dbxref=GI:311993162,GeneID:9926324;Name=18;codon_start=1;locus_tag=CC31p170;product=gp18 tail sheath protein;protein_id=YP_004010028.1;transl_table=11;translation=length.660
+NC_014662	GenBank	gene	95450	97432	.	+	1	ID=CC31p170.gene;Alias=CC31p170;Dbxref=GeneID:9926324;Name=18;locus_tag=CC31p170
+NC_014662	GenBank	CDS	97550	98041	.	+	1	ID=CC31p171;Dbxref=GI:311993163,GeneID:9926325;Name=19;codon_start=1;locus_tag=CC31p171;product=gp19 tail tube protein;protein_id=YP_004010029.1;transl_table=11;translation=length.163
+NC_014662	GenBank	gene	97550	98041	.	+	1	ID=CC31p171.gene;Alias=CC31p171;Dbxref=GeneID:9926325;Name=19;locus_tag=CC31p171
+NC_014662	GenBank	CDS	98102	99670	.	+	1	ID=CC31p172;Dbxref=GI:311993164,GeneID:9926326;Name=20;codon_start=1;locus_tag=CC31p172;product=gp20 portal vertex protein of head;protein_id=YP_004010030.1;transl_table=11;translation=length.522
+NC_014662	GenBank	gene	98102	99670	.	+	1	ID=CC31p172.gene;Alias=CC31p172;Dbxref=GeneID:9926326;Name=20;locus_tag=CC31p172
+NC_014662	GenBank	CDS	99670	99912	.	+	1	ID=CC31p173;Dbxref=GI:311993165,GeneID:9926327;Name=67;codon_start=1;locus_tag=CC31p173;product=gp67 prohead core protein;protein_id=YP_004010031.1;transl_table=11;translation=length.80
+NC_014662	GenBank	gene	99670	99912	.	+	1	ID=CC31p173.gene;Alias=CC31p173;Dbxref=GeneID:9926327;Name=67;locus_tag=CC31p173
+NC_014662	GenBank	CDS	99928	100353	.	+	1	ID=CC31p174;Dbxref=GI:311993166,GeneID:9926328;Name=68;codon_start=1;locus_tag=CC31p174;product=gp68 prohead core protein;protein_id=YP_004010032.1;transl_table=11;translation=length.141
+NC_014662	GenBank	gene	99928	100353	.	+	1	ID=CC31p174.gene;Alias=CC31p174;Dbxref=GeneID:9926328;Name=68;locus_tag=CC31p174
+NC_014662	GenBank	CDS	100353	100994	.	+	1	ID=CC31p175;Dbxref=GI:311993167,GeneID:9926329;Name=21;codon_start=1;locus_tag=CC31p175;product=gp21 prohead core scaffold protein and protease;protein_id=YP_004010033.1;transl_table=11;translation=length.213
+NC_014662	GenBank	gene	100353	100994	.	+	1	ID=CC31p175.gene;Alias=CC31p175;Dbxref=GeneID:9926329;Name=21;locus_tag=CC31p175
+NC_014662	GenBank	CDS	101028	101843	.	+	1	ID=CC31p176;Dbxref=GI:311993168,GeneID:9926330;Name=22;codon_start=1;locus_tag=CC31p176;product=gp22 prohead core scaffold protein;protein_id=YP_004010034.1;transl_table=11;translation=length.271
+NC_014662	GenBank	gene	101028	101843	.	+	1	ID=CC31p176.gene;Alias=CC31p176;Dbxref=GeneID:9926330;Name=22;locus_tag=CC31p176
+NC_014662	GenBank	CDS	101866	103428	.	+	1	ID=CC31p177;Dbxref=GI:311993169,GeneID:9926331;Name=23;codon_start=1;locus_tag=CC31p177;product=gp23 major head protein;protein_id=YP_004010035.1;transl_table=11;translation=length.520
+NC_014662	GenBank	gene	101866	103428	.	+	1	ID=CC31p177.gene;Alias=CC31p177;Dbxref=GeneID:9926331;Name=23;locus_tag=CC31p177
+NC_014662	GenBank	CDS	103514	104797	.	+	1	ID=CC31p178;Dbxref=GI:311993170,GeneID:9926332;Name=24;codon_start=1;locus_tag=CC31p178;product=gp24 head vertex protein;protein_id=YP_004010036.1;transl_table=11;translation=length.427
+NC_014662	GenBank	gene	103514	104797	.	+	1	ID=CC31p178.gene;Alias=CC31p178;Dbxref=GeneID:9926332;Name=24;locus_tag=CC31p178
+NC_014662	GenBank	CDS	104830	105375	.	-	1	ID=CC31p179;Dbxref=GI:311993171,GeneID:9926333;Name=CC31p179;codon_start=1;product=hypothetical protein;protein_id=YP_004010037.1;transl_table=11;translation=length.181
+NC_014662	GenBank	gene	104830	105375	.	-	1	ID=CC31p179.gene;Alias=CC31p179;Dbxref=GeneID:9926333;Name=CC31p179
+NC_014662	GenBank	CDS	105375	106379	.	-	1	ID=CC31p180;Dbxref=GI:311993172,GeneID:9926334;Name=rnlB;Note=RnlB;codon_start=1;locus_tag=CC31p180;product=RNA ligase 2;protein_id=YP_004010038.1;transl_table=11;translation=length.334
+NC_014662	GenBank	gene	105375	106379	.	-	1	ID=CC31p180.gene;Alias=CC31p180;Dbxref=GeneID:9926334;Name=rnlB;locus_tag=CC31p180
+NC_014662	GenBank	CDS	106388	106609	.	-	1	ID=CC31p181;Dbxref=GI:311993173,GeneID:9926335;Name=CC31p181;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010039.1;transl_table=11;translation=length.73
+NC_014662	GenBank	gene	106388	106609	.	-	1	ID=CC31p181.gene;Alias=CC31p181;Dbxref=GeneID:9926335;Name=CC31p181
+NC_014662	GenBank	CDS	106751	107332	.	-	1	ID=CC31p182;Dbxref=GI:311993174,GeneID:9926336;Name=24.3;codon_start=1;locus_tag=CC31p182;product=hypothetical protein;protein_id=YP_004010040.1;transl_table=11;translation=length.193
+NC_014662	GenBank	gene	106751	107332	.	-	1	ID=CC31p182.gene;Alias=CC31p182;Dbxref=GeneID:9926336;Name=24.3;locus_tag=CC31p182
+NC_014662	GenBank	CDS	107408	108106	.	-	1	ID=CC31p183;Dbxref=GI:311993175,GeneID:9926337;Name=hoc-B;codon_start=1;locus_tag=CC31p183;product=head outer capsid protein;protein_id=YP_004010041.1;transl_table=11;translation=length.232
+NC_014662	GenBank	gene	107408	108106	.	-	1	ID=CC31p183.gene;Alias=CC31p183;Dbxref=GeneID:9926337;Name=hoc-B;locus_tag=CC31p183
+NC_014662	GenBank	CDS	108097	108219	.	-	1	ID=CC31p184;Dbxref=GI:311993176,GeneID:9926338;Name=hoc-A;codon_start=1;locus_tag=CC31p184;product=head outer capsid protein;protein_id=YP_004010042.1;transl_table=11;translation=length.40
+NC_014662	GenBank	gene	108097	108219	.	-	1	ID=CC31p184.gene;Alias=CC31p184;Dbxref=GeneID:9926338;Name=hoc-A;locus_tag=CC31p184
+NC_014662	GenBank	CDS	108253	109008	.	-	1	ID=CC31p185;Dbxref=GI:311993177,GeneID:9926339;Name=inh;codon_start=1;locus_tag=CC31p185;product=inhibitor of prohead protease gp21;protein_id=YP_004010043.1;transl_table=11;translation=length.251
+NC_014662	GenBank	gene	108253	109008	.	-	1	ID=CC31p185.gene;Alias=CC31p185;Dbxref=GeneID:9926339;Name=inh;locus_tag=CC31p185
+NC_014662	GenBank	CDS	109061	110563	.	+	1	ID=CC31p186;Dbxref=GI:311993178,GeneID:9926340;Name=uvsW;codon_start=1;locus_tag=CC31p186;product=RNA-DNA and DNA-DNA helicase%2C ATPase;protein_id=YP_004010044.1;transl_table=11;translation=length.500
+NC_014662	GenBank	gene	109061	110563	.	+	1	ID=CC31p186.gene;Alias=CC31p186;Dbxref=GeneID:9926340;Name=uvsW;locus_tag=CC31p186
+NC_014662	GenBank	CDS	110571	110801	.	+	1	ID=CC31p187;Dbxref=GI:311993179,GeneID:9926341;Name=uvsW.1;codon_start=1;locus_tag=CC31p187;product=hypothetical protein;protein_id=YP_004010045.1;transl_table=11;translation=length.76
+NC_014662	GenBank	gene	110571	110801	.	+	1	ID=CC31p187.gene;Alias=CC31p187;Dbxref=GeneID:9926341;Name=uvsW.1;locus_tag=CC31p187
+NC_014662	GenBank	CDS	110855	111022	.	-	1	ID=CC31p188;Dbxref=GI:311993180,GeneID:9926342;Name=uvsY.-2;codon_start=1;locus_tag=CC31p188;product=hypothetical protein;protein_id=YP_004010046.1;transl_table=11;translation=length.55
+NC_014662	GenBank	gene	110855	111022	.	-	1	ID=CC31p188.gene;Alias=CC31p188;Dbxref=GeneID:9926342;Name=uvsY.-2;locus_tag=CC31p188
+NC_014662	GenBank	CDS	111056	111469	.	-	1	ID=CC31p189;Dbxref=GI:311993181,GeneID:9926343;Name=uvsY;Note=UvsY;codon_start=1;locus_tag=CC31p189;product=recombination%2C repair and ssDNA binding protein;protein_id=YP_004010047.1;transl_table=11;translation=length.137
+NC_014662	GenBank	gene	111056	111469	.	-	1	ID=CC31p189.gene;Alias=CC31p189;Dbxref=GeneID:9926343;Name=uvsY;locus_tag=CC31p189
+NC_014662	GenBank	CDS	111546	111944	.	-	1	ID=CC31p190;Dbxref=GI:311993182,GeneID:9926344;Name=25;codon_start=1;locus_tag=CC31p190;product=gp25 base plate wedge subunit;protein_id=YP_004010048.1;transl_table=11;translation=length.132
+NC_014662	GenBank	gene	111546	111944	.	-	1	ID=CC31p190.gene;Alias=CC31p190;Dbxref=GeneID:9926344;Name=25;locus_tag=CC31p190
+NC_014662	GenBank	CDS	111944	112573	.	-	1	ID=CC31p191;Dbxref=GI:311993183,GeneID:9926345;Name=26;codon_start=1;locus_tag=CC31p191;product=gp26 base plate hub subunit;protein_id=YP_004010049.1;transl_table=11;translation=length.209
+NC_014662	GenBank	gene	111944	112573	.	-	1	ID=CC31p191.gene;Alias=CC31p191;Dbxref=GeneID:9926345;Name=26;locus_tag=CC31p191
+NC_014662	GenBank	CDS	112722	113375	.	+	1	ID=CC31p192;Dbxref=GI:311993184,GeneID:9926346;Name=51;codon_start=1;locus_tag=CC31p192;product=gp51 base plate hub assembly catalyst;protein_id=YP_004010050.1;transl_table=11;translation=length.217
+NC_014662	GenBank	gene	112722	113375	.	+	1	ID=CC31p192.gene;Alias=CC31p192;Dbxref=GeneID:9926346;Name=51;locus_tag=CC31p192
+NC_014662	GenBank	CDS	113372	114556	.	+	1	ID=CC31p193;Dbxref=GI:311993185,GeneID:9926347;Name=27;codon_start=1;locus_tag=CC31p193;product=gp27 base plate hub subunit;protein_id=YP_004010051.1;transl_table=11;translation=length.394
+NC_014662	GenBank	gene	113372	114556	.	+	1	ID=CC31p193.gene;Alias=CC31p193;Dbxref=GeneID:9926347;Name=27;locus_tag=CC31p193
+NC_014662	GenBank	CDS	114513	115016	.	+	1	ID=CC31p194;Dbxref=GI:311993186,GeneID:9926348;Name=28;codon_start=1;locus_tag=CC31p194;product=gp28 base plate distal hub subunit;protein_id=YP_004010052.1;transl_table=11;translation=length.167
+NC_014662	GenBank	gene	114513	115016	.	+	1	ID=CC31p194.gene;Alias=CC31p194;Dbxref=GeneID:9926348;Name=28;locus_tag=CC31p194
+NC_014662	GenBank	CDS	115013	116773	.	+	1	ID=CC31p195;Dbxref=GI:311993187,GeneID:9926349;Name=29;codon_start=1;locus_tag=CC31p195;product=gp29 base plate hub subunit%2C tail length determinator;protein_id=YP_004010053.1;transl_table=11;translation=length.586
+NC_014662	GenBank	gene	115013	116773	.	+	1	ID=CC31p195.gene;Alias=CC31p195;Dbxref=GeneID:9926349;Name=29;locus_tag=CC31p195
+NC_014662	GenBank	CDS	116783	117832	.	+	1	ID=CC31p196;Dbxref=GI:311993188,GeneID:9926350;Name=48;codon_start=1;locus_tag=CC31p196;product=gp48 base plate tail tube cap;protein_id=YP_004010054.1;transl_table=11;translation=length.349
+NC_014662	GenBank	gene	116783	117832	.	+	1	ID=CC31p196.gene;Alias=CC31p196;Dbxref=GeneID:9926350;Name=48;locus_tag=CC31p196
+NC_014662	GenBank	CDS	117832	118794	.	+	1	ID=CC31p197;Dbxref=GI:311993189,GeneID:9926351;Name=54;codon_start=1;locus_tag=CC31p197;product=gp54 base plate tail tube initiator;protein_id=YP_004010055.1;transl_table=11;translation=length.320
+NC_014662	GenBank	gene	117832	118794	.	+	1	ID=CC31p197.gene;Alias=CC31p197;Dbxref=GeneID:9926351;Name=54;locus_tag=CC31p197
+NC_014662	GenBank	CDS	118824	119114	.	-	1	ID=CC31p198;Dbxref=GI:311993190,GeneID:9926352;Name=alt.-3;codon_start=1;locus_tag=CC31p198;product=hypothetical protein;protein_id=YP_004010056.1;transl_table=11;translation=length.96
+NC_014662	GenBank	gene	118824	119114	.	-	1	ID=CC31p198.gene;Alias=CC31p198;Dbxref=GeneID:9926352;Name=alt.-3;locus_tag=CC31p198
+NC_014662	GenBank	CDS	119174	121309	.	-	1	ID=CC31p199;Dbxref=GI:311993191,GeneID:9926353;Name=alt;codon_start=1;locus_tag=CC31p199;product=RNA polymerase ADP-ribosylase;protein_id=YP_004010057.1;transl_table=11;translation=length.711
+NC_014662	GenBank	gene	119174	121309	.	-	1	ID=CC31p199.gene;Alias=CC31p199;Dbxref=GeneID:9926353;Name=alt;locus_tag=CC31p199
+NC_014662	GenBank	CDS	121364	121582	.	-	1	ID=CC31p200;Dbxref=GI:311993192,GeneID:9926354;Name=CC31p200;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010058.1;transl_table=11;translation=length.72
+NC_014662	GenBank	gene	121364	121582	.	-	1	ID=CC31p200.gene;Alias=CC31p200;Dbxref=GeneID:9926354;Name=CC31p200
+NC_014662	GenBank	CDS	121579	123027	.	-	1	ID=CC31p201;Dbxref=GI:311993193,GeneID:9926355;Name=30;codon_start=1;locus_tag=CC31p201;product=gp30 DNA ligase;protein_id=YP_004010059.1;transl_table=11;translation=length.482
+NC_014662	GenBank	gene	121579	123027	.	-	1	ID=CC31p201.gene;Alias=CC31p201;Dbxref=GeneID:9926355;Name=30;locus_tag=CC31p201
+NC_014662	GenBank	CDS	123086	123316	.	-	1	ID=CC31p202;Dbxref=GI:311993194,GeneID:9926356;Name=CC31p202;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010060.1;transl_table=11;translation=length.76
+NC_014662	GenBank	gene	123086	123316	.	-	1	ID=CC31p202.gene;Alias=CC31p202;Dbxref=GeneID:9926356;Name=CC31p202
+NC_014662	GenBank	CDS	123313	124182	.	-	1	ID=CC31p203;Dbxref=GI:311993195,GeneID:9926357;Name=30.2;codon_start=1;locus_tag=CC31p203;product=hypothetical protein;protein_id=YP_004010061.1;transl_table=11;translation=length.289
+NC_014662	GenBank	gene	123313	124182	.	-	1	ID=CC31p203.gene;Alias=CC31p203;Dbxref=GeneID:9926357;Name=30.2;locus_tag=CC31p203
+NC_014662	GenBank	CDS	124172	124348	.	-	1	ID=CC31p204;Dbxref=GI:311993196,GeneID:9926358;Name=CC31p204;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010062.1;transl_table=11;translation=length.58
+NC_014662	GenBank	gene	124172	124348	.	-	1	ID=CC31p204.gene;Alias=CC31p204;Dbxref=GeneID:9926358;Name=CC31p204
+NC_014662	GenBank	CDS	124496	124699	.	-	1	ID=CC31p205;Dbxref=GI:311993197,GeneID:9926359;Name=30.5;codon_start=1;locus_tag=CC31p205;product=hypothetical protein;protein_id=YP_004010063.1;transl_table=11;translation=length.67
+NC_014662	GenBank	gene	124496	124699	.	-	1	ID=CC31p205.gene;Alias=CC31p205;Dbxref=GeneID:9926359;Name=30.5;locus_tag=CC31p205
+NC_014662	GenBank	CDS	124696	124863	.	-	1	ID=CC31p206;Dbxref=GI:311993198,GeneID:9926360;Name=CC31p206;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010064.1;transl_table=11;translation=length.55
+NC_014662	GenBank	gene	124696	124863	.	-	1	ID=CC31p206.gene;Alias=CC31p206;Dbxref=GeneID:9926360;Name=CC31p206
+NC_014662	GenBank	CDS	124863	125330	.	-	1	ID=CC31p207;Dbxref=GI:311993199,GeneID:9926361;Name=CC31p207;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010065.1;transl_table=11;translation=length.155
+NC_014662	GenBank	gene	124863	125330	.	-	1	ID=CC31p207.gene;Alias=CC31p207;Dbxref=GeneID:9926361;Name=CC31p207
+NC_014662	GenBank	CDS	125370	125732	.	-	1	ID=CC31p208;Dbxref=GI:311993200,GeneID:9926362;Name=30.7;codon_start=1;locus_tag=CC31p208;product=hypothetical protein;protein_id=YP_004010066.1;transl_table=11;translation=length.120
+NC_014662	GenBank	gene	125370	125732	.	-	1	ID=CC31p208.gene;Alias=CC31p208;Dbxref=GeneID:9926362;Name=30.7;locus_tag=CC31p208
+NC_014662	GenBank	CDS	125803	126324	.	-	1	ID=CC31p209;Dbxref=GI:311993201,GeneID:9926363;Name=CC31p209;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010067.1;transl_table=11;translation=length.173
+NC_014662	GenBank	gene	125803	126324	.	-	1	ID=CC31p209.gene;Alias=CC31p209;Dbxref=GeneID:9926363;Name=CC31p209
+NC_014662	GenBank	CDS	126349	126741	.	-	1	ID=CC31p210;Dbxref=GI:311993202,GeneID:9926364;Name=30.8;codon_start=1;locus_tag=CC31p210;product=hypothetical protein;protein_id=YP_004010068.1;transl_table=11;translation=length.130
+NC_014662	GenBank	gene	126349	126741	.	-	1	ID=CC31p210.gene;Alias=CC31p210;Dbxref=GeneID:9926364;Name=30.8;locus_tag=CC31p210
+NC_014662	GenBank	CDS	126792	126995	.	-	1	ID=CC31p211;Dbxref=GI:311993203,GeneID:9926365;Name=CC31p211;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010069.1;transl_table=11;translation=length.67
+NC_014662	GenBank	gene	126792	126995	.	-	1	ID=CC31p211.gene;Alias=CC31p211;Dbxref=GeneID:9926365;Name=CC31p211
+NC_014662	GenBank	CDS	127048	127227	.	-	1	ID=CC31p212;Dbxref=GI:311993204,GeneID:9926366;Name=30.9;codon_start=1;locus_tag=CC31p212;product=hypothetical protein;protein_id=YP_004010070.1;transl_table=11;translation=length.59
+NC_014662	GenBank	gene	127048	127227	.	-	1	ID=CC31p212.gene;Alias=CC31p212;Dbxref=GeneID:9926366;Name=30.9;locus_tag=CC31p212
+NC_014662	GenBank	CDS	127376	127630	.	-	1	ID=CC31p213;Dbxref=GI:311993205,GeneID:9926367;Name=rIII;codon_start=1;locus_tag=CC31p213;product=lysis inhibition accessory protein%2C rapid lysis phenotype;protein_id=YP_004010071.1;transl_table=11;translation=length.84
+NC_014662	GenBank	gene	127376	127630	.	-	1	ID=CC31p213.gene;Alias=CC31p213;Dbxref=GeneID:9926367;Name=rIII;locus_tag=CC31p213
+NC_014662	GenBank	CDS	127756	128103	.	-	1	ID=CC31p214;Dbxref=GI:311993206,GeneID:9926368;Name=31;codon_start=1;locus_tag=CC31p214;product=gp31 head assembly cochaperone with GroEL;protein_id=YP_004010072.1;transl_table=11;translation=length.115
+NC_014662	GenBank	gene	127756	128103	.	-	1	ID=CC31p214.gene;Alias=CC31p214;Dbxref=GeneID:9926368;Name=31;locus_tag=CC31p214
+NC_014662	GenBank	CDS	128136	128465	.	-	1	ID=CC31p215;Dbxref=GI:311993207,GeneID:9926369;Name=31.1;codon_start=1;locus_tag=CC31p215;product=hypothetical protein;protein_id=YP_004010073.1;transl_table=11;translation=length.109
+NC_014662	GenBank	gene	128136	128465	.	-	1	ID=CC31p215.gene;Alias=CC31p215;Dbxref=GeneID:9926369;Name=31.1;locus_tag=CC31p215
+NC_014662	GenBank	CDS	128458	128772	.	-	1	ID=CC31p216;Dbxref=GI:311993208,GeneID:9926370;Name=CC31p216;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010074.1;transl_table=11;translation=length.104
+NC_014662	GenBank	gene	128458	128772	.	-	1	ID=CC31p216.gene;Alias=CC31p216;Dbxref=GeneID:9926370;Name=CC31p216
+NC_014662	GenBank	CDS	128765	129331	.	-	1	ID=CC31p217;Dbxref=GI:311993209,GeneID:9926371;Name=cd;Note=Cd;codon_start=1;locus_tag=CC31p217;product=dCMP deaminase;protein_id=YP_004010075.1;transl_table=11;translation=length.188
+NC_014662	GenBank	gene	128765	129331	.	-	1	ID=CC31p217.gene;Alias=CC31p217;Dbxref=GeneID:9926371;Name=cd;locus_tag=CC31p217
+NC_014662	GenBank	CDS	129331	129675	.	-	1	ID=CC31p218;Dbxref=GI:311993210,GeneID:9926372;Name=cd.1;codon_start=1;locus_tag=CC31p218;product=hypothetical protein;protein_id=YP_004010076.1;transl_table=11;translation=length.114
+NC_014662	GenBank	gene	129331	129675	.	-	1	ID=CC31p218.gene;Alias=CC31p218;Dbxref=GeneID:9926372;Name=cd.1;locus_tag=CC31p218
+NC_014662	GenBank	CDS	129675	129905	.	-	1	ID=CC31p219;Dbxref=GI:311993211,GeneID:9926373;Name=CC31p219;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010077.1;transl_table=11;translation=length.76
+NC_014662	GenBank	gene	129675	129905	.	-	1	ID=CC31p219.gene;Alias=CC31p219;Dbxref=GeneID:9926373;Name=CC31p219
+NC_014662	GenBank	CDS	129895	130188	.	-	1	ID=CC31p220;Dbxref=GI:311993212,GeneID:9926374;Name=CC31p220;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010078.1;transl_table=11;translation=length.97
+NC_014662	GenBank	gene	129895	130188	.	-	1	ID=CC31p220.gene;Alias=CC31p220;Dbxref=GeneID:9926374;Name=CC31p220
+NC_014662	GenBank	CDS	130188	130406	.	-	1	ID=CC31p221;Dbxref=GI:311993213,GeneID:9926375;Name=CC31p221;codon_start=1;product=hypothetical protein;protein_id=YP_004010079.1;transl_table=11;translation=length.72
+NC_014662	GenBank	gene	130188	130406	.	-	1	ID=CC31p221.gene;Alias=CC31p221;Dbxref=GeneID:9926375;Name=CC31p221
+NC_014662	GenBank	CDS	130420	130611	.	-	1	ID=CC31p222;Dbxref=GI:311993214,GeneID:9926376;Name=cd.5;codon_start=1;locus_tag=CC31p222;product=hypothetical protein;protein_id=YP_004010080.1;transl_table=11;translation=length.63
+NC_014662	GenBank	gene	130420	130611	.	-	1	ID=CC31p222.gene;Alias=CC31p222;Dbxref=GeneID:9926376;Name=cd.5;locus_tag=CC31p222
+NC_014662	GenBank	CDS	130611	131498	.	-	1	ID=CC31p223;Dbxref=GI:311993215,GeneID:9926377;Name=pseT;Note=PseT;codon_start=1;locus_tag=CC31p223;product=polynucleotide 5'-kinase and 3'-phosphatase;protein_id=YP_004010081.1;transl_table=11;translation=length.295
+NC_014662	GenBank	gene	130611	131498	.	-	1	ID=CC31p223.gene;Alias=CC31p223;Dbxref=GeneID:9926377;Name=pseT;locus_tag=CC31p223
+NC_014662	GenBank	CDS	131495	131833	.	-	1	ID=CC31p224;Dbxref=GI:311993216,GeneID:9926378;Name=CC31p224;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010082.1;transl_table=11;translation=length.112
+NC_014662	GenBank	gene	131495	131833	.	-	1	ID=CC31p224.gene;Alias=CC31p224;Dbxref=GeneID:9926378;Name=CC31p224
+NC_014662	GenBank	CDS	131823	132038	.	-	1	ID=CC31p225;Dbxref=GI:311993217,GeneID:9926379;Name=CC31p225;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010083.1;transl_table=11;translation=length.71
+NC_014662	GenBank	gene	131823	132038	.	-	1	ID=CC31p225.gene;Alias=CC31p225;Dbxref=GeneID:9926379;Name=CC31p225
+NC_014662	GenBank	CDS	132035	132514	.	-	1	ID=CC31p226;Dbxref=GI:311993218,GeneID:9926380;Name=CC31p226;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010084.1;transl_table=11;translation=length.159
+NC_014662	GenBank	gene	132035	132514	.	-	1	ID=CC31p226.gene;Alias=CC31p226;Dbxref=GeneID:9926380;Name=CC31p226
+NC_014662	GenBank	CDS	132563	132661	.	-	1	ID=CC31p227;Dbxref=GI:311993219,GeneID:9926381;Name=CC31p227;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010085.1;transl_table=11;translation=length.32
+NC_014662	GenBank	gene	132563	132661	.	-	1	ID=CC31p227.gene;Alias=CC31p227;Dbxref=GeneID:9926381;Name=CC31p227
+NC_014662	GenBank	CDS	132643	132858	.	-	1	ID=CC31p228;Dbxref=GI:311993220,GeneID:9926382;Name=pseT.2;codon_start=1;locus_tag=CC31p228;product=hypothetical protein;protein_id=YP_004010086.1;transl_table=11;translation=length.71
+NC_014662	GenBank	gene	132643	132858	.	-	1	ID=CC31p228.gene;Alias=CC31p228;Dbxref=GeneID:9926382;Name=pseT.2;locus_tag=CC31p228
+NC_014662	GenBank	CDS	132942	133298	.	-	1	ID=CC31p229;Dbxref=GI:311993221,GeneID:9926383;Name=pseT.3;codon_start=1;locus_tag=CC31p229;product=predicted membrane protein;protein_id=YP_004010087.1;transl_table=11;translation=length.118
+NC_014662	GenBank	gene	132942	133298	.	-	1	ID=CC31p229.gene;Alias=CC31p229;Dbxref=GeneID:9926383;Name=pseT.3;locus_tag=CC31p229
+NC_014662	GenBank	CDS	133286	133792	.	-	1	ID=CC31p230;Dbxref=GI:311993222,GeneID:9926384;Name=alc;Note=Alc;codon_start=1;locus_tag=CC31p230;product=inhibitor of host transcription;protein_id=YP_004010088.1;transl_table=11;translation=length.168
+NC_014662	GenBank	gene	133286	133792	.	-	1	ID=CC31p230.gene;Alias=CC31p230;Dbxref=GeneID:9926384;Name=alc;locus_tag=CC31p230
+NC_014662	GenBank	CDS	133856	134962	.	-	1	ID=CC31p231;Dbxref=GI:311993223,GeneID:9926385;Name=rnlA;Note=RnlA;codon_start=1;locus_tag=CC31p231;product=RNA ligase 1 and tail fiber attachment catalyst;protein_id=YP_004010089.1;transl_table=11;translation=length.368
+NC_014662	GenBank	gene	133856	134962	.	-	1	ID=CC31p231.gene;Alias=CC31p231;Dbxref=GeneID:9926385;Name=rnlA;locus_tag=CC31p231
+NC_014662	GenBank	CDS	134983	135396	.	-	1	ID=CC31p232;Dbxref=GI:311993224,GeneID:9926386;Name=denA;Note=DenA;codon_start=1;locus_tag=CC31p232;product=endonuclease II;protein_id=YP_004010090.1;transl_table=11;translation=length.137
+NC_014662	GenBank	gene	134983	135396	.	-	1	ID=CC31p232.gene;Alias=CC31p232;Dbxref=GeneID:9926386;Name=denA;locus_tag=CC31p232
+NC_014662	GenBank	CDS	135423	136562	.	-	1	ID=CC31p233;Dbxref=GI:311993225,GeneID:9926387;Name=nrdB;Note=NrdB;codon_start=1;locus_tag=CC31p233;product=aerobic NDP reductase%2C small subunit;protein_id=YP_004010091.1;transl_table=11;translation=length.379
+NC_014662	GenBank	gene	135423	136562	.	-	1	ID=CC31p233.gene;Alias=CC31p233;Dbxref=GeneID:9926387;Name=nrdB;locus_tag=CC31p233
+NC_014662	GenBank	CDS	136646	138901	.	-	1	ID=CC31p234;Dbxref=GI:311993226,GeneID:9926388;Name=nrdA;Note=NrdA;codon_start=1;locus_tag=CC31p234;product=aerobic NDP reductase%2C large subunit;protein_id=YP_004010092.1;transl_table=11;translation=length.751
+NC_014662	GenBank	gene	136646	138901	.	-	1	ID=CC31p234.gene;Alias=CC31p234;Dbxref=GeneID:9926388;Name=nrdA;locus_tag=CC31p234
+NC_014662	GenBank	CDS	138888	139199	.	-	1	ID=CC31p235;Dbxref=GI:311993227,GeneID:9926389;Name=nrdA.1;codon_start=1;locus_tag=CC31p235;product=hypothetical protein;protein_id=YP_004010093.1;transl_table=11;translation=length.103
+NC_014662	GenBank	gene	138888	139199	.	-	1	ID=CC31p235.gene;Alias=CC31p235;Dbxref=GeneID:9926389;Name=nrdA.1;locus_tag=CC31p235
+NC_014662	GenBank	CDS	139196	139429	.	-	1	ID=CC31p236;Dbxref=GI:311993228,GeneID:9926390;Name=CC31p236;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010094.1;transl_table=11;translation=length.77
+NC_014662	GenBank	gene	139196	139429	.	-	1	ID=CC31p236.gene;Alias=CC31p236;Dbxref=GeneID:9926390;Name=CC31p236
+NC_014662	GenBank	CDS	139429	140475	.	-	1	ID=CC31p237;Dbxref=GI:311993229,GeneID:9926391;Name=td;codon_start=1;locus_tag=CC31p237;product=dTMP thymidylate synthase;protein_id=YP_004010095.1;transl_table=11;translation=length.348
+NC_014662	GenBank	gene	139429	140475	.	-	1	ID=CC31p237.gene;Alias=CC31p237;Dbxref=GeneID:9926391;Name=td;locus_tag=CC31p237
+NC_014662	GenBank	CDS	140472	140822	.	-	1	ID=CC31p238;Dbxref=GI:311993230,GeneID:9926392;Name=CC31p238;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010096.1;transl_table=11;translation=length.116
+NC_014662	GenBank	gene	140472	140822	.	-	1	ID=CC31p238.gene;Alias=CC31p238;Dbxref=GeneID:9926392;Name=CC31p238
+NC_014662	GenBank	CDS	140809	141129	.	-	1	ID=CC31p239;Dbxref=GI:311993231,GeneID:9926393;Name=CC31p239;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010097.1;transl_table=11;translation=length.106
+NC_014662	GenBank	gene	140809	141129	.	-	1	ID=CC31p239.gene;Alias=CC31p239;Dbxref=GeneID:9926393;Name=CC31p239
+NC_014662	GenBank	CDS	141116	141709	.	-	1	ID=CC31p240;Dbxref=GI:311993232,GeneID:9926394;Name=frd;Note=Frd;codon_start=1;locus_tag=CC31p240;product=dihydrofolate reductase;protein_id=YP_004010098.1;transl_table=11;translation=length.197
+NC_014662	GenBank	gene	141116	141709	.	-	1	ID=CC31p240.gene;Alias=CC31p240;Dbxref=GeneID:9926394;Name=frd;locus_tag=CC31p240
+NC_014662	GenBank	CDS	141709	141921	.	-	1	ID=CC31p241;Dbxref=GI:311993233,GeneID:9926395;Name=CC31p241;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010099.1;transl_table=11;translation=length.70
+NC_014662	GenBank	gene	141709	141921	.	-	1	ID=CC31p241.gene;Alias=CC31p241;Dbxref=GeneID:9926395;Name=CC31p241
+NC_014662	GenBank	CDS	141921	142160	.	-	1	ID=CC31p242;Dbxref=GI:311993234,GeneID:9926396;Name=CC31p242;codon_start=1;product=hypothetical protein;protein_id=YP_004010100.1;transl_table=11;translation=length.79
+NC_014662	GenBank	gene	141921	142160	.	-	1	ID=CC31p242.gene;Alias=CC31p242;Dbxref=GeneID:9926396;Name=CC31p242
+NC_014662	GenBank	CDS	142160	142402	.	-	1	ID=CC31p243;Dbxref=GI:311993235,GeneID:9926397;Name=CC31p243;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010101.1;transl_table=11;translation=length.80
+NC_014662	GenBank	gene	142160	142402	.	-	1	ID=CC31p243.gene;Alias=CC31p243;Dbxref=GeneID:9926397;Name=CC31p243
+NC_014662	GenBank	CDS	142481	142804	.	-	1	ID=CC31p244;Dbxref=GI:311993236,GeneID:9926398;Name=CC31p244;codon_start=1;product=hypothetical protein;protein_id=YP_004010102.1;transl_table=11;translation=length.107
+NC_014662	GenBank	gene	142481	142804	.	-	1	ID=CC31p244.gene;Alias=CC31p244;Dbxref=GeneID:9926398;Name=CC31p244
+NC_014662	GenBank	CDS	142804	143088	.	-	1	ID=CC31p245;Dbxref=GI:311993237,GeneID:9926399;Name=frd.1;codon_start=1;locus_tag=CC31p245;product=hypothetical protein;protein_id=YP_004010103.1;transl_table=11;translation=length.94
+NC_014662	GenBank	gene	142804	143088	.	-	1	ID=CC31p245.gene;Alias=CC31p245;Dbxref=GeneID:9926399;Name=frd.1;locus_tag=CC31p245
+NC_014662	GenBank	CDS	143148	143396	.	-	1	ID=CC31p246;Dbxref=GI:311993238,GeneID:9926400;Name=CC31p246;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010104.1;transl_table=11;translation=length.82
+NC_014662	GenBank	gene	143148	143396	.	-	1	ID=CC31p246.gene;Alias=CC31p246;Dbxref=GeneID:9926400;Name=CC31p246
+NC_014662	GenBank	CDS	143429	143701	.	-	1	ID=CC31p247;Dbxref=GI:311993239,GeneID:9926401;Name=CC31p247;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010105.1;transl_table=11;translation=length.90
+NC_014662	GenBank	gene	143429	143701	.	-	1	ID=CC31p247.gene;Alias=CC31p247;Dbxref=GeneID:9926401;Name=CC31p247
+NC_014662	GenBank	CDS	143766	143990	.	-	1	ID=CC31p248;Dbxref=GI:311993240,GeneID:9926402;Name=CC31p248;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010106.1;transl_table=11;translation=length.74
+NC_014662	GenBank	gene	143766	143990	.	-	1	ID=CC31p248.gene;Alias=CC31p248;Dbxref=GeneID:9926402;Name=CC31p248
+NC_014662	GenBank	CDS	144165	145085	.	-	1	ID=CC31p249;Dbxref=GI:311993241,GeneID:9926403;Name=32;codon_start=1;locus_tag=CC31p249;product=gp32 single-stranded DNA binding protein;protein_id=YP_004010107.1;transl_table=11;translation=length.306
+NC_014662	GenBank	gene	144165	145085	.	-	1	ID=CC31p249.gene;Alias=CC31p249;Dbxref=GeneID:9926403;Name=32;locus_tag=CC31p249
+NC_014662	GenBank	CDS	145096	145749	.	-	1	ID=CC31p250;Dbxref=GI:311993242,GeneID:9926404;Name=59;codon_start=1;locus_tag=CC31p250;product=gp59 loader of gp41 DNA helicase;protein_id=YP_004010108.1;transl_table=11;translation=length.217
+NC_014662	GenBank	gene	145096	145749	.	-	1	ID=CC31p250.gene;Alias=CC31p250;Dbxref=GeneID:9926404;Name=59;locus_tag=CC31p250
+NC_014662	GenBank	CDS	145746	146045	.	-	1	ID=CC31p251;Dbxref=GI:311993243,GeneID:9926405;Name=33;codon_start=1;locus_tag=CC31p251;product=gp33 late promoter transcription accessory protein;protein_id=YP_004010109.1;transl_table=11;translation=length.99
+NC_014662	GenBank	gene	145746	146045	.	-	1	ID=CC31p251.gene;Alias=CC31p251;Dbxref=GeneID:9926405;Name=33;locus_tag=CC31p251
+NC_014662	GenBank	CDS	146023	146298	.	-	1	ID=CC31p252;Dbxref=GI:311993244,GeneID:9926406;Name=dsbA;Note=DsbA;codon_start=1;locus_tag=CC31p252;product=dsDNA binding protein%2C late transcription;protein_id=YP_004010110.1;transl_table=11;translation=length.91
+NC_014662	GenBank	gene	146023	146298	.	-	1	ID=CC31p252.gene;Alias=CC31p252;Dbxref=GeneID:9926406;Name=dsbA;locus_tag=CC31p252
+NC_014662	GenBank	CDS	146306	147229	.	-	1	ID=CC31p253;Dbxref=GI:311993245,GeneID:9926407;Name=rnh;codon_start=1;locus_tag=CC31p253;product=RNaseH ribonuclease;protein_id=YP_004010111.1;transl_table=11;translation=length.307
+NC_014662	GenBank	gene	146306	147229	.	-	1	ID=CC31p253.gene;Alias=CC31p253;Dbxref=GeneID:9926407;Name=rnh;locus_tag=CC31p253
+NC_014662	GenBank	CDS	147299	151093	.	+	1	ID=CC31p254;Dbxref=GI:311993246,GeneID:9926408;Name=34;codon_start=1;locus_tag=CC31p254;product=gp34 long tail fiber%2C proximal subunit;protein_id=YP_004010112.1;transl_table=11;translation=length.1264
+NC_014662	GenBank	gene	147299	151093	.	+	1	ID=CC31p254.gene;Alias=CC31p254;Dbxref=GeneID:9926408;Name=34;locus_tag=CC31p254
+NC_014662	GenBank	CDS	151093	152241	.	+	1	ID=CC31p255;Dbxref=GI:311993247,GeneID:9926409;Name=35;codon_start=1;locus_tag=CC31p255;product=gp35 hinge connector of long tail fiber%2C proximal connector;protein_id=YP_004010113.1;transl_table=11;translation=length.382
+NC_014662	GenBank	gene	151093	152241	.	+	1	ID=CC31p255.gene;Alias=CC31p255;Dbxref=GeneID:9926409;Name=35;locus_tag=CC31p255
+NC_014662	GenBank	CDS	152301	152954	.	+	1	ID=CC31p256;Dbxref=GI:311993248,GeneID:9926410;Name=36;codon_start=1;locus_tag=CC31p256;product=gp36 hinge connector of long tail fiber distal connector;protein_id=YP_004010114.1;transl_table=11;translation=length.217
+NC_014662	GenBank	gene	152301	152954	.	+	1	ID=CC31p256.gene;Alias=CC31p256;Dbxref=GeneID:9926410;Name=36;locus_tag=CC31p256
+NC_014662	GenBank	CDS	152962	155574	.	+	1	ID=CC31p257;Dbxref=GI:311993249,GeneID:9926411;Name=37;codon_start=1;locus_tag=CC31p257;product=gp37 long tail fiber%2C distal subunit;protein_id=YP_004010115.1;transl_table=11;translation=length.870
+NC_014662	GenBank	gene	152962	155574	.	+	1	ID=CC31p257.gene;Alias=CC31p257;Dbxref=GeneID:9926411;Name=37;locus_tag=CC31p257
+NC_014662	GenBank	CDS	155608	156393	.	+	1	ID=CC31p258;Dbxref=GI:311993250,GeneID:9926412;Name=38;codon_start=1;locus_tag=CC31p258;product=gp38 distal long tail fiber assembly catalyst;protein_id=YP_004010116.1;transl_table=11;translation=length.261
+NC_014662	GenBank	gene	155608	156393	.	+	1	ID=CC31p258.gene;Alias=CC31p258;Dbxref=GeneID:9926412;Name=38;locus_tag=CC31p258
+NC_014662	GenBank	CDS	156422	157078	.	+	1	ID=CC31p259;Dbxref=GI:311993251,GeneID:9926413;Name=t;codon_start=1;locus_tag=CC31p259;product=holin lysis mediator;protein_id=YP_004010117.1;transl_table=11;translation=length.218
+NC_014662	GenBank	gene	156422	157078	.	+	1	ID=CC31p259.gene;Alias=CC31p259;Dbxref=GeneID:9926413;Name=t;locus_tag=CC31p259
+NC_014662	GenBank	CDS	157087	157359	.	-	1	ID=CC31p260;Dbxref=GI:311993252,GeneID:9926414;Name=asiA;Note=AsiA;codon_start=1;locus_tag=CC31p260;product=anti-sigma 70 protein;protein_id=YP_004010118.1;transl_table=11;translation=length.90
+NC_014662	GenBank	gene	157087	157359	.	-	1	ID=CC31p260.gene;Alias=CC31p260;Dbxref=GeneID:9926414;Name=asiA;locus_tag=CC31p260
+NC_014662	GenBank	CDS	157427	157684	.	-	1	ID=CC31p261;Dbxref=GI:311993253,GeneID:9926415;Name=CC31p261;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010119.1;transl_table=11;translation=length.85
+NC_014662	GenBank	gene	157427	157684	.	-	1	ID=CC31p261.gene;Alias=CC31p261;Dbxref=GeneID:9926415;Name=CC31p261
+NC_014662	GenBank	CDS	157684	158034	.	-	1	ID=CC31p262;Dbxref=GI:311993254,GeneID:9926416;Name=CC31p262;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010120.1;transl_table=11;translation=length.116
+NC_014662	GenBank	gene	157684	158034	.	-	1	ID=CC31p262.gene;Alias=CC31p262;Dbxref=GeneID:9926416;Name=CC31p262
+NC_014662	GenBank	CDS	158027	158305	.	-	1	ID=CC31p263;Dbxref=GI:311993255,GeneID:9926417;Name=CC31p263;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010121.1;transl_table=11;translation=length.92
+NC_014662	GenBank	gene	158027	158305	.	-	1	ID=CC31p263.gene;Alias=CC31p263;Dbxref=GeneID:9926417;Name=CC31p263
+NC_014662	GenBank	CDS	158292	158414	.	-	1	ID=CC31p264;Dbxref=GI:311993256,GeneID:9926418;Name=CC31p264;codon_start=1;product=hypothetical protein;protein_id=YP_004010122.1;transl_table=11;translation=length.40
+NC_014662	GenBank	gene	158292	158414	.	-	1	ID=CC31p264.gene;Alias=CC31p264;Dbxref=GeneID:9926418;Name=CC31p264
+NC_014662	GenBank	CDS	158579	158890	.	-	1	ID=CC31p265;Dbxref=GI:311993257,GeneID:9926420;Name=arn.2;codon_start=1;locus_tag=CC31p265;product=hypothetical protein;protein_id=YP_004010123.1;transl_table=11;translation=length.103
+NC_014662	GenBank	gene	158579	158890	.	-	1	ID=CC31p265.gene;Alias=CC31p265;Dbxref=GeneID:9926420;Name=arn.2;locus_tag=CC31p265
+NC_014662	GenBank	CDS	158890	159273	.	-	1	ID=CC31p266;Dbxref=GI:311993258,GeneID:9926419;Name=arn.3;codon_start=1;locus_tag=CC31p266;product=hypothetical protein;protein_id=YP_004010124.1;transl_table=11;translation=length.127
+NC_014662	GenBank	gene	158890	159273	.	-	1	ID=CC31p266.gene;Alias=CC31p266;Dbxref=GeneID:9926419;Name=arn.3;locus_tag=CC31p266
+NC_014662	GenBank	CDS	159270	159680	.	-	1	ID=CC31p267;Dbxref=GI:311993259,GeneID:9926421;Name=arn.4;codon_start=1;locus_tag=CC31p267;product=hypothetical protein;protein_id=YP_004010125.1;transl_table=11;translation=length.136
+NC_014662	GenBank	gene	159270	159680	.	-	1	ID=CC31p267.gene;Alias=CC31p267;Dbxref=GeneID:9926421;Name=arn.4;locus_tag=CC31p267
+NC_014662	GenBank	CDS	159695	160339	.	-	1	ID=CC31p268;Dbxref=GI:311993260,GeneID:9926422;Name=motA;Note=MotA;codon_start=1;locus_tag=CC31p268;product=activator of middle period transcription;protein_id=YP_004010126.1;transl_table=11;translation=length.214
+NC_014662	GenBank	gene	159695	160339	.	-	1	ID=CC31p268.gene;Alias=CC31p268;Dbxref=GeneID:9926422;Name=motA;locus_tag=CC31p268
+NC_014662	GenBank	CDS	160449	160721	.	-	1	ID=CC31p269;Dbxref=GI:311993261,GeneID:9926423;Name=CC31p269;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010127.1;transl_table=11;translation=length.90
+NC_014662	GenBank	gene	160449	160721	.	-	1	ID=CC31p269.gene;Alias=CC31p269;Dbxref=GeneID:9926423;Name=CC31p269
+NC_014662	GenBank	CDS	160729	160992	.	-	1	ID=CC31p270;Dbxref=GI:311993262,GeneID:9926424;Name=CC31p270;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010128.1;transl_table=11;translation=length.87
+NC_014662	GenBank	gene	160729	160992	.	-	1	ID=CC31p270.gene;Alias=CC31p270;Dbxref=GeneID:9926424;Name=CC31p270
+NC_014662	GenBank	CDS	161180	162562	.	-	1	ID=CC31p271;Dbxref=GI:311993263,GeneID:9926425;Name=52;codon_start=1;locus_tag=CC31p271;product=gp52 topoisomerase II%2C medium subunit;protein_id=YP_004010129.1;transl_table=11;translation=length.460
+NC_014662	GenBank	gene	161180	162562	.	-	1	ID=CC31p271.gene;Alias=CC31p271;Dbxref=GeneID:9926425;Name=52;locus_tag=CC31p271
+NC_014662	GenBank	CDS	162569	162703	.	-	1	ID=CC31p272;Dbxref=GI:311993264,GeneID:9926426;Name=CC31p272;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010130.1;transl_table=11;translation=length.44
+NC_014662	GenBank	gene	162569	162703	.	-	1	ID=CC31p272.gene;Alias=CC31p272;Dbxref=GeneID:9926426;Name=CC31p272
+NC_014662	GenBank	CDS	162700	162882	.	-	1	ID=CC31p273;Dbxref=GI:311993265,GeneID:9926427;Name=CC31p273;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010131.1;transl_table=11;translation=length.60
+NC_014662	GenBank	gene	162700	162882	.	-	1	ID=CC31p273.gene;Alias=CC31p273;Dbxref=GeneID:9926427;Name=CC31p273
+NC_014662	GenBank	CDS	162884	163330	.	-	1	ID=CC31p274;Dbxref=GI:311993266,GeneID:9926428;Name=ndd;Note=Ndd;codon_start=1;locus_tag=CC31p274;product=nucleoid disruption protein;protein_id=YP_004010132.1;transl_table=11;translation=length.148
+NC_014662	GenBank	gene	162884	163330	.	-	1	ID=CC31p274.gene;Alias=CC31p274;Dbxref=GeneID:9926428;Name=ndd;locus_tag=CC31p274
+NC_014662	GenBank	CDS	163386	163592	.	-	1	ID=CC31p275;Dbxref=GI:311993267,GeneID:9926429;Name=CC31p275;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010133.1;transl_table=11;translation=length.68
+NC_014662	GenBank	gene	163386	163592	.	-	1	ID=CC31p275.gene;Alias=CC31p275;Dbxref=GeneID:9926429;Name=CC31p275
+NC_014662	GenBank	CDS	163603	163722	.	-	1	ID=CC31p276;Dbxref=GI:311993268,GeneID:9926430;Name=CC31p276;Note=predicted by GenMarkS;codon_start=1;product=hypothetical protein;protein_id=YP_004010134.1;transl_table=11;translation=length.39
+NC_014662	GenBank	gene	163603	163722	.	-	1	ID=CC31p276.gene;Alias=CC31p276;Dbxref=GeneID:9926430;Name=CC31p276
+NC_014662	GenBank	CDS	163789	164316	.	-	1	ID=CC31p277;Dbxref=GI:311993269,GeneID:9926431;Name=denB;Note=DenB;codon_start=1;locus_tag=CC31p277;product=DNA endonuclease IV;protein_id=YP_004010135.1;transl_table=11;translation=length.175
+NC_014662	GenBank	gene	163789	164316	.	-	1	ID=CC31p277.gene;Alias=CC31p277;Dbxref=GeneID:9926431;Name=denB;locus_tag=CC31p277
+NC_014662	GenBank	CDS	164279	164569	.	-	1	ID=CC31p278;Dbxref=GI:311993270,GeneID:9926432;Name=CC31p278;codon_start=1;product=hypothetical protein;protein_id=YP_004010136.1;transl_table=11;translation=length.96
+NC_014662	GenBank	gene	164279	164569	.	-	1	ID=CC31p278.gene;Alias=CC31p278;Dbxref=GeneID:9926432;Name=CC31p278
+NC_014662	GenBank	CDS	164610	165521	.	-	1	ID=CC31p279;Dbxref=GI:311993271,GeneID:9926433;Name=rIIB;codon_start=1;locus_tag=CC31p279;product=protector from prophage-induced early lysis;protein_id=YP_004010137.1;transl_table=11;translation=length.303
+NC_014662	GenBank	gene	164610	165521	.	-	1	ID=CC31p279.gene;Alias=CC31p279;Dbxref=GeneID:9926433;Name=rIIB;locus_tag=CC31p279
+# GFF3 saved to stdout13237
 ##FASTA
 >NC_014662
 TTACTCATCTTCATCTTTACCTTTTAAGGAAGGAGCGCTTTCCAGCGCTCTCATAATACG
@@ -3910,7 +3344,7 @@ ACTTTAACTTCCGGTTCAACTTCCGCTTTACGGCTTTTAATTTCATTAACAACACGACGA
 ATAGTATCAACAGAACAAGAATAAATTTCTGCTAATTCGGTTTGAGTATAGCCCTGCATG
 AATTCATCATGAATGGCTACTTTTTCTACATCATTAAACATTTTAACAACAGAGACTTTC
 
->CC31p001.p01
+>CC31p001
 MKLIADNEEVLGSAGKKTKFTIQASPKAFMILSDKLYKNKIRAVVRELTTNWLDAHILNG
 KQDVPCEIKCPNKLDPRFIIRDFGPGMSDFQIRGNDEEPGLYNSYFASTKAESNDFIGAL
 GLGSKSPFSYTKSFTIVSYHDGEARGYMAVMNNGEPDIRPLFVEPMKEGEQTGIEITVPV
@@ -3924,15 +3358,15 @@ ELYWSGIDIETIRTLAKELGVTEFYVIRPNSAKVAKLNDNLESLDRFIVDEFIKIIDDLD
 ADEYLPSTFFNRRVVSNIINTPELKWLLKFITGKDNGERVSRINEIGRNLKNTYITASPD
 GSSQIREDLALCVRIYNKLTDAASAEVDAAFKKFEKEYPVIEHMLNEWRVANYADDISRI
 MRALESAPSLKGKDEDE
->CC31p002.p01
+>CC31p002
 MLTLKPSAELFDDAVYKEYRIIQRFFDIGEAEEFKERFKEIRNKIFTTDTATAEELLEVA
 ELIKRHCD
->CC31p003.p01
+>CC31p003
 MILDDGTLVNLENVAECIKQNGERHLTEHGGSPDDPYHIKFKQAIDYIVNCIETRQTIPM
 NLRTFALKVVYNRREKYTIKQMAKILNSIGTIKC
->CC31p004.p01
+>CC31p004
 MSQIWVTLVDGSYGYMWGDALPLPGDTVTIRVRHTNGSYTKVTGIVSRASW
->CC31p005.p01
+>CC31p005
 MMIKNEIKILSDREHIIKRSGMYIGSSAMEAHERFLFGKFQSVTYVPGVIKLIDEIIDNS
 VDEAIRTNFKFANKISVELKGNKVIVTDNGRGLPQAPVVTPEGDEIPGPVAAWTRPRAGG
 NFGDDAERKTGGMNGVGSALTNIFSVTFAGATCDGQNEIIVRCSNGAENISWDSKPAKEK
@@ -3944,11 +3378,11 @@ FLTEGDSAIGYLLTTRDRKLHGGYPLRGKFLNTWGMTAAEAMKNKEVFDICAITGLTIGE
 DYENLNYKNIAIMTDADVDGTGSIYPSLLAFFSNWPRLFEEGRIRFVKTPVIIMSKGDKQ
 KWYYTAAEYEAEKDELAGWKLRYIKGLGSLEEDEYERVIQEPHYDVVSLPENWKELFEMV
 MGDDAAPRKVWMSE
->CC31p006.p01
+>CC31p006
 MKGPSGPLLFTFSTKYDKIALPKEENIMRFGLTVEHKNLLKQLKIVNSALGRWKFALWPT
 RIVDGSYIWLEKYYEIRHEHVHQNEDGSYECEAYYGIDIYAYTNSREVRHKFYKKVYSSA
 RWAAYNPSYNPIFGEEAKTHLLQYKAELEEKLSQI
->CC31p007.p01
+>CC31p007
 MATDIWTTVHPIPWRNTSFLYLPWWIHNILIKAKEEGKDWREYADPQYALQIDTLKQAYV
 DYGEVNFIESRNGYQYTLSEYTVDGPDPQPPLGPMLQPVAVMSNPPTQKLIKGVGISGNA
 TLVSGGTGYTFGDILDIPGATGDVNGQIRVTAVGSNGEITTTQVRKPGVYATAPTGEISA
@@ -3958,37 +3392,37 @@ SLVGVNTAFGGIYVDTGKTITAITRPAKMIWQLGDSYTFGTMATQASFNDFRFYCDKLGL
 VGLADGIGGSGWTSTSSTQPQARITAKLATLSFTPDIITLALGYNDAPAGRIDLLKTNFR
 ESIALIKQYQPAAKIIVFGPATPLGMTDQIAAVRDALIELTTELNLEFVDVKGWVTAENA
 NLYTSNDNVHPNDQGYFWRGSQFTNVLQGKV
->CC31p008.p01
+>CC31p008
 MKYINRAIVAALFAFGVAGCTDADNATRILEANGFSNIEITGYSWFSCSEKDTQSTGFKA
 VGPTGVKVEGAVCSGILFKNSTIRFE
->CC31p009.p01
+>CC31p009
 MGTRPRIRFMKSGESRVIKLHSGKIIKVTKK
->CC31p010.p01
+>CC31p010
 MPLYDYQCEACGEKSEKNVKISERDNPQPCKFLNCEGEMKRVVSAPAVHYDGLKSGDY
->CC31p011.p01
+>CC31p011
 MEEIMQVLDITPVLQVSARYTENKPWRNITSVMLQLSSETGEMCDWINRPHRQKEIFAGE
 CADVINCVIDALWLHMRDKMDGASHEEVALAVTEELNRQLRLKTKKWSEAVNAII
->CC31p012.p01
+>CC31p012
 MPNFIKGRTYRLPEENEQWFLSQSFHNERLLDDIKSKGPEFTVLEVQEDCNGDSAVKVRF
 EGTGETSWDGFYITADEREYFEDVTGGGSWRAGVVYKCINLSAVGASSINSRFVREVGTK
 VFKVSKMMNDCERTLEIEYIHNDGYTAKMKITFTPGEYRYFKVISEDDYEEYSPICSMES
 LDEQIAAIKEPEEPEEWNAEVEGVMVFKIESEAERKKAIEILQTMKWKK
->CC31p013.p01
+>CC31p013
 MKNQPIITGITRDEFEDTLYNPDLVVVQKDVAGHLEHTQIAYVYENVGDTLPIYGMFRQI
 SDDGTEYWKETYNA
->CC31p014.p01
+>CC31p014
 MASKMIGKSVKVIGGQNKGLVGWIISDNAARGQYIINVAGPTLGSSGFKISAKYHFVEVN
 DPIDTALVTAKSKFERKPVSVDLHNALENSSGKTIDGMGAWVSLVYRDEDTDQIVANVVF
 MGEYAVVPTDNINYVMSYGNRPGKA
->CC31p015.p01
+>CC31p015
 MIKDFIIDWETFGNVSRSAVIDVAAVVFDPNPEVVETFDELVQRGMKLKFNLKAQQGVRL
 FGASTMKWWKSQSEEARKNLLPSDEDIDHVEGLYKLLQFLKDNGVDPWKSFGWCRGQSFD
 FPILVDILREGEARKGIAEKDIDTFGLEPCKFWNQRDVRTAIEALLLTRDLTTTPLRKGV
 LDGFIAHDSIHDCAKDILMLKYAQRYALGLEDAPEGDEIDPLSLPKGRG
->CC31p016.p01
+>CC31p016
 MYTITVEDAEAIVAGVKDNMVSNPSTTTERGINIKGSQIVLELNDIIRDAKAISWYTGYY
 PKIALSEFVAGNIREFKEMT
->CC31p017.p01
+>CC31p017
 MLNEGQKATFNRVVERIKAGRGGHITINGPAGTGKTTMTKFIINYLISTGVSGVMLAAPT
 HGAKRVLSKLAGMAANTIHSILKINPTTYEENMLFEQSEVPDMAKCRVLICDEASMYDRK
 LFQIIMASVPSWCLIIAIGDKSQIRPVEPGSTVPALSPFFTHKDFEQLYLTEVMRSNAPI
@@ -3997,74 +3431,74 @@ SVDKLNSIIRRRIFQTEEPFIVGEVVVMQEPLIKELEYDGKKFSEVIFNNGQYVRILSCK
 ESSDFIGAKGVPGEYMVRHWDLELETYGDEDDYYRETIRVIADEQEQNKFQFFLAKAADT
 YKNWNKGGKAPWKDFWAAKRRYHKVKALPCSTFHKAQGVSVDNCYVYTPCIHMADAELAQ
 QLLYVGTTRARKNVYYV
->CC31p018.p01
+>CC31p018
 MHYGYALITKDKDGFEIPFYESWDKDPLGMCIIFTGKYAAERYCGTQLGKLQYLMKYGRK
 IEYQETKWLFFKRDIIEHIPLTEQERRNVQQMINTLQVKKVKVA
->CC31p019.p01
+>CC31p019
 MAKPLEIVVATRLVNTYASATRRQKDFGLTMSYLANIAQQKVCAYSGEPFCEGVNDDMMT
 LERFDNDKGYVPGNVIPVKKKYNSARGNFSLEELIEKRDELASRIVRAADAGGHVIVDQQ
 EPESEDPLAGIAKKYHKQYLAILNNIAKREQHMKQKGVTAEVKKSLQARITGGKAELKRL
 RKVSGNTDKLASKAATTSKKATKAENSVHNYDIVIKGLTRFQNLSFIDKAKLNKGLPLSA
 SMFQLIRGKM
->CC31p020.p01
+>CC31p020
 MAFYQSPVIEVEITPSIPVPSGGIYEYWEGSEEVERKMLESEVNSMFTDEEQAVLWKCLN
 DKVEDWVNRGLDKVIRRRMTTVTPEMLYRGVNRRMLNVLQNVEVGEVFTSERVVSFSTDF
 NTARSFASFGCYGTKTIIRWSNPTIAYNYQEDMLKILAAAPNCEFSAAPYDPLAKIDRKN
 KINMVQDEQEWMIANRNEVPSN
->CC31p021.p01
+>CC31p021
 MFEEDIPEGYVEVDMKSGPKVDQSIATELELIFKKHGVDCTKALCEELSSLWADPPPWTP
 WAK
->CC31p022.p01
+>CC31p022
 MTDEKQYKITTFGLEFVSRDFPSFTDKRHPLHKREIMVAICYNPFLEYGTSYRDNVDPSE
 LKNGWPEGVDVIIKEYNTYVKTKNSPFDTQDSFLIGGWKIPQTNLIDIIPEPKFGDKSID
 TVKIPNMMHTDGYGITHVNNWLITDQFDMILFRKGIWHLLGVPKTEALPR
->CC31p023.p01
+>CC31p023
 MVMNFVRGLFGNPRPDAQIKAEETRLDESIKEHMYGANDMAVAYEEGANEHREWIYMGDG
 MMEEVIVKKEKVQRNGQTYTGRVTHTPVNHQNHSSSSRVSSYDSPMIHTTSYIDSPSNTS
 CDTGGGFTCD
->CC31p024.p01
+>CC31p024
 MTPLNEENTMNVKTTPWRKPVGDCGGISDLVRLKYIEKETNTDFFVDVKLHAYREVGTSI
 ECAIEVLYYDLVKVDGVYKRNVFNIQFLNWSY
->CC31p025.p01
+>CC31p025
 MPYVNIKTKARTFKGTSIPAKEVSVDFKLYSDVHKIAGTMYIISTTETALFSTKFEYNQR
 DAWVAFNEELVNGPAPSDD
->CC31p026.p01
+>CC31p026
 MVFDFYAWQKAGRPASPYKGSDAYDLRLHWKFNEIEAYTAVLIDGDWVILVRGGGYFSVT
 DKFLVNK
->CC31p027.p01
+>CC31p027
 MAHFNECSHLIEGADQANGAYNAVIDNRQDPLQVMLDMQKSLQIKLAEDKPFSNRHPDSL
 ETAGEVLAWLRAQDDYIADETRELYTALGGMSNGEKAASAVWKPWKAQHVEMQAKKIKDL
 SPEDQLEIKFELIDQLHFFLNKIMALGMTAEEVFKLYYLKNAENFARQERGY
->CC31p028.p01
+>CC31p028
 MNQEQHAFLKLGEECTEVAMLCSKIIQFGIDSEYEGKTNRARLIAELNDIMGCLLNLRVH
 TDFDFVEDREEVWKKFEKMEKFRKISENLGFVAK
->CC31p029.p01
+>CC31p029
 MSWVDNEFAYRAFSHLPRFKQVTNGHRFKLNFRCPICGDSQKDQFKARGWAYEQPTGGIV
 VHCYNCDAHLGLAKYLRENEPDLYREYILEVRKEQGQSRAAPKKEVKLPPVEKKFIQKLD
 YCERLDRLSPAHPICKYVAGRKIPKDKWNRLWFTTQWPALVNSVNEGTYSHEKNEPRLVI
 PIFNEKGKIESFQGRALSKDAPQKYMTIKAHELATKIYGQDTVDPNKLVFVMEGPLDSLF
 INNAIAITGGSIELSMVPYEGNRAWIMDHEPRHPDTIKRMKKLIDAGERVVFWDKSPWSS
 KDVNDMIMKEGATPEQIMDYINNNIESGLMAKMRFTRYAKI
->CC31p030.p01
+>CC31p030
 MSTIKSGIDAVYAYKFIRLMQKPFTEWKAYEAKIIDEKGTVLKRPTTPEEKASYTAFHAS
 VRSIKRMLTTVPGLNGVASMMSAWSAVASRYNITESEQKEIFEALPLFEDMVAGDSGGSV
 QNIASGTTTGAIVNKGPETLPKKRKRIKVNLNKL
->CC31p031.p01
+>CC31p031
 MSTFILIMTLISEHGGVAMNQIEFKPTQTGPTAEELCNQAGEEWRTSARDFSTSAKFVCV
 KR
->CC31p032.p01
+>CC31p032
 MYKMKAVCDEHQGLIRFIDECGCECGSVHYDIFKRVLKVDLSFESSFVHQGQKLTKQLIE
 KLAKDSAWESGIDDDLLWEGIEVICVDCESFEERLDYTGSDDDIFNAWMKR
->CC31p033.p01
+>CC31p033
 MIFEGRDLVDYHDAELAQLRLRFEREIDTGLTRWGFPADPRESYRKGLVLVAIKIEQERR
 CTK
->CC31p034.p01
+>CC31p034
 MKKLVLALIFAISSCSAVPAMAKADYTSIPCIKFVEGDWDKVKPKLIHDLEAGADKNQKM
 LIEDLGESDLVVAGTNLYCENASVPEVLEWIGL
->CC31p035.p01
+>CC31p035
 MKLNQMLLVVRNTYDNTKPQAEIKDCLPGTLVVKSDDAKLECTGPVREALELGKTLIVVI
 PPFNDKHGGVTIGVTTLENDDYRLIRLTNVKHA
->CC31p036.p01
+>CC31p036
 MGDEYFEHGPAKNVFKLIHQHVLKYQAVPSKTALAVALDNSQLVETEVQGASELINKLQD
 TPEDLNWLVAETERFVQESAMYNATSKIIEIQTNAQLPPEKRNKKLPDVGAIPDIMRAAL
 SISFDSYIGHDWMEDHEARWLAYQNKARKVAFKLNILNRITKGGAETGTLNVLLAGVNVG
@@ -4073,11 +3507,11 @@ MEKWRSKNTLGRLIIKQYPTGGAHANTFRALLNELKLKKNFVPDVIIIDYLGICASCRIK
 VYTENSYTLVKAIAEELRALAVESETVLWTAAQTTRSGWDASDISMGDVAESAGLPATAD
 FMLAVIETEELAQQGQQLIKQIKSRYGDKNINNKFLIGVSKGNQRWVEIAQEHGEQPTSV
 KETSGAQQRVAEGNRMTRVEQNASARAKLDALAEDLKF
->CC31p037.p01
+>CC31p037
 MNWKITKMKNNFEDLDLDLTDVEVQDETPSSEGEFERTERMFKKSLEIIQKAMENVVQEI
 LITLEDGEEHIVYVTSLHLDESGQVSLEFSTLDESRKADLAPHVEKCIKIQIQQAHADIM
 RKKKRFKLF
->CC31p038.p01
+>CC31p038
 MSDLKSRLIKASTSKMTASLDKSKFFNEKDVVRTKIPMLNIAISGALDGGMQSGLTIFAG
 PSKHFKSNMSLTMVSAYMTKYPDAICLFYDSEFGITPAYLRAMGVDPDRVVHTPVQSVEQ
 LKIDMVNQLEEIERGEKVIVFIDSIGNLASKKETEDALNEKSVADMTRAKSLKSLFRIVT
@@ -4085,30 +3519,30 @@ PYFSIKNIPCVAVNHTIETIEMFSKTVMTGGTGPMYSADTVFIIGKRQIKDGTDLQGYQF
 VLNAEKSRTVKEKSKFFIDVKFDGGIDPYSGLLDMALELGFVVKPKNGWYAREYLDVDTG
 EMVREEKSWRAKDTSSTAFWGPLFKHQPFRDAIKNRYQLGAIETNAVVDEEVDALINSKT
 EEFHAPEGEVRATPASIEDELENYEDEE
->CC31p039.p01
+>CC31p039
 MKIAILNLGNNIQGFKTTPASETIYLSECLKDMGLDVDLISMKQTIYGIAFDDVPDPNVY
 DRVLVVNASLNFYGGEENKMNKAAYMFLNKYKSKIYYLFTDIRLPWEQAWRRMSKKKWSS
 KYTEEQFIVRSPIRVISQGRDLEQAKRIHSDRLVGVSKDRMEFVHFALDRHKMYHSVFKI
 AADGIKMRDLIYGGTFRSGNREQKMVEYLFDTGLDVEFFGSVKADQFKNPEFPWTTPPVF
 PGKVDSREMVQRNSTAYATIVLGDKTYDNNQITPRVWEALASTAVAFFDSTFDPDMNIME
 GNEFFYVSNRQELVDKINKIKNDEDFRIETLEYQHKILQKYLDEKPIWQAEFKKAIEI
->CC31p040.p01
+>CC31p040
 MEMIQFVIPSYNRAGAVTALDMFPTGYVPHLVVRESQKEEYEMHYGALAKIVTIPDDVNG
 IAGTRRLITEMYQGQRIWMLDDDTTIHTTEIRAKDDRRILHDVGMTWDEFNKLTQYVEAA
 MDCGFYHGHARLPIFKIDSKWGHFRENSYGFTNTFYDLSKLSADDIGYGIVDLSEDTYAF
 LKLINMGYPHLAIFKYLVKSGKGQAPGGVSSMRNAAKQNRALEKIHADFPTQARWKSEGD
 PTKTMFGTDEPLKVLRMCVAKKQKSDAFNKFSEIEPTL
->CC31p041.p01
+>CC31p041
 MIVTPLTNEDIRDELCHALFNEMFVIDKTGAKTIELIGPSFVVTEDSIFGTVNQEYVERE
 LAWYKSKSLFVKDIPGGTPAIWEQVSSSKGEINSNYGWAIWSAENYNQFSFCATELIEKP
 DSRRAIMIYTRPSMQVDFERDGMSDFMCTNTVQYLIRDGRVNAIVNMRSNDVVFGFRNDY
 AWQKYVLESLVETVNAGSGEKYVPGDIIWNAGSLHVYERHFYLVDYYRQTGRIDVKKSDY
 KGKWK
->CC31p042.p01
+>CC31p042
 MKFLAVAAAMLLAGCAYQGDTVHASTVGQVKYVGGTGLVYARSTPQINQSSVRAGEEYLA
 QQQANDPIARDQARVMKKQREFDATYEKQVAARKCQAIVEFHGAGLYQTMYNNPTSKNIN
 AFENFRSSGQYEAFKRCMKKNYEEAK
->CC31p043.p01
+>CC31p043
 MAQEFYISIETAGNDIIERYIDSNGVERQRRIEYSPTMFSHAQQGVKTKFFDIYGKPCVK
 NTFPTMKDARDWIRRMEDIGLEAMGMDDFKLAYISDTYGSEIVYDKKFIRVANCDIEVTG
 DKFPDPMKAMYEIDAITHYDSIDDKFYVFDLLDSLYGSVSEWDVKLAARSDKEGGDEVPQ
@@ -4125,37 +3559,37 @@ AEPHLKIMGMETQQSSTPKAVQKALEESIRRMVQEGEESLQEYYKQFEKEYRQLDYKVIA
 EVKTCNDIGKYDDNGFPGLKCPYHVRGALTYNRATAGFSVTPILEGNKVMVLPLRQGNPF
 GDKCIAWPSGTELPQEIRQDVLAWLDYTTLFQKSFVKPLAGMSEASGLDYEEKASLDNMF
 DF
->CC31p044.p01
+>CC31p044
 MFEGTKEEQIERQKEQLRAAMTPDGKRVYPDGYAFMAYWKDEEGVVQYEAAQI
->CC31p045.p01
+>CC31p045
 MIEITLKQPEDFLKVKETLTRMGIANNKDKVLYQSCHILQKQGKYYIVHFKEMLKLDGRP
 VTIDSEDYIRRDSIAQLLQGWGLLDIVTPDVHLAEMQNNFRVITFQQKSEWTLKSKYTIG
 A
->CC31p046.p01
+>CC31p046
 MSLFEDDVQLNEHQIAWYSKDEAEIKRLSDTFKETAENEFFAIIGAINEKKDISIGTRDY
 SKFMVENALSQFPECMPSVYVMNLVGSGLSDEAHFNYLKAAVPRGRRFGKWAKLNESAQE
 TLVLKVLMNHYTININDAERYRVTLANKNKLSETLKRLKGTVTDELVKSITKNVKEQKQL
 KKLALEW
->CC31p047.p01
+>CC31p047
 MLSINEKEHIFEQKYRPQSISECILPEFDRQVFDAIIKKGTIPHMILVSASPGTGKTTLA
 KALCNDVGVEMMFVNGSDCKIDFVRGPLTNFATAASLSGKQKVIVIDEFDRSGLAESQRH
 LRSFMEAYSSNCTIIITANNIDGIIEPLQSRCRVIKFGQATDDDKRNMMKEMIRRCVEIC
 KNENIKVEDLKVIAALVNKNFPDFRKTIGDLDHYSSKGVIDSGILDLVTKTSGDISDVLD
 ALKSKDVKQLRALAPKYAVNYSWFIEKLANELYTKLDKASIIRMYEIVGENNQYHGVAAS
 TELHITYMFMQLVVEMQFK
->CC31p048.p01
+>CC31p048
 MKLSKDTLNILKNFSTINSGIMLKPGKFIMTRAVNGTTYAEATIADEIDFEVAIYELNGF
 LGILSLVNEDAEISLADDGNIKIADARSTIFWPAADPSTIVFPSKPIPFPVASVIVDFKS
 EDLQQLMRVSRGLQIDTITITNKDGKIVLNGFNKVEDSALVRTKYSLTLGDYDGTNNFNF
 VINMGNMKMQPADYKLLLWAQGKKTAAKFEGEHASYVVAMEADSTHDF
->CC31p049.p01
+>CC31p049
 MLNIVTDVKEIQPKNVRTDSNPNNQNKIRRAWVLMLPEEIKEAIKRKLPDAEVRFAYYSS
 VDNSVSEKWIEVMRKHYDRSIKAGAKVILDKVGGERLEDEFCTNADEQLLVAAEIVAQEV
 YDSFAPFVVKSESSETEIELN
->CC31p050.p01
+>CC31p050
 MKQYATGNELLTFPELKRYVLINNFSGEEHIVTEQHLKDAFGKDYDKISSNRHPAWTVSE
 FFE
->CC31p051.p01
+>CC31p051
 MKIFKLNRVKYQNIMSVGGQPIDIQLDKVHKTLITGKNGAGKSTMLEAITFALFGKPFRD
 FKKGQLINSTNKKGLLCELWMEYDGHSYYIKRGQKPNVFEIERDGAKLDEAASVKDFQSY
 FEELIGMSYTSFKQVVVLGTAGYTPFMGLSTPARRKLVEDLLEVSIIAEMDKLNKSLVRE
@@ -4166,63 +3600,63 @@ ERIRKIKAAIDKAAEEFIDYSDEIKTLNEELNKIVDTKSNSVMEKYLRGILTEMFKDSGI
 KGLIIKKYIPLFNKQINSYLKVMDADYVFTLNEEFNETIKSRGREEFSYNSFSQGEKARI
 DIALLFTWRDIAELVSGVKINCLFLDEVFDSATDVDGVKSITQILNKMQDSNIFIISHRD
 HDPQAYGQHLQMKKVGRFTVLE
->CC31p052.p01
+>CC31p052
 MKILHTGDWHLGVKGDDPWLQEIQRNGIRQKIEYSKKHGITVWIQYGDIFDVRKAITHKT
 MEFAREIADMLAEAGITMHTIIGNHDMHYKNKIHPNAITEVLGKHDHIKIYDVPTTVDFD
 GCLIDLIPWLCDENVASIMKHVKESSAEYCIGHWELNGFYYYKGLKSHGLEPDFLKSYKQ
 VWSGHFHTISSAANVKYIGTPWTLTAGDENDPRGFWIFDTATESMDFVPNETTWHVRLQY
 PFTGKIDYNDYKNLSVRVIVTDVDKDITKFETELEKVVHELRMVSKIDNSVESDDEEDIE
 VKSLLDLMSEYIDALEDLSPTDNAALKKFAQALYVEAQNQ
->CC31p053.p01
+>CC31p053
 MLPRSMPEDWPSGDYMCTCRHCGINYIGPKRSIFCNICNTSERPEPKIDYEAIHNSKIEM
 WKKFNEAKKLAEELGYVLVKKI
->CC31p054.p01
+>CC31p054
 MLVQKPFKRLKVNAGFTLSVSNGVMAVKLSETHYRVLGSTGPAVKASPKEVVWVDTLQVK
 PWWKL
->CC31p055.p01
+>CC31p055
 MNERNIDSVEQIDDNEEERIKRLIEEESQRRANAMATKIFKKNRREIKRLNDHAAGAVLE
 NNFEAYKYALCKLRDIYKQPYNDEIIRVNWQTTRQQVWEIINAGTETV
->CC31p056.p01
+>CC31p056
 MRLTINLAGFLEEVPDYDAIPYLLKMYMREVLDLDIRIDPKNPHDAEFTSDNAEITHSYN
 LGENDFSITIDYKSK
->CC31p057.p01
+>CC31p057
 MANYVNNKELLKAITEWKQQCREAGKPVRQNDTIGRAIMLISEGLSKRFNFSGYTRSWKD
 EMISDGVEASIKGLHNFDETKYDNPHAYITRACFNAFVQRIKKERKEVAKKYSYFVHNVY
 DARDDDMVALVDETFIQDIYDKMTHYETSTYKQPGSDKKSDVVDEGPNLDFLYEADD
->CC31p058.p01
+>CC31p058
 MSRITLDNIEITSFRVTGLGEFFVDKWMGITFSDSNEPGPSLEYVWRGHVSKLNENGYIE
 LWKSWLRFCNENAFEPELDFVTFRKLMIKCFSLYELLK
->CC31p059.p01
+>CC31p059
 MKYNQFTITVLNYGDWVIRRDGTVYFSDEETGAYWESDIAIFRDYTPDILYREFCEETCE
 DLEPMHFNTFKTLIEDTFRIFDL
->CC31p060.p01
+>CC31p060
 MNKIESDLQLAGFQTKRTEDGRLMIEGTSKNDVDFVIEEDFDAWWVYEYTGKDYHSVDAF
 GSMDEAIECAKELIL
->CC31p061.p01
+>CC31p061
 MNEGISVIILISHKIDVWHAKLHARFVFGTNWEDINNAVDYLKACEMINKNFQVRYFPVQ
 DRSVDYPFYHMWEEGMTEEELKEYLDE
->CC31p062.p01
+>CC31p062
 MINVKVYFKCDPGFKPYADFTSNKRYVPVKLCREFGPSLKAIKLKGSNQLIWPLPDMIET
 RMDLEMFIGFFMGAKAHMEFHLHHGHRSRYEIHLTVPGYKEEWL
->CC31p063.p01
+>CC31p063
 MSQAIKNVLNAFVFPKVEAMKVDGEFKDVIVTPKLLDKWEVELHGTMKENDQKIGKARIR
 ELVVAYILSEFNLDAFGIPTIKRKEISDSTIRKMKNQRKKGFVDLKIVKAAK
->CC31p064.p01
+>CC31p064
 MITLKKKVTVELGVFIRSESRGQERMNIEINNVEVVLRGRSCMTEVSISAARHRPSSITN
 AIYALISDIEKDEAAELTRAIYEYVKNC
->CC31p065.p01
+>CC31p065
 MENSQLRAKIYGIPEDVYRCAGCAAVKEIFDEFKIPYEFIDVIYMAGDVQYNYKAIEEAA
 KASGVFPSKRVNYPVVILGGVYYPNLRTIKERLGELGYDLDSLD
->CC31p066.p01
+>CC31p066
 MKHIKSFFNGTRTALSKLLAYIVIAYGIIVAVPALLVFGMAVIIAPKTDDKPKLSPEEVT
 ARIRRMTDALKDIGLDDKLEVTVNGKLTTKS
->CC31p067.p01
+>CC31p067
 MNILNKLALNANFIIQSWGEEFPALYVFAGIVTFS
->CC31p068.p01
+>CC31p068
 MKYDRIYPCDFVNGPGCRVVLFVTGCLHKCEGCYNKSTWNPRNGTEFTGETIEEIRELLS
 KDYIQGITLTGGDPLYPDNRETIEALLKCLHNSHPHKDVWMWTGYKFEDIKDLELLNYVD
 VIIDGKYEQSLPTKKLWRGSDNQRLWINSGTWNEEHNEHPE
->CC31p069.p01
+>CC31p069
 MTIESEIQGLINRTNKDLLNENANKDSRVFPTQRDLMAGIVSKHIARQVISPTVLNAHDK
 GLIHFHDLDYSPALPFTNCCLVDLKGMLSNGFKLGNAQIETPKSIGVATAIMAQITAQVA
 SHQYGGTTFANVDVVLAPFVEKTFFKHLRDAERYGIEHVNDYVYAIEKTEKDVYDAFQAY
@@ -4234,312 +3668,312 @@ LLKCLNDYLAEWTKETGFAFSLYSTPAENLCYRFCKIDAEVHGDIKGVTDKGWYTNSFHV
 SVEEKISPFGKIDRESIFHFIAKGGHISYVELPDMKNNLKGLEAVWDYAVEHLDYFGVNM
 PVDKCFTCGSTHEMTPTEDGFICHECGESDPKKMNTIRRTCGYLGNPSERGFNLGKNKEI
 MHRTKHCEV
->CC31p070.p01
+>CC31p070
 MLLTSKLYKEEKQRLFDAQHGICPICKRELDGDVQSNHLDHDHELNGPKAGKVRGLLCNL
 CNAAEGQMKHKFNRSGLKGREVDYLEWLESLLTYLKNDYTKNNIHPNFIGDKSKEFSRLG
 KPEMIAEMNAYGFTYSEDDSKPKLVASFKKQLRKSLK
->CC31p071.p01
+>CC31p071
 MSFLNKVFRVIAEDEELLSQFPEFVKGAEFKVLSISKVGESTGMTSVQFKNGPYVHVKTA
 THPEISGQDSWFWCFYSDEIDHLEELEELEELSSDQYGSSGDIPRNLFNGKDITAQLYKM
 AGQENCDSEEYDLMQAAADYIRWLEAQLEFNSRKF
->CC31p072.p01
+>CC31p072
 MGYALKPWYAARWETLEPEEEERFPEDDYNEPTNNELIDMEFGYEFPE
->CC31p073.p01
+>CC31p073
 MISEMKEKILKEIMEDHDGHSEYYDFEDSDYLEEVDHDEWTQNHKYQYRQVVYYSKKHDV
 HVAVNETRSGSYHTDWYYMEPDVSLVEKREREVTKTITEWVTL
->CC31p074.p01
+>CC31p074
 MSLNSVLIDPKKEEVICSAELNRLRECEALLWEVERSLPSGLESWVDDEVLETLRGE
->CC31p075.p01
+>CC31p075
 MTFKVFGYDSKHFKCVPCINSKRLLDAKRKDYEFISVTSGNEADGTPIFNEEVISELLVR
 LNRPSRVGLTMPQIFDEKGSPIGGFTELKEYLK
->CC31p076.p01
+>CC31p076
 MSRKEYMMEAEDSLLRMMVAYHKDHGKMPDSYSVLKSALTRAHSFAFGSINREVAKRLGV
 KWDHRTQNHPDYDKVVSSVIEDISSDIQGFRLRQQAF
->CC31p077.p01
+>CC31p077
 MNPFQSSAISETEEMKSLFKELREVAGRICLQYAEEKGENLNMDHVHRSLHASIDFDVIM
 FKTYAYHQLNSQPNTSLPMSEKIAIAAHESYKRLKEL
->CC31p078.p01
+>CC31p078
 MKTTGALWKEFYNDEAFWEGYYHDDTLVLFDDVEVEEYENPAPDAVVTIESGYVYKHNED
 SFAAHDLRLETFFKRWKKKQTTRTIVVTINKDDFDEVFETISKIPGVKAVK
->CC31p079.p01
+>CC31p079
 MSLIDLKLDTNTIRQLFPEGTEIRAALQQSVIQNIVKEMVLKDSDNKIRKAVSQEIELLG
 ARVPSVKAAVETELKTFFTKRGWNNYDSTFELDQAMRKEAIEVAQNIIQNKIAKCIEEAA
 KKLENRIEDTLRMTEHRWEQMIVSRINNHFGNMLDKAIAERIAAAFPEVKK
->CC31p080.p01
+>CC31p080
 MTTRMKFLIAAICFWCFSIFTDVRPDFSKDQLIKAELVQLYSGTSSGKYSHLEFIAVYED
 QNGRRFDREISPAFYSMAQVGSTYDLEIRPELIYSEYRQGWNVAWSFGSAFLYIITYILA
 FFFSVIVCLPKSVIDWMNSDII
->CC31p081.p01
+>CC31p081
 MKKQLAEDVDLSQEILDDPEGMERLLAATRWEAMMEMVERREAAAKQVTPCPKCDSIQVQ
 LVNWQTPQLQMKCRICFHKFVKELK
->CC31p082.p01
+>CC31p082
 MKLVNVLTNNNFNTYIKELIANAEASFNFVPGEGLRADRIEKLGCIRQWISTILNTEFGK
 MGIDARINATRIATGDANKPDAWIDVLRTSGILRRVKANNRLRHYLMQAPDEYNALYYNA
 DGDKTNVHTNKMHNQSAVNFIINQFSFEFPRLLRLGAAFLTENDKAKTNFMLSTSKWTIP
 TVSFIEESEDVMTITIRAGRENGDMERISKQIISALKRMNIVRFHNLVVETPRQHQIMVN
 LNIKKSEDFVAPEEPIVTPNTVKEIVETPVDAGKVIKAKINELEKEFNELETKKRNLNDE
 VSRISSRTIQLKRQMETLRISLEVISEPKAGV
->CC31p083.p01
+>CC31p083
 MEIIGAILVYLAIGAVSTGFFKLVEDWFIDIDGDTAAWIIMTWPIVWVIFIFKVATWPLF
 WICAIIFD
->CC31p084.p01
+>CC31p084
 MLILSNWVDNTALYPPAYIYAGMAKGKAEKQAEAICEELYKFTWGDKKNVLGELREIWRH
 ANILCKLNYDGSVKREVIEKTFDKLQEALIEANNKLVETFKKHQDLNKWYKDHLQVSNAQ
 LKEAVYTYKQAQLCIIEAREILWKS
->CC31p085.p01
+>CC31p085
 MLTEIIDSILDENRKAHAARRAKVEERALELNAGWAKTRYGREGFDKVVAPTWGIDDRPH
 APFDGYLWENDLGEVEAYHAGSYLPYVTELDYFDKPEYTGDHGWWKLRLTAAMYVELKLY
 GHPIEVREPYKRWELEDFTTVMMVEVRAHKNILAAIQEASKKFFDELYESFKKNKGEAPT
 GKQIVKGKVVSVKCWEDYYGMQVKMTVRLENGATVYGSLPKAVPMDYRGVIEFSATFEHA
 KDDSTHSFFKRPTKVVIC
->CC31p086.p01
+>CC31p086
 MFQKNNKEAKLDFYNRMTDSIVEYKNAIDEASDDWIRNATACDDTPDNNTGKRLYHKKRC
 KALISMDREQLQAAHLFEMEKIINETLYNNQLQTAVIEKSVWFSGDPNTPAYH
->CC31p087.p01
+>CC31p087
 MGYGLDELNDWYDDYEDEDYENEEYGYEPRPINLHGERIEVLRLLSDAQRHNKDGKGKHS
 SKSAKGQKPTTRYDIMEPIYRNNALMKVGSTLVCPSCGEPFKKKSYQQKFCRTNGNKCKD
 YFWNCHPDRIGRTEEWKQ
->CC31p088.p01
+>CC31p088
 MVTPILIAIAIAVYLLGGVFFASTFAWCLGMPASSCHTAKQKVVKCLAEWSMVLFYPFWI
 IFMVVVLIAGK
->CC31p089.p01
+>CC31p089
 MSPEEIRALLKEMLKENLTIEVRNDSLFGTLEVEVKFDDELITSSSIYRSDVENLLRKDL
 W
->CC31p090.p01
+>CC31p090
 MSKLITYEIKFKRFVNGIWDEKFRVATVKAENQYQAVWHLGTYNDDQNIEDVIVMVQSKD
 GNPSHFEEGWTYETLSGDKVLMTKFKDLGLDRRTGYETIMDENGHHRYSRRDLGRCTGSK
 SNDPCNIQLGVFWMRMDIDDPYDFIMERKYSDNGKGVKSKERIEMKL
->CC31p091.p01
+>CC31p091
 MKVVNVKESDVYVARISPDDRRSEVYGYYDSYFKAEESVAGKSFYGSNGTVDHQPQKAIT
 LTFEDGSKLSFLRTSAFEIRTETEAERVARLEKVKQNALSKLNPEEKRALGLI
->CC31p092.p01
+>CC31p092
 MKTITITKGTNFGKEISGTFEFIDQWFPKDLSEADAAQGDGKVFVMIDGKKRGVWVFHGD
 YKIEGQVTKEVLTESVEEMKARIAKRFNVMGLMTAGLVNGNIRSLIISGAAGIGKTFSLD
 KALTKADARGDIEYKMVNGKISGIGLYCRLWESRHSNSVLLIDDVDVFSDMDILNLLKAA
 LDSGEKRKVCWSTASAFLEEKDIPNEFEFEGTVVFITNVDIDKELERGSKLAPHLSALVS
 RSVYLDLGVHTNEEIMSRVEDVIMTTDMLQNRGLKHYQVLDVLAFMQNNVNRLRNVSLRT
 ALYLADFVATDEKNWTEIAEVTMLK
->CC31p093.p01
+>CC31p093
 MTVYVDVLMNHGWKLRGHPTKNCHMFTDGDIEELHKVAEAIGMKRSWFQDKRIKHYDLRA
 DRRQKAVELGAVEVSRREAVKIWRTLK
->CC31p094.p01
+>CC31p094
 MKTTPIEVKKLIDTEEISACFESFLEDATEDNAVYLAQKIIETYLDKNQ
->CC31p095.p01
+>CC31p095
 MFTSAIAYGIIALSKPKENKMKTLEIVVKNIAQAKAVAQEYKVEITSEKQISEKYYIVLE
 GTSDALIDFVDEFFLNSSVRPYYINEILES
->CC31p096.p01
+>CC31p096
 MATSKIFYAVTEFDFGGMGHKQHMAPAIIEYVEYMEKILKTKENAKAAGTLIEAVTPVKS
 KMVQMPNGRKAKLFNVGNEVWARYSDGSATPYIA
->CC31p097.p01
+>CC31p097
 MVTLLLAQLWWIMPVFIALVYLAAGWLITNALVKRGYIETPFNYLFSIILWLPVGVIKVI
 WHILSWLLYQPKLFAERQLEKHSK
->CC31p098.p01
+>CC31p098
 MKTIMKGYFGSHLYGTSTPESDTDFKEIFVPHPKEILLGRAMNHTNLNTNNTSTKNSHDD
 VDHELYSLKYFLQLAATGETVALDMLHTPANMVVKSELPEVWKFIQDNRWRFYTTDMKAY
 LGYVRKQAAKYGVKGSRLAELRKVLEVLEPYPEWKYEDRPKDKAHNVRWKVADIAHLLPT
 SEFLEWTDFVDHKSGVQKFYNVLGRKFQTTITVAEMKYSLTKLWNEYGERARKAEANEGV
 DWKALSHALRGGLQLQEIYTTGDLVYPLKDAEFIKKVKAGTIPFKEVQEWLENCVDEVER
 QSIIASKNGMPDKVDMTFWDEFLEEVYLANHNSYYR
->CC31p099.p01
+>CC31p099
 MIEIEVVTTKKKLSMSLLKQMPMASISGIKFAMMDPSQRVLGYVNAFKWNKIDIQVAIIN
 IGSDWALVPLYETVLKEHVQREQHPDGQEYHTHEVKYYYSQQKVGNINRTSKKSEDKEHV
 EQCVKITNELVKFAKGQHIYL
->CC31p100.p01
+>CC31p100
 MFIRQVKAKGLVKKELEVGRSITVQSGTTEFDGEIDFISRCQGTTHIFLKINKNQRAVLK
 VYSTRIMIELFVYSEDKITSYGVTNVYVTSNRNKYLVDFTNFRPKEGRYTETYEAEASGF
 KNIPVVVGDVFQKGSKEFTVIAITKNGGTMFLESESGDGLPVNLNDTSLISAFGGQFTWG
 QPTK
->CC31p101.p01
+>CC31p101
 MLKQDHNYVINGESAKFNATVERGLMGLFPVAEFTFPDGKIIRVVHNNLKGTSTASDLMD
 RAIAYRNGSWRFV
->CC31p102.p01
+>CC31p102
 MQINTNSWHYKLVTMNGAESAPRSLCPYFWKGVWHTFLLAFAAFAVCFAGWGSGVDLATW
 LFAKCGVVLSSAAAIIPGLIVGWLILAAVFGTIFCIGYGIYKVISRRKEKKEAAEWEARK
 NGTYVPPQPNIIIAFIKARKEKFCPTLEFK
->CC31p103.p01
+>CC31p103
 MAKCTLDWKVPGLDATISYEAESVHGGHANIKTLLLVNDEKDVLTIISQGEEVELLKEEA
 EKLLSWLQVTIPHMTNSKNFK
->CC31p104.p01
+>CC31p104
 MSLSLELKDIIVTRQYDGIQYEICTHVSATGFLMYNFSTQYKPRLERFLKYHESLPYSSR
 IVRANSEEYTETMLKIQEQLKERARKEQANG
->CC31p105.p01
+>CC31p105
 MKDPWGYEQFHLGSLDIRTKEDEIVLEHAVPEGACYAGSPLRLSKEEALKVAFFILKLYA
 GEVNEPKS
->CC31p106.p01
+>CC31p106
 MKHTFESGSVHGPLVLEVRGNFCKLGHVDDEDLFKIHFRLDKAHLIECNQCPNIDYTDYG
 DDSFTFEAKDGSYGCVSFCSKKNLDNFLKAIKEMQ
->CC31p107.p01
+>CC31p107
 MASGWGPSDDGFAAIEATVSDGIEWARLELIKSQNRESEKYCEDCDGEIPEARRKAQKGC
 TRCVACQSSHDTIIKASYNRRGSKDSQLR
->CC31p108.p01
+>CC31p108
 MNRITKLSDFVPGRIMYHVYGVSRTETTVSLDEVSKYIILSKPYRSPTSDILMVDIICEY
 TDINGETKRSYRTQICPGDNAVFEDHKRKPHNLNRLFGDVESALEFMAELKANKFSSPED
 QEYADYWDTSPSSGRKNGLGHLR
->CC31p109.p01
+>CC31p109
 MKTKFEDFITTGKKLPEDEFIGLLMASASYFHSAHFETKSYARHKAYNFFFDAIPELTDK
 FGEQWLGWSGKKYTPSIPSQQDLPTDTIEMLDSITAKAESIYEKMPGAIRNTIDEINGIV
 FQTKYLLSLE
->CC31p110.p01
+>CC31p110
 MTLRALAAILFAATLISPVSAEEANFEQYADGAMAVYSKFKEPSKEESERFFSFIKQRWA
 ASSCTTQCTEEGVHAGKQYVSLTKVKLENEI
->CC31p111.p01
+>CC31p111
 MKHLNDKQLRNLGVSQLEEIKCEIGHAISSLNEEFRQHGARPDYLRKRQLQKYLDKVKAV
 LQHKLNTGQR
->CC31p112.p01
+>CC31p112
 MSRTIRRKGWHVTTSSKWHAQKNNKFAYIKRYTEYVKTKKDEEYQQKYVDKQIKENMERP
 LELASMMKERHRDSFWKTLRWMRYASPIPRVFHKMEIKHSLRNDTDYNWDEKAARKYEKG
 LCQMLWD
->CC31p113.p01
+>CC31p113
 MTIDVLFWLFAFPTAGFVIAALLGFLKILIEGKVSP
->CC31p114.p01
+>CC31p114
 MKLVICYRCLHVYDHDTATRTKTKRLRVKEVECPKCKCKVTLG
->CC31p115.p01
+>CC31p115
 MISTKQEALEELRDMLQRNTVVLGWSEKPVTFEELIRARQGDEIIDEIFEVIDR
->CC31p116.p01
+>CC31p116
 MNKNVKIFNTVLLAITLVAFVFLGIKGHAISKQIEANKLLADKVCQLVVEGDYVSEAYYS
 GNFECYKKVL
->CC31p117.p01
+>CC31p117
 MAQLYFNYASMNAGKSASLLTAAHNYKERGMGTLILKPAIDTRDSANEVVSRVGLHAEAN
 TITEDMDILEFFKWAQTQKDIHCVFVDEAQFLTQSHVLQLCQIVDLYNTPVMAYGLRTDF
 RGNLFKGSAALLATADKLCELKGVCHCGRKATMVARVDQEGNAIVEGDTIELGGEDKYVS
 LCRKHWCEMTGIYE
->CC31p118.p01
+>CC31p118
 MIVKYIKGDIVKLYSEGKVIAHGCNCFHTMGAGVAGQLASKFPVILSTDKAATDYAAREK
 LGTFSLALAAKGGACFNLYTQYEPGPNLDYGALVNAFQKMDKFLSGSLFKMEVHIPRIGA
 GIAGGDWEKIEALINMFTPNVDIVVVDWDGE
->CC31p119.p01
+>CC31p119
 MKIAAFLLALPLSVNAWEKLPGYPDNIYAINGRLVETTGSFKKNIEVSYYPKKKAFGVSF
 YNYSNKEDQAIIPGGSIHFRGCGAKSSGTIDGVSIDFSERDLKSFKNLTCGEEIYVRVYD
 EFENYATYQFKSIPELRKR
->CC31p120.p01
+>CC31p120
 MKKLFVLLVVFALSGCKVDFSTEQDDSLTLAKQFCTKTNTECLNILSFDFDKTYAEGQTD
 SGSRFKWSTLVARKAKDLESLCDNAPDMNVCEEYRDTLLRVYIAGLSK
->CC31p121.p01
+>CC31p121
 MKKALCAALLLVSSLGFASEHTFSNVQLDNLQYAYSFGEQFQKNGKYKDHSKRYDNNGLG
 YIMAALVWQESSAGLRTTGKHGHHAYGIFQNYLPTLRERVKQAGWSMTDAEIIRMAKNRK
 HSAAWAYIELSYWLDRHNGDMRKAIASYNAGNKWKAGNKYASEVLAKANYLKSRKMLHYT
 VE
->CC31p122.p01
+>CC31p122
 MTTNPEVFIRRNKLRRRFETEFKSVNDSIRSACASAGIPAFFIKYSNHLLDRAIQREIDE
 EYVFALFHKVHNHVTEIHEFLEMPMLPIDPSEIDPEVEYRPQRLEITDGTLWLGMTVSLP
 NPEHPFRGHSMQCRMAFVNDKRLKGKISTKIIKL
->CC31p123.p01
+>CC31p123
 MSIRNKVSESFSEAINAMEEKMEQLVDEAMKIHDPSTSEEFNRVQDKISKLRQRLADTKR
 LRNNVLLQVFYDDQNY
->CC31p124.p01
+>CC31p124
 MSIEDIKGYKPHTEDKIGKVNAIKDAELRLGLIFKALEEEHVKVYMDLDVDKISDEEFDL
 AHERITQIRNAIQHLKEASMWACRSVFQPEEKY
->CC31p125.p01
+>CC31p125
 MNAYQILNGTHKGTIYLEDGDKARVIVSKTLAEDSIVDVETFFGLESREVGIESQPVVKV
 EGGQHLNVNVLTKETLEDAVQHPEKYPQLTIRVSGYAVRFNSLTSEQQRDVIARTFTKEM
 
->CC31p126.p01
+>CC31p126
 MEAHANGVWNEETKQWEDAKTGLLISGYGINEPIKIREYDKETDEEIQYP
->CC31p127.p01
+>CC31p127
 MMKENFNKGLRALGMTTSEYIRFLRSTGKCDIESLINILHIKFSDGAVLEPKLYRFLDGP
 FKGSLFLCTSPDVGLMNEHPWFEVEFISGPCKGIKTSSLITYDRRVISLEPTWRKLLSTS
 PTTWLNLSATGFQTKANKI
->CC31p128.p01
+>CC31p128
 MEILEPWKALTNGNFMKTKSLFAPYLSLMHAFKIRADDCIEILKESHYTPIDILREYATL
 KIDGGRQSGKTKAIAEFAADWLHDGGTVWIISTHQRNSEETARRIRACYEKELIHQANPD
 EAKRMIIMDTVRSFLSNGGSKARGRTLNRILYIIEEPMKLPEMEKFYEAHFKGPFYACVH
 QSHISGEEMMPLFFVIGMQ
->CC31p129.p01
+>CC31p129
 MKTYNEFITEAAEQKRVPGGYIWIEEIKPGEDMGTYKVTIDDPKGKGRITLKDNIAGYKA
 ARTVATGHMRKVMVDNPSNKFAAKVFRRVGNKLHDPFS
->CC31p130.p01
+>CC31p130
 MTRINLTLVSELADQHLMAEYRELPRVFGAVRKHVQNGKKLKDFKISSVFILGTGHVTFF
 YDKLEFLHKRQINIIAECLKRGFKIQDTTAQDISDIPVEWRNDYIPTSDALKISQARLDE
 KIAQRPKWYKHYGKAIYN
->CC31p131.p01
+>CC31p131
 MKTYNEFMFEAKREMSGKELYAAATKGAEEIETILAAEFGKVSRVINQRDIDVNGTRVSV
 NFDPTTGTYFMMVGKDYHKGIKKDKLVGKIKSLTRK
->CC31p132.p01
+>CC31p132
 MDIFGMLRIDEGYDSKIYKDTEGFWTIGIGHLLTRDPSLDVAKRELDKLVGRPCNGQITK
 AEAEAIFAKDVDKATRGILGNAVLKPVYDVLDGVRRAALINMVFQMGVAGVASFPASMRL
 LKSKQWEAAAKELANSKWYRQTPNRAKRVIATFKTGTWKAYENL
->CC31p133.p01
+>CC31p133
 MSKKIKEVSAGIIFFTEDYELFMGRVTNSGLGGGPSRWDIPKGHIEEGETPIEAAIRECR
 EETGFVDYDQSLLVDLGRHDYASNKDIHLFQYMHPVEHSQFRDCICTAYHTDEDGNEFPE
 IDAFALIHPRMWNVVMGPSLFSVMQKLYPKVIQDALWEC
->CC31p134.p01
+>CC31p134
 MSIAVFVKSESADSYLYSFNDNESVDDIRNRLSTGLEMFTPISDWMVEGSFDSDEDMIEE
 VESIMQRLREISWGEI
->CC31p135.p01
+>CC31p135
 MSCPATIFTSLNGEINGSVHHNWGWIPPSDYEVATKVLRIVENVPGELRNGELAAKWDKL
 YIPPFGNMLKEKYWDMYDTLKNIHYGLMDRKDFKLSDFLEEKV
->CC31p136.p01
+>CC31p136
 MIKTLFRGFKDAGSYDNFGWTIGTIIICFMFTMLNGFGLYWGLYFFSPLYGEQLLFVGWM
 AGILTPFYWIGKWLFYLGQVQRGTFDQKKEWKLFKRKSKSKEVPSGEDALNFIQGIRGTR
 
->CC31p137.p01
+>CC31p137
 MKYNPKMNIRHFEREIADRFKSKYEDNVCWTIIILTVFLSNFAVWWFNGFVAEMIITVPL
 SALCSLFVVIVLASFIKWCYCKIHVKLFTKAKAIYDDKQNLENFISRCRIKR
->CC31p138.p01
+>CC31p138
 MGYQPKSELRELAAKAEFLHMIIFLAFSSVAVLLIFVPALILNDGVYAPIWVVVSMFLSI
 PVLLWSHGKSQEIAIWWVMRPENKRLAEQNAKVLHNRIIRESEEFITECRGKNEIQS
->CC31p139.p01
+>CC31p139
 MNSTELKAKIAKTDSLSTKVRYILTRNEKLCWCVALTLYGIIVFWGWSDITNLPKEERAD
 SAGAMAAFTCFGWGMFGIIVMLIGEFVNFIAQILIGMRRNRIISKLSKAERFECFINDCR
 KARK
->CC31p140.p01
+>CC31p140
 MLLVIGSRALHHHGLIEYSDVKNSDWDFIASPGEWLHFKNRMNGTEVEVQSPNVQAFKCM
 HNGRETYFEAYIFEYNDESSSELLAHYAVFNGCYDALSQMYWATPEMCLAIKMSHRFKKN
 TRFFQKTMHHIRFLRNKGIVLDSKLKKISELRQKETLAYSHPNLDVDKDSFFKDDFYIYD
 HDSIHEAVALAGRPAYTFYMKDGSEVMTSKEKFDSLPEELKLAGVYEETCVLALERHQIP
 NNFNPDPTGSFMYALEKVCTSITSGWFREYAWENYHKIVAMHKKLGKTDYVKRFKQNFDM
 IRPFK
->CC31p141.p01
+>CC31p141
 MKGLDRNCCYIIDHYFYYPNKYGSHDSCCLAVLMDVVICNGKLDTGIREAAGDIVLQLRE
 REHPWDSLPDQIFDLLGGWNWKKCYPANRPEEPIENFIRMCRKNRLQHQSSVL
->CC31p142.p01
+>CC31p142
 MSISKTWHKVFKSIQGLRSDEYYSFSSGINIPIELVTPQWIKPDSMGNEIAPGDIVALDK
 SGKYSGCMVGILLGWTEQGYRVAGFQTSTNFPEHRTIEGSLRSPHQVFLVKSMNSTVLK
->CC31p143.p01
+>CC31p143
 MMTNLAHMRTASKETVRNRKKKLKERMARIINNTSMEPSEKIFVKNAMKSIFDELSLIHQ
 NTAREHYEHQ
->CC31p144.p01
+>CC31p144
 MNQIKELYTKAKAWVKKTYDVDSPMNKFDWILIGVATGVVLTFIKSVIVSCGVLGILIHH
 AYKRG
->CC31p145.p01
+>CC31p145
 MKRCEIIGNIFTVVTLGALGTSIFGWPFLSNSELISSVVLTLVAGIISFVMDKIANEPN
->CC31p146.p01
+>CC31p146
 MKTYQEFINEATAPKTFVINTQASLDDEYAEAILKSLAKNGVEVSASDFKKGSSEMFVSI
 TKGSKAKIKSSFGVARTDQIDNHDFKQTGVKRQNTIASRGIK
->CC31p147.p01
+>CC31p147
 MINFQDLGSGLYVAAKFSDLTLDAIESLQRELKVPNPVPRHKIHSTICYSRVNVPYTCSS
 GSFEVARKGHLEVWDHGESPVLVLVLDSEYLKHRHRYARALGATHDFPDYTPHITLSYNV
 GPLSFKGEVQIPVVLDREYKEPLKLDWAEDLK
->CC31p148.p01
+>CC31p148
 MSEQIQKLEGTVTALKSRLFDANEEISQAQAVIQNLSAGFQEIIKLVGVTGDENGSVEIK
 AVVEAVRALVPEQLELDEVEPEAE
->CC31p149.p01
+>CC31p149
 MKLIFIIGKKRSGKDTTADYLANNYKTKKFQLAGPIKDTLADCWNPDLTQKTGVSLNRLD
 FEGKGYDREQILLLNNKDVIDYMKRCVYRLLDRKLKAGKRENGFFIHDNGDFSFSGNTKI
 EALINKNTKPWTVRRLMQTLGTDIFCNMVDRMYWLKLFAIDYVDSFHDDLDFYIVPDTRQ
 DHELDAARAMGATVIHVVRPDSESSQDTHITEAGLPIRDGDIVITNDGSLEDLYSKIEKV
 IK
->CC31p150.p01
+>CC31p150
 MDANQLFNQTNITNFIVDIPDAGLTKAFTLNVQSATIPGIRIPITETPSGQGGLARSQLP
 GSTFEHDPLVIRFLVDEDLNSWLQMYQWMLSINNYIDFNSQAWKPGFTPPHVSVHMLDNS
 KKKIVMSFHYYGAWCSDLGEVEFSYTEDTDPAVICTAMFPFKYLQIEKDGKIIVGKQNIE
 QAAQSRSSVGMHPSMR
->CC31p151.p01
+>CC31p151
 MAIFELLNEGAQPIARTVPKDERKWVEIGVEYAEAKKKGATAKSFAEEKGIKYATFTKAM
 SRYASRIKTAVQVAKLEGKSPKKLTRQERQLVMINSFRQSIRQKIANEGAAVNNKSARWF
 NETMKKNIRGHQVSKPTPGKLYAYMYDAKHKDTLPFWDRFPLIIYLGLGKQGSTTLMYGL
 NLHYIPPKARQQFLEELLKQYANTPTITNKTKLKINWSQVKGFAGADKMIKAYLPGHIKG
 SLVEIKPADWANVVMLPTQQFMSKGKRYSATAVWKS
->CC31p152.p01
+>CC31p152
 MAYSGKFMPKNHEKYRGDIRKITYRSSWESWFMKWLDANPEIVKWNSEEVVIPYFCNAEG
 KKRRYFMDFWFRDVNGQEFFVEVKPKKETQPPPKPAKLTTAAKKRYIDEIYTWSVNQDKW
 SAAQKVAEKNNIKFRLLTEDGLKRLGWKG
->CC31p153.p01
+>CC31p153
 MLFSFFDPITYTAKTVDENAKPISMTDIFRNYKAYFKRVAANYRLRTYYIQGSPRPEELS
 NIIYGNPQLYWVLLMCNDNYDPYYGWITSQEAAYRASEQRYENAGGNQVLYHVDAKGERY
 YNLVESETNPGTWYDKGDTLQEHPQYQGALAAVDVYEAAILENEKKRQIKIISPADIDTF
 IADLIREMEIA
->CC31p154.p01
+>CC31p154
 MEMISNSLQWFTGVVEDRMDPLKRGRVRVRVHGLHPFQKTQGPVMGVPTEDLPWMSPIFP
 VTSAAISGVGGSVTGPVEGTHVYGHFLDKYRQNGIILGTYAANATARPNRTEGFSDPTGQ
 YPRYLGNDTNALNQGGVEGDDYTANIVQDNNLDTGINPDDTDLANIPEDNNPNYTIEAML
@@ -4550,14 +3984,14 @@ GSDDPWGPPIPQTGRILFKEPESSYNGQYPYVHTMETESGHIQEFDDTPGYERYRIVHPT
 GTYEEVAPDGRRTRKTVGDLYDMTGGDGNILISGDKKVNVGGDETYYNMANKTTQIDGSN
 TLFIRGDETKTIEGDGTLYVKGNIKIVVDGNADILVKGDAKTQVEGNHDYTVNGNVTWSV
 KGNVSMNVTGNWAETMQTMSSKASGQYTVDGSRIDIG
->CC31p155.p01
+>CC31p155
 MVDILPVSTELPDIQEGGSVNQTFTAQLEATDTLESINIIDFQPTPGITVSGANYTGVYE
 SVFSFGGDALKYREGNEFKVAQSWESLPPPGTADLYLWKAPSKLERTFTYTVKVTYWRQG
 EDTTGPSGEPVTPPPVKMEMTKTYSQLVYGNWSKWAEQLRSYVYARP
->CC31p156.p01
+>CC31p156
 MAGLSYDKALTAGHSAYPPTQVNATQGKVFVGGIAVLVDGDQITPHTKTVKPYDTHGGSV
 QPRTSKVFVTGKKAVQMADPISCGDTVAESSNKVFIHG
->CC31p157.p01
+>CC31p157
 MATTEPFNYQLKRTANAIPEVFIGGTFQEIKKNFVDWLRGQNEFLDYDFEGSRMNVLLDL
 LAYNTLYIQQFGNSAVYESFMRTANLRSSVVQAAQDNGYLPSSRSAAKTEIMLECTHALN
 ENSLRIPRGTRFLAYARDTSADPYPFVTTEDVIALKDQNSLYFPRVKLAQGRIVRTELKY
@@ -4569,7 +4003,7 @@ IKVTYALNKLQESEQWLHGQIIDKIDEYYTNEVEIFNAQFAKSRMLTYVDRADHSIIGSS
 AEIEMVREVQNFFETPSAGIKYYNQITPRSLKSSEFKFTKGTSSYMVRLAGTVGDSKKGK
 VVLGPFKAGDLVATPAAPIYTGSDFEKLPVTDGRNTYFVVGEVDYPSDYIYWNIAALNIN
 SSLFDVQSIELYALPKENNIFTKDGSLIVFENDLRPQYTTITLEPIAQ
->CC31p158.p01
+>CC31p158
 MTVKAPSVTSLRITKLSANQVQIKWDDVGANFFYFVELAETRNSNGEIILPENYQWRNLG
 YTAENEFFEDNYIRPLSYYVMRVAVAAEGFEQSNWKMTEEFQSFETNVYTFEMMREMTLS
 KQFIEEKFTKNNQDFVNFNRDTIMASLMDETFQFSPDYRTSSSVDNFILKEDEYHEIQGD
@@ -4588,21 +4022,21 @@ GVRGKELVENTIEYINRNRSYYVMKIKSNLPTSRYRNDVLRFVHPVGFGFIGITLLTMFI
 NVGLTLKHVQTIINKYKNYKWDAGLPSIWADRVAQLDSNGDIEHDPVTGEALYLPHPRAG
 EDFDIPADYDAENNNSVIAGQLPSERRKPMSPTFDQSAVTFSNWRDLVDARLIDKVNIPR
 DPANPTQVKINE
->CC31p159.p01
+>CC31p159
 MNDSSVIYRSIVTSKFRTEKMLNFYESIGDGDNQNTIYITFGRSEPWSDNESEVGFAPPY
 PVDNTQGVEDMWTHMMGSVKVMPSMLDAIIPRKDWGDIRYPNPRNFAIGEIVVVNSAPYN
 ATEVGSGWMVYRCIDIPDAGTCSINTIKNKEECIKLGGKWTSSVQSAFPPRGRGDATNDN
 KIDMKDGYLWEYLYEIPPDVSINRCTNEYIVVPWPDEVKEDPERWGYNNNLEWEHDAYGI
 IYRVKAYTIRFKAYFDSVYFPEAALPGNKGFRQISVITNPLEAKKIPSEPNKKAKNLWYN
 PIDLSRHSGEMIYMENRPPIIMAMDQTEEINIIFEF
->CC31p160.p01
+>CC31p160
 MFEQEAKQLIDVGEIGNASTGDILFDGGNKINDNFNGIYNAFGDQRKMALDNGQGQGVGQ
 VIHATGYWQKSNDPLEFTTPVPNGSQYDIDTSGGAVQVTLSKGVRGEAVFFCNSNGSFSP
 TNPLTIDANDTFATVTGSLRITSPYVFVKCWCISDEGGRSVWDYSVESMFGEKHIPTDGT
 WQLGAAGTSTNIPLFHNTEFTVAKYLITAETSNGSKAKSCEINIHIDRVKREVNSVEYAV
 IRIGAVDTPATSTTPEVIDKIFVPSFSINPTTGYVVLTLTPGVAGLKAAVKAIATQKIGN
 PR
->CC31p161.p01
+>CC31p161
 MKQDIKIGQAVDDGSGDYLRKGGQKINENFDELYYELGDGDVPYAAGAWKNHKTSSGATL
 TAEWGKAYVLDTSTGRMNVRLPKGTANDYNKVIRFRDVYATWQVNPVTIIPGSGDTLKGD
 SRPREIRTQFADLEMVYCPPGRWEYVENKQINRISNSELSTVVRKEFLVKTAGQTDFPDV
@@ -4614,12 +4048,12 @@ RITDQNKPGWPNVVPEPAQSIEVNNVQNLFDLVYPIGTIYENAVNPNNPATYMGFGTWVL
 WGQGKVIAGWNNDTTDPYFAMNNNDLDVNGNPSHTAGGTGGTTSNELENAQIPAAQTTEK
 VLVVDPNGPIVVGGCQFDPDEQGPAYTKYREAVANINPTHTPPKSVNNVQPYITAYRWLR
 VS
->CC31p162.p01
+>CC31p162
 MISVSSSKAGLKSRSAAFLQYELASGSIDVMNTQPLGSNTISQKYQGVDFPNVQSAIEDV
 RGFAILPIGSIVINDTGTSPEGIQQIDDWTFTGTVEFEGKTTGDSVLVDVYGFMVPALVG
 DTDTEFTAKVKTTLENAITAGEIISSVEVSSSAGNILNVKYIDNQEHVLPSYSSCGISIS
 ASIQSPSKVGYGSWELIGRQSLTFDGASAPTVLQYFKRMG
->CC31p163.p01
+>CC31p163
 MATNTLNHISDESKYKTFNPAGTSFPSNITNVQAALAALKPIAVNGVPDATETVKGIIRI
 ATQQEVNDGDSANTVVTPKTLKERLGNPQATETTIGLTRYATTPEAIAGTVSTAAVVPTG
 LKGAIDNAFTTRTAKESVLGVIKLATIAMAEAGTDDTSAMTPLKTQRAIAKATAVLPVYG
@@ -4629,7 +4063,7 @@ TARVNGRLDMGSGFINNQQIATVNMLVDSVPIGTIIMWPGQNPPSSDWMHCNGALLNRSD
 PQFSTLFSIIGILYGGDATRFALPDMRGMFPRGVGKSNIMNQYSGNDSKGKPGLGAGCGG
 ASLGQSMPQSVRKHKHESGWGEHYKRSDARNGCTVRNGYLGSNRSDYDNYKYFTNDGDEV
 EPANIRDSFGTMNTEGLMGDENRPWSIALNFVIKVR
->CC31p164.p01
+>CC31p164
 MSTIDLTPLPYVNGLPDEGQSRVNWIKNGEELTGASTKNGVDGNLNRGPVQVQQNVEVLD
 GNIVVVRDSLEQSNVRIKNVEDALGVIGDVDVVKQIGINTAAIKVLQTDTGELKTTSEDH
 GLRITHIEEDVGEYDPSRDSVYRPVREDLLWIKTELGAYPGQDINGMSVPMAPGRGLKKR
@@ -4638,30 +4072,30 @@ NSIGSLASDMENVLDSIGYTNGVTNLYQKVVINENGITEINRKLSDQTVGLIPRVDLIES
 AIGKDSQPSTINGRIKINSNEITALKSIVGADTSSGLRGQVAWINQVVGITESGQPAPTN
 SLIGQINTLTTMQNQMANTIQDIQVDIGNNNEGLKGQVIRLNSIVMGTNPNGSTVEERGL
 LSTVKTHDTDIASIKLAQNNFISEAPKDGKAYVRKDGAWVDLDTILNPTP
->CC31p165.p01
+>CC31p165
 MAANTARNPKELKDVILRRLGAPIINVELTEDMIYDCIQRALELFGEYHYDGLNKGYQVI
 HIGDDEIGCGQFKNGVFDFSDRNIFAVTQIVRTNVGSLTSMDGNATYPWFTDFLLGMAGI
 NGGMGSSCNKAYGPNAFGADLGYFTQLTTYWSMMQDMLAPLPDFWFNDATGQLKIMGNFQ
 LGDVIVVECWTKSYIDVDKMVGNTAGYGTAGPETSWTLPDVYDNPDKRLTGYRAGEELSI
 VQGSYNNRWVKDYAHILAKELLGQVLARHQGMQLPGGVTLNGERLIEEARLEKEYALEQL
 YLLDPPTGVLVG
->CC31p166.p01
+>CC31p166
 MMNKNLFAKLENKSGYSRTNEEEVLNPYVNFHNHFNTQALFDTLVAESIQMRGVKCYYVP
 REYVKPDYVFGEDLQSKFTKAWQFAAYINSFEGYEGANTFYSKFGMQVNDEVTLSINPGL
 FKHQVNGQEPKEGDLIYFPMDNSLFEISWVEPYDPFYQAGRNAIRKITAEKFIYSGEQLK
 PELQRNDGINIPEFSELDLDPIHELDGLSDINEVPYQEVDQMNDEADKDVKQYEVVNGTG
 SPKVEPPRNRPPANHVASPFDDGFML
->CC31p167.p01
+>CC31p167
 MLGDLFSNIQVQRVREDIGKTYIRVPITYASKEHFMMKLNKWTSVNNEDGPAKVETILPR
 INLHLVDMMYNPTYKTGQLNRSAMSNPNSKTGTISQYNPTPIKMIFELGIFTRHQDDMFQ
 IVEQIMPYFQPHFNTTMTELFENEITFERDIRITFQSISIDEQIEGEKQSRRRLEWAIMF
 EVNGWLYPPAFDLSGEIRTIYLDFHANSRELVNEGVFESVDSEVDPRDVEIQDWDGKSIQ
 KYDSDSTPIPKEPEPPGPRGV
->CC31p168.p01
+>CC31p168
 MSEQLDITKLLDIGDLPGINGEEVITYEPLQLIPVESHPQNRTPDLEDDYTIVRRNMHHQ
 SQMLMDAAKIFLETAKNSDSPRHMEVFSTLIGQMTSTNKELLRLHKEMKEITNENTNTKG
 AGNQAVNINNATVFVGSPSDMMDEYGDAYEAQEAREEKVINGTTS
->CC31p169.p01
+>CC31p169
 MEQPLNVLNDYHPLNEGQKIVIRPPGSLEKKIEDGITFFKSQWDEKWYPEKFEDYLRIHQ
 IVKIRLQGEDPTNFGTFKDKNNKRSRYMGLPNLKRANIKTNWTKEMVQEWKKCRDDIVYF
 AEKYCAITHIDYGTIKVQLRDYQRDMLRIMSSKRMTCCNLSRQLGKTTVVAIFLAHFVCF
@@ -4673,7 +4107,7 @@ PQWEQVGVLHSNSISHLILPDIVHKYLMEYNEAPVYIELNSTGVSVAKSLYMDLEYENVI
 CDSMVDLGMKQTKRTKAVGCSTLKDLIEKDKLIIHHKATVQEFRTFSEKGVSWAAEEGYH
 DDLIMGLVIFAWLTTQTKFADYADKDDLRLASEVFRNELEDMNDDYAPVVLVDDGRDVTD
 YTPTHGVSFI
->CC31p170.p01
+>CC31p170
 MALLSPGVELKETSVQSTIVNNATGRAALAGKFQWGPVGQVVQVTNEVELVDIFGTPDSQ
 TADYFMSAMNFLQYGNDLRISRAVNREVAKNSSPIAGNVQITISAAGSNYAVGDTVRVKY
 NVNIIESAGKVTQVDGNGGILAVSVPSAKIIAYAKSINQYPDLGSNWTAEVTSASSGVAA
@@ -4686,11 +4120,11 @@ TDNISQPWMSPAGYNRGQILNVIKLAIEPRQSQRDRLYQEAINPVTGTGGDGFVLFGDKT
 ATKVPTPFDRINVRRLFNMLKTNIGNASKYRLFEMNDNFTRSSFRMETSQYLSGIKSLGG
 VYEFRVVCDTTNNTPAVIDRNEFVASFYIKPARSINYITLNFVATATGADFDELIGPQAQ
 
->CC31p171.p01
+>CC31p171
 MELTDLTRAFESGDFARPNLFEVEIPYLGKNFSFKCKAAPLPAGIVEKIPVGYMNRKLNV
 AGDRTFDDWTVTIYNDDAHNTRQAIVEWQGIAAGQGNEITGGSPAEYKKKAIVRQFARDS
 KTITREIEITGVWPTNVGEVQLDWDSNNEVETFEVTFCLDWWL
->CC31p172.p01
+>CC31p172
 MKFDVLSLFAPWAKVDEQEYDQQLNNNLESITAPKFDDGATEIESERGDIAGAGLFQRMY
 GQNEPGMKNTRELIDTYRQLMNNYEVDNAVQEIVLDAIVYEDEHPVVALDLDKTNFSPAI
 KDRLQEEFNEVLTCLNFERKGLDHFRRWYVDSRIFFHKIINPKNPKEGIQELRRLDPRNI
@@ -4700,25 +4134,25 @@ HIMNTMKNRVVYDASTGKIKNQQHNMSMTEDYWLQRRDGKAVTEIDNMPGATGMNEMDDV
 RWFKNNLYQALRVPLSRIPNDQQGGVQFDAGTGITRDELQFAKFIRELQHKFEEIFLDPL
 RTNLVLKGVMSEDDWKDEINNIKIVFHRDSYFTELKDAEVTERRFNMLQMAEPFIGKYIS
 HQTAMKTILQMTDEQIEQEAKQIELESKEARFQDPDQEQEDF
->CC31p173.p01
+>CC31p173
 MEDFISALKSNDLVKAKKAFGAIMLEQTADLISQRRVEIAQSIMIEGEEKEDDEDENDDS
 EDEGKEKPESKDEKDSEDED
->CC31p174.p01
+>CC31p174
 MLIVPDEYEVVLENIEAAIPEAESRFKQLSEALDKADINTIVENMLPIEPEVAIAMGSLN
 EEMQLNEFIVKHVSSRGEITRTKDRKTRERQAFQTTGLSKAKRRAIARKVVKSKRANPSG
 TVRGNRKRKKAMKRRQALGLS
->CC31p175.p01
+>CC31p175
 MNEPQLLIEHWGQPGEILNGVPMLESYDGSDAGLKPGLYIEGVFMQAEVVNRNKRLYPKR
 VLEKAVANYIKEQVSTKQALGELNHPPRANVDPMQAAIIIEDMWWKGNDVYGRARIIEGD
 HGPGDKLAANIRAGWIPGVSSRGLGSLTETNKGYRIVNEGFKLTVGVDAVWGPSAPDAWV
 TPKQISESAEAQVAKKNDDESFKALVESLEKAL
->CC31p176.p01
+>CC31p176
 MLKDILLQEAQNIEATVAVDSIFESVELSPEVKAKFETVFEATVKKHAVELAESHITKIA
 EMADEKLKDAKDEAEEKAEKKLTEHASRFFNHIAQEWMNENKLAVDKGIKAELFESMFAG
 MKELFVEHNVVLPEESVDVVAEMEEELAEAREEISNLFEGISARDEKINTMLRESAVMES
 TKDLTDVQKEKVASLTEGMEYSDEFSSKLSAIVEMVKGSVEKEVVNESINTTDNDADGLN
 FITEEHIEPEEKVSKQPSMMDAYVASAARLS
->CC31p177.p01
+>CC31p177
 MKKINPLVEKWTPLLENEALPEIVGAGKKALIAKIMENQESAIKTEPAFRDEKIAEAFGS
 FLTEAEIGGDHGYDAQNIAAGQTSGAVTQIGPAVMGMVRRAIPNLIAFDICGVQPMSSPT
 GQVFALRAVYGKDPLAAGAKEAFHPMYAPDAMFSGQGAAEKFAAVKAADVLTVGTIVVHD
@@ -4728,7 +4162,7 @@ INREVVDWINYSAQLGKTGMTQTVGSKAGVFDFQDPVDIRGARWAGESFKALLFQIDKEA
 AEIARQTGRGAGNFIIASRNVVNALAAVDTGVTPAAQGLGQGFNADTTKTVFAGILGGRY
 KVYIDQYARQDYFTIGYKGANEMDAGIYYAPYVALTPLRGSDPKNFQPVMGFKTRYGIGI
 NPFADSASQQPNARIQSGMPSIVNSVGKNAYFRRIWVKGL
->CC31p178.p01
+>CC31p178
 MANIHDLLRESTTTTSSISARPSLVALTRATTKLIYSDIVATQRTTQPTAAFYGIKYLNP
 NKELTFLTGATYAGQTGTEDRKSIETLTASNKDSFGKGDLFKYDDIVYKVLVDNPFDQIT
 ETDLEVVIQISLVKLTTRLMSDAAITSKFETAGADIAEAKFQIDKWQTQVKSRKLKTSLT
@@ -4737,40 +4171,40 @@ ASAPEAGRSLYRMVCEMVSHIQRSTSFTATFAVASTRAAAVLAASGWLKHKPEDDDYLSQ
 NAYGFLANGLPLYCDTNTPLDYVIVGVVEDIGDKEVVSSIFYAPYTEGIDLDDPEHVGAF
 KVIVDPESLQPSVALFVRYALSANPYTVAKDEKEARIIDGGDMDKMAGRSDLSVLLGVKL
 PKIIIED
->CC31p179.p01
+>CC31p179
 MRLALIGSRETPRRVLDVMSLTGQALSESGHFSYSGGAPGADESWLSRYDRERSLRIIPY
 EGFNGLKTGVGVKVWKDFPNEVRIRSVIKAREVTSYWDECRDIVKTLFARNALQVLGEDC
 QSPVDMVLFYAPIKLSSVTGGTRVAVDIAKRHGIPCYNLYEKEIYQRFKEKYAPTFDIFA
 L
->CC31p180.p01
+>CC31p180
 MFEKYSTLENHYNGKFIERIRNAGFDVSETWVAREKIHGTNFSVIVTKDSIQPAKRTGPI
 LPAEDFFGYMVIMGRYNESFKAVQAALTGATVAYQIFGEFAGGGIQKGVDYGEKDFYVFD
 IKVTTESGESSYVDDFMMERMCNVFGFKMAPLLGRGKFDDLIQIPNMLDVVVNRYNQAIE
 AHGLEEANTMPFQAVVSESNIAEGYVLKPCYPKFFPNGSRVAIKCKNSKFSEKAKSDKPI
 KAKVELTDVDKVAFSTLAAYATLNRVNNVISKIGQVGPKDFGKVMGLTVQDILEEAGREE
 IFITDADNPDVVKKELVNYVQGVIRPVWIELVSN
->CC31p181.p01
+>CC31p181
 MAESANTNLPKEVQTHIEDHLRDAAARGKFEALYIIPSEWYSHETAIKGFLNKEKFSYEF
 NSDYQGKSFKIKF
->CC31p182.p01
+>CC31p182
 MTPIEIHFKHECGLSFIEIAREAGIKPEEAALYYAKVESAKAKSKRKEKVVYRKRLSNVD
 VKSRHQKTFAVHEDFVMTHYPEKHIGYATVVIKNIKHALDNTFVAAAHGYNKFLSPSAFA
 RALSDYEQQESKFYKSGTKIMVEVEKSLNPSGMVLDWMRMKVDEDYTITSGMKCKLVCKR
 DARGNKKYKVIPL
->CC31p183.p01
+>CC31p183
 MVVVQSSVTDTLDYTADSAGTKVVKVTSTTKAGEDPDDIQTATTNLTVNDVMNLTVTISA
 QSQTVKVGESYSATCGVTGQPSGATLAYKWSTGETTADISAVAQTEGNVALTCEVTAKAT
 GYEDTVKTSNVLNITVEAAEPVVPDECPILYVHPLPHRSSAYIWAGWWVMDAIQKLTEEG
 KDWKTATASDTPYYCHLATLAKMIEDYPEVDVQESRNGRIVHRSALEAGIIY
->CC31p184.p01
+>CC31p184
 MATTVDLTPLNPTIKVGDSQQFTATVNGAPEGATITYEWL
->CC31p185.p01
+>CC31p185
 MLDKDYIAEIGALEKKEAKEKLAEYAETFGIKLKKTKAFDNMVADLEVELAKLAEEPMPE
 DNDGLSIYDLIQADDEAKGTAIFKDEAKEEARLLIDSVSADAPQVKVTDIDPHFGKPMDS
 VKGVILEAPIGDSVIAVSDDGEVHKIPVGNMTQDEFNEAMDKVVKVIETDTFELPADFSP
 SLHLIGRNPGYATLPWWIYQWILENPDWKSRPLSFEHPTAHQTLLSLIYYIKRNGSVQVR
 ETRNSSFVTLS
->CC31p186.p01
+>CC31p186
 MHDINVKFHDFSHVFIECDESTFHELRDYFSFEADGYKFNPKYRYGHWDGRIRLLNYDRL
 LPFGLVGQIRKFANSMGYSVYFEPKIFETEEITREAFDDWLGNLNIYSGSKKIEPHWYQK
 DAVFEGLVNRRRILNLPTSAGKSLIQCLLARYYVENYEGKILIIVPTTALVDQMINDFCD
@@ -4780,30 +4214,30 @@ LRYPDEFTVKMKGKTYQEEIKVITNAKRRNKWIANLAVKLAKRDENAFLMFKHVAHGKEL
 FEMIKELGYEKVYYVSGEVSTEVRNALKVMAENGTGIIVVASYGVFSTGISVKNLHHVIL
 AHPVKSKIIVLQTIGRVLRKHDSKSVATVWDIIDDMGVKPKSANAKKKYVHLNYALKHAL
 ERIQRYADEKFNYVMKQIDI
->CC31p187.p01
+>CC31p187
 MKTFEEVIYEATIDTFMSKIAQCQTLEGLEELEAYYKKRVKEADLKDTDDISIRDALAGK
 RMEFESEDESESEEEF
->CC31p188.p01
+>CC31p188
 MSEKICAVCKQPIDSALVVETDKGPVHPGACYNYAIELPVSESAEEQLNETQLLM
->CC31p189.p01
+>CC31p189
 MKLEDLQEELKQDLIIDSTKLQYEAANNPVLYGKWLTKLSAIRKEMLRIEASKKSALKQK
 LDYYTGRGDGDEFSMDRYEKSEMKTVLSADKEVLRIDTSLQYWGILLEFCRDAMDAIKSR
 GFSIKHIIDMRRFEAGD
->CC31p190.p01
+>CC31p190
 MANINDLYSDLDPELKMNWSKDVARARGLRAIKNSLLGIITTRKGSRPFDPNFGCDLQDQ
 LFENMTPLTADTVERNITSAIRNYEPRIRRLQVNVTPVYDDYTLIVEVQFSVIDNPDDLE
 QIKLQLASSSRN
->CC31p191.p01
+>CC31p191
 MNYDYKFEVQINGSDIQCRAFTLEEYKELIDGKINGNIGEVVKRLINNCTSARNLNKQES
 ELLLIQLWSHSLGEVNHENIWICPEGHETLTPINFTSAQIDEPEELWYPLANFKLKLRYP
 KLFDDKNIAQMIATCIEYIYVNGETISIEDLNDKEIDDLYSAITEEDIIRIKNMLLKPTV
 YLAVPVKCQKCGATHVEVIKGLKEFFRYL
->CC31p192.p01
+>CC31p192
 MQHKTYEEQKVIIKELLADYFGEYPETLRPYMFMKVFTGSIGKTKIPVAFTCPTCEKQKQ
 VLFDISQEDLVEPTIEVAGITIAFKFPEKEYEDKAAMIYDCIKAIKYNNQWYPWKEMSED
 NQIQVIEAIDFTTFEKIYTQLTPMRFELKMKCCELRTNVYEDILSVFKLLINPDEIFSFY
 QINHTLVKSSYDLNSIMGMIPIERSIALSLVEKDNKK
->CC31p193.p01
+>CC31p193
 MTVLQRPGFPNLSIKLYENYDAWLDNRFLELAATVTTLTMRDGLYGRNEGMLQFYDNKNM
 HTRMNGDQIIQISVANANSKRTLNRIYGCKHFSVSVDSKGDNIIAIQLGLVHEIINLKFS
 RCFFNDAGESIKEMIGVIYQETPHIAPAINSINTYVPRVPWTSTLKDYLAWVREISLAVE
@@ -4811,11 +4245,11 @@ SDQFVFVWEDIYGINMMDYAFMIAQEPIPVVVGEPRQIGQMVNELNTDLAYDFEWLTKAN
 QFTRNPMANATFYAHSFLDNQFPRIVTGDGYNSVLVSRSGSYSEMTYRNAYEEALRLGTM
 AQYDGYAKCTMVGNFEYTPGQKINFFDPKNQFRTNFYVDEVIHEVSNNESITTLYMFTNG
 QNLSPVEPIKVKNEFKPNTSNENNSSEPEGNKNS
->CC31p194.p01
+>CC31p194
 MKTIQVNQKEIKIPKLGLKHHNMLKEVKSPEENLSLLINSIHPGLTPAEIDYVSIHLLEF
 NGKIKSKVVKDDFEYDLSTLRIVQRLEFQFAGHTFKFRAPEQFEGFGGVDKMLSKCLETV
 DGKKEDVDFMKMPAFVTKWADDISSTVAVSGPNGDIRGVAKIIGIFE
->CC31p195.p01
+>CC31p195
 MKTENMKTMRRKVIEEGRSERDAAKAASTQAESLSVLSSQLDDLQTQAELTSEVIEDKGN
 QVIDALNRVDQSIIDTTAGAELTAEASERTTEAVKQQTEVSNKISDKLSKLTELLNERLS
 AITPNLPQISVPDTSLSVVEDAVPVDIVTPGLPELLQELIPDPVNNTNNPNDAFFPTVPE
@@ -4826,24 +4260,24 @@ RTGNSLSKEDQDTLAKYQSSKIEKGENFFDKVSQGKTWIVNKITGDANISDFVTDEERTA
 QNEKLRQMKPEEREQVLKKGNEARAAIVRFEKYMEQINPDDKRSVQSADKAYANLQTQLN
 DTDLNNSPITKKELNARMNIVTAKYDKLKGKEPQPAPSSQSEDVKKVESIEKNKAAEKAS
 LGTGAGAAAANLFNTNNVINNSRTINTVSPVTSTNAPGVFGATGVN
->CC31p196.p01
+>CC31p196
 MAIRATEILDKAFGSGEKTSAGQSSISSTRRSTVTAQYPAERSAGNDAAGDLRVHDLYKN
 GLLFTAYDMSSRTTPDLRSMRQSQLSKSASSILNSLGIKNNGQVDKSPIANILLPRSKSD
 VESISHKFNDVGDSLMTRGNNSATGVLSNVASTAVFGALDSITQGLMADNNEQIYNTARS
 MYAGADNRTKVFTWDLTPRSVADLVSIIQIYEYFNYFSYGETGNSTYAKELKGQLDEWYK
 TTLLSPLTPDGADLNNTMFENITSFLSNVIVVTNPTVWFIRNFGKTSKFDGRAEVFGPCQ
 IQSIRFDKTPNGQFNGLAIAPNMPSTFTLEITFREILTLNRASLYAEGF
->CC31p197.p01
+>CC31p197
 MLNLDEFNNQVMNVDFQRTNMFSCVFATSPSAKSQLLLDQFGGMLYNNLPVSGDWLGLSQ
 GEFTQGLTSIITAGTQELVRKSGVSKYLIGAMTNRVVQSLLGEFEVGTYLLDFFNMAFPT
 SGLMIYSAKIPDNRLSHETDWLHNSPNIRITGRELEPLTLSFRMDSEASNWRAMQDWVNS
 VQDPVTGLRALPVDVEADIQVNLHARNGLPHTVCMFTGCVPVSCGSPEFTWDGDNQIAVF
 DVQFAYRVMQVGAVGRQAAADWVEDRLVHAIGNISDDMGLDSSLSRLSRLGGAAGGITQM
 GNAIGRKTGMWNSTSKILGL
->CC31p198.p01
+>CC31p198
 MKSILRMNGQETVVEGVVPVSDEFNNMVFNEIQKIAKGMVEMVPLAPFGIPEDKCEGYIA
 YTLNGKFNGEVPFKITVTNIEQSSEVVLNAFVVFRK
->CC31p199.p01
+>CC31p199
 MTEFQLNEIFDADSEMLPVTNLYPKTKIPQIFAIAAPEGSVALRMCSYTGGGDVNKNVKP
 GDKMMHAIVLGVSEKGTLVKLKNLGGNPLGVISTMFDLVSQTVKKYKMDAVMFRINKSKM
 GGQARAVQMIINRLVMSRLGGRFVILKELYDYDKKYVYVLIHRKNVDLSTIPGIPEISTE
@@ -4856,10 +4290,10 @@ WRSQSVRKPIFEAMVKNRVFYFRNYVSTSLSPIIFGGWKGNQAVAMASDNTRAVLNQPDN
 SAETVKLASMTYAELGLTDEVHAAKDVQQAESTRVMIGWAITGGEKVNVVYPGDLSNMSG
 EMEVILPRGTMLKVNSIVDASYSDGLVYDNQKFIQGEVMTADQLDEAVVYDGDVLMETGE
 VVEYSDEPQPEPSPYDFEGFVKSTKASESNKILALLASMIDVEDTPEKFVL
->CC31p200.p01
+>CC31p200
 MKFYLEIITIAHPGEGSGRAANVTQSLVELPFRPQGEVESFTDGRVSGINKHEVIATRGG
 GKVEIFRNIIAV
->CC31p201.p01
+>CC31p201
 MILDIINEIASIGSTKEKEAIIRRHKDNELLKRVFRMTYDGKLQYYIKKWDTRPKGDIHL
 TLEDMLYLLEEKLAKRVVTGNAAKEKLEIALSQTSDADAEVVKKVLLRDLRCGASRSIAN
 KVWKNLIPEQPQMLASSYDEKGIEKNIKFPAFAQLKADGARAFAEVRGDELDDVKILSRA
@@ -4869,104 +4303,104 @@ ALELMVQGYSQMILIENHIVHNLDEAKVIYRKYVDEGLEGIILKNIGAFWENTRSKNLYK
 FKEVITIDLRIVDIYEHSKQPGKAGGFYLESECGLIKVKAGSGLKDKPGKDAHELDRTRI
 WENKNDYIGGVLESECNGWLAAEGRTDYVKLFLPIAIKMRRDKDVANTFADIWGDFHEVT
 GL
->CC31p202.p01
+>CC31p202
 MINVIEWFPQTDKTKRLESFANKEEFFKARNIHADNQKQREMIDAMFNGAIYITRKNGGV
 LYHRTLAELIREYRGQ
->CC31p203.p01
+>CC31p203
 MSNKPIISTDVDGVLVKWQSGLPYFAQKYNLPVHHILEMIIDDQFVAPKDLFGVDEEFAQ
 QLMVKYNCSDFIRYLAAYDDALKVVNALKDKYDFVAVTALGTSVDAKLNRQFNLNALFPG
 AFLETFICDHAEPKTKLFEKIKEKYGDRVVAYIDDLPHHVDSAYEVFGGEVNCMFMPRGQ
 RDTSSKYGEKVHNWEHVQRLMNQREFQESLGDKLSDLFKKVEKTTPNWPFDKFPEFPKKW
 VNPGPSDYKPWYEHPGNLPVYNPGVGYGIGTGIEYLNRQPTAKTTIGKA
->CC31p204.p01
+>CC31p204
 MQVKYDMKGLDVLKRLNQGGIKVGELTTLLSGVGQPSLPGKSCIAAYMIAKMKAKNVK
->CC31p205.p01
+>CC31p205
 MKYHILQAVQLRKGGIPGVICDTAEAIPEYGVQPAYEVQWVDGNTDIRLECEIEPLKAAN
 DEIYETV
->CC31p206.p01
+>CC31p206
 MIITIPRNKAPEFERGMLSNPMIEVLGVTVSDTEVKYQLECPDFFRQIPTYAVAE
->CC31p207.p01
+>CC31p207
 MSIIDKEFKLTESGVTCLKNRGSSYSDELLKLLNNGLTSFTVKKIDGGGNIIAIDVDGKL
 HHANVGVFNVVWCFFLATDIHKYLEEVKQASVDKDFWMMTIPASRSQSPFCVGPYTEDEA
 TEKAQKQIRNAIEGVRVLIVKQVAEAKVKTVLETL
->CC31p208.p01
+>CC31p208
 MNFTNFNRKYVQDNAWDVSTTLLWEHKNGTVAQIDMYWEDNYVFISFENGPTLDVKLKGS
 VISIGFHDDHRTRDLGTHPSWNGDNRKILVKLYLRHVLSLKTTEEQREAIWDIVSNEFVI
 
->CC31p209.p01
+>CC31p209
 MKSDVLYRLDKEGFLKFAEGCNQRVNQLIADYIGDRPFYIAKGEAIASGSIGLIRFENEG
 WISPKGADIDGMNGDSCPWFTSNEIKNFLIETEEKTVEVMYAAFGQTKKENVWLNLDQVG
 EARSIATLMTSEEAHDACKSFLRKNIEGKAAIMKMIATAKTEQVPQTIFTEVN
->CC31p210.p01
+>CC31p210
 MVTENKMNTINLNAKIKTKDHDGYKAIEVEEPMWHLSSWQGDVVHCMTPDGPSTDFCWYI
 VLTNWFTGSEYVLKTSIHGHIRSETYEDEDGYSEDVVWYENGRTRADNLIEKMKKTGTVN
 LDNWTERKMF
->CC31p211.p01
+>CC31p211
 MFKRKFIFKVTSEYPAEYSHMDSIFFYEKVATLWPWEDAVKVGNSMLESLPSFGIWTDTE
 YHSCEKL
->CC31p212.p01
+>CC31p212
 MAKQAKAKTAVKEVVGTSKRAGYKRGSNKRINQLTDKLASRARKVIAHDTAFGNPRKKA
->CC31p213.p01
+>CC31p213
 MSMNKQLEHALHLQRNSWNAGHENYGASIDVYAEALEVLKGFKHLNPVQADLRDALALKD
 ELKFAKPLCSAARKAVRHFVVTLK
->CC31p214.p01
+>CC31p214
 MLKQQGVTMDLPIKAIGEHVILVSEPPQQGDEIVSSGGIVIGKQETGQIPDMCEIYSIGA
 DVPEGIFEVGMLVPLPTGQIRNVPHPLVAAGMKKPKEIAQKFVTCHWKSIPCIYG
->CC31p215.p01
+>CC31p215
 MTKKTKLTEAEKVQIRDTLKPILARGESQVVFEKVDGTIRSLRCTRDHDIIPSDLVESTG
 SQVSRKESTEAIPVWDTEKHAWRSFKLDSIVSVNGVKVEHLLKLVQVKG
->CC31p216.p01
+>CC31p216
 MLDLNKTKITAEPEDITGYVAQRLRDLEIYTVEIPGPTFQLEQANGASCFEVVSKIADDL
 DYAIAAINEYNPIVVFLREVTKEPSGKYKFRFQYLAEYKGQTND
->CC31p217.p01
+>CC31p217
 MKASTVLQIAYLISQESKCCSWKVGAVIEKNGRIISTGYNGSPAGGVNCCDHAEDKGWLV
 KKPGSGLRQDGPIPKYGLDTKFRAEHSEWSKINEIHAELNAILFAARNGSSIEGATMYVT
 LSPCPDCAKAIAQSGIKKLVYCETYDKNIDGWDNILRDAGIEIHHVPKTNLNKLNWYNVE
 NYCGVENA
->CC31p218.p01
+>CC31p218
 MNLTDIFDGVRKEHYNACGDKSQFTEDGVGFIRSVLACDRLVNSCVGYDGILITSKDQTS
 PVVGERFYGDVFFDKKKRFKDGVFIITSTVQEIIPLHTEITLIKTDRSNYLVIQ
->CC31p219.p01
+>CC31p219
 MTSDKTFTRIEFLEKLKEFAQALANKVPGAEVQLRPDRVSNGALITITHNGKDQTALLTL
 DRHGHVTMTNVLGDII
->CC31p220.p01
+>CC31p220
 MGIHTEVRPGLSSFRKVAEVVVAQVADNFLFVPATAPTHAQIHADIVGALQILWKGIKFK
 VTPSFNSYSMTFDFRLDIDKDDPIFFSVIYSWDNSDF
->CC31p221.p01
+>CC31p221
 MMYNKHEQVKEEAYKLLREIVGMNMTPELINKLAQIRTDMNSRYKDEYYVEFVPIGEVIT
 HFVVNVKVHTVH
->CC31p222.p01
+>CC31p222
 MGYHECWAIINSSTGCVVIFDNHYCVYGEEGAAWETCLKVRAANPERSYTVKKTKLMLPW
 HRR
->CC31p223.p01
+>CC31p223
 MKKIILTRGAPGCGKSTWANEYVAKNPGWYILSRDDFREKLFGLDARNAYKYSKHKERAV
 TAAQISAAVSLLDLEHTKGVIVCDTNLNPKTVEKWELRFKGLYEMSFQDFHVPWTELVKR
 NQYRGDKAVPIDVLRHFYTLMEVEKVYVPDLSKPKAVIFDLDGTLADNHHRSPFDLDKCA
 EDAPKEMVIELLKMLRQKGFKILTVSGRESGTKEDETVYRRMTQKWVLDHVGETHGHWQR
 KQGDSRKDDIVKEEIFWRDIAPHYNIKLAVDDRAQVVEMWRRIGVECWQVAHGDF
->CC31p224.p01
+>CC31p224
 MSIKILLEKYRKASYAYSYGLRVDDGSVRAEQELENIARDLDEAGANLRRAVKAKAPELA
 NVMSNLMTTQLFAQGSYLSALLKGRKEEWLAKTLADYNKAKADVDNFVKELE
->CC31p225.p01
+>CC31p225
 MNKFAKMALEGAISELKARAIDYGSAKTRMQMEDGYLTYEDLVVETMQAKARYDEATARV
 NVIIEEIANVH
->CC31p226.p01
+>CC31p226
 MRYFVKDGSFLSAIKKTQLRKLCMQGARHKTPLMRKATVSPWFEIIGGKPTVVSVRVFAP
 GTETIPSHVFKLKEQTYISEETWFKIFAPVEDYDEWYGIRMEEDYKRDLIDKLIEAASIY
 GQIKSNCANGFISDVEGSMRPAGKDVRDIRKSLYEALGL
->CC31p227.p01
+>CC31p227
 MRKFTLGAKLFCFGLFIAAVACSVALAMVVTF
->CC31p228.p01
+>CC31p228
 MHPSWPDQIKPWNGHWTIVEVDGRPFVGMPYSDSQEFRIWLNDVLRYTKDANGMICYYRY
 ELKEPKCVNSR
->CC31p229.p01
+>CC31p229
 MFKITNIHVILVALGLTAYGFIQYQSSRIDGLKEDLKQMQQIAEANGKAIEKLKTDFVNL
 NKYDETRKENRAEADKSDAKMAKDAKREHVVKAKPKLVEKQLNESFNKLTLEFQEATK
->CC31p230.p01
+>CC31p230
 MLNLITAEELVEIYEGTHHDGIRIFKNSRPLGYITDLRVAYSRDQKRQKARKEYSNRVNE
 ERAEKMPEAVEEMRSFLDNHLTKYGAEVMINISQPNVHVNGCKCYIIVDPIYGKHRLGVS
 NPRLSASEMAEMVDPCFKIQNSPAEHHILINGLSQDDIVQAIIKLCSK
->CC31p231.p01
+>CC31p231
 MTLCNDETRFFYRDDVSPMGYKYRTFSYHYASYSDWLLPSALECRGIMFELDVDDIPVRI
 ASRPMEKFFNLNETPFTMNLDLSKVKYMLAKEDGSLVSTYLDGENRIRFKSKTSIKSEQA
 VEASAMLASIEHLDLAEALIDLAKDGFTANFEYCSPQNRIVLSYPKKMLVLLNVRENDTG
@@ -4974,11 +4408,11 @@ EYVDYEDLLAHPVFRKYLVEAFEVPKGDFVSKLRAEEQIEGYVMVMEDGLRFKLKTEWYT
 ALHHTKDSIINNERLFECIVNNAADDLRGMFDSDEFALGKINAFETQYLNYLRSSLKLCQ
 DFYATHRGKDRKSYAANAQAETALAGLPQVFGIIMKMYAGDLDDDQLITKLNCAFLKNTK
 PFTPAEYI
->CC31p232.p01
+>CC31p232
 MKDIANEFSFIEYTQLKLLPDCTIDQVQVPNKLNVVYAIAVDDELVYIGKTKNLRKRINY
 YRTAINRKDQTSDSTKSAKIYDALMSGKTVSFYARQCFNLLINNELGEMSISTMDLEEPM
 FIKKFNPPWNTQHKGKK
->CC31p233.p01
+>CC31p233
 MTEPMFFGSGLGIARYDIQRHRTFEELIEKQLSFFWRPEEVNLMTDRAQFEKLPVGQQNV
 FLDNLKYQSLLDSIQGRAPAAVLSALISDPSLDTWNQTWTFSETIHSRSYTHIMRNLLND
 PAKVFDEIVLDEAIMKRAETIGHYYDDVILKTRLWENAKERYEESLGSCQQNDIEMYEGY
@@ -4986,7 +4420,7 @@ VIDAKRELMKALYLCLHVINGLEAIRFYVSFACTFNFHKNMEIMEGNSKIMKFIARDEQL
 HLKGTQYIIRQLQLGTDGEEWVQIARECEQEAVDIFMEINRQEKEWAVHLWRDGGVPGLS
 VKILHDFIDYLTVSRMRSCGLPCPITDAPVRHPIPWIREYLNSDAVQSAPQEVEISSYLV
 AQIDNDVDADVLLKFRKYL
->CC31p234.p01
+>CC31p234
 MKVIKSSGTSQEFTPEKLIKVLEWGCENTRVDPYELYQAIVPHLQDGMTTYDIQRAATKV
 AASMISIEEPDYQYVASNLAMFNLRKQVYGQFEPRSFIDQISFGVNHNKYDKEVLAKWSA
 EEIALLESKIVHDRDFEMTYAGTMQLIEKYLVKDRSTGQIIETPQFAFMLIGMTLHQDDG
@@ -5000,80 +4434,80 @@ ALIKASIKLAKEKGPCEYYKDTRWSRGELPIDWYNKRIDQLAAPNYVCDWEALRAELKQY
 GIRNSTLSALMPCESSSQVSNSTNGIEPPRGPVSIKESKEGSFNQVVPNVELNADLYDYA
 WKLAKQGNKPYLTQVAIMLKWVCQSASANTYYDPQNYEKGKVPMSVMMDDLLYFWYFGGK
 TLYYHNTRDGSGNDDFEIEKPKAEDCSACKL
->CC31p235.p01
+>CC31p235
 MRACRVVNKYHSDFDVNIQRGTMWGNDVGKNAGSREAAIEAFKEDFIKRIRSGEIKREHL
 ETLRGMRLGCTCKPKACHGDIIAHIVNRLFKDTFTLEDLHESN
->CC31p236.p01
+>CC31p236
 MPHLRIVIQNNEEDPIAEVYNIRDSEIPKVGSIIQVRGARLYVRNVVHAYEKAHGFEEFG
 LESNQLIHDTWFIVEVK
->CC31p237.p01
+>CC31p237
 MKQYQQLIQHIFDEGYVTDDRTGTGTCAVFGTQLRFDLQEGFPAVTTKKLAWKACIAELL
 WFLSGSTNVNDLRLRQHGSPTNGKTVWDDNYENQARSMGYVDGELGPVYGKQWRDFMGVD
 QLTLVINRIKELPNDRRQIVTAWNPLDIPKMALPPCHMIYQFNVRNGLLDLQWYQRSVDV
 FLGLPFNIASYAALIHIVAKMTGLKPGHLVFTGGNTHIYSNHIEQCEEILRREPKELCNL
 EIDFPIEFERWQTSSQLKWINRFAVIEDFKLVNYESHPTIKGKNGCMITKFTNALGSIVY
 AQTDEQLCDADFKLNSSIMINGYFHIVLAHHIEIVGESTERVVIVSKA
->CC31p238.p01
+>CC31p238
 MKINNHLTLIQEEAQKNWALVIEGNPPTIEQYKRKPELYKTIPHGFYRIDVEINDTWAAD
 EGIRIAHGLGVKIMMNTRQTIHHIAKGNVVISGNTMTVFGRFDKQGREIFFRPGNQ
->CC31p239.p01
+>CC31p239
 MNGYNLRLLETYKTQKKWKNWNKVHGVYELSFAVGDIREYRNGEYTIYDGTGNNPIELCR
 SMKSVLLASMNGNVSFSNGCVTMIGDFFKSGSQVFFNPLEEQYENQ
->CC31p240.p01
+>CC31p240
 MLQLVYAYCGTKTVDGQNEYAFGLKDGLPWGHIKRDMQNFAKRTKDTVVIMGAKTWMSMP
 TALKGRKCIVVQDMNRPFAQAKDGLFPDGYMSPEEFKAFLDKTNNYYTNHGGIRIRLLPN
 DNYSVIGGKGILETAQPYADRIVQTSIQKKHRVNSDVTLDMSFISYPAWENAFQMVETSW
 VRCDELTSLTETVYERI
->CC31p241.p01
+>CC31p241
 MQITMTLEEFEEAKAKAHKSGYNKAVDEITTGLKQSYDDMTKGFFSRIGREANIEFTRRL
 YNALIKCRKS
->CC31p242.p01
+>CC31p242
 MELEYKDICLVKIGPDFCLDTLYANEAYDKPFIVETTYGTVHTVELVWEQGRNKNYRFAI
 GSGDDGYILPKYVAYIEVR
->CC31p243.p01
+>CC31p243
 MKRKNIELKEFEYKTPHELGLMMKSQHYSGLLVLEDKWGSIFQAELCKEDGHFSFVKPGE
 DMDYGIDPDDIAFIEEKGLL
->CC31p244.p01
+>CC31p244
 MSNHIHSIAYPKVKVRCQFENFPGVSWITMEYDPHSRGNRVSGIIETGYGTFPLDDQIIN
 GYLQRQKVGAAFIFTKAAFEELACAVEDGMELMRRLVRAAGYDSNSF
->CC31p245.p01
+>CC31p245
 MKLQRQSIKLGSEYNGKWYFIIEGNDPEVIEAAEDRLREMETGAVRGDGLVLTWDNYCDG
 CPCYNDGFGSGFWIEISEVEAFKAAWKIAKKEPK
->CC31p246.p01
+>CC31p246
 MFYVLSEDYSYDGSKNIWAGNNLVQLFDKASTPKCMKLVEDECYDLVVEVFSLEGKMVKH
 VYVEAKHMKTFDAFKKLLKVDD
->CC31p247.p01
+>CC31p247
 MKQLVIDIVCDLVKENGKVVDLQFDDGSRFNSPFSGLKFEVVNESGQGDGWPEIKLIGHQ
 VDIGLWVKNFYAQDEEDYEYIMEMMEDYTA
->CC31p248.p01
+>CC31p248
 MAHIYLGVADEEHFEAEVEQFGLNCELAGDVEWGYEYKVFGPREKIVKFLTESYCVGADE
 TGEFLADTISEICN
->CC31p249.p01
+>CC31p249
 MFKRKNPAALASQLASLSGSKGFNSEDKGEWKLKLDNAGNGQAVIRFLPGKGDEGVPFAV
 LVNHGFKKGGKWYIENCTSTHGDYDSCPVCQYLSKNDSYNTNNEEYKLLKRKTSYYANIL
 VVKDPAAPENEGKVFKYRFGKKIWDKINAMVAVDVEMGETPIDVTCAFEGANFVLKVKKV
 SGFSNYDESKFLGQSEIPNIEDEAYQAQLQEQMVDLTTLTAKDQFKSFEDNQKKFLQVMG
 TAAMGTAASRASAQADKVGEDLDNFEDDLANFNAGSQKSAPAEDFMETGGSASSGDEDLD
 ELLNGL
->CC31p250.p01
+>CC31p250
 MIKLRMPPNGGRYIDGKSVYKLYLMLKNHFNGRYDVVKYNWCMRVSDKAYDKRRDKYFFK
 KLSEKYTLKELTLIFISNLVANQDAWIGEISDADALVFYREYIGKLKLIKSNFEEDVRNI
 YYFSKKVEVKSLNELFDYNDKVNSSYIFKLLQSNIISFETFIILDSFLDIINKHDQATDN
 LVWSNYSTKLHAYRKILNVDREEAKQLFIKTVKNCKY
->CC31p251.p01
+>CC31p251
 MTLFSLNDETPAEKPDSVTTLVDKQNNGFAIEALVNEHGMSYLEAATHWLEENSFPETAF
 AKYIPGNIIEKIMSEALDDNLLRPSFSKQQKTNTLDFLL
->CC31p252.p01
+>CC31p252
 MAKEKKEPVEFDEAVHGADLKKLIVEAADHKLKISGFQTLIGDIRTRAKDELGVDGKMFN
 RLLTLYFKSARDEFEAETEEAIELYDTVFPK
->CC31p253.p01
+>CC31p253
 MSNLNCLFDEEDQVKDGYILVDLSQIALATAMHTFKDKEKITTPMLRHLVLSTLKFNAFK
 FRKDGYNKVIICCDNAKSGYWRRDKAYYYKKNRADGREESEWDWEGYFEGIRTVIEEFEK
 YMPYHMMNIDKMEADDHIAVLTKKLSLEGNKVLIVSSDGDFTQLHKYPNVTQWSPMQKKF
 VKAKTGSPALDCMMKVVKGDKKDNVAAITVRSDFWYTRVDGERTPPTKTAFVEQCCDAED
 ITTILEGEQLKRFYENRVLIDFDYIPEDIANQILDYYNSYKVPPRGKIYPYFVKSGLSKL
 TKNVNDF
->CC31p254.p01
+>CC31p254
 MADSIKRKFRGAEGFDAAGEKIVNVATADRTVLSDGVNVEFLIQENTLQQYDETRGYTSG
 FAVIYDNRIWVSNRDIAKPAGAFNELFWNSVRTDAKWRVVSSGTTTLKSGEFISVDTNKG
 NDMVFTLPNNPQDGDTIMLKDIGNKTGTVGVVINASVQDIVLRDPTNKVRSVRMTHPLSQ
@@ -5096,7 +4530,7 @@ GDSMTGPLQIQAPLTVQIPEGRVAPDVKPSDDNPASWSASITTATIYNKLPGYGVPVMEK
 DSEGQDTGFVDHYEYVKGPGVLTQHGIGKTAVYQIWAPRPTVQELNHNAQTFWIRNFNIV
 TNDWDEWGKMYTSVQRPTAGEIGAVSTSGSAFNNLTIRDWLQIKNVRIVPNETTRTVDFI
 WVDE
->CC31p255.p01
+>CC31p255
 MAKMMASFGQGFVQTQVLSENNSVKYKLAFAAGVAQSTPSEAYYTFQDEPAGVQYDGPGI
 NLREFNPATNQMLNFKTFNLNPEDANAATKAFVQHMQTLPASDNLLIITSYERLYSSPSV
 DALMKSLGSVMWPSIFLTTNYGCNYCALYSIRRKKIIAENTTYSDFKKENRDIRPALEFI
@@ -5104,12 +4538,12 @@ YDKANDIGATGYSQKAIDDSNTYIIDKDNPSKRFPQQLEQISPINQYGIAPGDKMQWNFE
 VKGDSSLTAPGQNIRVNLRWFQGTSYLSGAVVETQPTDADKWMWHQRYVTVPDNADGFTI
 IASRYPEVAGSEGSGAIREMMLTQVSRAVEPLMDPAGFGVNGIRMNNMISDGVDENTLLV
 LPDTEDDKSGNIYSADFREYND
->CC31p256.p01
+>CC31p256
 MADLKANSTIGGLPIWHQGSFPLFPINDTLLYKTYKVYTEYDKPQAADNDFVSKANGGIY
 AKPVQFSQGLTFLDDKGATVTIGKATGTAGATYTASIKVPAQFAFETGEGKPFVIFDPVT
 DMTKPRLVVMGDVLGKFLYDEAGRVYSPGNKPNNVDVGLGNVSNDAQVKINTTTLQTMAG
 PLAAPNLSSLNAASAPQHVPRFDQIVVRDSIQDFGTY
->CC31p257.p01
+>CC31p257
 MATIKQIQFKRSNVAGKRPLPADIAEGELAINIKDSTLFTKNADGQIIDLGFAKGGRIDG
 DVVQVGNYTQTGNYITSGDVSAKTILASAGVSSNGDIVAERGVIRTRAASSGNAHLWFEG
 EEITGENRNKERGVLYATQQTDTDGRVNLRVYNGKAHAANTNNALFVFNGAGDFAAPKDL
@@ -5125,54 +4559,54 @@ NGANTGVMVSGITSGSDKGLIRGNVDGGAHDQWENRSSGLQLDCPSSDDSAYNVWKATKW
 GAYHIAAMDVYAPSGNGYVRLVIRNGGAHIWNNSSYTSPVQINAPEFYLTSDISLKKDIR
 SIEDSRSNLHKVEIKRYAMKDGSNDNAIGVIAQEVQEVYPELVNENKDTGKLSVNYRGLS
 SVLWKIVQEQDKELEDVKSRLARIEELLSK
->CC31p258.p01
+>CC31p258
 MAIAGPNIGTSWFRETGQRPMSAARVAVRLPARPGGARQMVGLSKEVNYNIGANNSYNKD
 TLINYLRSQGSTPVVVTITGNLVSYSSGVACLEFPANLPNAYVHLIINGGVTLYGRGGNG
 GVKGNGAAGGHAINNQFGTRLRITNNGAIAGGGGGGGGNSANGGMGGGGRPFGYADKTHP
 PAAATSRAATDGTLTSPGIGAEYKIGTAVQYTCGSGGNVGANGGASTGRLGTNYGGGSAG
 RAVIGNAPTWNKVGTIYGSRV
->CC31p259.p01
+>CC31p259
 MTQRTPLPGISDILFGVLDRLFKDNATGRVLASRIVALIVVFILSLTWYRLDAIMQVWKE
 SRYETYTKVLQQDKEAKFEASALEQLQIAHVSSNADFSAIYSFRPRNLNYFVDLIAYEGR
 LPSTVNEKNLGGFPVDKTSNEYSAHLRGAYFSSEDEFVFLPTKKKDGELKYMYSCPYFNL
 DNVYAGTVSMYWYSKPLLNENRLAAICSQAARTLGRAK
->CC31p260.p01
+>CC31p260
 MSKLEIVREIVTVASVLIKFGSEHILEKREHFIAFLNEIGIKNDLGRPLNQSNFRKMIEE
 MTAEEKQQLVEEFNEGFESVYRYMMMYSKP
->CC31p261.p01
+>CC31p261
 MNQTVEIQRYLEGMMNKLALGDMVDYSYQEAMEICHWMKRRVRVVGAEWYISAELIDGRY
 AIRYDSGDEYVTLPGHVLQRWEVVN
->CC31p262.p01
+>CC31p262
 MNKISHIEAERKAWDEHTSVVDAITPVYHLVVWFSLSQEEQDCSWKYFEDTTFQKFVNAI
 NHPESLLTHCEIKASEETFCYFTVSSKRSVSDVMQGYQFLKGVADEFELKINYEKI
->CC31p263.p01
+>CC31p263
 MSTSEIKMVPYVTYTSERLREFQDQFNGTGIFYDTLSEIENDVKSDINDNDFIIRMFLNG
 TFEIVAISDKRIEDAIAHIDNIIDEMTEGYYE
->CC31p264.p01
+>CC31p264
 MNNPVAKHDFNKGGAHKDMKRQEKESRRKQKHKGKGYEHI
->CC31p265.p01
+>CC31p265
 MSDLSCLRHNIILIKTQIASLQRANEMMDENWGTYANDPGFRMAEHPFMKKLLGKDYICP
 FETPYNGGVKPFLLDIYKAMNNEMIKELERRLEQLNENNTQKE
->CC31p266.p01
+>CC31p266
 MNGDLIETQNIGERIPEICFIKADWWDGRLLQRVIVCAANRFKLKDGGELVIPGTRHYSK
 DMALVLDQMRDKVVSEQVYGDDQGFLDQWGNYLTRKEALIIATHAGQINTRRQKGGPADT
 LFSEDLY
->CC31p267.p01
+>CC31p267
 MNMKNLNAQIDRVKKSMNRPAILNELQRCAERVTDEHYLPTEAWEVWFRGTHLGSIERKY
 KGCYAVHSSLGRHCGDCATYMQALARFIDSCSVVIAKKELEEVEEWINEVVKEPELRVWG
 IREPKTLWQKIKGFFK
->CC31p268.p01
+>CC31p268
 MSKVIYIVKASENSISENAANVLIVVAKKDFITSSEVRDVLADKLSAASVNSNIGVLIKK
 GLIEKSGDGLIVSAEGQEIINQAAVIYAEENAPELLEKRNTRKARPITDQMEADKNLMME
 ILATKDNLFTIKKLDVYRSNFIAVLEKRTFGIRSFEVSNKGNFRISGYKMTEEQVKHFED
 LGMVAKHSKNGNVYLDIPRTQENIENIIHAVDTL
->CC31p269.p01
+>CC31p269
 MKTLINNLNALLANSGVDLDDTMHAARLHSSNTDSNSYLTIWYNTESENYVLVWVYVNNY
 DMVAVLDAEVEDVAETLNEAKKLFADFFRG
->CC31p270.p01
+>CC31p270
 MISIIVAALKNGGVITETSDFAYVKFNRMSIDKDTQARYWVMVYDHNESQYILTEVLVDL
 ETMEADFVGCPELEGTFEEVLEAYVAK
->CC31p271.p01
+>CC31p271
 MTTIFDMMAKQVDDSIGQLNLRDLQSIIDNEAKEFAIYTVENRAIPNLIDGFKPVQRFVI
 ARALDLSRGNKEKFHKLASVAGGVADLGYHHGEGSAQDAGALMANTWNNNYPLLDGQGNF
 GSRLVQKAAASRYIFCRISDNFRKVYKDTEIAPEHKDKEHVPPAFYLPIIPTVLLNGVQG
@@ -5181,28 +4615,28 @@ TSASQMYISEIPAKFDRETYVEKVLEPMVDKNFISYVDDCSKTGFGFKVKFKKDYMLGEC
 DEKYRHEKIMRDFKLVEKMSQFIVVIDENGKLNDKFQSSSELIKHFVEVRKTYIVKRIEH
 KIKECDEAFKLALAKAMFIKEVIEGSIVIQGKTRKQLTSELESRPTYAPFADKLVSMNIY
 HITSDEAKKLAQQAKDLKAELKYWQETTPETEYMKDLEAL
->CC31p272.p01
+>CC31p272
 MKLTVSIILALIIASAGFVGVCYVIYEIMLFLACVMMDLGNLIW
->CC31p273.p01
+>CC31p273
 MSPFKQIWALVFLLMAPLFIASGIFIWEGLTPPPRVIGSMCFGVAALAVERLFYYTGLTK
 
->CC31p274.p01
+>CC31p274
 MRDYMTRGDILAAGGTHVVSVKNGETVGYVDPSVLAEPGFYFMVKGASAWRAVAARFYVG
 RQRSKSGFMNVLSQIRQGRSQLGRTMRSNNVIYDVYFIPADKMKPLTTGFGKGQLALAFT
 RKHNDSYQNLEEMNRMLNDNFKFILQAY
->CC31p275.p01
+>CC31p275
 MGRKVYSSSMNKMQKIFWIFFSIIAIMVFVGIGFSIWATVEIVNVIQTEGLKGAVEVLMN
 GAQQSSGL
->CC31p276.p01
+>CC31p276
 MNIIKKILKAIWTLTLLMVLFGAFAFALAHDVVMAWINF
->CC31p277.p01
+>CC31p277
 MKALKTFTRAFSDLTPEDRVKIKSTAAYSLRQDPDQDKTEVINRCAIAQLAEKAVADWMD
 GYVAGGQENHDDPYTYAWDVLAHPRFCGLRVEVKTHQSDSKWISVTTGYSGDYPGGSGIN
 LGPFLTHRIADCIIILDVVESGPSVYQFTLKFAGDHEDLKSVVRKSNYQGWYLNL
->CC31p278.p01
+>CC31p278
 MINPFNVSDSAVVNLRGDHYAKSVYCRKLVKHPGDVHYAWLHCDEVVNEIPPADAEYLEE
 DDRIYFGELHIRGIYGKDESRPVEIESPEDFYPGVQ
->CC31p279.p01
+>CC31p279
 MFNDVEKVAIHDEFMQGYTQTELAEIYSCSVDTIRRVVNEIKSRKAEVEPEVKVTSPVKV
 FNPEDVVWAGSSKFLSITVGRDTYAADKDHPNFKEALQFCVDGDFESAINLINIEKAITS
 YVDGNIRIENGQLFYQDIEIKSGLVDRIINDMQNGEDFEFYLPFLENLLENPSKTAVTRL


### PR DESCRIPTION
Reverts galaxyproject/tools-iuc#642

I'm reverting this due to having broken the build. This won't fix the MTS, I'll upload a previous version of the bioperl tool there.

The travis build passed in #642 (and @bgruening and I were happy with it) which justified the merge. The fact that the PR build passed means I'm not immediately understanding what happened there. Investigating now.