### PR TITLE
Perform shed_update only if $CHUNK file is not empty and only on its lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
+sudo: false
 language: python
 python: 2.7
 
-matrix:
-  include:
-    - python: 2.7
-      env: CHUNK=xaa
-    - python: 2.7
-      env: CHUNK=xab
-    - python: 2.7
-      env: CHUNK=xac
-    - python: 2.7
-      env: CHUNK=xad
+env:
+  - CHUNK=xaa
+  - CHUNK=xab
+  - CHUNK=xac
+  - CHUNK=xad
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ matrix:
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
   - export GALAXY_RELEASE=release_16.04
-  - export CONDA_PREFIX=$HOME/conda
+  - export CONDA_PREFIX="$HOME/conda"
 
 install:
   - pip install -q flake8 planemo
-  - planemo conda_init --conda_prefix $CONDA_PREFIX
-  - export PATH=$CONDA_PREFIX/bin:$PATH
+  - planemo conda_init --conda_prefix "$CONDA_PREFIX"
+  - export PATH="$CONDA_PREFIX/bin:$PATH"
   - conda create -y -q -c bioconda --name iuc_conda samtools=0.1.19 bcftools
   - . activate iuc_conda
   - planemo --version
@@ -31,26 +31,26 @@ install:
   - cat changed_repositories.list
 
 script:
-  - cd $TRAVIS_BUILD_DIR && flake8 -v --exclude=.git .
+  - cd "$TRAVIS_BUILD_DIR" && flake8 -v --exclude=.git .
   - |
     if [ -s changed_repositories.list ]
     then
       split -n l/4 changed_repositories.list
-      export PLANEMO_TEST_RUN="True"
     fi
-  - echo $CHUNK
+  - echo "$CHUNK"
   - |
-    if [ ${CHUNK} ] && [ -s ${CHUNK} ]
+    if [ "${CHUNK}" ] && [ -s "${CHUNK}" ]
     then
-      cat $CHUNK
-      for DIR in `cat $CHUNK`; do planemo conda_install --conda_ensure_channels r,bioconda,iuc --conda_prefix $CONDA_PREFIX $DIR ; done
-      for DIR in `cat $CHUNK`; do planemo test --conda_dependency_resolution --conda_prefix $CONDA_PREFIX --galaxy_branch $GALAXY_RELEASE  --galaxy_source $GALAXY_REPO $DIR || exit 1; done
+      cat "$CHUNK"
+      export PLANEMO_TEST_RUN=True
+      while read -r DIR; do planemo conda_install --conda_ensure_channels r,bioconda,iuc --conda_prefix "$CONDA_PREFIX" "$DIR"; done < "$CHUNK"
+      while read -r DIR; do planemo test --conda_dependency_resolution --conda_prefix "$CONDA_PREFIX" --galaxy_branch $GALAXY_RELEASE --galaxy_source $GALAXY_REPO "$DIR" || exit 1; done < "$CHUNK"
     fi
 
 after_success:
-  - | 
-    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" -a "$PLANEMO_TEST_RUN" == "True" ]
-    then 
-      for DIR in `cat changed_repositories.list`; do planemo shed_update --shed_target testtoolshed --shed_email $SHED_EMAIL --shed_password $SHED_PASSWORD --force_repository_creation $DIR || exit 1; done
-      for DIR in `cat changed_repositories.list`; do planemo shed_update --shed_target toolshed --shed_email $SHED_EMAIL --shed_password $SHED_PASSWORD --force_repository_creation $DIR || exit 1; done
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" -a "$PLANEMO_TEST_RUN" == 'True' ]
+    then
+      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email $SHED_EMAIL --shed_password $SHED_PASSWORD --force_repository_creation "$DIR" || exit 1; done < "$CHUNK"
+      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email $SHED_EMAIL --shed_password $SHED_PASSWORD --force_repository_creation "$DIR" || exit 1; done < "$CHUNK"
     fi


### PR DESCRIPTION
Also:
- Quote Bash variables that may contain spaces.
- Use 'read' Bash builtin to read `$CHUNK` file line-by-line in order to prevent problems with whitespaces.