### PR TITLE
Set zlib environment for install of fontconfig

### DIFF
--- a/packages/package_fontconfig_2_11_1/tool_dependencies.xml
+++ b/packages/package_fontconfig_2_11_1/tool_dependencies.xml
@@ -12,6 +12,9 @@
                 <actions os="linux" architecture="x86_64">
                   <action type="download_by_url" sha256sum="b6b066c7dce3f436fdc0dfbae9d36122b38094f4f53bd8dffd45e195b0540d8d">https://depot.galaxyproject.org/software/fontconfig/fontconfig_2.11.1_src_all.tar.gz</action>
                     <action type="set_environment_for_install">
+                        <repository name="package_zlib_1_2_8" owner="iuc" prior_installation_required="True">
+                            <package name="zlib" version="1.2.8" />
+                        </repository>
                         <repository name="package_freetype_2_5_2" owner="iuc" prior_installation_required="True">
                             <package name="freetype" version="2.5.2" />
                         </repository>


### PR DESCRIPTION
This is needed by libpng which is a dependency of freetype, which is a
dependency of fontconfig.

Fixes #813 