### PR TITLE
Fix linking bam and bai files for bam_to_scidx tool

### DIFF
--- a/tools/bam_to_scidx/bam_to_scidx.xml
+++ b/tools/bam_to_scidx/bam_to_scidx.xml
@@ -13,8 +13,9 @@
     </stdio>
     <command>
         <![CDATA[
-            ln -f -s "${input_bam.metadata.bam_index}" "${input_bam}.bai" &&
-            java -jar $__tool_directory__/BAMtoscIDX.jar -b "$input_bam" -i "${input_bam}.bai" -p $require_proper_mate_pairing -r $read -m $min_insert_size -M $max_insert_size -o "$output" 1>/dev/null
+            ln -s "${input_bam}" "localbam.bam" &&
+            ln -f -s "${input_bam.metadata.bam_index}" "localbam.bam.bai" &&
+            java -jar $__tool_directory__/BAMtoscIDX.jar -b localbam.bam -i localbam.bam.bai -p $require_proper_mate_pairing -r $read -m $min_insert_size -M $max_insert_size -o "$output" 1>/dev/null
         ]]>
     </command>
     <inputs>


### PR DESCRIPTION
@bgruening pointed out a flaw in how I was linking bam and bai files in this tool https://github.com/gregvonkuster/tools-iuc/tree/master/tools/pe_histogram, which I based on this bam_to_scidx tool.  So I made this fix as soon as I could.  Perhaps this will have a positive affect on this issue https://github.com/galaxyproject/galaxy/issues/2460 for this tool running on Galaxy main, but I'm not sure.