### PR TITLE
Enable meme 4.11.1 to find graphicsmagick at compile time

### DIFF
--- a/packages/package_graphicsmagick_1_3_20/tool_dependencies.xml
+++ b/packages/package_graphicsmagick_1_3_20/tool_dependencies.xml
@@ -7,7 +7,11 @@
                 <action type="autoconf">--enable-shared=yes</action>
                 <action type="set_environment">
                     <environment_variable name="GRAPHICSMAGICK_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>
-                    <environment_variable name="PATH" action="append_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="DYLD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
                 </action>
             </actions>
         </install>

--- a/packages/package_meme_4_11_1/tool_dependencies.xml
+++ b/packages/package_meme_4_11_1/tool_dependencies.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tool_dependency>
+    <package name="graphicsmagick" version="1.3.20">
+        <repository name="package_graphicsmagick_1_3_20" owner="iuc" prior_installation_required="True"/>
+    </package>
     <package name="libxslt" version="1.1.28">
         <repository name="package_libxslt_1_1_28" owner="iuc" prior_installation_required="True"/>
     </package>
@@ -11,6 +14,9 @@
             <actions>
                 <action type="download_by_url" sha256sum="62602045b25c8422c59f441025b710629c2fbb602bf618fffeeab5654f521088">https://depot.galaxyproject.org/software/meme/meme_4.11.1_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
+                    <repository name="package_graphicsmagick_1_3_20" owner="iuc">
+                        <package name="graphicsmagick" version="1.3.20" />
+                    </repository>
                     <repository name="package_libxslt_1_1_28" owner="iuc">
                         <package name="libxslt" version="1.1.28" />
                     </repository>


### PR DESCRIPTION
Some meme features require it to be compiled using either ImageMagick or GraphicsMagick.  This version uses GraphicsMagick to be compatible with conda.