### PR TITLE
Enable meme 4.11.0 to find ImageMagick at compile time

### DIFF
--- a/packages/package_imagemagick_6_9_3/tool_dependencies.xml
+++ b/packages/package_imagemagick_6_9_3/tool_dependencies.xml
@@ -7,7 +7,11 @@
                 <action type="autoconf"/>
                 <action type="set_environment">
                     <environment_variable name="IMAGEMAGICK_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>
-                    <environment_variable name="PATH" action="append_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="DYLD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
                 </action>
             </actions>
         </install>

--- a/packages/package_meme_4_11_0/tool_dependencies.xml
+++ b/packages/package_meme_4_11_0/tool_dependencies.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tool_dependency>
+    <package name="imagemagick" version="6.9.3">
+        <repository name="package_imagemagick_6_9_3" owner="iuc" prior_installation_required="True"/>
+    </package>
     <package name="libxslt" version="1.1.28">
         <repository name="package_libxslt_1_1_28" owner="iuc" prior_installation_required="True"/>
     </package>
@@ -11,6 +14,9 @@
             <actions>
                 <action type="download_by_url" sha256sum="5dc4841f4816ef25bdb4bd088c76606c1b42726e7d65cc417f0f8c49fe7e237f">https://depot.galaxyproject.org/software/meme/meme_4.11.0_src_all.tar.gz</action>
                 <action type="set_environment_for_install">
+                    <repository name="package_imagemagick_6_9_3" owner="iuc">
+                        <package name="imagemagick" version="6.9.3" />
+                    </repository>
                     <repository name="package_libxslt_1_1_28" owner="iuc">
                         <package name="libxslt" version="1.1.28" />
                     </repository>


### PR DESCRIPTION
Some meme features require it to be compile dwith either ImageMagick or GraphicsMagick.  This version uses ImageMagick due to historical reasons.