### PR TITLE
Avoid compiling trinity's packaged samtools

### DIFF
--- a/packages/package_trinity_2_1_1/tool_dependencies.xml
+++ b/packages/package_trinity_2_1_1/tool_dependencies.xml
@@ -118,6 +118,7 @@
                 </action>
 
                 <action type="shell_command">sed -i.bak -e 's/-ltinfo//' trinity-plugins/Makefile</action> <!-- tinfo is included in ncurses lib-->
+                <action type="shell_command">sed -i.bak 's/\(trinity_essentials:.*\) samtools/\1/' trinity-plugins/Makefile</action> <!-- samtools does not compile with package_zlib_1_2_8, but does not need to be built -->
                 <action type="shell_command">sed -i.bak -e '/tar xvf samtools-0.1.19.tar.bz2/a \\tsed -i.bak -e "s|-lcurses|-lncurses|" samtools-0.1.19/Makefile samtools-0.1.19/Makefile' trinity-plugins/Makefile</action> <!-- ncurses instead of curses -->
 
                 <action type="shell_command">make</action>


### PR DESCRIPTION
Closes #836
The packaged version of samtools with trinity won't compile when the
environment is setup for `package_zlib_1_2_8`. Since the packaged
version is not needed, we can simply avoid compiling it.