### PR TITLE
Set max_ins_size only in paired-end mode

### DIFF
--- a/tools/trinity/align_and_estimate_abundance.xml
+++ b/tools/trinity/align_and_estimate_abundance.xml
@@ -38,6 +38,8 @@
                 --SS_lib_type $inputs.strand.library_type
             #end if
 
+            --max_ins_size $inputs.paired_fragment_length
+
         #else:
             --single $inputs.input
 
@@ -51,8 +53,6 @@
                 --SS_lib_type $inputs.strand.library_type
             #end if
         #end if
-
-        --max_ins_size $inputs.paired_fragment_length
 
         ## Additional parameters.
         #if $additional_params.gene_map.has_gene_map == "no":


### PR DESCRIPTION
`$inputs.paired_fragment_length` is only set when in paired-end mode and thus should only appear on the command line when paired-end mode was selected, otherwise we get the error `cannot find 'paired_fragment_length' while searching for 'inputs.paired_fragment_length'`