### PR TITLE
More specific output filters

### DIFF
--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -79,25 +79,25 @@
     <outputs>
         <data format="gtf" label="${tool.name} on ${on_string}: Assembled transcripts" name="output_gtf" />
         <data format="gtf" label="${tool.name} on ${on_string}: Gene abundance estimates" name="gene_abundance_estimation">
-            <filter>option_set['abundance_estimation']</filter>
+            <filter>option_set['options'] == 'advanced' and option_set['abundance_estimation']</filter>
         </data>
         <data format="gff3" label="${tool.name} on ${on_string}: Coverage" name="coverage">
-            <filter>guide['use_guide'] == "yes"</filter>
+            <filter>guide['use_guide'] == 'yes'</filter>
         </data>
         <data format="tabular" from_work_dir="e_data.ctab" label="${tool.name} on ${on_string}: exon-level expression measurements" name="exon_expression">
-            <filter>guide['output_ballgown']</filter>
+            <filter>guide['use_guide'] == 'yes' and guide['output_ballgown']</filter>
         </data>
         <data format="tabular" from_work_dir="i_data.ctab" label="${tool.name} on ${on_string}: intron-level expression measurements" name="intron_expression">
-            <filter>guide['output_ballgown']</filter>
+            <filter>guide['use_guide'] == 'yes' and guide['output_ballgown']</filter>
         </data>
         <data format="tabular" from_work_dir="t_data.ctab" label="${tool.name} on ${on_string}: transcript-level expression measurements" name="transcript_expression">
-            <filter>guide['output_ballgown']</filter>
+            <filter>guide['use_guide'] == 'yes' and guide['output_ballgown']</filter>
         </data>
         <data format="tabular" from_work_dir="e2t.ctab" label="${tool.name} on ${on_string}: exon to transcript mapping" name="exon_transcript_mapping">
-            <filter>guide['output_ballgown']</filter>
+            <filter>guide['use_guide'] == 'yes' and guide['output_ballgown']</filter>
         </data>
         <data format="tabular" from_work_dir="i2t.ctab" label="${tool.name} on ${on_string}: intron to transcript mapping" name="intron_transcript_mapping">
-            <filter>guide['output_ballgown']</filter>
+            <filter>guide['use_guide'] == 'yes' and guide['output_ballgown']</filter>
         </data>
     </outputs>
     <tests>
@@ -204,4 +204,3 @@ StringTie has the following options::
     </help>
     <expand macro="citations" />
 </tool>
-    


### PR DESCRIPTION
Fix #882.

It seems over-specifying the filter is needed: for example, if advanced options are not specified, `option_set['abundance_estimation']` is not set, but the original filter will pass anyway and the output dataset created. @jmchilton: is this a Galaxy bug?