### PR TITLE
Genome input param is not needed for BAM input

### DIFF
--- a/tools/bedtools/genomeCoverageBed.xml
+++ b/tools/bedtools/genomeCoverageBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_genomecoveragebed" name="Genome Coverage" version="@WRAPPER_VERSION@.0">
+<tool id="bedtools_genomecoveragebed" name="Genome Coverage" version="@WRAPPER_VERSION@.1">
     <description>compute the coverage over an entire genome</description>
     <macros>
         <import>macros.xml</import>
@@ -8,11 +8,11 @@
     <command>
 <![CDATA[
         bedtools genomecov
-        #if $input.ext == "bam"
-            -ibam '$input'
+        #if $input_type.input_type_select == 'bam'
+            -ibam '$input_type.input'
         #else
-            -i '$input'
-            -g $genome
+            -i '$input_type.input'
+            -g '$input_type.genome'
         #end if
 
         $split
@@ -42,9 +42,19 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,bam" name="input" type="data" label="The BAM or BED file from which coverage should be computed">
-              <validator type="unspecified_build" />
-        </param>
+        <conditional name="input_type">
+            <param name="input_type_select" type="select" label="Input type">
+                <option value="bed">BED/VCF/GFF</option>
+                <option value="bam">BAM</option>
+            </param>
+            <when value="bed">
+                <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file" />
+                <expand macro="genome" />
+            </when>
+            <when value="bam">
+                <param format="bam" name="input" type="data" label="BAM file" />
+            </when>
+        </conditional>
         <conditional name="report">
             <param name="report_select" type="select" label="Output type">
                 <option value="bg" selected="true">BedGraph coverage file</option>
@@ -62,7 +72,6 @@
                     help="Combine all positions with a depth >= max into a single bin in the histogram. (-max)"/>
             </when>
         </conditional>
-        <expand macro="genome" />
         <expand macro="split" />
         <param name="strand" type="select" label="Calculate coverage based on" help="(-strand)">
             <option value="">both strands combined</option>
@@ -88,8 +97,9 @@
     </outputs>
     <tests>
         <test>
+            <param name="input_type_select" value="bed" />
             <param name="input" value="genomeCoverageBed1.bed" ftype="bed" />
-            <param name="genome" value="genomeCoverageBed1.len" />
+            <param name="genome" value="genomeCoverageBed1.len" ftype="tabular" />
             <param name="report_select" value="hist" />
             <output name="output" file="genomeCoverageBed_result1.bed" ftype="tabular" />
         </test>


### PR DESCRIPTION
Also quote `genome` param in `<command>`.

Requested by @ethering.