### PR TITLE
Upgrade setuptools for html5lib (planemo dep)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - export CONDA_PREFIX="$HOME/conda"
 
 install:
+  # html5lib (planemo dep) requires setuptools >= 18.5
+  - pip install --upgrade setuptools
   - pip install -q flake8 planemo
   - planemo conda_init --conda_prefix "$CONDA_PREFIX"
   - export PATH="$CONDA_PREFIX/bin:$PATH"


### PR DESCRIPTION
Prevent the following error during `pip install planemo`:
```
html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)
```