### PR TITLE
Set allow_duplicate_entries="False" for Tool Data Tables.

### DIFF
--- a/data_managers/data_manager_bowtie_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_bowtie_index_builder/tool_data_table_conf.xml.sample
@@ -1,16 +1,16 @@
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>
     <!-- Locations of indexes in the Bowtie mapper format -->
-    <table name="bowtie_indexes" comment_char="#">
+    <table name="bowtie_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/bowtie_indices.loc" />
     </table>
     <!-- Locations of indexes in the Bowtie color-space mapper format -->
-    <table name="bowtie_indexes_color" comment_char="#">
+    <table name="bowtie_indexes_color" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/bowtie_indices_color.loc" />
     </table>

--- a/data_managers/data_manager_gemini_database_downloader/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_gemini_database_downloader/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="gemini_databases" comment_char="#">
+    <table name="gemini_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/gemini_databases.loc" />
     </table>

--- a/data_managers/data_manager_hisat2_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_hisat2_index_builder/tool_data_table_conf.xml.sample
@@ -1,12 +1,12 @@
 <!-- Use the file tool_data_table_conf.xml.oldlocstyle if you don't want to update your loc files as changed in revision 4550:535d276c92bc-->
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>
     <!-- Locations of indexes in the hisat mapper format -->
-    <table name="hisat2_indexes" comment_char="#">
+    <table name="hisat2_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/hisat2_indexes.loc" />
     </table>

--- a/data_managers/data_manager_mothur_toolsuite/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_mothur_toolsuite/tool_data_table_conf.xml.sample
@@ -1,17 +1,17 @@
 <tables>
-  <table name="mothur_aligndb" comment_char="#">
+  <table name="mothur_aligndb" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_aligndb.loc" />
   </table>
-  <table name="mothur_lookup" comment_char="#">
+  <table name="mothur_lookup" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_lookup.loc" />
   </table>
-  <table name="mothur_map" comment_char="#">
+  <table name="mothur_map" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_map.loc" />
   </table>
-  <table name="mothur_taxonomy" comment_char="#">
+  <table name="mothur_taxonomy" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_taxonomy.loc" />
   </table>

--- a/data_managers/data_manager_snpeff/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_snpeff/tool_data_table_conf.xml.sample
@@ -1,17 +1,17 @@
 <tables>
-    <table name="snpeffv_genomedb" comment_char="#">
+    <table name="snpeffv_genomedb" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, value, name, path</columns>
         <file path="tool-data/snpeffv_genomedb.loc" />
     </table>
-    <table name="snpeffv_regulationdb" comment_char="#">
+    <table name="snpeffv_regulationdb" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_regulationdb.loc" />
     </table>
-    <table name="snpeffv_annotations" comment_char="#">
+    <table name="snpeffv_annotations" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_annotations.loc" />
     </table>
-    <table name="snpeffv_databases" comment_char="#">
+    <table name="snpeffv_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, value, name</columns>
         <file path="tool-data/snpeffv_databases.loc" />
     </table>

--- a/data_managers/data_manager_snpsift_dbnsfp/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_snpsift_dbnsfp/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="snpsift_dbnsfps" comment_char="#">
+    <table name="snpsift_dbnsfps" comment_char="#" allow_duplicate_entries="False">
         <columns>key, build, name, value, annotations</columns>
         <file path="tool-data/snpsift_dbnsfps.loc" />
     </table>

--- a/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
@@ -1,11 +1,11 @@
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>
     <!-- Locations of indexes in the BWA mapper format -->
-    <table name="rnastar_index" comment_char="#">
+    <table name="rnastar_index" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/rnastar_index.loc" />
     </table>

--- a/tool_collections/snpeff/tool_data_table_conf.xml.sample
+++ b/tool_collections/snpeff/tool_data_table_conf.xml.sample
@@ -1,17 +1,17 @@
 <tables>
-    <table name="snpeffv_genomedb" comment_char="#">
+    <table name="snpeffv_genomedb" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, value, name, path</columns>
         <file path="tool-data/snpeffv_genomedb.loc" />
     </table>
-    <table name="snpeffv_regulationdb" comment_char="#">
+    <table name="snpeffv_regulationdb" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_regulationdb.loc" />
     </table>
-    <table name="snpeffv_annotations" comment_char="#">
+    <table name="snpeffv_annotations" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_annotations.loc" />
     </table>
-    <table name="snpeffv_databases" comment_char="#">
+    <table name="snpeffv_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, value, name</columns>
         <file path="tool-data/snpeffv_databases.loc" />
     </table>

--- a/tool_collections/snpsift/snpsift_dbnsfp/tool_data_table_conf.xml.sample
+++ b/tool_collections/snpsift/snpsift_dbnsfp/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="snpsift_dbnsfps" comment_char="#">
+    <table name="snpsift_dbnsfps" comment_char="#" allow_duplicate_entries="False">
         <columns>key, build, name, value, annotations</columns>
         <file path="tool-data/snpsift_dbnsfps.loc" />
     </table>

--- a/tool_collections/snpsift/snpsift_dbnsfp_generic/tool_data_table_conf.xml.sample
+++ b/tool_collections/snpsift/snpsift_dbnsfp_generic/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="snpsift_dbnsfp" comment_char="#">
+    <table name="snpsift_dbnsfp" comment_char="#" allow_duplicate_entries="False">
         <columns>dbkey, build, name, value, annotations</columns>
         <file path="tool-data/snpsift_dbnsfp.loc" />
     </table>

--- a/tool_collections/snpsift/snpsift_genesets/tool_data_table_conf.xml.sample
+++ b/tool_collections/snpsift/snpsift_genesets/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="snpeff_msigdb_database" comment_char="#">
+    <table name="snpeff_msigdb_database" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/snpeff_msigdb_database.loc" />
     </table>

--- a/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
+++ b/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="twobit" comment_char="#">
+    <table name="twobit" comment_char="#" allow_duplicate_entries="False">
         <columns>dbkey, value</columns>
         <file path="tool-data/twobit.loc" />
     </table>

--- a/tools/gatk2/tool_data_table_conf.xml.sample
+++ b/tools/gatk2/tool_data_table_conf.xml.sample
@@ -1,11 +1,11 @@
 <tables>
     <!-- Location of Picard dict files valid for GATK -->
-    <table name="gatk2_picard_indexes" comment_char="#">
+    <table name="gatk2_picard_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/gatk2_picard_index.loc" />
     </table>
     <!-- Available of GATK references -->
-    <table name="gatk2_annotations" comment_char="#">
+    <table name="gatk2_annotations" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, gatk_value, tools_valid_for</columns>
         <file path="tool-data/gatk2_annotations.txt" />
     </table>

--- a/tools/gemini/tool_data_table_conf.xml.sample
+++ b/tools/gemini/tool_data_table_conf.xml.sample
@@ -1,5 +1,5 @@
 <tables>
-    <table name="gemini_databases" comment_char="#">
+    <table name="gemini_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/gemini_databases.loc" />
     </table>

--- a/tools/hisat2/tool_data_table_conf.xml.sample
+++ b/tools/hisat2/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <tables>
     <!-- Locations of indexes in the HISAT mapper format -->
-    <table name="hisat2_indexes" comment_char="#">
+    <table name="hisat2_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/hisat2_indexes.loc" />
     </table>

--- a/tools/kraken_taxonomy_report/tool_data_table_conf.xml.sample
+++ b/tools/kraken_taxonomy_report/tool_data_table_conf.xml.sample
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tables>
     <!-- Locations of Kraken database in the required format -->
-    <table name="kraken_databases" comment_char="#">
+    <table name="kraken_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/kraken_databases.loc" />
     </table>

--- a/tools/kraken_taxonomy_report/tool_data_table_conf.xml.test
+++ b/tools/kraken_taxonomy_report/tool_data_table_conf.xml.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tables>
     <!-- Locations of Kraken database in the required format -->
-    <table name="kraken_databases" comment_char="#">
+    <table name="kraken_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="${__HERE__}/test-data/test_database.loc" />
     </table>

--- a/tools/meme/tool_data_table_conf.xml.sample
+++ b/tools/meme/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>

--- a/tools/mothur/tool_data_table_conf.xml.sample
+++ b/tools/mothur/tool_data_table_conf.xml.sample
@@ -1,17 +1,17 @@
 <tables>
-  <table name="mothur_aligndb" comment_char="#">
+  <table name="mothur_aligndb" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_aligndb.loc" />
   </table>
-  <table name="mothur_lookup" comment_char="#">
+  <table name="mothur_lookup" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_lookup.loc" />
   </table>
-  <table name="mothur_map" comment_char="#">
+  <table name="mothur_map" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_map.loc" />
   </table>
-  <table name="mothur_taxonomy" comment_char="#">
+  <table name="mothur_taxonomy" comment_char="#" allow_duplicate_entries="False">
     <columns>name, value</columns>
     <file path="tool-data/mothur_taxonomy.loc" />
   </table>

--- a/tools/rgrnastar/tool_data_table_conf.xml.sample
+++ b/tools/rgrnastar/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <!-- Use the file tool_data_table_conf.xml.oldlocstyle if you don't want to update your loc files as changed in revision 4550:535d276c92bc-->
 <tables>
-    <table name="rnastar_index" comment_char="#">
+    <table name="rnastar_index" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/rnastar_index.loc" />
     </table>

--- a/tools/transtermhp/tool_data_table_conf.xml.sample
+++ b/tools/transtermhp/tool_data_table_conf.xml.sample
@@ -1,7 +1,7 @@
 <!-- Use the file tool_data_table_conf.xml.oldlocstyle if you don't want to update your loc files as changed in revision 4550:535d276c92bc-->
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>


### PR DESCRIPTION
Prevents duplicate entries from appearing in data table when they exist in the files. Prevents cases where a duplicate entry occurs and is then passed as a comma separated list onto the command line (which breaks most tools).

I just did all of the data tables here, if folks could review and check if any of these tables actually should allow duplicate entries, that would be a big help.
