### PR TITLE
The twobitreader dependency was missing in the deepTools package

### DIFF
--- a/packages/package_python_2_7_deeptools_2_3_3/tool_dependencies.xml
+++ b/packages/package_python_2_7_deeptools_2_3_3/tool_dependencies.xml
@@ -6,6 +6,9 @@
     <package name="pybigwig" version="0.2.8">
         <repository name="package_python_2_7_10_pybigwig_0_2_8" owner="iuc" prior_installation_required="True"/>
     </package>
+    <package name="twobitreader" version="3.1.4">
+        <repository name="package_python_2_7_10_twobitreader_3_1_4" owner="iuc" prior_installation_required="True"/>
+    </package>
     <package name="matplotlib" version="1.4">
         <repository name="package_python_2_7_matplotlib_1_4" owner="iuc" prior_installation_required="True" />
     </package>
@@ -39,6 +42,9 @@
                     </repository>
                     <repository name="package_python_2_7_10_pybigwig_0_2_8" owner="iuc">
                         <package name="pybigwig" version="0.2.8" />
+                    </repository>
+                    <repository name="package_python_2_7_10_twobitreader_3_1_4" owner="iuc">
+                        <package name="twobitreader" version="3.1.4" />
                     </repository>
                     <package sha256sum="047511c9a6231207fa6ee49f901f9afa0f81c57e4bc03840392e48ed67d97203">https://pypi.python.org/packages/c1/03/982c3656e85e6f264b37d5f6e594d030d6dd99064913eb423d2b40fcebe3/deepTools-2.3.3.tar.gz</package>
                 </action>


### PR DESCRIPTION
Apparently we never updated the package dependencies to add twobitreader.