### PR TITLE
SnpEff: solved conda incompatibilities and test-case

### DIFF
--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -9,7 +9,7 @@
     <command>
 <![CDATA[
         if [ -z "\$SNPEFF_JAR_PATH" ]; then
-            export SNPEFF_JAR_PATH=\$(dirname \$(dirname \$(which snpEff))/../../snpeff/share/snpeff*/snpEff.jar) ;
+            export SNPEFF_JAR_PATH=\$(dirname \$(realpath \$(which snpEff))) ;
         fi ;
 
         java -Xmx6G -jar "\$SNPEFF_JAR_PATH/snpEff.jar" eff

--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -8,6 +8,10 @@
     <expand macro="version_command" />
     <command>
 <![CDATA[
+        if [ -z "\$SNPEFF_JAR_PATH" ]; then
+            export SNPEFF_JAR_PATH=\$(dirname \$(dirname \$(which snpEff))/../../snpeff/share/snpeff*/snpEff.jar) ;
+        fi ;
+
         java -Xmx6G -jar "\$SNPEFF_JAR_PATH/snpEff.jar" eff
         -c "\$SNPEFF_JAR_PATH/snpEff.config"
         -i $inputFormat -o ${outputConditional.outputFormat} -upDownStreamLen $udLength
@@ -359,9 +363,9 @@
         <output name="snpeff_output">
             <assert_contents>
             <!-- Check that deleletions were evaluated -->
-            <has_text_matching expression="Y\t59030478\t.*EFF=INTERGENIC" />
+            <has_text_matching expression="Y\t59030478\t.*intergenic_region" />
             <!-- Check that insertion on last line was NOT evaluated -->
-            <has_text_matching expression="Y\t59032947\t.*SF=5\tGT" />
+            <has_text_matching expression="Y\t59032947\t.*\tGT" />
             </assert_contents>
         </output>
         </test>

--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -9,7 +9,7 @@
     <command>
 <![CDATA[
         if [ -z "\$SNPEFF_JAR_PATH" ]; then
-            export SNPEFF_JAR_PATH=\$(dirname \$(realpath \$(which snpEff))) ;
+            export SNPEFF_JAR_PATH=\$(dirname \$((echo "import os" ; echo "print os.path.realpath('"\$(which snpEff)"')") | python)) ;
         fi ;
 
         java -Xmx6G -jar "\$SNPEFF_JAR_PATH/snpEff.jar" eff

--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -13,7 +13,7 @@
   <xml name="version_command">
     <version_command><![CDATA[
     if [ -z "$SNPEFF_JAR_PATH" ]; then
-        export SNPEFF_JAR_PATH=$(dirname $(dirname $(which snpEff))/../../snpeff/share/snpeff*/snpEff.jar) ;
+        export SNPEFF_JAR_PATH=$(dirname $(realpath $(which snpEff))) ;
     fi ; java -jar "$SNPEFF_JAR_PATH/snpEff.jar" -version
     ]]></version_command>
   </xml>

--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -11,7 +11,11 @@
     </stdio>
   </xml>
   <xml name="version_command">
-    <version_command>java -jar "$SNPEFF_JAR_PATH/snpEff.jar" -version</version_command>
+    <version_command><![CDATA[
+    if [ -z "$SNPEFF_JAR_PATH" ]; then
+        export SNPEFF_JAR_PATH=$(dirname $(dirname $(which snpEff))/../../snpeff/share/snpeff*/snpEff.jar) ;
+    fi ; java -jar "$SNPEFF_JAR_PATH/snpEff.jar" -version
+    ]]></version_command>
   </xml>
   <token name="@WRAPPER_VERSION@">4.1</token>
   <token name="@SNPEFF_VERSION@">SnpEff4.1</token>


### PR DESCRIPTION
This solves SnpEff in situations where conda is used - the wrapper depends on a shell variable that is tool dependencies specific. With some (ugly) bash scripting I was able to mimic this behavior and solve the issue.

Also the tests have been slightly changed as I couldn't reproduce the test result from the earlier XML file