### PR TITLE
Upload packages on-merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - echo $TRAVIS_COMMIT_RANGE
   - |
       planemo ci_find_repos --exclude_from .tt_blacklist \
-                            --exclude packages --exclude data_managers \
+                            --exclude data_managers \
                             --changed_in_commit_range $TRAVIS_COMMIT_RANGE \
                             --chunk_count 4 --chunk ${CHUNK} \
                             --output changed_repositories_chunk.list


### PR DESCRIPTION
I would like to upload packages after merging PR to master. This needs changes to planemo and the packages needs to be one the list of to-be-uploaded-repos. But this can cause troubles. First packages needs to be uploaded before tools and ultimately the packages needs to be sorted according to a DAG of there dependencies.

Anyone a more pragmatic idea to solve this?