### PR TITLE
Removed featureCounts from .tt_blacklist thanks to @peterjc

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -1,7 +1,6 @@
 tools/blastxml_to_gapped_gff3
 tools/dexseq
 tools/differential_count_models
-tools/featurecounts
 tools/gatk2
 tools/gemini
 tools/gff3_rebase

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -434,7 +434,7 @@ Gene regions should be provided in the GFF/GTF format:
 
 Output format
 -------------
-FeatureCounts produces a table containing the counted reads, per gene, per row. Optionally the last column can be set to be the effective gene-length. These tables are compatible with the DESeq2 Galaxy wrapper by IUC.
+FeatureCounts produces a table containing counted reads, per gene, per row. Optionally the last column can be set to be the effective gene-length. These tables are compatible with the DESeq2 Galaxy wrapper by IUC. Column names are added as metadata object.
     ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btt656</citation>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -1,4 +1,4 @@
-<tool id="htseq_count" name="htseq-count" version="0.6.1galaxy2">
+<tool id="htseq_count" name="htseq-count" version="0.6.1galaxy2" profile="16.04">
     <description> - Count aligned reads in a BAM file that overlap features in a GFF file</description>
     <requirements>
         <requirement type="package" version="0.6.1.post1">htseq</requirement>


### PR DESCRIPTION
I forgot to remove featureCounts from the blacklist so let's hope the test still passes. Therefore some small changes to trigger testing. I also added `profile="16.04"` to htseq-count because of the metadata feature.

Thanks @peterjc 