### PR TITLE
Enable VCF to be used for annotating GEMINI database.

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -2,7 +2,6 @@ tools/blastxml_to_gapped_gff3
 tools/dexseq
 tools/differential_count_models
 tools/gatk2
-tools/gemini
 tools/htseq
 tools/gff3_rebase
 tools/jbrowse

--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -11,6 +11,7 @@ tools/progressivemauve
 tools/rglasso
 tools/rgrnastar
 tools/taxonomy
+tools/gemini
 tools/taxonomy_krona_chart
 tools/tool_factory_2
 tools/transtermhp

--- a/tools/gemini/gemini_annotate.xml
+++ b/tools/gemini/gemini_annotate.xml
@@ -1,4 +1,4 @@
-<tool id="gemini_@BINARY@" name="GEMINI @BINARY@" version="@VERSION@.0">
+<tool id="gemini_@BINARY@" name="GEMINI @BINARY@" version="@VERSION@.1">
     <description>adding your own custom annotations</description>
     <macros>
         <import>gemini_macros.xml</import>

--- a/tools/gemini/gemini_annotate.xml
+++ b/tools/gemini/gemini_annotate.xml
@@ -10,11 +10,13 @@
     <command>
 <![CDATA[
 
-    bgzip -c "$annotate_source" > tabixed.gz &&
-    tabix -p bed tabixed.gz &&
+    ## For GEMINI to work correctly, tabixed file must have form [name].[bed|vcf].gz
+    #set $tabixed_file = "tabixed.%s.gz" % $annotate_source.ext
+    bgzip -c "$annotate_source" > $tabixed_file &&
+    tabix -p "$annotate_source.ext" $tabixed_file &&
 
         gemini @BINARY@
-            -f tabixed.gz
+            -f $tabixed_file
             -c $column_name
             -a $a.a_selector
             #if $a.a_selector == 'extract':
@@ -30,7 +32,7 @@
     </command>
     <inputs>
         <expand macro="infile" />
-        <param name="annotate_source" type="data" format="bed" label="File containing the annotations in BED format" help="(-f)"/>
+        <param name="annotate_source" type="data" format="vcf,bed" label="File containing the annotations in BED/VCF format" help="(-f)"/>
 
         <param name="column_name" type="text" value=""
             label="The name of the column to be added to the variant table" 
@@ -45,12 +47,12 @@
             <param name="a_selector" type="select" label="How should the annotation file be used?" help="(-a)">
                 <option value="boolean">Did a variant overlap a region or not? (boolean)</option>
                 <option value="count">How many regions did a variant overlap? (count)</option>
-                <option value="extract" selected="True">Extract specific values from a BED file. (extract)</option>
+                <option value="extract" selected="True">Extract specific values from a BED/VCF file. (extract)</option>
             </param>
             <when value="extract">
 
-                <param name="column_extracts" label="Column to extract information from for list annotations"
-                    type="data_column" data_ref="annotate_source" force_select="true" help="(-e)"/>
+                <param name="column_extracts" label="Column to extract information from for list annotations. For BED files, this is the column number. For VCF files, this is the name of the INFO field."
+                    type="text" force_select="true" help="(-e)"/>
 
 
                 <param name="column_type" type="select" label="What data type(s) should be used to represent the new values in the database?"

--- a/tools/gemini/gemini_macros.xml
+++ b/tools/gemini/gemini_macros.xml
@@ -2,7 +2,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="0.18.1">gemini</requirement>
-            <requirement type="package" version="0.2.6">tabix</requirement>
+            <requirement type="package" version="1.3.1">htslib</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/gemini/gemini_macros.xml
+++ b/tools/gemini/gemini_macros.xml
@@ -2,7 +2,9 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="0.18.1">gemini</requirement>
-            <requirement type="package" version="1.3.1">htslib</requirement>
+            <requirement type="package" version="0.2.6">tabix</requirement>
+            <!-- for conda useage -->
+            <!--requirement type="package" version="1.3.1">htslib</requirement-->
             <yield />
         </requirements>
     </xml>


### PR DESCRIPTION
Currently only BED files can be used for annotating a GEMINI database. This commit enables VCF files to be used for annotation as well.