### PR TITLE
Fix matplotlib installation in some environments

### DIFF
--- a/packages/package_python_2_7_10/tool_dependencies.xml
+++ b/packages/package_python_2_7_10/tool_dependencies.xml
@@ -67,6 +67,7 @@
             $INSTALL_DIR/bin/python setup.py install --prefix=$INSTALL_DIR
         </action>
         <action type="set_environment">
+            <environment_variable action="set_to" name="LDFLAGS">-L$INSTALL_DIR/lib/python2.7 -L$INSTALL_DIR/lib/python2.7/config</environment_variable>
             <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
             <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
             <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR/lib</environment_variable>


### PR DESCRIPTION
In the specific case where I encountered this issue, matplotlib was trying to link to /usr/local/lib/libpython2.7.a, when it should have been using $INSTALL_DIR/lib/python2.7/config/libpython2.7.a

This was fixed by adding LDFLAGS as in the tool dependency definition.
