### PR TITLE
Fix TRAVIS_COMMIT_RANGE when empty or after rebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - . activate iuc_conda
   - planemo --version
   - conda --version
+  - if ! git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; then TRAVIS_COMMIT_RANGE=master...; fi
   - echo $TRAVIS_COMMIT_RANGE
   - |
       planemo ci_find_repos --exclude_from .tt_blacklist \


### PR DESCRIPTION
Workaround for https://github.com/travis-ci/travis-ci/issues/2668 , should fix #961.

I should note that TravisCI testing works properly only for:
- pull requests
- pushes on branches, but not force-pushes (i.e. rebases).

In fact, in case of a rebase this change will use `git diff master...`, i.e. it will test all the tools changed in the non-master branch since it was branched from master, while normally it would test only the changes since the last push on this branch.