### PR TITLE
abricate: fixes deployment issue #2

### DIFF
--- a/packages/package_abricate_0_3/.shed.yml
+++ b/packages/package_abricate_0_3/.shed.yml
@@ -3,4 +3,4 @@ description: Contains a tool dependency definition that downloads and compiles v
 homepage_url: https://github.com/tseemann/abricate
 long_description: Mass screening of contigs for antiobiotic resistance genes
 name: package_abricate_0_3
-owner: madisonflannery
+owner: iuc


### PR DESCRIPTION
There was no package under @madiflannery in the MTS - let's maintain it by IUC