### PR TITLE
Add deepTools 2.3.6

### DIFF
--- a/packages/package_python_2_7_deeptools_2_3_6/.shed.yml
+++ b/packages/package_python_2_7_deeptools_2_3_6/.shed.yml
@@ -1,0 +1,12 @@
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version
+  2.3.6 of deepTools.
+long_description: |
+  User-friendly tools for the normalization and visualization of deep-sequencing data
+
+  https://github.com/fidelram/deepTools
+name: package_python_2_7_deeptools_2_3_6
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_python_2_7_deeptools_2_3_6
+type: tool_dependency_definition

--- a/packages/package_python_2_7_deeptools_2_3_6/tool_dependencies.xml
+++ b/packages/package_python_2_7_deeptools_2_3_6/tool_dependencies.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='utf-8'?>
+<tool_dependency>
+    <package name="numpy" version="1.9">
+        <repository name="package_python_2_7_numpy_1_9" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="pybigwig" version="0.2.8">
+        <repository name="package_python_2_7_10_pybigwig_0_2_8" owner="iuc" prior_installation_required="True"/>
+    </package>
+    <package name="twobitreader" version="3.1.4">
+        <repository name="package_python_2_7_10_twobitreader_3_1_4" owner="iuc" prior_installation_required="True"/>
+    </package>
+    <package name="matplotlib" version="1.4">
+        <repository name="package_python_2_7_matplotlib_1_4" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="scipy" version="0.14">
+        <repository name="package_python_2_7_scipy_0_14" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="pysam" version="0.8.3">
+        <repository name="package_python_2_7_pysam_0_8_3" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="deepTools" version="2.3.6">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <repository name="package_python_2_7_pysam_0_8_3" owner="iuc">
+                        <package name="pysam" version="0.8.3" />
+                    </repository>
+                    <repository name="package_python_2_7_numpy_1_9" owner="iuc">
+                        <package name="numpy" version="1.9" />
+                    </repository>
+                    <repository name="package_python_2_7_matplotlib_1_4" owner="iuc">
+                        <package name="matplotlib" version="1.4" />
+                    </repository>
+                    <repository name="package_python_2_7_scipy_0_14" owner="iuc">
+                        <package name="scipy" version="0.14" />
+                    </repository>
+                    <repository name="package_python_2_7_10_pybigwig_0_2_8" owner="iuc">
+                        <package name="pybigwig" version="0.2.8" />
+                    </repository>
+                    <repository name="package_python_2_7_10_twobitreader_3_1_4" owner="iuc">
+                        <package name="twobitreader" version="3.1.4" />
+                    </repository>
+                    <package sha256sum="2d1f207d99230abcda632f6f23f8bd482aa7ecc6de6284c7096bb8d4facdd44c">https://pypi.python.org/packages/75/cc/52774ca1df27e4b0dc503972f782fd01d8ee611d8ad89abfe7b36d7c633f/deepTools-2.3.6.tar.gz</package>
+                </action>
+
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="PYTHONPATH" action="prepend_to">$INSTALL_DIR</environment_variable>
+                    <environment_variable name="DEEPTOOLS_ROOT_PATH" action="set_to">$INSTALL_DIR</environment_variable>
+                    <environment_variable name="DEEPTOOLS_PYTHONPATH" action="set_to">$INSTALL_DIR</environment_variable>
+                    <environment_variable name="DEEPTOOLS_PATH" action="set_to">$INSTALL_DIR/bin</environment_variable>
+                    <!-- libpng lib path -->
+                    <environment_variable action="set_to" name="LIBPNG_LIB_PATH">$ENV[LIBPNG_LIB_PATH]</environment_variable>
+                    <environment_variable action="prepend_to" name="LD_LIBRARY_PATH">$ENV[LIBPNG_LIB_PATH]</environment_variable>
+                    <!-- disable the config file of deepTools -->
+                    <environment_variable name="DEEP_TOOLS_NO_CONFIG" action="set_to">TRUE</environment_variable>
+                </action>
+             </actions>
+         </install>
+         <readme>
+            Installation of deepTools from Fidel Ramirez.
+            https://github.com/fidelram/deepTools
+         </readme>
+     </package>
+</tool_dependency>


### PR DESCRIPTION
This bumps the version of deepTools to 2.3.6, which addresses a bug hitting someone on usegalaxy.org at the moment. N.B., the package is being added to bioconda now.

@bgruening: Can you push out the 2.3.6 wrappers to the toolshed? I believe I've already updated the XML for them.

ping: @jennaj