### PR TITLE
Add py2bit-0.2.0, which will be needed by the next deepTools release

### DIFF
--- a/packages/package_python_2_7_py2bit_0_2_0/.shed.yml
+++ b/packages/package_python_2_7_py2bit_0_2_0/.shed.yml
@@ -1,0 +1,9 @@
+name: package_python_2_7_py2bit_0_2_0
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads and compiles version 0.2.0 of py2bit
+long_description: |
+  A python extension written in C for quick access to 2bit files. This extension uses lib2bit.
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/packages/package_python_2_7_py2bit_0_2_0
+type: tool_dependency_definition

--- a/packages/package_python_2_7_py2bit_0_2_0/tool_dependencies.xml
+++ b/packages/package_python_2_7_py2bit_0_2_0/tool_dependencies.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="python" version="2.7.10">
+        <repository name="package_python_2_7_10" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="py2bit" version="0.2.0">
+        <install version="1.0">
+            <actions>
+                <action type="setup_python_environment">
+                    <repository name="package_python_2_7_10" owner="iuc">
+                        <package name="python" version="2.7.10" />
+                    </repository>
+                    <!-- Just download from pypi -->
+                    <package md5sum="f10c0a6a1f3f9cbccc295c3271670e90">https://pypi.python.org/packages/d7/58/258f2da779d078fa663346063727071dee8667fd9f49e0e85ab98bfa37e9/py2bit-0.1.0.tar.gz</package>
+                </action>
+                <action type="set_environment">
+                    <environment_variable action="prepend_to" name="PYTHONPATH">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>Compiles and installs py2bit, which requires a compiler (typically gcc).</readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
py2bit will be required by the next deepTools release, so please consider this PR so that it's already available once that comes out.

As an aside, this is a convenient package for reading 2bit files that works with python 2 or 3, if anyone happens to need to do such a thing.