### PR TITLE
Add built-in HMM model database for hmmscan

### DIFF
--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -9,7 +9,7 @@
   <command><![CDATA[
 #if $inputHmmConditional.inputHmmSource == "history":
     ## "Press" database
-    hmmpress $$inputHmmConditional.hmmfile
+    hmmpress "$inputHmmConditional.hmmfile"
 #end if
 ## Scan
 hmmscan

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -27,7 +27,7 @@ hmmscan
 > '$output'
 #if $input_hmm_conditional.input_hmm_source == "history":
     ## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
-    && rm ''${input_hmm_conditional.hmmfile}.h3m' ''${input_hmm_conditional.hmmfile}.h3i' ''${input_hmm_conditional.hmmfile}.h3f' ''${input_hmm_conditional.hmmfile}.h3p';
+    && rm '${input_hmm_conditional.hmmfile}.h3m' '${input_hmm_conditional.hmmfile}.h3i' '${input_hmm_conditional.hmmfile}.h3f' '${input_hmm_conditional.hmmfile}.h3p';
 #end if
       ]]></command>
   <inputs>
@@ -42,8 +42,8 @@ hmmscan
     <expand macro="seed"/>
   </inputs>
   <outputs>
-    <data format="txt" name="output" label="HMM matches of $seqfile.name again the profile database"/>
-    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name again the profile database">
+    <data format="txt" name="output" label="HMM matches of $seqfile.name against the profile database"/>
+    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name against the profile database">
       <filter>'tblout' in oformat</filter>
     </data>
     <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name against the profile database">

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -23,8 +23,8 @@ hmmscan
 @SEED@
 
 @INPUTHMMCHOICE@
-$seqfile
-> $output
+'$seqfile'
+> '$output'
 #if $input_hmm_conditional.input_hmm_source == "history":
     ## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
     && rm ''${input_hmm_conditional.hmmfile}.h3m' ''${input_hmm_conditional.hmmfile}.h3i' ''${input_hmm_conditional.hmmfile}.h3f' ''${input_hmm_conditional.hmmfile}.h3p';

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmscan" name="hmmscan" version="@WRAPPER_VERSION@.0">
+<tool id="hmmer_hmmscan" name="hmmscan" version="@WRAPPER_VERSION@.1">
   <description>search sequence(s) against a profile database</description>
   <macros>
     <import>macros.xml</import>
@@ -7,8 +7,10 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
-## "Press" database
-hmmpress $hmmfile;
+#if $inputHmmConditional.inputHmmSource == "history":
+    ## "Press" database
+    hmmpress $$inputHmmConditional.hmmfile
+#end if
 ## Scan
 hmmscan
 
@@ -20,14 +22,14 @@ hmmscan
 @CPU@
 @SEED@
 
-$hmmfile
+@INPUTHMMCHOICE@
 $seqfile
 > $output;
 ## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
 rm ${hmmfile}.h3m ${hmmfile}.h3i ${hmmfile}.h3f ${hmmfile}.h3p;
       ]]></command>
   <inputs>
-    <expand macro="input_hmm" />
+    <expand macro="input_hmm_choice" />
     <!-- todo use Galaxy features like data libraries/data tables/??? -->
     <param name="seqfile" type="data" format="fasta" label="Sequence file"/>
     <expand macro="oformat_with_opts"/>

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -9,7 +9,7 @@
   <command><![CDATA[
 #if $inputHmmConditional.inputHmmSource == "history":
     ## "Press" database
-    hmmpress "$inputHmmConditional.hmmfile"
+    hmmpress "$inputHmmConditional.hmmfile";
 #end if
 ## Scan
 hmmscan
@@ -25,8 +25,10 @@ hmmscan
 @INPUTHMMCHOICE@
 $seqfile
 > $output;
-## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
-rm ${hmmfile}.h3m ${hmmfile}.h3i ${hmmfile}.h3f ${hmmfile}.h3p;
+#if $inputHmmConditional.inputHmmSource == "history":
+    ## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
+    rm ${inputHmmConditional.hmmfile}.h3m ${inputHmmConditional.hmmfile}.h3i ${inputHmmConditional.hmmfile}.h3f ${inputHmmConditional.hmmfile}.h3p;
+#end if
       ]]></command>
   <inputs>
     <expand macro="input_hmm_choice" />
@@ -40,20 +42,21 @@ rm ${hmmfile}.h3m ${hmmfile}.h3i ${hmmfile}.h3f ${hmmfile}.h3p;
     <expand macro="seed"/>
   </inputs>
   <outputs>
-    <data format="txt" name="output" label="HMM matches of $seqfile.name in $hmmfile.name"/>
-    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name in $hmmfile.name">
+    <data format="txt" name="output" label="HMM matches of $seqfile.name again the profile database"/> <!-- in $hmmfile.name"/>-->
+    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
       <filter>'tblout' in oformat</filter>
     </data>
-    <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name in $hmmfile.name">
+    <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
       <filter>'domtblout' in oformat</filter>
     </data>
-    <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name in $hmmfile.name">
+    <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
       <filter>'pfamtblout' in oformat</filter>
     </data>
   </outputs>
   <tests>
     <test>
-      <param name="hmmfile" value="MADE1.hmm"/>
+      <param name="inputHmmConditional|inputHmmSource" value="history"/>
+      <param name="inputHmmConditional|hmmfile" value="MADE1.hmm"/>
       <param name="seqfile" value="dna_target.fa"/>
       <expand macro="oformat_test" />
       <expand macro="seed_test" />

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -7,9 +7,9 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
-#if $inputHmmConditional.inputHmmSource == "history":
+#if $input_hmm_conditional.input_hmm_source == "history":
     ## "Press" database
-    hmmpress "$inputHmmConditional.hmmfile";
+    hmmpress '$input_hmm_conditional.hmmfile' &&
 #end if
 ## Scan
 hmmscan
@@ -24,10 +24,10 @@ hmmscan
 
 @INPUTHMMCHOICE@
 $seqfile
-> $output;
-#if $inputHmmConditional.inputHmmSource == "history":
+> $output
+#if $input_hmm_conditional.input_hmm_source == "history":
     ## Remove pressed database. Eventually will be replaced with a dedicated tool/datatype
-    rm ${inputHmmConditional.hmmfile}.h3m ${inputHmmConditional.hmmfile}.h3i ${inputHmmConditional.hmmfile}.h3f ${inputHmmConditional.hmmfile}.h3p;
+    && rm ''${input_hmm_conditional.hmmfile}.h3m' ''${input_hmm_conditional.hmmfile}.h3i' ''${input_hmm_conditional.hmmfile}.h3f' ''${input_hmm_conditional.hmmfile}.h3p';
 #end if
       ]]></command>
   <inputs>
@@ -42,21 +42,21 @@ $seqfile
     <expand macro="seed"/>
   </inputs>
   <outputs>
-    <data format="txt" name="output" label="HMM matches of $seqfile.name again the profile database"/> <!-- in $hmmfile.name"/>-->
-    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
+    <data format="txt" name="output" label="HMM matches of $seqfile.name again the profile database"/>
+    <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name again the profile database">
       <filter>'tblout' in oformat</filter>
     </data>
-    <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
+    <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name against the profile database">
       <filter>'domtblout' in oformat</filter>
     </data>
-    <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name again the profile database"> <!-- in $hmmfile.name">-->
+    <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name against the profile database">
       <filter>'pfamtblout' in oformat</filter>
     </data>
   </outputs>
   <tests>
     <test>
-      <param name="inputHmmConditional|inputHmmSource" value="history"/>
-      <param name="inputHmmConditional|hmmfile" value="MADE1.hmm"/>
+      <param name="input_hmm_conditional|input_hmm_source" value="history"/>
+      <param name="input_hmm_conditional|hmmfile" value="MADE1.hmm"/>
       <param name="seqfile" value="dna_target.fa"/>
       <expand macro="oformat_test" />
       <expand macro="seed_test" />

--- a/tools/hmmer3/hmmsearch.xml
+++ b/tools/hmmer3/hmmsearch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmsearch" name="hmmsearch" version="@WRAPPER_VERSION@.0">
+<tool id="hmmer_hmmsearch" name="hmmsearch" version="@WRAPPER_VERSION@.1">
   <description>search profile(s) against a sequence database</description>
   <macros>
     <import>macros.xml</import>
@@ -17,12 +17,12 @@ hmmsearch
 @CPU@
 @SEED@
 
-$hmmfile
+@INPUTHMMCHOICE@
 $seqdb
 > $output
       ]]></command>
   <inputs>
-    <expand macro="input_hmm" />
+    <expand macro="input_hmm_choice" />
     <!-- todo use Galaxy features like data libraries/data tables/??? -->
     <param name="seqdb" type="data" format="fasta" label="Sequence database to search against"/>
     <expand macro="oformat_with_opts"/>

--- a/tools/hmmer3/hmmsearch.xml
+++ b/tools/hmmer3/hmmsearch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmsearch" name="hmmsearch" version="@WRAPPER_VERSION@.1">
+<tool id="hmmer_hmmsearch" name="hmmsearch" version="@WRAPPER_VERSION@.0">
   <description>search profile(s) against a sequence database</description>
   <macros>
     <import>macros.xml</import>
@@ -17,12 +17,12 @@ hmmsearch
 @CPU@
 @SEED@
 
-@INPUTHMMCHOICE@
+$hmmfile
 $seqdb
 > $output
       ]]></command>
   <inputs>
-    <expand macro="input_hmm_choice" />
+    <expand macro="input_hmm" />
     <!-- todo use Galaxy features like data libraries/data tables/??? -->
     <param name="seqdb" type="data" format="fasta" label="Sequence database to search against"/>
     <expand macro="oformat_with_opts"/>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -391,6 +391,29 @@ $aps_select
     <param name="w_length" label="Window Length"
         help="(--w_length)" optional="True" type="integer" />
   </xml>
+  <token name="@INPUTHMMCHOICE@">
+#if $inputHmmConditional.inputHmmSource == "history":
+    $inputHmmConditional.hmmfile
+#else:
+    $inputHmmConditional.index
+#end if
+  </token>
+  <xml name="input_hmm_choice">
+    <conditional name="inputHmmConditional">
+          <param name="inputHmmSource" type="select" label="Use a built-in HMM model database or own from your history" >
+            <option value="indexed" selected="True">Use a built-in HMM modal database</option>
+            <option value="history">Use a HMM database from history</option>
+          </param>
+          <when value="indexed">
+            <param name="index" type="select" label="Select a HMM model database" help="If your database of interest is not listed, contact the Galaxy team">
+              <yield />
+            </param>
+          </when>
+          <when value="history">
+            <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>
+          </when>  <!-- history -->
+        </conditional>  <!-- inputHmmConditional -->
+  </xml>
   <xml name="input_hmm">
     <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>
   </xml>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -1082,7 +1082,7 @@ The wrappers were written by Eric Rasche and is licensed under Apache2_. The
 documentation is copied from the HMMER3 documentation.
 
 .. _Apache2: http://www.apache.org/licenses/LICENSE-2.0
-.. _HMMER3: https://cryptogenomicon.org/
+.. _HMMER3: http://hmmer.org/
 
 
   ]]></token>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -392,30 +392,30 @@ $aps_select
         help="(--w_length)" optional="True" type="integer" />
   </xml>
   <token name="@INPUTHMMCHOICE@">
-#if $inputHmmConditional.inputHmmSource == "history":
-    "$inputHmmConditional.hmmfile"
+#if $input_hmm_conditional.input_hmm_source == "history":
+    '$input_hmm_conditional.hmmfile'
 #else:
-    "$inputHmmConditional.index.fields.db_path"
+    '$input_hmm_conditional.index.fields.db_path'
 #end if
   </token>
   <xml name="input_hmm_choice">
-    <conditional name="inputHmmConditional">
-          <param name="inputHmmSource" type="select" label="Use a built-in HMM model database or own from your history" >
-            <option value="indexed" selected="True">Use a built-in HMM modal database</option>
-            <option value="history">Use a HMM database from history</option>
-          </param>
-          <when value="indexed">
-            <param name="index" type="select" label="Select a HMM model database" help="If your database of interest is not listed, contact the Galaxy team">
-              <options from_data_table="hmm_database">
-                <filter type="sort_by" column="2"/>
-                <validator type="no_options" message="No indexes are available for the selected input dataset"/>
-              </options>
-            </param>
-          </when>
-          <when value="history">
-            <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>
-          </when>  <!-- history -->
-        </conditional>  <!-- inputHmmConditional -->
+    <conditional name="input_hmm_conditional">
+      <param name="input_hmm_source" type="select" label="Use a built-in HMM model database or own from your history" >
+        <option value="indexed" selected="True">Use a built-in HMM modal database</option>
+        <option value="history">Use a HMM database from history</option>
+      </param>
+      <when value="indexed">
+        <param name="index" type="select" label="Select a HMM model database" help="If your database of interest is not listed, contact the Galaxy administrator">
+          <options from_data_table="hmm_database">
+            <filter type="sort_by" column="2"/>
+            <validator type="no_options" message="No indexes are available for the selected input dataset"/>
+          </options>
+        </param>
+      </when>
+      <when value="history">
+        <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>
+      </when>  <!-- history -->
+    </conditional>  <!-- input_hmm_conditional -->
   </xml>
   <xml name="input_hmm">
     <param name="hmmfile" type="data" label="HMM model" format="hmm2,hmm3"/>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -401,7 +401,7 @@ $aps_select
   <xml name="input_hmm_choice">
     <conditional name="input_hmm_conditional">
       <param name="input_hmm_source" type="select" label="Use a built-in HMM model database or own from your history" >
-        <option value="indexed" selected="True">Use a built-in HMM modal database</option>
+        <option value="indexed" selected="True">Use a built-in HMM model database</option>
         <option value="history">Use a HMM database from history</option>
       </param>
       <when value="indexed">

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -550,7 +550,7 @@ it off if you know you will have no problem with biased composition hits.
 **Advanced Documentation**
 
 A more detailed look at the internals of the various filter pipelines was
-posted on the `developer's blog <http://selab.janelia.org/people/eddys/blog/?p=508>`__.
+posted on the `developer's blog <https://cryptogenomicon.org/>`__.
 The information posted there may be useful to those who are struggling with
 poor-scoring sequences.
 
@@ -1067,7 +1067,7 @@ slightly different expected score distributions.
 Attribution
 -----------
 
-This Galaxy tool relies on HMMER3_ from http://hmmer.janelia.org/
+This Galaxy tool relies on HMMER3_ from https://cryptogenomicon.org/
 Internally the software is cited as:
 
 ::
@@ -1082,7 +1082,7 @@ The wrappers were written by Eric Rasche and is licensed under Apache2_. The
 documentation is copied from the HMMER3 documentation.
 
 .. _Apache2: http://www.apache.org/licenses/LICENSE-2.0
-.. _HMMER3: http://hmmer.janelia.org/
+.. _HMMER3: https://cryptogenomicon.org/
 
 
   ]]></token>

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -395,7 +395,7 @@ $aps_select
 #if $inputHmmConditional.inputHmmSource == "history":
     "$inputHmmConditional.hmmfile"
 #else:
-    "$inputHmmConditional.index"
+    "$inputHmmConditional.index.fields.db_path"
 #end if
   </token>
   <xml name="input_hmm_choice">

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -550,7 +550,7 @@ it off if you know you will have no problem with biased composition hits.
 **Advanced Documentation**
 
 A more detailed look at the internals of the various filter pipelines was
-posted on the `developer's blog <https://cryptogenomicon.org/>`__.
+posted on the `developer's blog <https://cryptogenomicon.org/2011/09/19/hmmer3-is-stubborn/>`__.
 The information posted there may be useful to those who are struggling with
 poor-scoring sequences.
 
@@ -1067,7 +1067,7 @@ slightly different expected score distributions.
 Attribution
 -----------
 
-This Galaxy tool relies on HMMER3_ from https://cryptogenomicon.org/
+This Galaxy tool relies on HMMER3_
 Internally the software is cited as:
 
 ::

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -393,9 +393,9 @@ $aps_select
   </xml>
   <token name="@INPUTHMMCHOICE@">
 #if $inputHmmConditional.inputHmmSource == "history":
-    $inputHmmConditional.hmmfile
+    "$inputHmmConditional.hmmfile"
 #else:
-    $inputHmmConditional.index
+    "$inputHmmConditional.index"
 #end if
   </token>
   <xml name="input_hmm_choice">
@@ -406,7 +406,10 @@ $aps_select
           </param>
           <when value="indexed">
             <param name="index" type="select" label="Select a HMM model database" help="If your database of interest is not listed, contact the Galaxy team">
-              <yield />
+              <options from_data_table="hmm_database">
+                <filter type="sort_by" column="2"/>
+                <validator type="no_options" message="No indexes are available for the selected input dataset"/>
+              </options>
             </param>
           </when>
           <when value="history">

--- a/tools/hmmer3/readme.rst
+++ b/tools/hmmer3/readme.rst
@@ -29,6 +29,7 @@ The recommended installation is by means of the toolshed_.
 History
 =======
 
+* v0.2      - Add build-in hmm database for hmmscan and hmmsearch
 * v0.1      - Initial public release
 
 

--- a/tools/hmmer3/readme.rst
+++ b/tools/hmmer3/readme.rst
@@ -29,7 +29,7 @@ The recommended installation is by means of the toolshed_.
 History
 =======
 
-* v0.2      - Add build-in hmm database for hmmscan and hmmsearch
+* v0.1.1    - hmmscan: add the possibility to scan a build-in hmm profile database
 * v0.1      - Initial public release
 
 

--- a/tools/hmmer3/readme.rst
+++ b/tools/hmmer3/readme.rst
@@ -29,7 +29,7 @@ The recommended installation is by means of the toolshed_.
 History
 =======
 
-* v0.1.1    - hmmscan: add the possibility to scan a build-in hmm profile database
+* v0.1.1    - hmmscan: add the possibility to scan a built-in hmm profile database
 * v0.1      - Initial public release
 
 

--- a/tools/hmmer3/tool-data/hmm_database.loc.sample
+++ b/tools/hmmer3/tool-data/hmm_database.loc.sample
@@ -1,0 +1,10 @@
+#This is a sample file that enables the hmmer tools to find the HMM databases
+#You will need to create these data files and then create
+#a hmm_database.loc file similar to this one (store it in this directory)
+#that points to the directories in which those files are stored.
+#The hmm_database_indices.loc file has this format (longer white space characters are TAB characters):
+#
+#<unique_build_id>   <display_name>   <file_base_path>
+#
+#So, for example:
+#pfam_a	Pfam-a	/data/db/pfam/Pfam-A.hmm

--- a/tools/hmmer3/tool_data_table_conf.xml.sample
+++ b/tools/hmmer3/tool_data_table_conf.xml.sample
@@ -1,0 +1,7 @@
+<tables>
+    <!-- Locations of indexes in the HMM database format -->
+    <table name="hmm_database" comment_char="#">
+        <columns>value, name, db_path</columns>
+        <file path="tool-data/hmm_database.loc" />
+    </table>
+</tables>


### PR DESCRIPTION
A really soft PR to add the possibility to scan a "build-in" database like pfam-a
I only add this feature for hmmscan because I'm not sure it's interesting for the other hmm*
But let me know if you disagree. 