### PR TITLE
package_trinity_2_2_0

### DIFF
--- a/packages/package_trinity_2_2_0/tool_dependencies.xml
+++ b/packages/package_trinity_2_2_0/tool_dependencies.xml
@@ -110,7 +110,7 @@
                     <package sha256sum="d16ad5910aee6247990a19745511a5d50e19fa8c236000cbf99395e06c73c9f8">
                         https://depot.galaxyproject.org/software/BiocGenerics/BiocGenerics_0.14.0_src_all.tar.gz
                     </package>
-                    <package sha256sum="f16b6316fdbd7ab0077644d41a3286a688b0b75cc34686383e10f139f0955ae1">
+                    <package sha256sum="1191c0022bcba15e5b896f6197ac91bc7fb4679e150e9c32ad4181a812ec74f1">
                         https://depot.galaxyproject.org/software/Biobase/Biobase_2.30.0_src_all.tar.gz
                     </package>
                 </action>


### PR DESCRIPTION
update checksum

```
File "/w/galaxy/galaxy3/galaxy/lib/tool_shed/galaxy_install/install_manager.py", line 125, in install_and_build_package_via_fabric
    tool_dependency = self.install_and_build_package( install_environment, tool_dependency, actions_dict )
  File "/w/galaxy/galaxy3/galaxy/lib/tool_shed/galaxy_install/install_manager.py", line 110, in install_and_build_package
    initial_download=False )
  File "/w/galaxy/galaxy3/galaxy/lib/tool_shed/galaxy_install/tool_dependencies/recipe/recipe_manager.py", line 31, in execute_step
    initial_download=initial_download )
  File "/w/galaxy/galaxy3/galaxy/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py", line 1362, in execute_step
    self.url_download( work_dir, filename, url, extract=False, checksums=checksums )
  File "/w/galaxy/galaxy3/galaxy/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py", line 201, in url_download
    raise Exception( 'Given sha256 checksum does not match with the one from the downloaded file (%s != %s).' % (downloaded_checksum, expected) )

Given sha256 checksum does not match with the one from the downloaded file (1191c0022bcba15e5b896f6197ac91bc7fb4679e150e9c32ad4181a812ec74f1 != f16b6316fdbd7ab0077644d41a3286a688b0b75cc34686383e10f139f0955ae1).
```