### PR TITLE
use single quotes in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ env:
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
   - export GALAXY_RELEASE=release_16.07
-  - export PLANEMO_CONDA_PREFIX="$HOME/conda"
+  - export PLANEMO_CONDA_PREFIX='$HOME/conda'
 
 install:
   - pip install flake8 planemo
   - planemo conda_init
-  - export PATH="$PLANEMO_CONDA_PREFIX/bin:$PATH"
+  - export PATH='$PLANEMO_CONDA_PREFIX/bin:$PATH'
   - conda create -y -q -c bioconda --name iuc_conda samtools=0.1.19 bcftools
   - . activate iuc_conda
   - planemo --version
   - conda --version
-  - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?
+  - git diff --quiet '$TRAVIS_COMMIT_RANGE' -- ; GIT_DIFF_EXIT_CODE=$?
   - |
-    if [ "$GIT_DIFF_EXIT_CODE" -gt 1 ] ; then
+    if [ '$GIT_DIFF_EXIT_CODE' -gt 1 ] ; then
       git remote set-branches --add origin master;
       git fetch;
       TRAVIS_COMMIT_RANGE=origin/master...;
@@ -33,20 +33,20 @@ install:
   - |
       planemo ci_find_repos --exclude_from .tt_blacklist \
                             --exclude packages --exclude data_managers \
-                            --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
-                            --chunk_count 4 --chunk "${CHUNK}" \
+                            --changed_in_commit_range '$TRAVIS_COMMIT_RANGE' \
+                            --chunk_count 4 --chunk '${CHUNK}' \
                             --output changed_repositories_chunk.list
   - cat changed_repositories_chunk.list
 
 script:
-  - cd "$TRAVIS_BUILD_DIR" && flake8 --exclude=.git .
-  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR" || exit 1; done < changed_repositories_chunk.list
-  - while read -r DIR; do planemo conda_install "$DIR"; done < changed_repositories_chunk.list
-  - while read -r DIR; do planemo test --conda_dependency_resolution --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR" || exit 1; done < changed_repositories_chunk.list
+  - cd '$TRAVIS_BUILD_DIR' && flake8 --exclude=.git .
+  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive '$DIR' || exit 1; done < changed_repositories_chunk.list
+  - while read -r DIR; do planemo conda_install '$DIR'; done < changed_repositories_chunk.list
+  - while read -r DIR; do planemo test --conda_dependency_resolution --galaxy_branch '$GALAXY_RELEASE' --galaxy_source '$GALAXY_REPO' '$DIR' || exit 1; done < changed_repositories_chunk.list
 
 after_success:
   - |
-    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
-      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
+    if [ '$TRAVIS_PULL_REQUEST' == "false" -a '$TRAVIS_BRANCH' == "master" ]; then
+      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email '$SHED_EMAIL' --shed_password '$SHED_PASSWORD' --force_repository_creation '$DIR' || exit 1; done < changed_repositories_chunk.list
+      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email '$SHED_EMAIL' --shed_password '$SHED_PASSWORD' --force_repository_creation '$DIR' || exit 1; done < changed_repositories_chunk.list
     fi


### PR DESCRIPTION
Ran into this when using this testing in our own repo and our randomly generated password had some special characters in it. 

Any reason to not just use single quotes everywhere?