### PR TITLE
Jbrowse: add missing tool_data_table_conf.xml.sample file

### DIFF
--- a/tools/jbrowse/tool-data/all_fasta.loc.sample
+++ b/tools/jbrowse/tool-data/all_fasta.loc.sample
@@ -1,0 +1,18 @@
+#This file lists the locations and dbkeys of all the fasta files
+#under the "genome" directory (a directory that contains a directory
+#for each build). The script extract_fasta.py will generate the file
+#all_fasta.loc. This file has the format (white space characters are
+#TAB characters):
+#
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
+#
+#So, all_fasta.loc could look something like this:
+#
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3	/path/to/genome/apiMel3/apiMel3.fa
+#hg19canon	hg19	Human (Homo sapiens): hg19 Canonical	/path/to/genome/hg19/hg19canon.fa
+#hg19full	hg19	Human (Homo sapiens): hg19 Full	/path/to/genome/hg19/hg19full.fa
+#
+#Your all_fasta.loc file should contain an entry for each individual
+#fasta file. So there will be multiple fasta files for each build,
+#such as with hg19 above.
+#

--- a/tools/jbrowse/tool_data_table_conf.xml.sample
+++ b/tools/jbrowse/tool_data_table_conf.xml.sample
@@ -1,0 +1,7 @@
+<tables>
+    <!-- Locations of all fasta files under genome directory -->
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+</tables>


### PR DESCRIPTION
I just noticed the latest changes to jbrowse tools (#994) were not pushed to MTS. I have tried doing it by hand, and it complained about "This file requires an entry in the tool_data_table_conf.xml file". Here's a fix for it.

I also get these errors, but I suppose it's harmless (these images/html are not used by the tool):
```
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/bam.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/bigwig.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/blast.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/opacity.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/sections.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/static/images/styling.png" contains image content.
The file "/srv/toolshed/main/var/data/repos/001/repo_1536/test-data/index.html" contains HTML content.
```