### PR TITLE
Travis update to 16.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ python: 2.7
 env:
   - CHUNK=0
   - CHUNK=1
-  - CHUNK=2
-  - CHUNK=3
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
-  - export GALAXY_RELEASE=release_16.07
+  - export GALAXY_RELEASE=release_16.10
   - export PLANEMO_CONDA_PREFIX="$HOME/conda"
 
 install:

--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -161,7 +161,7 @@
 This tool is part of the `bedtools package`_ from the `Quinlan laboratory`_.
 
 .. _bedtools package: https://github.com/arq5x/bedtools2
-.. _Quinlan laboratory: http://cphg.virginia.edu/quinlan/
+.. _Quinlan laboratory: http://quinlanlab.org
 
 
 **Citation**

--- a/tools/bedtools/reldist.xml
+++ b/tools/bedtools/reldist.xml
@@ -8,10 +8,10 @@
     <command>
 <![CDATA[
         bedtools reldist
-        -a $inputA
-        -b $inputB
+        -a '$inputA'
+        -b '$inputB'
         $detail
-        > "$output"
+        > '$output'
 ]]>
     </command>
     <inputs>


### PR DESCRIPTION
As part of the next release we should switch to this next release and test tools against latest stable.
This PR should also test Galaxy 16.10.

@galaxyproject/iuc 