### PR TITLE
depend also on python2

### DIFF
--- a/tools/ebi_tools/macros.xml
+++ b/tools/ebi_tools/macros.xml
@@ -1,6 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
+            <requirement type="package" version="2.7.12">python</requirement>
             <requirement type="package" version="3.1.1">xmltramp2</requirement>
             <requirement type="package" version="1.12">urllib3</requirement>
             <yield/>


### PR DESCRIPTION
Since your tools are python2 only, a python3 environment will not work. We need to strictly state python2 as dependency.

ping @bebatut 