### PR TITLE
Multiselect fixes

### DIFF
--- a/tools/ebi_tools/generate_macros.py
+++ b/tools/ebi_tools/generate_macros.py
@@ -16,10 +16,10 @@ def add_option(value, name, selected=False):
 def add_select_parameter(name, label, multiple=False):
     to_write = '<param '
     to_write += 'name="%s" ' % (name)
-    to_write += 'type="select" '
-    to_write += 'label="%s" ' % (label)
+    to_write += 'type="select"'
     if multiple:
-        to_write += 'multiple=\"true\"'
+        to_write += ' multiple="true" optional="false"'
+    to_write += ' label="%s"' % (label)
     to_write += '>\n'
     return to_write
 
@@ -30,6 +30,7 @@ def write_macros_file(macros_filepath, domains_fields):
 
     to_write += '%s<xml name="requirements">\n' % (spaces)
     to_write += '%s<requirements>\n' % (2 * spaces)
+    to_write += '%s<requirement type="package" version="2.7.12">python</requirement>\n' % (3 * spaces)
     to_write += '%s<requirement type="package" version="3.1.1">xmltramp2</requirement>\n' % (3 * spaces)
     to_write += '%s<requirement type="package" version="1.12">urllib3</requirement>\n' % (3 * spaces)
     to_write += '%s<yield/>\n' % (3 * spaces)
@@ -44,7 +45,7 @@ def write_macros_file(macros_filepath, domains_fields):
         'Domain to query'))
 
     sorted_domains = [(d, domains_fields[d]['name']) for d in domains_fields.keys()]
-    sorted_domains = sorted(sorted_domains, key=lambda tup: tup[1])
+    sorted_domains.sort(key=lambda tup: tup[1])
     for domain in sorted_domains:
         to_write += '%s%s' % (4 * spaces, add_option(
             domain[0],
@@ -65,7 +66,6 @@ def write_macros_file(macros_filepath, domains_fields):
                 field,
                 field,
                 selected=True))
-        to_write += '%s<validator type="no_options" message="Please select at least one field" />\n' % (5 * spaces)
         to_write += '%s</param>\n' % (4 * spaces)
 
         to_write += '%s<repeat name="queries" title="Add a query">\n' % (

--- a/tools/ebi_tools/macros.xml
+++ b/tools/ebi_tools/macros.xml
@@ -9,7 +9,7 @@
     </xml>
     <xml name="inputs">
         <conditional name="searched_domain">
-            <param name="domain" type="select" label="Domain to query" >
+            <param name="domain" type="select" label="Domain to query">
                 <option value="sra-analysis">Analysis</option>
                 <option value="arrayexpress-repository">ArrayExpress</option>
                 <option value="genome_assembly">Assembly</option>
@@ -122,7 +122,7 @@
             </param>
 
             <when value="sra-analysis">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="SRA-STUDY" selected="true">SRA-STUDY</option>
@@ -130,15 +130,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PROJECT">PROJECT</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="SRA-STUDY">SRA-STUDY</option>
@@ -152,7 +151,7 @@
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -173,7 +172,7 @@
             </when>
 
             <when value="arrayexpress-repository">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="data_protocol" selected="true">data_protocol</option>
@@ -191,15 +190,14 @@
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="submitter_keywords" selected="true">submitter_keywords</option>
                     <option value="tissue" selected="true">tissue</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="acc">acc</option>
@@ -235,7 +233,7 @@
                         <option value="updated_date">updated_date</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -256,7 +254,7 @@
             </when>
 
             <when value="genome_assembly">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="SAMPLE" selected="true">SAMPLE</option>
@@ -265,15 +263,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="PROJECT">PROJECT</option>
                         <option value="SAMPLE">SAMPLE</option>
@@ -290,7 +287,7 @@
                         <option value="strain">strain</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -311,7 +308,7 @@
             </when>
 
             <when value="wgs_masters">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
@@ -321,15 +318,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="PROJECT">PROJECT</option>
                         <option value="PUBMED">PUBMED</option>
@@ -356,7 +352,7 @@
                         <option value="strain">strain</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -377,7 +373,7 @@
             </when>
 
             <when value="emblrelease_con">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="CABRI" selected="true">CABRI</option>
                     <option value="DOI" selected="true">DOI</option>
@@ -407,15 +403,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="CABRI">CABRI</option>
                         <option value="DOI">DOI</option>
@@ -476,7 +471,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -497,7 +492,7 @@
             </when>
 
             <when value="emblnew_con">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="DOI" selected="true">DOI</option>
                     <option value="EC" selected="true">EC</option>
@@ -519,15 +514,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="DOI">DOI</option>
                         <option value="EC">EC</option>
@@ -577,7 +571,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -598,7 +592,7 @@
             </when>
 
             <when value="atlas-genes">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ATLAS" selected="true">ATLAS</option>
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="ENSFAMILY" selected="true">ENSFAMILY</option>
@@ -615,15 +609,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="organism_part" selected="true">organism_part</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ATLAS">ATLAS</option>
                         <option value="EMBL">EMBL</option>
                         <option value="ENSFAMILY">ENSFAMILY</option>
@@ -669,7 +662,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -690,7 +683,7 @@
             </when>
 
             <when value="biomodels">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="3DMET" selected="true">3DMET</option>
                     <option value="BIND" selected="true">BIND</option>
                     <option value="BIOMODELSDATABASE" selected="true">BIOMODELSDATABASE</option>
@@ -754,15 +747,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="3DMET">3DMET</option>
                         <option value="BIND">BIND</option>
                         <option value="BIOMODELSDATABASE">BIOMODELSDATABASE</option>
@@ -862,7 +854,7 @@
                         <option value="uniprot_name">uniprot_name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -883,20 +875,19 @@
             </when>
 
             <when value="biosamples">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="acc">acc</option>
                         <option value="description">description</option>
                         <option value="domain_source">domain_source</option>
@@ -905,7 +896,7 @@
                         <option value="searchwords">searchwords</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -926,20 +917,19 @@
             </when>
 
             <when value="biosamples-groups">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="acc">acc</option>
                         <option value="description">description</option>
                         <option value="domain_source">domain_source</option>
@@ -948,7 +938,7 @@
                         <option value="searchwords">searchwords</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -969,7 +959,7 @@
             </when>
 
             <when value="chebi">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARRAYEXPRESS" selected="true">ARRAYEXPRESS</option>
                     <option value="ARRAYEXPRESSATLAS" selected="true">ARRAYEXPRESSATLAS</option>
                     <option value="BIOMODELS" selected="true">BIOMODELS</option>
@@ -1026,15 +1016,14 @@
                     <option value="iupac_name" selected="true">iupac_name</option>
                     <option value="name" selected="true">name</option>
                     <option value="smiles" selected="true">smiles</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA_CITATION">AGRICOLA_CITATION</option>
                         <option value="ARRAYEXPRESS">ARRAYEXPRESS</option>
                         <option value="ARRAYEXPRESSATLAS">ARRAYEXPRESSATLAS</option>
@@ -1115,7 +1104,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1136,7 +1125,7 @@
             </when>
 
             <when value="chembl-activity">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL-ASSAY" selected="true">CHEMBL-ASSAY</option>
                     <option value="CHEMBL-DOCUMENT" selected="true">CHEMBL-DOCUMENT</option>
                     <option value="CHEMBL-MOLECULE" selected="true">CHEMBL-MOLECULE</option>
@@ -1144,15 +1133,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="standard_type" selected="true">standard_type</option>
                     <option value="standard_value" selected="true">standard_value</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEMBL-ASSAY">CHEMBL-ASSAY</option>
                         <option value="CHEMBL-DOCUMENT">CHEMBL-DOCUMENT</option>
                         <option value="CHEMBL-MOLECULE">CHEMBL-MOLECULE</option>
@@ -1170,7 +1158,7 @@
                         <option value="standard_value">standard_value</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1191,7 +1179,7 @@
             </when>
 
             <when value="chembl-assay">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL-ACTIVITY" selected="true">CHEMBL-ACTIVITY</option>
                     <option value="CHEMBL-DOCUMENT" selected="true">CHEMBL-DOCUMENT</option>
                     <option value="CHEMBL-TARGET" selected="true">CHEMBL-TARGET</option>
@@ -1199,15 +1187,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEMBL-ACTIVITY">CHEMBL-ACTIVITY</option>
                         <option value="CHEMBL-DOCUMENT">CHEMBL-DOCUMENT</option>
                         <option value="CHEMBL-TARGET">CHEMBL-TARGET</option>
@@ -1222,7 +1209,7 @@
                         <option value="tax_id">tax_id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1243,20 +1230,19 @@
             </when>
 
             <when value="chembl-document">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="title" selected="true">title</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PUBMED">PUBMED</option>
                         <option value="doi">doi</option>
                         <option value="domain_source">domain_source</option>
@@ -1268,7 +1254,7 @@
                         <option value="year">year</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1289,7 +1275,7 @@
             </when>
 
             <when value="chembl-molecule">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL-ACTIVITY" selected="true">CHEMBL-ACTIVITY</option>
                     <option value="alogp" selected="true">alogp</option>
                     <option value="canonical_smiles" selected="true">canonical_smiles</option>
@@ -1299,15 +1285,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="molecular_weight" selected="true">molecular_weight</option>
                     <option value="polar_surface_area" selected="true">polar_surface_area</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEMBL-ACTIVITY">CHEMBL-ACTIVITY</option>
                         <option value="alogp">alogp</option>
                         <option value="canonical_smiles">canonical_smiles</option>
@@ -1326,7 +1311,7 @@
                         <option value="structure_type">structure_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1347,21 +1332,20 @@
             </when>
 
             <when value="chembl-target">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL-ASSAY" selected="true">CHEMBL-ASSAY</option>
                     <option value="CHEMBL-TARGETCOMPONENTS" selected="true">CHEMBL-TARGETCOMPONENTS</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="organism" selected="true">organism</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEMBL-ASSAY">CHEMBL-ASSAY</option>
                         <option value="CHEMBL-TARGETCOMPONENTS">CHEMBL-TARGETCOMPONENTS</option>
                         <option value="domain_source">domain_source</option>
@@ -1373,7 +1357,7 @@
                         <option value="tax_id">tax_id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1394,7 +1378,7 @@
             </when>
 
             <when value="chembl-target_component">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL-TARGET" selected="true">CHEMBL-TARGET</option>
                     <option value="accession" selected="true">accession</option>
                     <option value="component_synonym" selected="true">component_synonym</option>
@@ -1402,15 +1386,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEMBL-TARGET">CHEMBL-TARGET</option>
                         <option value="accession">accession</option>
                         <option value="component_synonym">component_synonym</option>
@@ -1420,7 +1403,7 @@
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1441,7 +1424,7 @@
             </when>
 
             <when value="coding_release">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="DICTYBASE" selected="true">DICTYBASE</option>
@@ -1473,15 +1456,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="DICTYBASE">DICTYBASE</option>
@@ -1541,7 +1523,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1562,7 +1544,7 @@
             </when>
 
             <when value="coding_update">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="DOI" selected="true">DOI</option>
@@ -1588,15 +1570,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="DOI">DOI</option>
@@ -1650,7 +1631,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1671,7 +1652,7 @@
             </when>
 
             <when value="dgva">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="NCBI_TAXID" selected="true">NCBI_TAXID</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
@@ -1687,15 +1668,14 @@
                     <option value="variant_sample" selected="true">variant_sample</option>
                     <option value="variant_type" selected="true">variant_type</option>
                     <option value="variation_level" selected="true">variation_level</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="NCBI_TAXID">NCBI_TAXID</option>
                         <option value="PUBMED">PUBMED</option>
@@ -1713,7 +1693,7 @@
                         <option value="variation_level">variation_level</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1734,7 +1714,7 @@
             </when>
 
             <when value="atlas-genes-differential">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ATLAS" selected="true">ATLAS</option>
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="ENSFAMILY" selected="true">ENSFAMILY</option>
@@ -1750,15 +1730,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="organism_part" selected="true">organism_part</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ATLAS">ATLAS</option>
                         <option value="EMBL">EMBL</option>
                         <option value="ENSFAMILY">ENSFAMILY</option>
@@ -1847,7 +1826,7 @@
                         <option value="tumor_stage">tumor_stage</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1868,27 +1847,26 @@
             </when>
 
             <when value="efo">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EFO" selected="true">EFO</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EFO">EFO</option>
                         <option value="domain_source">domain_source</option>
                         <option value="id">id</option>
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1909,7 +1887,7 @@
             </when>
 
             <when value="ega">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EGA" selected="true">EGA</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
@@ -1920,15 +1898,14 @@
                     <option value="name" selected="true">name</option>
                     <option value="omics_type" selected="true">omics_type</option>
                     <option value="technology_type" selected="true">technology_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EGA">EGA</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
@@ -1962,7 +1939,7 @@
                         <option value="url">url</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -1983,7 +1960,7 @@
             </when>
 
             <when value="emdb">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="DOI" selected="true">DOI</option>
                     <option value="EMDB" selected="true">EMDB</option>
                     <option value="GO" selected="true">GO</option>
@@ -2003,15 +1980,14 @@
                     <option value="obsoletedDate_date" selected="true">obsoletedDate_date</option>
                     <option value="resolution" selected="true">resolution</option>
                     <option value="specimenstate" selected="true">specimenstate</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="DOI">DOI</option>
                         <option value="EMDB">EMDB</option>
                         <option value="GO">GO</option>
@@ -2047,7 +2023,7 @@
                         <option value="vitrificationinstrument">vitrificationinstrument</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2068,7 +2044,7 @@
             </when>
 
             <when value="epo">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="TAXON" selected="true">TAXON</option>
                     <option value="acc" selected="true">acc</option>
@@ -2078,15 +2054,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="offset_end" selected="true">offset_end</option>
                     <option value="offset_start" selected="true">offset_start</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="MD5">MD5</option>
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="TAXON">TAXON</option>
@@ -2110,7 +2085,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2131,7 +2106,7 @@
             </when>
 
             <when value="elixir-registry">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PMID" selected="true">PMID</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
@@ -2140,15 +2115,14 @@
                     <option value="mirror" selected="true">mirror</option>
                     <option value="name" selected="true">name</option>
                     <option value="version" selected="true">version</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="DOI">DOI</option>
                         <option value="PMID">PMID</option>
                         <option value="collection">collection</option>
@@ -2175,7 +2149,7 @@
                         <option value="version">version</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2196,7 +2170,7 @@
             </when>
 
             <when value="ensembl_gene">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARRAYEXPRESS" selected="true">ARRAYEXPRESS</option>
                     <option value="BIOGRID" selected="true">BIOGRID</option>
                     <option value="CCDS" selected="true">CCDS</option>
@@ -2300,15 +2274,14 @@
                     <option value="system_name" selected="true">system_name</option>
                     <option value="transcript" selected="true">transcript</option>
                     <option value="transcript_count" selected="true">transcript_count</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ARRAYEXPRESS">ARRAYEXPRESS</option>
                         <option value="BIOGRID">BIOGRID</option>
                         <option value="CCDS">CCDS</option>
@@ -2453,7 +2426,7 @@
                         <option value="zfin_id_synonym">zfin_id_synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2474,7 +2447,7 @@
             </when>
 
             <when value="ensemblGenomes_gene">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGD_GENE" selected="true">AGD_GENE</option>
                     <option value="AGD_TRANSCRIPT" selected="true">AGD_TRANSCRIPT</option>
                     <option value="ANT_GENOMES_PORTAL" selected="true">ANT_GENOMES_PORTAL</option>
@@ -2612,15 +2585,14 @@
                     <option value="system_name" selected="true">system_name</option>
                     <option value="transcript" selected="true">transcript</option>
                     <option value="transcript_count" selected="true">transcript_count</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGD_GENE">AGD_GENE</option>
                         <option value="AGD_TRANSCRIPT">AGD_TRANSCRIPT</option>
                         <option value="AGI_GENE">AGI_GENE</option>
@@ -2821,7 +2793,7 @@
                         <option value="transcript_version">transcript_version</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2842,7 +2814,7 @@
             </when>
 
             <when value="ensemblGenomes_genome">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="NCBI_TAXONOMY_ID" selected="true">NCBI_TAXONOMY_ID</option>
                     <option value="assembly_accession" selected="true">assembly_accession</option>
                     <option value="assembly_name" selected="true">assembly_name</option>
@@ -2860,15 +2832,14 @@
                     <option value="name" selected="true">name</option>
                     <option value="production_name" selected="true">production_name</option>
                     <option value="strain" selected="true">strain</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="NCBI_TAXONOMY_ID">NCBI_TAXONOMY_ID</option>
                         <option value="alias">alias</option>
                         <option value="assembly_accession">assembly_accession</option>
@@ -2895,7 +2866,7 @@
                         <option value="strain">strain</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2916,7 +2887,7 @@
             </when>
 
             <when value="ensemblGenomes_seqRegion">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="NCBI_TAXONOMY_ID" selected="true">NCBI_TAXONOMY_ID</option>
                     <option value="coord_system" selected="true">coord_system</option>
                     <option value="domain_source" selected="true">domain_source</option>
@@ -2927,15 +2898,14 @@
                     <option value="name" selected="true">name</option>
                     <option value="production_name" selected="true">production_name</option>
                     <option value="species" selected="true">species</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="NCBI_TAXONOMY_ID">NCBI_TAXONOMY_ID</option>
                         <option value="coord_system">coord_system</option>
                         <option value="domain_source">domain_source</option>
@@ -2947,7 +2917,7 @@
                         <option value="species">species</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -2968,7 +2938,7 @@
             </when>
 
             <when value="ensemblGenomes_variant">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="NCBI_TAXONOMY_ID" selected="true">NCBI_TAXONOMY_ID</option>
                     <option value="associated_gene" selected="true">associated_gene</option>
                     <option value="description" selected="true">description</option>
@@ -2982,15 +2952,14 @@
                     <option value="study" selected="true">study</option>
                     <option value="synonym" selected="true">synonym</option>
                     <option value="variation_source" selected="true">variation_source</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="NCBI_TAXONOMY_ID">NCBI_TAXONOMY_ID</option>
                         <option value="associated_gene">associated_gene</option>
                         <option value="description">description</option>
@@ -3007,7 +2976,7 @@
                         <option value="variation_source">variation_source</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3028,7 +2997,7 @@
             </when>
 
             <when value="enzymeportal">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="CHEMBL" selected="true">CHEMBL</option>
                     <option value="INTENZ" selected="true">INTENZ</option>
@@ -3044,15 +3013,14 @@
                     <option value="name" selected="true">name</option>
                     <option value="scientific_name" selected="true">scientific_name</option>
                     <option value="status" selected="true">status</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEBI">CHEBI</option>
                         <option value="CHEMBL">CHEMBL</option>
                         <option value="INTENZ">INTENZ</option>
@@ -3075,7 +3043,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3096,7 +3064,7 @@
             </when>
 
             <when value="enzymeportal_enzymes">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="CHEMBL" selected="true">CHEMBL</option>
                     <option value="INTENZ" selected="true">INTENZ</option>
@@ -3118,15 +3086,14 @@
                     <option value="scientific_name" selected="true">scientific_name</option>
                     <option value="synonym" selected="true">synonym</option>
                     <option value="uniprot_name" selected="true">uniprot_name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEBI">CHEBI</option>
                         <option value="CHEMBL">CHEMBL</option>
                         <option value="INTENZ">INTENZ</option>
@@ -3150,7 +3117,7 @@
                         <option value="uniprot_name">uniprot_name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3171,7 +3138,7 @@
             </when>
 
             <when value="atlas-experiments">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARRAYEXPRESS" selected="true">ARRAYEXPRESS</option>
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
@@ -3187,15 +3154,14 @@
                     <option value="omics_type" selected="true">omics_type</option>
                     <option value="publication_date" selected="true">publication_date</option>
                     <option value="sample_protocol" selected="true">sample_protocol</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ARRAYEXPRESS">ARRAYEXPRESS</option>
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="PUBMED">PUBMED</option>
@@ -3280,7 +3246,7 @@
                         <option value="tumor_stage">tumor_stage</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3301,7 +3267,7 @@
             </when>
 
             <when value="gnps">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="dataset_file" selected="true">dataset_file</option>
@@ -3316,15 +3282,14 @@
                     <option value="species" selected="true">species</option>
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="technology_type" selected="true">technology_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="acc">acc</option>
@@ -3351,7 +3316,7 @@
                         <option value="technology_type">technology_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3372,7 +3337,7 @@
             </when>
 
             <when value="go">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARACYC" selected="true">ARACYC</option>
                     <option value="BIOCYC" selected="true">BIOCYC</option>
                     <option value="BRENDA" selected="true">BRENDA</option>
@@ -3454,15 +3419,14 @@
                     <option value="replaced_by" selected="true">replaced_by</option>
                     <option value="subset" selected="true">subset</option>
                     <option value="synonym" selected="true">synonym</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ARACYC">ARACYC</option>
                         <option value="BIOCYC">BIOCYC</option>
                         <option value="BRENDA">BRENDA</option>
@@ -3570,7 +3534,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3591,7 +3555,7 @@
             </when>
 
             <when value="gpcrdb">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="SWISSPROT" selected="true">SWISSPROT</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="TREMBL" selected="true">TREMBL</option>
@@ -3600,15 +3564,14 @@
                     <option value="gpcr-family" selected="true">gpcr-family</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="SWISSPROT">SWISSPROT</option>
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="TREMBL">TREMBL</option>
@@ -3619,7 +3582,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3640,7 +3603,7 @@
             </when>
 
             <when value="gpmdb">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="MASSIVE" selected="true">MASSIVE</option>
                     <option value="PRIDE" selected="true">PRIDE</option>
@@ -3655,15 +3618,14 @@
                     <option value="publication" selected="true">publication</option>
                     <option value="species" selected="true">species</option>
                     <option value="submission_date" selected="true">submission_date</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="MASSIVE">MASSIVE</option>
                         <option value="PRIDE">PRIDE</option>
@@ -3692,7 +3654,7 @@
                         <option value="submitter_mail">submitter_mail</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3713,7 +3675,7 @@
             </when>
 
             <when value="hgnc">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CCDS" selected="true">CCDS</option>
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="ENSEMBL_GENE" selected="true">ENSEMBL_GENE</option>
@@ -3739,15 +3701,14 @@
                     <option value="gd_status" selected="true">gd_status</option>
                     <option value="id" selected="true">id</option>
                     <option value="id_without_prefix" selected="true">id_without_prefix</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CCDS">CCDS</option>
                         <option value="EMBL">EMBL</option>
                         <option value="ENSEMBL_GENE">ENSEMBL_GENE</option>
@@ -3775,7 +3736,7 @@
                         <option value="id_without_prefix">id_without_prefix</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3796,7 +3757,7 @@
             </when>
 
             <when value="human_diseases">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="KW" selected="true">KW</option>
                     <option value="MEDGEN" selected="true">MEDGEN</option>
                     <option value="MESH" selected="true">MESH</option>
@@ -3805,15 +3766,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="KW">KW</option>
                         <option value="MEDGEN">MEDGEN</option>
                         <option value="MESH">MESH</option>
@@ -3827,7 +3787,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3848,7 +3808,7 @@
             </when>
 
             <when value="imgt-hla">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EMBL-ENA" selected="true">EMBL-ENA</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="description" selected="true">description</option>
@@ -3856,15 +3816,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="organism" selected="true">organism</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EMBL-ENA">EMBL-ENA</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="creation_date">creation_date</option>
@@ -3876,7 +3835,7 @@
                         <option value="organism">organism</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3897,7 +3856,7 @@
             </when>
 
             <when value="ipd-kir">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EMBL-ENA" selected="true">EMBL-ENA</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="description" selected="true">description</option>
@@ -3905,15 +3864,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="organism" selected="true">organism</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EMBL-ENA">EMBL-ENA</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="creation_date">creation_date</option>
@@ -3925,7 +3883,7 @@
                         <option value="organism">organism</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3946,7 +3904,7 @@
             </when>
 
             <when value="ipd-mhc">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EMBL-ENA" selected="true">EMBL-ENA</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
@@ -3955,15 +3913,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="organism" selected="true">organism</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EMBL-ENA">EMBL-ENA</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
@@ -3975,7 +3932,7 @@
                         <option value="organism">organism</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -3996,7 +3953,7 @@
             </when>
 
             <when value="intact-complexes">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEMBL" selected="true">CHEMBL</option>
                     <option value="CHEMBL_TARGET" selected="true">CHEMBL_TARGET</option>
                     <option value="DIP" selected="true">DIP</option>
@@ -4023,15 +3980,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="3d-r-factors">3d-r-factors</option>
                         <option value="CHEMBL">CHEMBL</option>
                         <option value="CHEMBL_TARGET">CHEMBL_TARGET</option>
@@ -4086,7 +4042,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4107,7 +4063,7 @@
             </when>
 
             <when value="intact-experiments">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BRENDA" selected="true">BRENDA</option>
                     <option value="DOI" selected="true">DOI</option>
                     <option value="EFO" selected="true">EFO</option>
@@ -4132,15 +4088,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BRENDA">BRENDA</option>
                         <option value="DOI">DOI</option>
                         <option value="EFO">EFO</option>
@@ -4173,7 +4128,7 @@
                         <option value="participant_detection_method">participant_detection_method</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4194,7 +4149,7 @@
             </when>
 
             <when value="intact-interactions">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AFCS" selected="true">AFCS</option>
                     <option value="BRENDA" selected="true">BRENDA</option>
                     <option value="CELL_ONTOLOGY" selected="true">CELL_ONTOLOGY</option>
@@ -4230,15 +4185,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AFCS">AFCS</option>
                         <option value="BRENDA">BRENDA</option>
                         <option value="CELL_ONTOLOGY">CELL_ONTOLOGY</option>
@@ -4282,7 +4236,7 @@
                         <option value="participant_detection_method">participant_detection_method</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4303,7 +4257,7 @@
             </when>
 
             <when value="intact-interactors">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AFCS" selected="true">AFCS</option>
                     <option value="CAMJEDB" selected="true">CAMJEDB</option>
                     <option value="CAS_REGISTRY_NUMBER" selected="true">CAS_REGISTRY_NUMBER</option>
@@ -4358,15 +4312,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AFCS">AFCS</option>
                         <option value="BIND_SMID">BIND_SMID</option>
                         <option value="CAMJEDB">CAMJEDB</option>
@@ -4440,7 +4393,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4461,7 +4414,7 @@
             </when>
 
             <when value="intenz">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CAS" selected="true">CAS</option>
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="EC" selected="true">EC</option>
@@ -4476,15 +4429,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CAS">CAS</option>
                         <option value="CHEBI">CHEBI</option>
                         <option value="EC">EC</option>
@@ -4507,7 +4459,7 @@
                         <option value="systematic_name">systematic_name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4528,7 +4480,7 @@
             </when>
 
             <when value="interpro">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CATH" selected="true">CATH</option>
                     <option value="CAZY" selected="true">CAZY</option>
                     <option value="CDD" selected="true">CDD</option>
@@ -4565,15 +4517,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="type" selected="true">type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CATH">CATH</option>
                         <option value="CAZY">CAZY</option>
                         <option value="CDD">CDD</option>
@@ -4626,7 +4577,7 @@
                         <option value="type">type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4647,7 +4598,7 @@
             </when>
 
             <when value="iprmatches">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CDD" selected="true">CDD</option>
                     <option value="GENE3D" selected="true">GENE3D</option>
                     <option value="HAMAP" selected="true">HAMAP</option>
@@ -4668,15 +4619,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CDD">CDD</option>
                         <option value="GENE3D">GENE3D</option>
                         <option value="HAMAP">HAMAP</option>
@@ -4700,7 +4650,7 @@
                         <option value="signatureName">signatureName</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4721,7 +4671,7 @@
             </when>
 
             <when value="jpo">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="TAXON" selected="true">TAXON</option>
                     <option value="acc" selected="true">acc</option>
@@ -4731,15 +4681,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="offset_end" selected="true">offset_end</option>
                     <option value="offset_start" selected="true">offset_start</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="TAXON">TAXON</option>
                         <option value="acc">acc</option>
@@ -4757,7 +4706,7 @@
                         <option value="references">references</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4778,7 +4727,7 @@
             </when>
 
             <when value="kipo">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="TAXON" selected="true">TAXON</option>
                     <option value="acc" selected="true">acc</option>
@@ -4788,15 +4737,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="offset_end" selected="true">offset_end</option>
                     <option value="offset_start" selected="true">offset_start</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="TAXON">TAXON</option>
                         <option value="acc">acc</option>
@@ -4814,7 +4762,7 @@
                         <option value="references">references</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4835,7 +4783,7 @@
             </when>
 
             <when value="lrg">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CCDS" selected="true">CCDS</option>
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="GENEID" selected="true">GENEID</option>
@@ -4871,15 +4819,14 @@
                     <option value="organism" selected="true">organism</option>
                     <option value="status" selected="true">status</option>
                     <option value="transcript_source" selected="true">transcript_source</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CCDS">CCDS</option>
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="GENEID">GENEID</option>
@@ -4903,7 +4850,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4924,7 +4871,7 @@
             </when>
 
             <when value="large-assembly">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="DOI" selected="true">DOI</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXON" selected="true">TAXON</option>
@@ -4932,15 +4879,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="DOI">DOI</option>
                         <option value="MD5">MD5</option>
                         <option value="PROJECT">PROJECT</option>
@@ -4965,7 +4911,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -4986,20 +4932,19 @@
             </when>
 
             <when value="pdbechem">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="acc" selected="true">acc</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="acc">acc</option>
                         <option value="comp_synonyms">comp_synonyms</option>
                         <option value="description">description</option>
@@ -5013,7 +4958,7 @@
                         <option value="weight">weight</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5034,7 +4979,7 @@
             </when>
 
             <when value="medline">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="MESH_DESCRIPTOR_NAME" selected="true">MESH_DESCRIPTOR_NAME</option>
                     <option value="ORCID" selected="true">ORCID</option>
                     <option value="author" selected="true">author</option>
@@ -5049,15 +4994,14 @@
                     <option value="pagination" selected="true">pagination</option>
                     <option value="publication_date" selected="true">publication_date</option>
                     <option value="volume" selected="true">volume</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="MESH_DESCRIPTOR_NAME">MESH_DESCRIPTOR_NAME</option>
                         <option value="ORCID">ORCID</option>
                         <option value="affiliation">affiliation</option>
@@ -5079,7 +5023,7 @@
                         <option value="volume">volume</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5100,22 +5044,21 @@
             </when>
 
             <when value="merops_clan">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PFAM" selected="true">PFAM</option>
                     <option value="SCOP" selected="true">SCOP</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PFAM">PFAM</option>
                         <option value="SCOP">SCOP</option>
                         <option value="acc">acc</option>
@@ -5138,7 +5081,7 @@
                         <option value="subclans">subclans</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5159,7 +5102,7 @@
             </when>
 
             <when value="merops_family">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CATH" selected="true">CATH</option>
                     <option value="HOMSTRAD" selected="true">HOMSTRAD</option>
                     <option value="HSSP" selected="true">HSSP</option>
@@ -5171,15 +5114,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CATH">CATH</option>
                         <option value="HOMSTRAD">HOMSTRAD</option>
                         <option value="HSSP">HSSP</option>
@@ -5210,7 +5152,7 @@
                         <option value="subfamilies">subfamilies</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5231,7 +5173,7 @@
             </when>
 
             <when value="merops_id">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="EMBLCDS" selected="true">EMBLCDS</option>
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
@@ -5247,15 +5189,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EMBL">EMBL</option>
                         <option value="EMBLCDS">EMBLCDS</option>
                         <option value="ENSEMBL">ENSEMBL</option>
@@ -5290,7 +5231,7 @@
                         <option value="structure">structure</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5311,20 +5252,19 @@
             </when>
 
             <when value="mesh">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="MESH_PHARMA" selected="true">MESH_PHARMA</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="MESH_PHARMA">MESH_PHARMA</option>
                         <option value="annotation">annotation</option>
                         <option value="creation_date">creation_date</option>
@@ -5342,7 +5282,7 @@
                         <option value="qualifierui">qualifierui</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5363,7 +5303,7 @@
             </when>
 
             <when value="massive">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="dataset_file" selected="true">dataset_file</option>
@@ -5378,15 +5318,14 @@
                     <option value="species" selected="true">species</option>
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="technology_type" selected="true">technology_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="acc">acc</option>
@@ -5408,7 +5347,7 @@
                         <option value="technology_type">technology_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5429,7 +5368,7 @@
             </when>
 
             <when value="metabolights">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="HMDB" selected="true">HMDB</option>
                     <option value="KEGG" selected="true">KEGG</option>
@@ -5452,15 +5391,14 @@
                     <option value="study_status" selected="true">study_status</option>
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="technology_type" selected="true">technology_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="3d_desi_imaging_ms_dataset_of_a_human_colorectal_adenocarcinoma_protocol">3d_desi_imaging_ms_dataset_of_a_human_colorectal_adenocarcinoma_protocol</option>
                         <option value="3d_maldi_imaging_ms_dataset_of_a_human_oral_squamous_cell_carcinoma_protocol">3d_maldi_imaging_ms_dataset_of_a_human_oral_squamous_cell_carcinoma_protocol</option>
                         <option value="3d_maldi_imaging_ms_dataset_of_a_mouse_kidney_protocol">3d_maldi_imaging_ms_dataset_of_a_mouse_kidney_protocol</option>
@@ -5529,7 +5467,7 @@
                         <option value="technology_type">technology_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5550,7 +5488,7 @@
             </when>
 
             <when value="metabolights_dataset">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="HMDB" selected="true">HMDB</option>
                     <option value="KEGG" selected="true">KEGG</option>
@@ -5572,15 +5510,14 @@
                     <option value="study_status" selected="true">study_status</option>
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="technology_type" selected="true">technology_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="3d_desi_imaging_ms_dataset_of_a_human_colorectal_adenocarcinoma_protocol">3d_desi_imaging_ms_dataset_of_a_human_colorectal_adenocarcinoma_protocol</option>
                         <option value="3d_maldi_imaging_ms_dataset_of_a_human_oral_squamous_cell_carcinoma_protocol">3d_maldi_imaging_ms_dataset_of_a_human_oral_squamous_cell_carcinoma_protocol</option>
                         <option value="3d_maldi_imaging_ms_dataset_of_a_mouse_kidney_protocol">3d_maldi_imaging_ms_dataset_of_a_mouse_kidney_protocol</option>
@@ -5652,7 +5589,7 @@
                         <option value="technology_type">technology_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5673,7 +5610,7 @@
             </when>
 
             <when value="metabolome_express">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="description" selected="true">description</option>
@@ -5686,15 +5623,14 @@
                     <option value="publication" selected="true">publication</option>
                     <option value="publication_date" selected="true">publication_date</option>
                     <option value="study_factor" selected="true">study_factor</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEBI">CHEBI</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="acc">acc</option>
@@ -5736,7 +5672,7 @@
                         <option value="treatmentid">treatmentid</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5757,7 +5693,7 @@
             </when>
 
             <when value="metabolomics_workbench">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
@@ -5775,15 +5711,14 @@
                     <option value="submission_date" selected="true">submission_date</option>
                     <option value="technology_type" selected="true">technology_type</option>
                     <option value="tissue" selected="true">tissue</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEBI">CHEBI</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
@@ -5816,7 +5751,7 @@
                         <option value="tissue">tissue</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5837,24 +5772,23 @@
             </when>
 
             <when value="hmmer_hmm">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="content" selected="true">content</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="domain_source">domain_source</option>
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5875,22 +5809,21 @@
             </when>
 
             <when value="hmmer_seq">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="PDB" selected="true">PDB</option>
                     <option value="UNIPROT" selected="true">UNIPROT</option>
                     <option value="content" selected="true">content</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="PDB">PDB</option>
                         <option value="UNIPROT">UNIPROT</option>
@@ -5898,7 +5831,7 @@
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5919,7 +5852,7 @@
             </when>
 
             <when value="metagenomics_projects">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="METAGENOMICS_RUNS" selected="true">METAGENOMICS_RUNS</option>
                     <option value="METAGENOMICS_SAMPLES" selected="true">METAGENOMICS_SAMPLES</option>
                     <option value="biome_name" selected="true">biome_name</option>
@@ -5927,15 +5860,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="METAGENOMICS_RUNS">METAGENOMICS_RUNS</option>
                         <option value="METAGENOMICS_SAMPLES">METAGENOMICS_SAMPLES</option>
                         <option value="biome">biome</option>
@@ -5950,7 +5882,7 @@
                         <option value="releaseDate_date">releaseDate_date</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -5971,7 +5903,7 @@
             </when>
 
             <when value="metagenomics_runs">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="GO" selected="true">GO</option>
                     <option value="INTERPRO" selected="true">INTERPRO</option>
                     <option value="METAGENOMICS_PROJECTS" selected="true">METAGENOMICS_PROJECTS</option>
@@ -5987,15 +5919,14 @@
                     <option value="project_name" selected="true">project_name</option>
                     <option value="sample_name" selected="true">sample_name</option>
                     <option value="temperature" selected="true">temperature</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="GO">GO</option>
                         <option value="INTERPRO">INTERPRO</option>
                         <option value="METAGENOMICS_PROJECTS">METAGENOMICS_PROJECTS</option>
@@ -6019,7 +5950,7 @@
                         <option value="temperature">temperature</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6040,7 +5971,7 @@
             </when>
 
             <when value="metagenomics_samples">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENVO" selected="true">ENVO</option>
                     <option value="METAGENOMICS_PROJECTS" selected="true">METAGENOMICS_PROJECTS</option>
                     <option value="METAGENOMICS_RUNS" selected="true">METAGENOMICS_RUNS</option>
@@ -6051,15 +5982,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="project_name" selected="true">project_name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENVO">ENVO</option>
                         <option value="METAGENOMICS_PROJECTS">METAGENOMICS_PROJECTS</option>
                         <option value="METAGENOMICS_RUNS">METAGENOMICS_RUNS</option>
@@ -6098,7 +6028,7 @@
                         <option value="temperature">temperature</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6119,20 +6049,19 @@
             </when>
 
             <when value="nrnl1">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EM_PAT" selected="true">EM_PAT</option>
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EM_PAT">EM_PAT</option>
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="domain_source">domain_source</option>
@@ -6142,7 +6071,7 @@
                         <option value="md5">md5</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6163,21 +6092,20 @@
             </when>
 
             <when value="nrnl2">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EM_PAT" selected="true">EM_PAT</option>
                     <option value="PATENTFAMILIES" selected="true">PATENTFAMILIES</option>
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EM_PAT">EM_PAT</option>
                         <option value="PATENTFAMILIES">PATENTFAMILIES</option>
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
@@ -6190,7 +6118,7 @@
                         <option value="patent_priority_date">patent_priority_date</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6211,7 +6139,7 @@
             </when>
 
             <when value="nrpl1">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EPOP" selected="true">EPOP</option>
                     <option value="JPOP" selected="true">JPOP</option>
                     <option value="KPOP" selected="true">KPOP</option>
@@ -6219,15 +6147,14 @@
                     <option value="USPOP" selected="true">USPOP</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EPOP">EPOP</option>
                         <option value="JPOP">JPOP</option>
                         <option value="KPOP">KPOP</option>
@@ -6240,7 +6167,7 @@
                         <option value="md5">md5</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6261,7 +6188,7 @@
             </when>
 
             <when value="nrpl2">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EPOP" selected="true">EPOP</option>
                     <option value="JPOP" selected="true">JPOP</option>
                     <option value="KPOP" selected="true">KPOP</option>
@@ -6270,15 +6197,14 @@
                     <option value="USPOP" selected="true">USPOP</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EPOP">EPOP</option>
                         <option value="JPOP">JPOP</option>
                         <option value="KPOP">KPOP</option>
@@ -6294,7 +6220,7 @@
                         <option value="patent_priority_date">patent_priority_date</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6315,7 +6241,7 @@
             </when>
 
             <when value="non-coding_release">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="DOI" selected="true">DOI</option>
@@ -6338,15 +6264,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="DOI">DOI</option>
@@ -6395,7 +6320,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6416,7 +6341,7 @@
             </when>
 
             <when value="non-coding_update">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="DOI" selected="true">DOI</option>
@@ -6430,15 +6355,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="DOI">DOI</option>
@@ -6478,7 +6402,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6499,21 +6423,20 @@
             </when>
 
             <when value="omim">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="OMIM" selected="true">OMIM</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="title" selected="true">title</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="OMIM">OMIM</option>
                         <option value="allelic_variations">allelic_variations</option>
                         <option value="alternative_title">alternative_title</option>
@@ -6527,7 +6450,7 @@
                         <option value="title">title</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6548,7 +6471,7 @@
             </when>
 
             <when value="pdbe">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CATH" selected="true">CATH</option>
                     <option value="EC" selected="true">EC</option>
                     <option value="GO" selected="true">GO</option>
@@ -6564,15 +6487,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CATH">CATH</option>
                         <option value="EC">EC</option>
                         <option value="GO">GO</option>
@@ -6601,7 +6523,7 @@
                         <option value="source_organism">source_organism</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6622,7 +6544,7 @@
             </when>
 
             <when value="pride">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
@@ -6649,15 +6571,14 @@
                     <option value="submitter_keywords" selected="true">submitter_keywords</option>
                     <option value="technology_type" selected="true">technology_type</option>
                     <option value="tissue" selected="true">tissue</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXONOMY">TAXONOMY</option>
@@ -6705,7 +6626,7 @@
                         <option value="tissue">tissue</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6726,19 +6647,18 @@
             </when>
 
             <when value="patentFamilies">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="domain_source">domain_source</option>
                         <option value="id">id</option>
@@ -6746,7 +6666,7 @@
                         <option value="patent_priority">patent_priority</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6767,7 +6687,7 @@
             </when>
 
             <when value="patentdb">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EPO" selected="true">EPO</option>
                     <option value="IPC" selected="true">IPC</option>
                     <option value="description" selected="true">description</option>
@@ -6776,15 +6696,14 @@
                     <option value="name" selected="true">name</option>
                     <option value="patent_number" selected="true">patent_number</option>
                     <option value="publication_date" selected="true">publication_date</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EPO">EPO</option>
                         <option value="IPC">IPC</option>
                         <option value="MC">MC</option>
@@ -6801,7 +6720,7 @@
                         <option value="type">type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6822,7 +6741,7 @@
             </when>
 
             <when value="ebiweb_people">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="email" selected="true">email</option>
                     <option value="fax" selected="true">fax</option>
@@ -6835,15 +6754,14 @@
                     <option value="room" selected="true">room</option>
                     <option value="surname" selected="true">surname</option>
                     <option value="tel" selected="true">tel</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="bio">bio</option>
                         <option value="domain_source">domain_source</option>
                         <option value="email">email</option>
@@ -6858,7 +6776,7 @@
                         <option value="tel">tel</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6879,7 +6797,7 @@
             </when>
 
             <when value="peptide_atlas">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="FLYBASE" selected="true">FLYBASE</option>
                     <option value="INSECTBASE" selected="true">INSECTBASE</option>
@@ -6910,15 +6828,14 @@
                     <option value="species" selected="true">species</option>
                     <option value="technology_type" selected="true">technology_type</option>
                     <option value="tissue" selected="true">tissue</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="FLYBASE">FLYBASE</option>
                         <option value="INSECTBASE">INSECTBASE</option>
@@ -6969,7 +6886,7 @@
                         <option value="tissue">tissue</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -6990,7 +6907,7 @@
             </when>
 
             <when value="pfam">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="GO" selected="true">GO</option>
                     <option value="INTERPRO" selected="true">INTERPRO</option>
                     <option value="acc" selected="true">acc</option>
@@ -6999,15 +6916,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
                     <option value="type" selected="true">type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="GO">GO</option>
                         <option value="INTERPRO">INTERPRO</option>
                         <option value="acc">acc</option>
@@ -7026,7 +6942,7 @@
                         <option value="type">type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7047,7 +6963,7 @@
             </when>
 
             <when value="pombase">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EC_NUMBER" selected="true">EC_NUMBER</option>
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="ENTREZGENE" selected="true">ENTREZGENE</option>
@@ -7085,15 +7001,14 @@
                     <option value="system_name" selected="true">system_name</option>
                     <option value="transcript" selected="true">transcript</option>
                     <option value="transcript_count" selected="true">transcript_count</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EC_NUMBER">EC_NUMBER</option>
                         <option value="EMBL">EMBL</option>
                         <option value="ENSEMBLVARIATION">ENSEMBLVARIATION</option>
@@ -7148,7 +7063,7 @@
                         <option value="transcript">transcript</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7169,7 +7084,7 @@
             </when>
 
             <when value="rnacentral">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="DICTYBASE" selected="true">DICTYBASE</option>
                     <option value="DOI" selected="true">DOI</option>
                     <option value="ECO" selected="true">ECO</option>
@@ -7217,15 +7132,14 @@
                     <option value="pub_title" selected="true">pub_title</option>
                     <option value="rna_type" selected="true">rna_type</option>
                     <option value="species" selected="true">species</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="DICTYBASE">DICTYBASE</option>
                         <option value="DOI">DOI</option>
                         <option value="ECO">ECO</option>
@@ -7284,7 +7198,7 @@
                         <option value="species">species</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7305,7 +7219,7 @@
             </when>
 
             <when value="reactome">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARACYC" selected="true">ARACYC</option>
                     <option value="BIOMODELS_DATABASE" selected="true">BIOMODELS_DATABASE</option>
                     <option value="CAS" selected="true">CAS</option>
@@ -7355,15 +7269,14 @@
                     <option value="species" selected="true">species</option>
                     <option value="stid" selected="true">stid</option>
                     <option value="type" selected="true">type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ARACYC">ARACYC</option>
                         <option value="BIOMODELS_DATABASE">BIOMODELS_DATABASE</option>
                         <option value="CAS">CAS</option>
@@ -7429,7 +7342,7 @@
                         <option value="type">type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7450,7 +7363,7 @@
             </when>
 
             <when value="sra-experiment">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="SAMPLE" selected="true">SAMPLE</option>
@@ -7461,15 +7374,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="PROJECT">PROJECT</option>
                         <option value="SAMPLE">SAMPLE</option>
@@ -7491,7 +7403,7 @@
                         <option value="library_strategy">library_strategy</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7512,7 +7424,7 @@
             </when>
 
             <when value="sra-run">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="SRA-EXPERIMENT" selected="true">SRA-EXPERIMENT</option>
                     <option value="SRA-SAMPLE" selected="true">SRA-SAMPLE</option>
                     <option value="SRA-STUDY" selected="true">SRA-STUDY</option>
@@ -7520,15 +7432,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="SRA-EXPERIMENT">SRA-EXPERIMENT</option>
                         <option value="SRA-SAMPLE">SRA-SAMPLE</option>
                         <option value="SRA-STUDY">SRA-STUDY</option>
@@ -7541,7 +7452,7 @@
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7562,7 +7473,7 @@
             </when>
 
             <when value="ebiweb_resources">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
@@ -7571,15 +7482,14 @@
                     <option value="short_name" selected="true">short_name</option>
                     <option value="thumbnail" selected="true">thumbnail</option>
                     <option value="url" selected="true">url</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="activity">activity</option>
                         <option value="category">category</option>
                         <option value="cluster">cluster</option>
@@ -7593,7 +7503,7 @@
                         <option value="short_name">short_name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7614,7 +7524,7 @@
             </when>
 
             <when value="rhea">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="CHEBI" selected="true">CHEBI</option>
                     <option value="CITATION" selected="true">CITATION</option>
                     <option value="ECOCYC" selected="true">ECOCYC</option>
@@ -7630,15 +7540,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="CHEBI">CHEBI</option>
                         <option value="CITATION">CITATION</option>
                         <option value="ECOCYC">ECOCYC</option>
@@ -7656,7 +7565,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7677,21 +7586,20 @@
             </when>
 
             <when value="sbo">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="SBO" selected="true">SBO</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="SBO">SBO</option>
                         <option value="comment">comment</option>
                         <option value="description">description</option>
@@ -7702,7 +7610,7 @@
                         <option value="synonym">synonym</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7723,7 +7631,7 @@
             </when>
 
             <when value="sra-sample">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="SRA-SUBMISSION" selected="true">SRA-SUBMISSION</option>
                     <option value="TAXON" selected="true">TAXON</option>
@@ -7733,15 +7641,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="scientific_name" selected="true">scientific_name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="ENA-CHECKLIST">ENA-CHECKLIST</option>
                         <option value="SRA-SUBMISSION">SRA-SUBMISSION</option>
@@ -7759,7 +7666,7 @@
                         <option value="secondary_id">secondary_id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7780,7 +7687,7 @@
             </when>
 
             <when value="emblrelease_standard">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="CABRI" selected="true">CABRI</option>
@@ -7839,15 +7746,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="CABRI">CABRI</option>
@@ -7940,7 +7846,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -7961,7 +7867,7 @@
             </when>
 
             <when value="emblnew_standard">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="CABRI" selected="true">CABRI</option>
@@ -8001,15 +7907,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="CABRI">CABRI</option>
@@ -8083,7 +7988,7 @@
                         <option value="topology">topology</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8104,7 +8009,7 @@
             </when>
 
             <when value="ebiweb_corporate">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="content" selected="true">content</option>
                     <option value="content_signature" selected="true">content_signature</option>
                     <option value="description" selected="true">description</option>
@@ -8113,15 +8018,14 @@
                     <option value="mime_type" selected="true">mime_type</option>
                     <option value="name" selected="true">name</option>
                     <option value="namespace" selected="true">namespace</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="author">author</option>
                         <option value="content">content</option>
                         <option value="content_signature">content_signature</option>
@@ -8138,7 +8042,7 @@
                         <option value="namespace">namespace</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8159,22 +8063,21 @@
             </when>
 
             <when value="project">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="TAXON" selected="true">TAXON</option>
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PUBMED">PUBMED</option>
                         <option value="TAXON">TAXON</option>
                         <option value="acc">acc</option>
@@ -8187,7 +8090,7 @@
                         <option value="strain">strain</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8208,7 +8111,7 @@
             </when>
 
             <when value="sra-study">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
                     <option value="SRA-STUDY" selected="true">SRA-STUDY</option>
@@ -8218,15 +8121,14 @@
                     <option value="existing_study_type" selected="true">existing_study_type</option>
                     <option value="id" selected="true">id</option>
                     <option value="new_study_type" selected="true">new_study_type</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PROJECT">PROJECT</option>
                         <option value="PUBMED">PUBMED</option>
                         <option value="SRA-STUDY">SRA-STUDY</option>
@@ -8243,7 +8145,7 @@
                         <option value="new_study_type">new_study_type</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8264,19 +8166,18 @@
             </when>
 
             <when value="sra-submission">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="acc">acc</option>
                         <option value="alias">alias</option>
                         <option value="center_name">center_name</option>
@@ -8285,7 +8186,7 @@
                         <option value="id">id</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8306,7 +8207,7 @@
             </when>
 
             <when value="taxonomy">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="acronym" selected="true">acronym</option>
                     <option value="anamorph" selected="true">anamorph</option>
@@ -8324,15 +8225,14 @@
                     <option value="offset_end" selected="true">offset_end</option>
                     <option value="offset_start" selected="true">offset_start</option>
                     <option value="synonym" selected="true">synonym</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="acronym">acronym</option>
                         <option value="anamorph">anamorph</option>
@@ -8356,7 +8256,7 @@
                         <option value="teleomorph">teleomorph</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8377,7 +8277,7 @@
             </when>
 
             <when value="tsa_masters">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="BIOSAMPLE" selected="true">BIOSAMPLE</option>
                     <option value="PROJECT" selected="true">PROJECT</option>
                     <option value="PUBMED" selected="true">PUBMED</option>
@@ -8387,15 +8287,14 @@
                     <option value="description" selected="true">description</option>
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="BIOSAMPLE">BIOSAMPLE</option>
                         <option value="PROJECT">PROJECT</option>
                         <option value="PUBMED">PUBMED</option>
@@ -8422,7 +8321,7 @@
                         <option value="strain">strain</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8443,7 +8342,7 @@
             </when>
 
             <when value="treefam">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ENSEMBL" selected="true">ENSEMBL</option>
                     <option value="HGNC" selected="true">HGNC</option>
                     <option value="PFAM" selected="true">PFAM</option>
@@ -8454,15 +8353,14 @@
                     <option value="domain_source" selected="true">domain_source</option>
                     <option value="id" selected="true">id</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ENSEMBL">ENSEMBL</option>
                         <option value="HGNC">HGNC</option>
                         <option value="PFAM">PFAM</option>
@@ -8478,7 +8376,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8499,7 +8397,7 @@
             </when>
 
             <when value="uspto">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="PATENT_NUMBER" selected="true">PATENT_NUMBER</option>
                     <option value="acc" selected="true">acc</option>
                     <option value="description" selected="true">description</option>
@@ -8508,15 +8406,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="offset_end" selected="true">offset_end</option>
                     <option value="offset_start" selected="true">offset_start</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="PATENT_NUMBER">PATENT_NUMBER</option>
                         <option value="acc">acc</option>
                         <option value="creation_date">creation_date</option>
@@ -8532,7 +8429,7 @@
                         <option value="sequence_version">sequence_version</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8553,7 +8450,7 @@
             </when>
 
             <when value="uniparc">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="EMBLWGS" selected="true">EMBLWGS</option>
                     <option value="EMBL_CON" selected="true">EMBL_CON</option>
@@ -8593,15 +8490,14 @@
                     <option value="gene_name" selected="true">gene_name</option>
                     <option value="id" selected="true">id</option>
                     <option value="length" selected="true">length</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="EMBL">EMBL</option>
                         <option value="EMBLWGS">EMBLWGS</option>
                         <option value="EMBL_CON">EMBL_CON</option>
@@ -8647,7 +8543,7 @@
                         <option value="uniprotkb_exclusion">uniprotkb_exclusion</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -8668,7 +8564,7 @@
             </when>
 
             <when value="uniprot">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="AGRICOLA" selected="true">AGRICOLA</option>
                     <option value="ALLERGOME" selected="true">ALLERGOME</option>
                     <option value="ARACHNOSERVER" selected="true">ARACHNOSERVER</option>
@@ -8838,15 +8734,14 @@
                     <option value="length" selected="true">length</option>
                     <option value="organism_scientific_name" selected="true">organism_scientific_name</option>
                     <option value="status" selected="true">status</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="AGRICOLA">AGRICOLA</option>
                         <option value="ALLERGOME">ALLERGOME</option>
                         <option value="ARACHNOSERVER">ARACHNOSERVER</option>
@@ -9042,7 +8937,7 @@
                         <option value="status">status</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -9063,7 +8958,7 @@
             </when>
 
             <when value="uniref100">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="UNIPARC" selected="true">UNIPARC</option>
                     <option value="UNIPROT" selected="true">UNIPROT</option>
@@ -9073,15 +8968,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="length" selected="true">length</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="UNIPARC">UNIPARC</option>
                         <option value="UNIPROT">UNIPROT</option>
@@ -9101,7 +8995,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -9122,7 +9016,7 @@
             </when>
 
             <when value="uniref50">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="UNIPARC" selected="true">UNIPARC</option>
                     <option value="UNIPROT" selected="true">UNIPROT</option>
@@ -9132,15 +9026,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="length" selected="true">length</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="UNIPARC">UNIPARC</option>
                         <option value="UNIPROT">UNIPROT</option>
@@ -9160,7 +9053,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -9181,7 +9074,7 @@
             </when>
 
             <when value="uniref90">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="TAXONOMY" selected="true">TAXONOMY</option>
                     <option value="UNIPARC" selected="true">UNIPARC</option>
                     <option value="UNIPROT" selected="true">UNIPROT</option>
@@ -9191,15 +9084,14 @@
                     <option value="id" selected="true">id</option>
                     <option value="length" selected="true">length</option>
                     <option value="name" selected="true">name</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="TAXONOMY">TAXONOMY</option>
                         <option value="UNIPARC">UNIPARC</option>
                         <option value="UNIPROT">UNIPROT</option>
@@ -9219,7 +9111,7 @@
                         <option value="name">name</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>
@@ -9240,7 +9132,7 @@
             </when>
 
             <when value="wormbaseParasite">
-                <param name="fields" type="select" label="Fields to extract" multiple="true">
+                <param name="fields" type="select" multiple="true" optional="false" label="Fields to extract">
                     <option value="ARRAYEXPRESS" selected="true">ARRAYEXPRESS</option>
                     <option value="EMBL" selected="true">EMBL</option>
                     <option value="ENSEMBL_ORTHOLOG" selected="true">ENSEMBL_ORTHOLOG</option>
@@ -9290,15 +9182,14 @@
                     <option value="system_name" selected="true">system_name</option>
                     <option value="transcript" selected="true">transcript</option>
                     <option value="transcript_count" selected="true">transcript_count</option>
-                    <validator type="no_options" message="Please select at least one field" />
                 </param>
                 <repeat name="queries" title="Add a query">
-                    <param name="combination_operation" type="select" label="Combination operation" >
+                    <param name="combination_operation" type="select" label="Combination operation">
                         <option value="AND">AND</option>
                         <option value="OR">OR</option>
                         <option value="NOT">NOT</option>
                     </param>
-                    <param name="query_field" type="select" label="Fields" >
+                    <param name="query_field" type="select" label="Fields">
                         <option value="ARRAYEXPRESS">ARRAYEXPRESS</option>
                         <option value="EMBL">EMBL</option>
                         <option value="ENSEMBL_ORTHOLOG">ENSEMBL_ORTHOLOG</option>
@@ -9353,7 +9244,7 @@
                         <option value="transcript">transcript</option>
                     </param>
                     <conditional name="comp_operation">
-                        <param name="operation" type="select" label="Comparison operation" >
+                        <param name="operation" type="select" label="Comparison operation">
                             <option value="equal">equal</option>
                             <option value="not">not</option>
                             <option value="range">range</option>

--- a/tools/hmmer3/hmmsearch.xml
+++ b/tools/hmmer3/hmmsearch.xml
@@ -35,13 +35,13 @@ $seqdb
   <outputs>
     <data format="txt" name="output" label="HMM matches of $hmmfile.name in $seqdb.name"/>
     <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $hmmfile.name in $seqdb.name">
-      <filter>'tblout' in str(oformat)</filter>
+      <filter>oformat and 'tblout' in oformat</filter>
     </data>
     <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $hmmfile.name in $seqdb.name">
-      <filter>'domtblout' in str(oformat)</filter>
+      <filter>oformat and 'domtblout' in oformat</filter>
     </data>
     <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $hmmfile.name in $seqdb.name">
-      <filter>'pfamtblout' in str(oformat)</filter>
+      <filter>oformat and 'pfamtblout' in oformat</filter>
     </data>
   </outputs>
   <tests>

--- a/tools/hmmer3/jackhmmer.xml
+++ b/tools/hmmer3/jackhmmer.xml
@@ -47,10 +47,10 @@ $seqdb
   <outputs>
     <data format="txt" name="output" label="PHMMER search of $seqfile.name in $seqdb.name"/>
     <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name in $seqdb.name">
-      <filter>'tblout' in str(oformat)</filter>
+      <filter>oformat and 'tblout' in oformat</filter>
     </data>
     <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name in $seqdb.name">
-      <filter>'domtblout' in str(oformat)</filter>
+      <filter>oformat and 'domtblout' in oformat</filter>
     </data>
   </outputs>
   <tests>

--- a/tools/hmmer3/nhmmer.xml
+++ b/tools/hmmer3/nhmmer.xml
@@ -42,13 +42,13 @@ $seqfile
     <data format="txt" name="output" label="NHMMER search of $seqfile.name in $hmmfile.name"/>
 
     <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name in $hmmfile.name">
-      <filter>'tblout' in str(oformat)</filter>
+      <filter>oformat and 'tblout' in oformat</filter>
     </data>
     <data format="txt" name="dfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name in $hmmfile.name">
-      <filter>'pfamtblout' in str(oformat)</filter>
+      <filter>oformat and 'pfamtblout' in oformat</filter>
     </data>
     <data format="txt" name="aliscoresout" label="Scores for positional matches of $seqfile.name in $hmmfile.name">
-      <filter>'aliscoresout' in str(oformat)</filter>
+      <filter>oformat and 'aliscoresout' in oformat</filter>
     </data>
   </outputs>
   <tests>

--- a/tools/hmmer3/nhmmscan.xml
+++ b/tools/hmmer3/nhmmscan.xml
@@ -49,13 +49,13 @@ $seqfile
     <data format="txt" name="output" label="HMM matches of $seqfile.name in $hmmfile.name"/>
 
     <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name in $hmmfile.name">
-      <filter>'tblout' in str(oformat)</filter>
+      <filter>oformat and 'tblout' in oformat</filter>
     </data>
     <data format="txt" name="dfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name in $hmmfile.name">
-      <filter>'pfamtblout' in str(oformat)</filter>
+      <filter>oformat and 'pfamtblout' in oformat</filter>
     </data>
     <data format="txt" name="aliscoresout" label="Scores for positional matches of $seqfile.name in $hmmfile.name">
-      <filter>'aliscoresout' in str(oformat)</filter>
+      <filter>oformat and 'aliscoresout' in oformat</filter>
     </data>
   </outputs>
   <tests>

--- a/tools/hmmer3/phmmer.xml
+++ b/tools/hmmer3/phmmer.xml
@@ -38,13 +38,13 @@ $seqdb
   <outputs>
     <data format="txt" name="output" label="PHMMER search of $seqfile.name in $seqdb.name"/>
     <data format="txt" name="tblout" label="Table of per-sequence hits from HMM matches of $seqfile.name in $seqdb.name">
-      <filter>'tblout' in str(oformat)</filter>
+      <filter>oformat and 'tblout' in oformat</filter>
     </data>
     <data format="txt" name="domtblout" label="Table of per-domain hits from HMM matches of $seqfile.name in $seqdb.name">
-      <filter>'domtblout' in str(oformat)</filter>
+      <filter>oformat and 'domtblout' in oformat</filter>
     </data>
     <data format="txt" name="pfamtblout" label="Table of per-sequence/per-domain hits from HMM matches of $seqfile.name in $seqdb.name">
-      <filter>'pfamtblout' in str(oformat)</filter>
+      <filter>oformat and 'pfamtblout' in oformat</filter>
     </data>
   </outputs>
   <tests>

--- a/tools/kobas/kobas_identify.xml
+++ b/tools/kobas/kobas_identify.xml
@@ -43,7 +43,7 @@
 
         <expand macro="input_kobasdb"/>
 
-        <param type="select" label="Database" argument="--db" multiple="True" display="checkboxes" help="Select your desired databases:
+        <param type="select" label="Database" argument="--db" multiple="True" optional="false" display="checkboxes" help="Select your desired databases:
 (Note: the Corrected P-Values will be affected by the number of selected databases)">
             <option value="K">KEGG Pathway</option>
             <option value="n">PID</option>
@@ -58,7 +58,6 @@
             <option value="N">NHGRI GWAS Catalog</option>
             <option value="G">Gene Ontology</option>
             <option value="S">Gene Ontology Slim (GOslim)</option>
-            <validator type="no_options" message="You must pick at least one database."/>
         </param>
 
         <conditional name="bg">

--- a/tools/macs2/macs2_bdgdiff.xml
+++ b/tools/macs2/macs2_bdgdiff.xml
@@ -33,11 +33,10 @@
         <param name="depth2" type="integer" value="1" label="Sequence depth of condition 2 in million reads" help="default: 1 (--depth2)" />
         <param name="maxgap" type="integer" value="100" label="Maximum gap to merge nearby differential regions" help="Consider a wider gap for broad marks. Maximum gap should be smaller than minimum length. Default: 100 (-g)." />
 
-        <param name="outputs" type="select" display="checkboxes" multiple="True" label="Outputs">
+        <param name="outputs" type="select" display="checkboxes" multiple="True" optional="false" label="Outputs">
             <option value="--ofile-cond1">Unique regions in condition 1</option>
             <option value="--ofile-cond2">Unique regions in condition 2</option>
             <option value="--ofile-both-conditions" selected="true">Common regions in both conditions</option>
-            <validator type="no_options" message="Please select at least one output file." />
         </param>
     </inputs>
     <outputs>

--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -150,14 +150,13 @@
             </when>
         </conditional>
 
-        <param name="outputs" type="select" display="checkboxes" multiple="True" label="Outputs" help="PDF only created when model is build">
+        <param name="outputs" type="select" display="checkboxes" multiple="True" optional="false" label="Outputs" help="PDF only created when model is build">
             <option value="peaks_tabular" selected="True">Peaks as tabular file</option>
             <!--<option value="narrow">narrow Peaks</option>-->
             <option value="summits" selected="true">summits</option>
             <option value="bdg" selected="true">Scores in bedGraph files (--bdg)</option>
             <option value="html">Summary page (html)</option>
             <option value="pdf">Plot in PDF</option>
-            <validator type="no_options" message="Please select at least one output file." />
         </param>
 
         <conditional name="advanced_options">

--- a/tools/prokka/prokka.xml
+++ b/tools/prokka/prokka.xml
@@ -146,34 +146,34 @@ $input
     </inputs>
     <outputs>
         <data name="out_gff" format="gff" label="${tool.name} on ${on_string}: gff" from_work_dir="outdir/prokka.gff">
-            <filter>'gff' in outputs</filter>
+            <filter>outputs and 'gff' in outputs</filter>
         </data>
         <data name="out_gbk" format="txt" label="${tool.name} on ${on_string}: gbk" from_work_dir="outdir/prokka.gbk">
-            <filter>'gbk' in outputs</filter>
+            <filter>outputs and 'gbk' in outputs</filter>
         </data>
         <data name="out_fna" format="fasta" label="${tool.name} on ${on_string}: fna" from_work_dir="outdir/prokka.fna">
-            <filter>'fna' in outputs</filter>
+            <filter>outputs and 'fna' in outputs</filter>
         </data>
         <data name="out_faa" format="fasta" label="${tool.name} on ${on_string}: faa" from_work_dir="outdir/prokka.faa">
-            <filter>'faa' in outputs</filter>
+            <filter>outputs and 'faa' in outputs</filter>
         </data>
         <data name="out_ffn" format="fasta" label="${tool.name} on ${on_string}: ffn" from_work_dir="outdir/prokka.ffn">
-             <filter>'ffn' in outputs</filter>
+             <filter>outputs and 'ffn' in outputs</filter>
         </data>
         <data name="out_sqn" format="asn1" label="${tool.name} on ${on_string}: sqn" from_work_dir="outdir/prokka.sqn">
-             <filter>'sqn' in outputs</filter>
+             <filter>outputs and 'sqn' in outputs</filter>
         </data>
         <data name="out_fsa" format="fasta" label="${tool.name} on ${on_string}: fsa" from_work_dir="outdir/prokka.fsa">
-             <filter>'fsa' in outputs</filter>
+             <filter>outputs and 'fsa' in outputs</filter>
         </data>
         <data name="out_tbl" format="txt" label="${tool.name} on ${on_string}: tbl" from_work_dir="outdir/prokka.tbl">
-             <filter>'tbl' in outputs</filter>
+             <filter>outputs and 'tbl' in outputs</filter>
         </data>
         <data name="out_err" format="txt" label="${tool.name} on ${on_string}: err" from_work_dir="outdir/prokka.err">
-             <filter>'err' in outputs</filter>
+             <filter>outputs and 'err' in outputs</filter>
         </data>
         <data name="out_txt" format="txt" label="${tool.name} on ${on_string}: txt" from_work_dir="outdir/prokka.txt">
-             <filter>'txt' in outputs</filter>
+             <filter>outputs and 'txt' in outputs</filter>
         </data>
         <data name="out_log" format="txt" label="${tool.name} on ${on_string}: log" from_work_dir="outdir/prokka.log" />
     </outputs>

--- a/tools/vsearch/.shed.yml
+++ b/tools/vsearch/.shed.yml
@@ -1,11 +1,10 @@
 categories:
 - Sequence Analysis
 description: VSEARCH including searching, clustering, chimera detection, dereplication, sorting, masking and shuffling of sequences.
+homepage_url: https://github.com/torognes/vsearch
 long_description: |
   Open and free 64-bit multithreaded tool for processing metagenomic sequences,
   including searching, clustering, chimera detection, dereplication, sorting, masking and shuffling.
-
-  https://github.com/torognes/vsearch
 name: vsearch
 owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/vsearch

--- a/tools/vsearch/vsearch_macros.xml
+++ b/tools/vsearch/vsearch_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="1.9.7">vsearch</requirement>
+            <requirement type="package" version="@VERSION@">vsearch</requirement>
         </requirements>
     </xml>
     <token name="@VERSION@">1.9.7</token>
@@ -170,7 +170,7 @@
     <token name="@EXTERNAL_DOCUMENTATION@">
 <![CDATA[
 
-For details about this tool, please refer to the `github account <https://github.com/torognes/vsearch>`_ or the `vsearch manual <https://github.com/torognes/vsearch/raw/master/doc/vsearch_manual.pdf>`_.
+For details about this tool, please refer to the `GitHub repository <https://github.com/torognes/vsearch>`_ or the `vsearch manual <https://github.com/torognes/vsearch/releases/download/v1.9.7/vsearch_manual.pdf>`_.
 
 ]]>
     </token>

--- a/tools/vsearch/vsearch_macros.xml
+++ b/tools/vsearch/vsearch_macros.xml
@@ -159,12 +159,11 @@
     </xml>
 
     <xml name="general_output">
-        <param name="outputs" type="select" multiple="True" label="Select output files" help="">
+        <param name="outputs" type="select" multiple="True" optional="false" label="Select output files" help="">
             <option value="--alnout">Human-readable alignment output</option>
             <option value="--blast6out" selected="True">Blast-like tab-separated output</option>
             <option value="--fastapairs">Write query/target pairs of sequences</option>
             <yield/>
-            <validator type="no_options" message="Please select at least one output." />
         </param>
     </xml>
 


### PR DESCRIPTION
- Use `optional="false"` instead of `no_options` validator for multiselect
- Check that multiselect is not `None` in output filters

See commits for details.