### PR TITLE
Tripal data loaders

### DIFF
--- a/tools/tripal/.shed.yml
+++ b/tools/tripal/.shed.yml
@@ -1,0 +1,19 @@
+categories:
+- Web Services
+long_description: |
+  Galaxy tools allowing to load data into a distant Tripal server.
+
+  Tripal is a toolkit for construction of online biological (genetics, genomics, breeding, etc), community database,
+  and is a member of the GMOD family of tools. Tripal provides by default integration with the GMOD Chado database schema and Drupal, a popular Content Management Systems (CMS).
+
+  https://github.com/abretaud/python-tripal
+homepage_url: https://github.com/abretaud/python-tripal
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/tripal
+type: unrestricted
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "{{ tool_name }} (from the Tripal tool suite)"
+suite:
+  name: "suite_tripal"
+  description: Galaxy tools allowing to load data into a distant Tripal server.

--- a/tools/tripal/.shed.yml
+++ b/tools/tripal/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Web Services
 long_description: |
-  Galaxy tools allowing to load data into a distant Tripal server.
+  Galaxy tools allowing to load data into a remote Tripal server.
 
   Tripal is a toolkit for construction of online biological (genetics, genomics, breeding, etc), community database,
   and is a member of the GMOD family of tools. Tripal provides by default integration with the GMOD Chado database schema and Drupal, a popular Content Management Systems (CMS).
@@ -16,4 +16,4 @@ auto_tool_repositories:
   description_template: "{{ tool_name }} (from the Tripal tool suite)"
 suite:
   name: "suite_tripal"
-  description: Galaxy tools allowing to load data into a distant Tripal server.
+  description: Galaxy tools allowing to load data into a remote Tripal server.

--- a/tools/tripal/create_analysis.xml
+++ b/tools/tripal/create_analysis.xml
@@ -1,0 +1,57 @@
+<tool id="create_analysis" name="Create Analysis" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal create_analysis
+
+            @ANALYSIS@
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <expand macro="analysis" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="New Tripal analysis" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <section name="analysis">
+                <param name="name" value="Some analysis" />
+                <param name="program" value="blastp" />
+                <param name="program_version" value="2.5.0" />
+                <param name="algorithm" value="blast" />
+                <param name="source" value="NCBI" />
+                <param name="source_version" value="1.0" />
+                <param name="source_uri" value="http://ncbi.com/somewhere" />
+                <param name="description" value="My cool new test analysis" />
+                <param name="date" value="2016-12-12" />
+            </section>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Create Analysis**
+
+        With this tool, you can create a new analysis in the Tripal/Chado database.
+
+        Keep in mind that you cannot add multiple analysis with the same program, program version and source.
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/create_organism.xml
+++ b/tools/tripal/create_organism.xml
@@ -1,0 +1,130 @@
+<tool id="create_organism" name="Create Organism" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal create_organism
+            --genus '$genus'
+
+            #if str($species):
+                --species '$species'
+            #end if
+
+            --abbr '$abbr'
+
+            --common '$common'
+
+            #if str($description):
+                --description '$description'
+            #end if
+
+            #if $infra.use_infra:
+                --infraspecific-rank $infra.rank
+                --infraspecific-name $infra.name
+            #end if
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="genus"
+               argument="--genus"
+               type="text"
+               label="Genus"
+               help="e.g.: Homo" />
+
+        <param name="species"
+               argument="--species"
+               type="text"
+               label="Species"
+               optional="True"
+               help="e.g.: sapiens" />
+
+        <param name="abbr"
+               argument="--abbr"
+               type="text"
+               label="Abbreviation"
+               help="e.g.: H. sapiens" />
+
+        <param name="common"
+               argument="--common"
+               type="text"
+               label="Common name"
+               help="e.g.: Human" />
+
+        <param name="description"
+               argument="--description"
+               type="text"
+               label="Description"
+               optional="True" />
+
+        <conditional name="infra">
+            <param name="use_infra" type="boolean" checked="false" label="Specify an infraspecific rank" />
+            <when value="false"></when>
+            <when value="true">
+                <param name="rank"
+                       argument="--infraspecific-rank"
+                       type="integer"
+                       label="Infraspecific Rank"
+                       value=""
+                       help="Numeric ID from the Chado database" /> <!-- Will be the textual name in future python-tripal release -->
+                <param name="name"
+                       argument="--infraspecific-name"
+                       type="text"
+                       label="Infraspecific Name"
+                       help="The infraspecific name of the new organism (e.g. a strain name)" />
+            </when>
+        </conditional>
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="New Tripal organism" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="genus" value="Testus" />
+            <param name="species" value="testum" />
+            <param name="abbr" value="test" />
+            <param name="common" value="test stuff" />
+            <param name="common" value="My cool new test organism" />
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="genus" value="Testus" />
+            <param name="species" value="testum" />
+            <param name="abbr" value="test" />
+            <param name="common" value="test stuff" />
+            <param name="common" value="My cool new test organism" />
+            <conditional name="infra">
+                <param name="use_infra" value="True" />
+                <param name="rank" value="2" />
+                <param name="name" value="strain3" />
+            </conditional>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Create Organism**
+
+        With this tool, you can create a new organism in the Tripal/Chado database
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/index.xml
+++ b/tools/tripal/index.xml
@@ -1,0 +1,90 @@
+<tool id="index" name="Index Tripal data" version="@WRAPPER_VERSION@.0">
+    <description>using Elasticsearch</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal index
+
+            #if $table.mode == "single":
+                #if str($table.fields):
+                    --fields '${table.fields}'
+                #end if
+                --table '${table.table}'
+            #end if
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <conditional name="table">
+            <param name="mode"
+                   type="select"
+                   label="Data to index">
+                <option value="all" selected="true">Index all the Tripal content</option>
+                <option value="single">Index a specific table</option>
+            </param>
+            <when value="all"/>
+            <when value="single">
+                <param name="table"
+                       argument="--table"
+                       type="text"
+                       label="Table to index"
+                       help="The name of a Chado (or custom) table to index" />
+                <param name="fields"
+                       argument="--fields"
+                       type="text"
+                       optional="true"
+                       label="Fields to index"
+                       help="Space-separated list of column names to index (leave empty to index all the columns)" />
+            </when>
+        </conditional>
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Index Tripal data" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <conditional name="table">
+                <param name="mode" value="all" />
+            </conditional>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+        <test expect_failure="true" expect_exit_code="1">
+            <conditional name="table">
+                <param name="mode" value="singles" />
+                <param name="table" value="organism" />
+                <param name="fields" value="genus species description" />
+            </conditional>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Index using Elasticsearch**
+
+        With this tool, you can trigger indexing of a Tripal instance content using Elasticsearch.
+
+        The `tripal_elasticsearch <http://github.com/tripal/tripal_elasticsearch>`_ module must be installed and configured on the Tripal instance.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/load_blast.xml
+++ b/tools/tripal/load_blast.xml
@@ -1,0 +1,139 @@
+<tool id="load_blast" name="Load Blast results" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal load_blast
+
+            @ANALYSIS@
+
+            --blast-ext '${extension}'
+
+            $is_concat
+
+            --blastdb '${blastdb}'
+
+            --blast-parameters '${params}'
+
+            --max-hits '${max_hits}'
+
+            #if str($query_re):
+                --query-re '${query_re}'
+            #end if
+
+            $query_uniquename
+
+            --query-type '$query_type'
+
+            @AUTH@
+
+            '${results}'
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="results"
+               type="text"
+               label="Path to Blast results"
+               help="the path (single XML file, or directory containing multiple XML files) must be accessibe from the Tripal server" />
+
+        <param name="extension"
+               type="text"
+               value="xml"
+               label="Result file extension"
+               help="if using a directory containing multiple result files" />
+
+        <param name="is_concat"
+               type="boolean"
+               checked="false"
+               truevalue="--is-concat"
+               falsevalue=""
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+        <param name="blastdb"
+               type="text"
+               label="Name of the blast databank used"
+               help="must be in the Chado db table" />
+
+        <param name="params"
+               type="text"
+               label="Blast parameters used to produce the results" />
+
+        <param name="max_hits"
+               type="integer"
+               value="25"
+               label="Maximum number of hits kept" />
+
+        <param name="query_type"
+               type="text"
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+        <param name="query_re"
+               type="text"
+               optional="true"
+               label="Regular expression to extract the feature unique name from the blast query name"
+               help="leave empty if the first word in query name is sufficient" />
+
+        <param name="query_uniquename"
+               type="boolean"
+               checked="false"
+               truevalue="--query-uniquename"
+               falsevalue=""
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+       <expand macro="analysis" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Load Blast results into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="results" value="/some/where/over/the/rainbow/" />
+            <param name="is_concat" value="true" />
+            <param name="blastdb" value="genbank:protein" />
+            <param name="params" value="-e 0.001" />
+            <param name="query_type" value="mRNA" />
+            <param name="query_uniquename" value="true" />
+            <section name="analysis">
+                <param name="name" value="Some analysis" />
+                <param name="program" value="blastp" />
+                <param name="program_version" value="2.5.0" />
+                <param name="algorithm" value="blast" />
+                <param name="source" value="NCBI" />
+                <param name="source_version" value="1.0" />
+                <param name="source_uri" value="http://ncbi.com/somewhere" />
+                <param name="description" value="My cool new test analysis" />
+                <param name="date" value="2016-12-12" />
+            </section>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Load Blast results**
+
+        With this tool, you can load Blast results into the Tripal/Chado database.
+
+        A corresponding analysis will be created, keep in mind that you cannot add multiple analysis with the same program, program version and source.
+
+        The `tripal_analysis_blast <http://github.com/tripal/tripal_analysis_blast>`_ module must be installed and configured on the Tripal instance.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/load_fasta.xml
+++ b/tools/tripal/load_fasta.xml
@@ -1,0 +1,184 @@
+<tool id="load_fasta" name="Load a Fasta file" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal load_fasta
+
+            --organism '${organism}'
+
+            --analysis '${analysis}'
+
+            --sequence-type '${sequence_type}'
+
+            --method '${loading.method}'
+
+            --match-type '${loading.match_type}'
+
+            #if str($naming.re_name):
+                --re-name '${naming.re_name}'
+            #end if
+
+            #if str($naming.re_uniquename):
+                --re-uniquename '${naming.re_uniquename}'
+            #end if
+
+            #if str($relationships.rel_type) != "none":
+                --rel-type '${relationships.rel_type}'
+                --rel-subject-re '${relationships.rel_subject_re}'
+                --rel-subject-type '${relationships.rel_subject_type}'
+            #end if
+
+            #if str($ext_db.db_ext_id):
+                --db-ext-id '${ext_db.db_ext_id}'
+            #end if
+
+            #if str($ext_db.re_accession):
+                --re-accession '${ext_db.re_accession}'
+            #end if
+
+            @AUTH@
+
+            '${fasta}'
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="fasta"
+               type="text"
+               label="Path to Fasta file"
+               help="the path must be accessibe from the Tripal server" />
+
+        <param name="organism"
+               argument="--organism"
+               type="text"
+               label="Organism name"
+               help="abbreviation or common name as created with the 'Create Organism' tool" />
+
+        <param name="analysis"
+               argument="--analysis"
+               type="text"
+               label="Analysis name"
+               help="as named in the 'Create Analysis' tool" />
+
+        <param name="sequence_type"
+               argument="--sequence-type"
+               type="text"
+               label="Sequence type"
+               value="contig"
+               help="this should be a Sequence Ontology term" />
+
+        <conditional name="loading">
+            <param name="method"
+                   argument="--method"
+                   type="select"
+                   label="Loading method"
+                   help="select wether you expect feature to be already existing or not">
+                <option value="Insert and update" selected="true">Insert and update</option>
+                <option value="Insert only">Insert only</option>
+                <option value="Update only">Update only</option>
+            </param>
+            <when value="Insert and update">
+                <expand macro="match_type" />
+            </when>
+            <when value="Insert only"/>
+            <when value="Update only">
+                <expand macro="match_type" />
+            </when>
+        </conditional>
+
+        <section name="naming" title="Feature naming">
+            <param name="re_name"
+                   argument="--re-name"
+                   type="text"
+                   optional="true"
+                   label="Regular expression to extract feature name"
+                   help="this regex will be applied on the fasta definition line to generate the feature name" />
+
+            <param name="re_uniquename"
+                   argument="--re-uniquename"
+                   type="text"
+                   optional="true"
+                   label="Regular expression to extract feature uniquename"
+                   help="this regex will be applied on the fasta definition line to generate the feature uniquename" />
+        </section>
+
+        <conditional name="relationships">
+            <param name="rel_type"
+                   argument="--rel-type"
+                   type="select"
+                   label="Relationship type"
+                   help="Use this when inserting features that should be associated to other already existing features">
+                <option value="none" selected="true">No relationship</option>
+                <option value="part_of">Part of (for CDS sequences)</option>
+                <option value="derives_from">Derives from (for peptide sequences)</option>
+            </param>
+            <when value="none"/>
+            <when value="part_of">
+                <expand macro="feature_rel" />
+            </when>
+            <when value="derives_from">
+                <expand macro="feature_rel" />
+            </when>
+        </conditional>
+
+        <section name="ext_db" title="Cross references to external database">
+            <param name="db_ext_id"
+                   argument="--db-ext-id"
+                   type="integer"
+                   optional="true"
+                   label="External Database ID"
+                   help="Numeric ID from the Chado database" />
+
+            <param name="re_accession"
+                   argument="--re-accession"
+                   type="text"
+                   optional="true"
+                   label="Regular expression to extract the accession from external DB"
+                   help="this regex will be applied on the fasta definition line to generate the accession from external DB" />
+        </section>
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Load Fasta into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="fasta" value="/some/path/to/seq.fasta" />
+            <param name="organism" value="Testus testus" />
+            <param name="analysis" value="Annotation xx" />
+            <param name="sequence_type" value="mRNA" />
+            <conditional name="loading">
+                <param name="method" value="Insert and update" />
+                <param name="match_type" value="Unique name" />
+            </conditional>
+            <section name="naming">
+                <param name="re_name" value="([a-z]{4}[0-9]+)_suffix" />
+                <param name="re_uniquename" value="([a-z]{4}[0-9]+_suffix)" />
+            </section>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Load Fasta**
+
+        With this tool, you can load sequences from a Fasta file into the Tripal/Chado database.
+
+        Corresponding features can be created if needed.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/load_gff3.xml
+++ b/tools/tripal/load_gff3.xml
@@ -1,0 +1,180 @@
+<tool id="load_gff3" name="Load a GFF3 file" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal load_gff3
+
+            --organism '${organism}'
+
+            --analysis '${analysis}'
+
+            --import-mode '${import_mode}'
+
+            #if str($naming.mode) == 'manual':
+                --re-mrna '${naming.re_mrna}'
+                --re-protein '${naming.re_protein}'
+            #end if
+
+            #if str($advanced.landmark_type):
+                --landmark-type '${advanced.landmark_type}'
+            #end if
+
+            #if str($advanced.alt_id_attr):
+                --alt-id-attr '${advanced.alt_id_attr}'
+            #end if
+
+            ${advanced.create_organism}
+
+            #if str($target.target_organism):
+                --target-organism '${target.target_organism}'
+            #end if
+
+            #if str($target.target_type):
+                --target-type '${target.target_type}'
+            #end if
+
+            ${target.target_create}
+
+            @AUTH@
+
+            '${gff3}'
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="gff3"
+               type="text"
+               label="Path to GFF3 file"
+               help="the path must be accessibe from the Tripal server" />
+
+        <param name="organism"
+               argument="--organism"
+               type="text"
+               label="Organism name"
+               help="abbreviation or common name as created with the 'Create Organism' tool" />
+
+        <param name="analysis"
+               argument="--analysis"
+               type="text"
+               label="Analysis name"
+               help="as named in the 'Create Analysis' tool" />
+
+        <param name="import_mode"
+               argument="--import-mode"
+               type="select"
+               label="Loading method">
+            <option value="update" selected="true">Import everything, update when already existing</option>
+            <option value="add_only">Import only new features</option>
+        </param>
+
+        <conditional name="naming">
+            <param name="mode"
+                   type="select"
+                   label="Naming method for proteins"
+                   help="in case your GFF file does not contain polypeptide features">
+                <option value="auto">Automatic</option>
+                <option value="manual">Manual</option>
+            </param>
+            <when value="auto"/>
+            <when value="manual">
+                <param name="re_mrna"
+                       argument="--re-mrna"
+                       type="text"
+                       label="Regular expression for the mRNA name"
+                       help="this regex will be used to extract parts of the mRNA feature name" />
+
+                <param name="re_protein"
+                       argument="--re-protein"
+                       type="text"
+                       label="Replacement string for the protein name"
+                       help="will be used to generate the protein name based on the mRNA name" />
+            </when>
+        </conditional>
+
+        <section name="advanced" title="Advanced options" expanded="False">
+            <param name="landmark_type"
+                   argument="--landmark-type"
+                   type="text"
+                   optional="true"
+                   label="Landmark type"
+                   help="A Sequence Ontology type for the landmark sequences in the GFF fie (e.g. \'chromosome\'). Will be used to create them if they don't already exist." />
+
+            <param name="alt_id_attr"
+                   argument="--alt-id-attr"
+                   type="text"
+                   optional="true"
+                   label="ID attribute"
+                   help="Name of the GFF attribute that contains a unique identifier for each feature. Leave empty to use the 'ID' attribute" />
+
+            <param name="create_organism"
+                   argument="--create-organism"
+                   type="boolean"
+                   checked="false"
+                   truevalue="--create-organism"
+                   falsevalue=""
+                   label="Create organisms specified in 'organism' attribute"
+                   help="If not found, create features referenced in the target attribute." />
+        </section>
+
+        <section name="target" title="Target attribute handling" expanded="False">
+            <param name="target_organism"
+                   argument="--target-organism"
+                   type="text"
+                   optional="true"
+                   label="Target organism name"
+                   help="Name of organism corresponding to target attribute. Abbreviation or common name as created with the 'Create Organism' tool." />
+            <param name="target_type"
+                   argument="--target-type"
+                   type="text"
+                   optional="true"
+                   label="Target feature type"
+                   help="Type of features referenced in the target attribute. Should be a Sequence Ontology term." />
+            <param name="target_create"
+                   argument="--target-create"
+                   type="boolean"
+                   checked="false"
+                   truevalue="--target-create"
+                   falsevalue=""
+                   label="Create target features"
+                   help="If not found, create features referenced in the target attribute." />
+        </section>
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Load GFF3 into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="gff3" value="/some/path/to/annot.gff" />
+            <param name="organism" value="Testus testus" />
+            <param name="analysis" value="Annotation xx" />
+            <conditional name="naming">
+                <param name="mode" value="manual" />
+                <param name="re_mrna" value="([a-z]{4}[0-9]+)_rna" />
+                <param name="re_protein" value="([a-z]{4}[0-9]+)_prot" />
+            </conditional>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Load GFF3**
+
+        With this tool, you can load features from a GFF3 file into the Tripal/Chado database.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/load_go.xml
+++ b/tools/tripal/load_go.xml
@@ -1,0 +1,104 @@
+<tool id="load_go" name="Load Blast2GO results" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal load_go
+
+            @ANALYSIS@
+
+            #if str($query_re):
+                --re-name '${query_re}'
+            #end if
+
+            $query_uniquename
+
+            --query-type '$query_type'
+
+            @AUTH@
+
+            '${results}'
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="results"
+               type="text"
+               label="Path to Blast2Go results (GAF file)"
+               help="the path (single XML file, or directory containing multiple XML files) must be accessibe from the Tripal server" />
+
+        <param name="extension"
+               type="text"
+               value="gaf"
+               label="Result file extension"
+               help="if using a directory containing multiple result files" />
+
+        <param name="query_type"
+               type="text"
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+        <param name="query_re"
+               type="text"
+               optional="true"
+               label="Regular expression to extract the feature unique name from the query name"
+               help="leave empty if the first word in query name is sufficient" />
+
+        <param name="query_uniquename"
+               type="boolean"
+               checked="false"
+               truevalue="--query-uniquename"
+               falsevalue=""
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+       <expand macro="analysis" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Load Blast2GO results into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="results" value="/some/where/over/the/rainbow/" />
+            <param name="query_type" value="polypeptide" />
+            <param name="query_uniquename" value="true" />
+            <section name="analysis">
+                <param name="name" value="Some analysis" />
+                <param name="program" value="interproscan" />
+                <param name="program_version" value="58.2" />
+                <param name="algorithm" value="blast2go" />
+                <param name="source" value="NCBI" />
+                <param name="source_version" value="1.0" />
+                <param name="source_uri" value="http://ncbi.com/somewhere" />
+                <param name="description" value="My cool new test analysis" />
+                <param name="date" value="2016-12-12" />
+            </section>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Load Blast2Go results**
+
+        With this tool, you can load Blast2go results into the Tripal/Chado database.
+
+        A corresponding analysis will be created, keep in mind that you cannot add multiple analysis with the same program, program version and source.
+
+        The `tripal_analysis_go <http://github.com/tripal/tripal_analysis_go>`_ module must be installed and configured on the Tripal instance.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/load_interpro.xml
+++ b/tools/tripal/load_interpro.xml
@@ -1,0 +1,115 @@
+<tool id="load_interpro" name="Load InterProScan results" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal load_interpro
+
+            @ANALYSIS@
+
+            --interpro-parameters '${params}'
+
+            ${parse_go}
+
+            #if str($query_re):
+                --query-re '${query_re}'
+            #end if
+
+            $query_uniquename
+
+            --query-type '$query_type'
+
+            @AUTH@
+
+            '${results}'
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="results"
+               type="text"
+               label="Path to InterProScan results"
+               help="the path (single XML file, or directory containing multiple XML files) must be accessibe from the Tripal server" />
+
+        <param name="parse_go"
+               type="boolean"
+               checked="true"
+               truevalue="--parse-go"
+               falsevalue=""
+               label="Load GO annotation to the database" />
+
+        <param name="params"
+               type="text"
+               label="InterProScan parameters used to produce the results" />
+
+        <param name="query_type"
+               type="text"
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+        <param name="query_re"
+               type="text"
+               optional="true"
+               label="Regular expression to extract the feature unique name from the query name"
+               help="leave empty if the first word in query name is sufficient" />
+
+        <param name="query_uniquename"
+               type="boolean"
+               checked="false"
+               truevalue="--query-uniquename"
+               falsevalue=""
+               label="The feature type of the query"
+               help="It must be a valid Sequence Ontology term. e.g. 'gene', 'mRNA', 'contig'" />
+
+       <expand macro="analysis" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Load InterProScan results into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="results" value="/some/where/over/the/rainbow/" />
+            <param name="parse_go" value="true" />
+            <param name="params" value="--some --param" />
+            <param name="query_type" value="mRNA" />
+            <param name="query_uniquename" value="true" />
+            <section name="analysis">
+                <param name="name" value="Some analysis" />
+                <param name="program" value="interproscan" />
+                <param name="program_version" value="58.2" />
+                <param name="algorithm" value="interproscan" />
+                <param name="source" value="NCBI" />
+                <param name="source_version" value="1.0" />
+                <param name="source_uri" value="http://ncbi.com/somewhere" />
+                <param name="description" value="My cool new test analysis" />
+                <param name="date" value="2016-12-12" />
+            </section>
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Load InterProScan results**
+
+        With this tool, you can load InterProScan results into the Tripal/Chado database.
+
+        A corresponding analysis will be created, keep in mind that you cannot add multiple analysis with the same program, program version and source.
+
+        The `tripal_analysis_interpro <http://github.com/tripal/tripal_analysis_interpro>`_ module must be installed and configured on the Tripal instance.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/macros.xml
+++ b/tools/tripal/macros.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<macros>
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="1.5">python-tripal</requirement>
+            <yield/>
+        </requirements>
+    </xml>
+
+    <token name="@WRAPPER_VERSION@">1.5</token>
+
+    <xml name="citation">
+        <citations>
+            <citation type="doi">10.1093/database/bat075</citation>
+        </citations>
+    </xml>
+
+    <token name="@HELP_OVERVIEW@"><![CDATA[
+        **Python-tripal Overview**
+
+        Python-tripal provides several tools allowing to load data into a remote Chado-based Tripal database.
+        The tripal_rest_api Tripal module must be installed on the remote server to use these tools.
+    ]]></token>
+
+    <token name="@HELP@"><![CDATA[
+        **Useful Links**
+
+        `Tripal project website <http://tripal.info/>`_
+        `Tripal REST API module <http://github.com/abretaud/tripal_rest_api>`_: a Tripal module required to use these galaxy tools
+    ]]></token>
+
+    <token name="@HELP_JOB@"><![CDATA[
+        This tool will schedule a Tripal job that should be executed with a Cron task on the remote server.
+    ]]></token>
+
+    <xml name="tripal_auth">
+        <section name="auth" title="Tripal authentication">
+            <param name="url"
+                   type="text"
+                   label="Server URL"
+                   help="The root URL of the Tripal instance" />
+            <param name="user"
+                   type="text"
+                   label="Username" />
+            <param name="password"
+                   type="text"
+                   label="Password" />
+        </section>
+    </xml>
+
+    <token name="@AUTH@"><![CDATA[
+        '$auth.url' '$auth.user' '$auth.password'
+    ]]></token>
+
+    <xml name="test_auth">
+        <section name="auth">
+            <param name="url" value="http://tripal-example.org" />
+            <param name="user" value="admin" />
+            <param name="password" value="admin" />
+        </section>
+    </xml>
+
+    <xml name="analysis">
+        <section name="analysis" title="Analysis">
+            <param name="name"
+                   argument="--analysis-name"
+                   type="text"
+                   label="The analysis name" />
+            <param name="program"
+                   argument="--analysis-program"
+                   type="text"
+                   label="Program name"
+                   help="Name of the program that was used to perform this analysis (program + program version + source must be unique)" />
+            <param name="program_version"
+                   argument="--analysis-program-version"
+                   type="text"
+                   label="Program version"
+                   help="Version of the program that was used to perform this analysis (program + program version + source must be unique)" />
+            <param name="algorithm"
+                   argument="--analysis-algorithm"
+                   type="text"
+                   label="Algorithm"
+                   optional="True"
+                   help="Algorithm of the program that was used to perform this analysis (program + program version + source must be unique)" />
+            <param name="source"
+                   argument="--analysis-source-name"
+                   type="text"
+                   label="Source name" />
+            <param name="source_version"
+                   argument="--analysis-source-version"
+                   type="text"
+                   optional="True"
+                   label="Source version" />
+            <param name="source_uri"
+                   argument="--analysis-source-uri"
+                   type="text"
+                   optional="True"
+                   label="Source URI"
+                   help="URI where source data was retrieved" />
+            <param name="description"
+                   argument="--analysis-description"
+                   type="text"
+                   optional="True"
+                   label="Analysis description" />
+            <param name="date"
+                   argument="--analysis-date-executed"
+                   type="text"
+                   optional="True"
+                   label="Execution date"
+                   help="default: Today">
+                <validator type="regex" message="Date in YYYY-MM-DD format">^[0-9]{4}-[0-9]{2}-[0-9]{2}$</validator>
+            </param>
+        </section>
+    </xml>
+
+    <xml name="feature_rel">
+        <param name="rel_subject_re"
+               argument="--rel-subject-re"
+               type="text"
+               label="Regular expression to extract the unique name of the parent feature"
+               help="this regex will be applied on the fasta definition line to generate the unique name of the parent feature" />
+
+        <param name="rel_subject_type"
+               argument="--rel-subject-type"
+               type="text"
+               label="Sequence type of the parent"
+               help="this should be a Sequence Ontology term" />
+    </xml>
+
+    <xml name="match_type">
+        <param name="match_type"
+               argument="--match-type"
+               type="select"
+               label="Match type for already loaded features">
+            <option value="Unique name" selected="true">Unique name</option>
+            <option value="Name">Name</option>
+        </param>
+    </xml>
+
+    <token name="@ANALYSIS@"><![CDATA[
+        --analysis-name '$analysis.name'
+        --analysis-program '$analysis.program'
+        --analysis-program-version '$analysis.program_version'
+        #if $analysis.algorithm:
+            --analysis-algorithm '$analysis.algorithm'
+        #end if
+        --analysis-source-name '$analysis.source'
+        #if $analysis.source_version:
+            --analysis-source-version '$analysis.source_version'
+        #end if
+        #if $analysis.source_uri:
+            --analysis-source-uri '$analysis.source_uri'
+        #end if
+        #if $analysis.description:
+            --analysis-description '$analysis.description'
+        #end if
+        #if $analysis.date:
+            --analysis-date '$analysis.date'
+        #end if
+    ]]></token>
+</macros>

--- a/tools/tripal/populate_mview.xml
+++ b/tools/tripal/populate_mview.xml
@@ -1,0 +1,60 @@
+<tool id="populate_mview" name="Populate a materialized view" version="@WRAPPER_VERSION@.0">
+    <description></description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal populate_mview
+
+            --mview '${mview}'
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="mview"
+               argument="--mview"
+               type="text"
+               optional="true"
+               label="View name"
+               help="The materialized view name to populate (leave empty to populate all views)" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Populate a Tripal materialized view" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="mview" value="Test" />
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Populate Materialized View**
+
+        With this tool, you can populate a materialized view in a Tripal instance.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/sync_analysis.xml
+++ b/tools/tripal/sync_analysis.xml
@@ -1,0 +1,52 @@
+<tool id="sync_analysis" name="Synchronize an analysis" version="@WRAPPER_VERSION@.0">
+    <description>from Chado to Tripal</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal sync_analysis
+
+            --analysis '${analysis}'
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="analysis"
+               argument="--analysis"
+               type="text"
+               label="Analysis name"
+               help="as named in the 'Create Analysis' tool" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Synchronize Analysis into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="analysis" value="Annotation xx" />
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Synchronize Analysis**
+
+        With this tool, you can synchronize an analysis from the Chado database into the Tripal instance.
+        A corresponding Drupal node will be created.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/sync_features.xml
+++ b/tools/tripal/sync_features.xml
@@ -1,0 +1,76 @@
+<tool id="sync_features" name="Synchronize features" version="@WRAPPER_VERSION@.0">
+    <description>from Chado to Tripal</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal sync_features
+
+            #if str($types):
+                --types '${types}'
+            #end if
+
+            #if str($ids):
+                --ids '${ids}'
+            #end if
+
+            --organism '${organism}'
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="organism"
+               argument="--organism"
+               type="text"
+               label="Organism name"
+               help="abbreviation or common name as created with the 'Create Organism' tool" />
+
+        <param name="types"
+               argument="--types"
+               type="text"
+               optional="true"
+               label="Feature types to synchronize"
+               help="Space-delimited list of types of records to be synced (e.g. 'gene mRNA')" />
+
+        <param name="ids"
+               argument="--ids"
+               type="text"
+               optional="true"
+               label="Feature names to synchronize"
+               help="Space-delimited list of names of records to be synced (e.g. 'gene0001 gene0002')" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Synchronize features into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="organism" value="Testus testus" />
+            <param name="types" value="gene mRNA" />
+            <param name="types" value="gene0001 gene0002" />
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Synchronize Features**
+
+        With this tool, you can synchronize some features from the Chado database into the Tripal instance.
+        A corresponding Drupal node will be created for each feature.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>

--- a/tools/tripal/sync_organism.xml
+++ b/tools/tripal/sync_organism.xml
@@ -1,0 +1,52 @@
+<tool id="sync_organism" name="Synchronize an organism" version="@WRAPPER_VERSION@.0">
+    <description>from Chado to Tripal</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+        tripal sync_organism
+
+            --organism '${organism}'
+
+            @AUTH@
+
+            > $output_log
+    ]]></command>
+    <inputs>
+        <param name="organism"
+               argument="--organism"
+               type="text"
+               label="Organism name"
+               help="abbreviation or common name as created with the 'Create Organism' tool" />
+
+        <expand macro="tripal_auth" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="output_log" label="Synchronize Organism into Tripal" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="organism" value="Testus testus" />
+
+            <expand macro="test_auth" />
+
+            <assert_stderr>
+                <has_text text="Name or service not known" />
+            </assert_stderr>
+        </test>
+    </tests>
+    <help><![CDATA[
+        @HELP_OVERVIEW@
+
+        **Synchronize Organism**
+
+        With this tool, you can synchronize an organism from the Chado database into the Tripal instance.
+        A corresponding Drupal node will be created.
+
+        @HELP_JOB@
+
+        @HELP@
+    ]]></help>
+    <expand macro="citation"/>
+</tool>


### PR DESCRIPTION
Hello,
Finally, here are the galaxy wrappers for [python-tripal](https://github.com/abretaud/python-tripal).

It is intended to be used mainly in the [galaxy genome annotation project](https://github.com/galaxy-genome-annotation/), but it can be used on any tripal instance with corresponding modules installed.

The tests are quite basic, it just checks that it cannot find the server as expected. But python-tripal checks the input params before throwing the connection error, so it's better than nothing.

These tools could be a little too exotic to be in IUC, if you think it would be better in [GGA-galaxy-tools](https://github.com/galaxy-genome-annotation/galaxy-tools).

(next should be [python-chado](https://github.com/abretaud/python-chado) I think)