### PR TITLE
Remove deprecated `metadata_name` attribute from bwameth and add cate…

### DIFF
--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -41,7 +41,7 @@
                 <option value="indexed">Use a built-in index</option>
             </param>
             <when value="history">
-                <param name="reference" type="data" format="fasta" metadata_name="dbkey" label="Select a genome" help="in FASTA format" />
+                <param name="reference" type="data" format="fasta" label="Select a genome" help="in FASTA format" />
             </when>
             <when value="indexed">
                 <param name="index" type="select" label="Select a reference genome" help="If your genome of interest is not listed, contact your Galaxy admin">

--- a/tools/mothur/.shed.yml
+++ b/tools/mothur/.shed.yml
@@ -1,5 +1,7 @@
 name: mothur
 owner: iuc
+categories:
+  - Metagenomics
 description: Mothur wrappers
 long_description: |
     The mothur project seeks to offers a single piece of open-source, expandable software to fill the bioinformatics needs of the microbial ecology community.


### PR DESCRIPTION
…gory for mothur.

I'll admit that I don't know what the `metadata_name` tag was supposed to do, so I just removed it.
Or was this just to make sure a build had been specified and should be replaced with
```
 <validator type="unspecified_build" />
```
?