### PR TITLE
Fixed an error when moving html report (Validate mapping file)

### DIFF
--- a/tools/qiime/validate_mapping_file.xml
+++ b/tools/qiime/validate_mapping_file.xml
@@ -9,21 +9,21 @@
         validate_mapping_file.py
             -m '$mapping_fp'
             -o validate_mapping_file_output
-            '$verbose'
+            $verbose
             -c '$char_replace'
-            '$not_barcoded'
-            '$variable_len_barcodes'
-            '$disable_primer_check'
+            $not_barcoded
+            $variable_len_barcodes
+            $disable_primer_check
             #if str($added_demultiplex_field):
                 -j '$added_demultiplex_field'
             #end if
-            '$suppress_html'
+            $suppress_html
 
             #if not $suppress_html:
                 && mkdir -p '$html_report.files_path'
                 && cp validate_mapping_file_output/*.html '$html_report.files_path'
                 && cp validate_mapping_file_output/overlib.js '$html_report.extra_files_path'
-                && mv '$html_report.files_path/*.html' '$html_report'
+                && mv `ls $html_report.files_path/*.html` '$html_report'
             #end if
     ]]></command>
     <inputs>


### PR DESCRIPTION
Can we get the name of input file? Then, p26 can be simply:
mv '$html_report.files_path/<file name of $mapping_fp>.html' '$html_report'