### PR TITLE
Abort build immediately if a script command fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,11 @@ install:
   - cat changed_repositories_chunk.list
 
 script:
+  - set -e
   - cd "$TRAVIS_BUILD_DIR" && flake8 --exclude=.git .
-  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR" || exit 1; done < changed_repositories_chunk.list
+  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR"; done < changed_repositories_chunk.list
   - while read -r DIR; do planemo conda_install "$DIR"; done < changed_repositories_chunk.list
-  - while read -r DIR; do planemo test --conda_dependency_resolution --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR" || exit 1; done < changed_repositories_chunk.list
+  - while read -r DIR; do planemo test --conda_dependency_resolution --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"; done < changed_repositories_chunk.list
 
 after_success:
   - |


### PR DESCRIPTION
As explaind in https://docs.travis-ci.com/user/customizing-the-build#Customizing-the-Build-Step : "When one of the build commands returns a non-zero exit code, the Travis CI build runs the subsequent commands as well, and accumulates the build result."

xref. https://github.com/travis-ci/travis-ci/issues/1066

Example of a build which continued instead of aborting: https://travis-ci.org/galaxyproject/tools-iuc/jobs/191070928#L878