### PR TITLE
Collect standard error and standard output

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -57,6 +57,7 @@
                 $pe_parameters.exclude_chimerics
 
         "${alignment}"
+        2&gt;&amp;1 | grep .
 
         ## Removal of comment and column-header line
         && grep -v "^#" "output" | tail -n+2 > body.txt


### PR DESCRIPTION
When featureCoutns output Running result to stderr.

Running result is not collect and goes to stderr.
This featureCounts behavior is depended on
 featureCounts compile options I think.