### PR TITLE
Implement #1041 (add fastq output to hisat2)

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hisat2" name="HISAT" version="2.0.3.1">
+<tool id="hisat2" name="HISAT2" version="2.0.3.2">
     <description>A fast and sensitive alignment program</description>
     <macros>
         <import>hisat2_macros.xml</import>
@@ -380,6 +380,35 @@
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
             <output name="output_alignments" ftype="bam" file="hisat_output_3.bam" lines_diff="2" />
+        </test>
+        <test><!-- testing unaligned output (single dataset) -->
+            <param name="input_format_selector" value="fasta" />
+            <param name="paired_selector" value="single" />
+            <param name="reference_genome_source" value="history" />
+            <param name="history_item" value="phiX.fa" ftype="fasta" />
+            <param name="unaligned_file" type="boolean" value="true" />
+            <param name="aligned_file" type="boolean" value="true" />
+            <param name="reference_genome_source" value="history" />
+            <param name="history_item" value="phiX.fa" ftype="fasta" />
+            <param name="reads" value="test_unaligned_reads.fasta" ftype="fasta" />
+            
+            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
+        </test>
+        
+        <test>
+            <param name="input_format_selector" value="fasta" />
+            <param name="paired_selector" value="paired" />
+            <param name="reference_genome_source" value="history" />
+            <param name="history_item" value="phiX.fa" ftype="fasta" />
+            <param name="unaligned_file" type="boolean" value="true" />
+            <param name="aligned_file" type="boolean" value="true" />
+            <param name="reference_genome_source" value="history" />
+            <param name="history_item" value="phiX.fa" ftype="fasta" />
+            <param name="reads_f" value="test_unaligned_reads.fasta" ftype="fasta" />
+            <param name="reads_r" value="test_unaligned_reads.fasta" ftype="fasta" />
+            
+            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
+            <output name="output_unaligned_reads_r" file="test_unaligned_reads.fasta" />
         </test>
     </tests>
     <help>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -38,6 +38,12 @@
             @paired_end_options@
         #else:
             -U "${input_format.paired.reads}"
+            #if str( $input_format.paired.unaligned_file ) == "true":
+                --un '$output_unaligned_reads_l'
+            #end if
+            #if str( $input_format.paired.aligned_file ) == "true":
+                --al '$output_aligned_reads_l'
+            #end if
         #end if
         #if $input_format.input_format_selector == 'fasta':
             -f
@@ -84,6 +90,22 @@
             ${paired_options.dovetail} ${paired_options.contain} ${paired_options.overlap}
         #end if
         | samtools sort - -@ \${GALAXY_SLOTS:-2} -l 6 -o hsbam > "${output_alignments}"
+
+        ## Rename any output fastq files
+        #if str($input_format.paired.paired_selector) == 'paired' or str($input_format.paired.paired_selector) == 'paired_collection':
+            #if $output_unaligned_reads_l and $output_unaligned_reads_r:
+                #set left = str($output_unaligned_reads_l).replace(".dat", ".1.dat")
+                #set right = str($output_unaligned_reads_l).replace(".dat", ".2.dat")
+                ; mv $left $output_unaligned_reads_l;
+                mv $right $output_unaligned_reads_r
+            #end if
+            #if $output_aligned_reads_l and $output_aligned_reads_r:
+                #set left = str($output_aligned_reads_l).replace(".dat", ".1.dat")
+                #set right = str($output_aligned_reads_l).replace(".dat", ".2.dat")
+                ; mv $left $output_aligned_reads_l;
+                mv $right $output_aligned_reads_r
+            #end if
+        #end if
         ]]>
     </command>
     <inputs>
@@ -241,6 +263,86 @@
                   </action>
                 </when>
               </conditional>
+            </actions>
+        </data>
+        <data format="fastqsanger" name="output_unaligned_reads_l" label="${tool.name} on ${on_string}: unaligned reads (L)" >
+            <filter>input_format['paired']['unaligned_file'] is True</filter>
+            <actions>
+                <conditional name="input_format.paired.paired_selector">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads_f" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+            </actions>
+        </data>
+        <data format="fastqsanger" name="output_unaligned_reads_r" label="${tool.name} on ${on_string}: unaligned reads (R)" >
+            <filter>input_format['paired']['unaligned_file'] is True and input_format['paired']['paired_selector'] != 'single'</filter>
+            <actions>
+                <conditional name="input_format.paired.paired_selector">
+                    <when value="single" />
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads_r" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+            </actions>
+        </data>
+        <data format="fastqsanger" name="output_aligned_reads_l" label="${tool.name} on ${on_string}: aligned reads (L)" >
+            <filter>input_format['paired']['aligned_file'] is True</filter>
+            <actions>
+                <conditional name="input_format.paired.paired_selector">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads_f" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+            </actions>
+        </data>
+        <data format="fastqsanger" name="output_aligned_reads_r" label="${tool.name} on ${on_string}: aligned reads (R)" >
+            <filter>input_format['paired']['aligned_file'] is True and input_format['paired']['paired_selector'] != 'single'</filter>
+            <actions>
+                <conditional name="input_format.paired.paired_selector">
+                    <when value="single" />
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads_r" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="input_format.paired.reads" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
             </actions>
         </data>
     </outputs>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -291,7 +291,6 @@
             <filter>input_format['paired']['unaligned_file'] is True and input_format['paired']['paired_selector'] != 'single'</filter>
             <actions>
                 <conditional name="input_format.paired.paired_selector">
-                    <when value="single" />
                     <when value="paired">
                         <action type="format">
                             <option type="from_param" name="input_format.paired.reads_r" param_attribute="ext" />
@@ -331,7 +330,6 @@
             <filter>input_format['paired']['aligned_file'] is True and input_format['paired']['paired_selector'] != 'single'</filter>
             <actions>
                 <conditional name="input_format.paired.paired_selector">
-                    <when value="single" />
                     <when value="paired">
                         <action type="format">
                             <option type="from_param" name="input_format.paired.reads_r" param_attribute="ext" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -386,8 +386,8 @@
             <param name="paired_selector" value="single" />
             <param name="reference_genome_source" value="history" />
             <param name="history_item" value="phiX.fa" ftype="fasta" />
-            <param name="unaligned_file" type="boolean" value="true" />
-            <param name="aligned_file" type="boolean" value="true" />
+            <param name="unaligned_file" value="true" />
+            <param name="aligned_file" value="true" />
             <param name="reference_genome_source" value="history" />
             <param name="history_item" value="phiX.fa" ftype="fasta" />
             <param name="reads" value="test_unaligned_reads.fasta" ftype="fasta" />
@@ -400,8 +400,8 @@
             <param name="paired_selector" value="paired" />
             <param name="reference_genome_source" value="history" />
             <param name="history_item" value="phiX.fa" ftype="fasta" />
-            <param name="unaligned_file" type="boolean" value="true" />
-            <param name="aligned_file" type="boolean" value="true" />
+            <param name="unaligned_file" value="true" />
+            <param name="aligned_file" value="true" />
             <param name="reference_genome_source" value="history" />
             <param name="history_item" value="phiX.fa" ftype="fasta" />
             <param name="reads_f" value="test_unaligned_reads.fasta" ftype="fasta" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -96,14 +96,14 @@
             #if $output_unaligned_reads_l and $output_unaligned_reads_r:
                 #set left = str($output_unaligned_reads_l).replace(".dat", ".1.dat")
                 #set right = str($output_unaligned_reads_l).replace(".dat", ".2.dat")
-                ; mv $left $output_unaligned_reads_l;
-                mv $right $output_unaligned_reads_r
+                && mv '${left}' '${output_unaligned_reads_l}'
+                && mv '${right}' '${output_unaligned_reads_r}'
             #end if
             #if $output_aligned_reads_l and $output_aligned_reads_r:
                 #set left = str($output_aligned_reads_l).replace(".dat", ".1.dat")
                 #set right = str($output_aligned_reads_l).replace(".dat", ".2.dat")
-                ; mv $left $output_aligned_reads_l;
-                mv $right $output_aligned_reads_r
+                && mv '${left}' '${output_aligned_reads_l}'
+                && mv '${right}' '${output_aligned_reads_r}'
             #end if
         #end if
         ]]>
@@ -304,7 +304,7 @@
                 </conditional>
             </actions>
         </data>
-        <data format="fastqsanger" name="output_aligned_reads_l" label="${tool.name} on ${on_string}: aligned reads (L)" >
+        <data format="fastqsanger" name="output_aligned_reads_l" label="${tool.name} on ${on_string}: aligned reads${' (L)' if str($input_format.paired.paired_selector) != 'single' else ''}" >
             <filter>input_format['paired']['aligned_file'] is True</filter>
             <actions>
                 <conditional name="input_format.paired.paired_selector">

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -33,8 +33,8 @@
             </when>
             <when value="single">
                 <param format="@FTYPE@" label="Reads" name="reads" type="data" />
-                <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un; This triggers the --un parameter" />
-                <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al; This triggers the --al parameter" />
+                <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" argument="--un" />
+                <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" argument="--al" />
             </when>
         </conditional>
     </xml>
@@ -55,8 +55,8 @@
         </conditional>
     </xml>
     <xml name="paired_end_output">
-        <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un-conc; This triggers --un-conc for paired reads" />
-        <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al-conc; This triggers --al-conc for paired reads" />
+        <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" argument="--un-conc" />
+        <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" argument="--al-conc" />
     </xml>
     <token name="@paired_end_options@">
         #if str( $input_format.paired.unaligned_file ) == "true":

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -23,14 +23,18 @@
             <when value="paired_collection">
                 <param collection_type="paired" format="@FTYPE@" label="Paired reads" name="reads" type="data_collection" />
                 <expand macro="paired_end_conditional" />
+                <expand macro="paired_end_output" />
             </when>
             <when value="paired">
                 <param format="@FTYPE@" label="Forward reads" name="reads_f" type="data" />
                 <param format="@FTYPE@" label="Reverse reads" name="reads_r" type="data" />
                 <expand macro="paired_end_conditional" />
+                <expand macro="paired_end_output" />
             </when>
             <when value="single">
                 <param format="@FTYPE@" label="Reads" name="reads" type="data" />
+                <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un; This triggers the --un parameter" />
+                <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al; This triggers the --al parameter" />
             </when>
         </conditional>
     </xml>
@@ -50,7 +54,17 @@
             </when>
         </conditional>
     </xml>
+    <xml name="paired_end_output">
+        <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un/--un-conc; This triggers --un parameter for single reads and --un-conc for paired reads" />
+        <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al/--al-conc; This triggers --al parameter for single reads and --al-conc for paired reads" />
+    </xml>
     <token name="@paired_end_options@">
+        #if str( $input_format.paired.unaligned_file ) == "true":
+            --un-conc $output_unaligned_reads_l
+        #end if
+        #if str( $input_format.paired.aligned_file ) == "true":
+            --al-conc $output_aligned_reads_l
+        #end if  
         #if str($input_format.paired.paired_end_options.paired_end_options_selector) == 'advanced':
             ${input_format.paired.paired_end_options.no_mixed}
             ${input_format.paired.paired_end_options.no_discordant}

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -55,15 +55,15 @@
         </conditional>
     </xml>
     <xml name="paired_end_output">
-        <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un/--un-conc; This triggers --un parameter for single reads and --un-conc for paired reads" />
-        <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al/--al-conc; This triggers --al parameter for single reads and --al-conc for paired reads" />
+        <param name="unaligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write unaligned reads (in fastq format) to separate file(s)" help="--un-conc; This triggers --un-conc for paired reads" />
+        <param name="aligned_file" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Write aligned reads (in fastq format) to separate file(s)" help="--al-conc; This triggers --al-conc for paired reads" />
     </xml>
     <token name="@paired_end_options@">
         #if str( $input_format.paired.unaligned_file ) == "true":
-            --un-conc $output_unaligned_reads_l
+            --un-conc '${output_unaligned_reads_l}'
         #end if
         #if str( $input_format.paired.aligned_file ) == "true":
-            --al-conc $output_aligned_reads_l
+            --al-conc '${output_aligned_reads_l}'
         #end if  
         #if str($input_format.paired.paired_end_options.paired_end_options_selector) == 'advanced':
             ${input_format.paired.paired_end_options.no_mixed}

--- a/tools/hisat2/test-data/test_unaligned_reads.fasta
+++ b/tools/hisat2/test-data/test_unaligned_reads.fasta
@@ -1,0 +1,6 @@
+>read1
+aaaaaaaaaaaaaaaaaaaaaaaaaa
+>read2
+aaaaaataaaaaaaaaaaaaaaaaaa
+>read3
+aaaaaagaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
ping @yhoogstrate 

This enables the use of the `--un`/`--un-conc` and `--al`/`--al-conc` options in the hisat2 wrapper, as mentioned in #1041 . The changes are modelled on the devteam bowtie2 wrapper. I've tested single/paired/paired-collection with galaxy-docker-stable, though I haven't added any new tests for these features. Let me know if that should be done.