### PR TITLE
Bugfix for Busco

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -15,7 +15,9 @@
         --evalue ${adv.evalue}
         ${adv.long}
         --limit ${adv.limit}
-        --species ${adv.species}
+        #if $adv.species:
+            --species ${adv.species}
+        #end if
         --tarzip
     ]]></command>
 
@@ -39,7 +41,7 @@
         <section name="adv" title="Advanced Options" expanded="False">
             <param argument="--evalue" type="float" value="0.01" label="E-value cutoff for BLAST searches."/>
             <param argument="--limit" type="integer" value="3" label="How many candidate regions to consider"/>
-            <param argument="--species" type="text" value="generic" label="Name of existing Augustus species gene finding metaparameters"/>
+            <param argument="--species" type="text" optional="True" label="Name of existing Augustus species gene finding metaparameters"/>
             <param argument="--long" type="boolean" checked="false" truevalue="--long" falsevalue="" label="Optimization mode Augustus self-training" help="Adds considerably to run time, but can improve results for some non-model organisms"/>
         </section>
     </inputs>

--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -16,7 +16,7 @@
         ${adv.long}
         --limit ${adv.limit}
         #if $adv.species:
-            --species ${adv.species}
+            --species '${adv.species}'
         #end if
         --tarzip
     ]]></command>


### PR DESCRIPTION
Just a little bugfix for the --species of busco. It turns out "generic" is not a good default value (returns 0 results), it's better to specify a species only if we know exactly which one.