### PR TITLE
bcftools_call fix novel_rate param

### DIFF
--- a/tools/bcftools/bcftools_call.xml
+++ b/tools/bcftools/bcftools_call.xml
@@ -248,6 +248,8 @@ SNP/indel variant calling from VCF/BCF. To be used in conjunction with samtools 
   - Some of the original functionality has been temporarily lost in the process of transition to htslib, but will be added back on popular demand. 
   - The original calling model can be invoked with the -c option.
 
+The novel-rate option can be set to modify the likelihood of novel mutation for constrained -C trio calling. The trio genotype calling maximizes likelihood of a particular combination of genotypes for father, mother and the child P(F=i,M=j,C=k) = P(unconstrained) * Pn + P(constrained) * (1-Pn). By providing three values, the mutation rate Pn is set explicitly for SNPs, deletions and insertions, respectively. If two values are given, the first is interpreted as the mutation rate of SNPs and the second is used to calculate the mutation rate of indels according to their length as Pn=float*exp(-a-b*len), where a=22.8689, b=0.2994 for insertions and a=21.9313, b=0.2856 for deletions [pubmed:23975140]. If only one value is given, the same mutation rate Pn is used for SNPs and indels. 
+
 @REGIONS_HELP@
 @TARGETS_HELP@
 

--- a/tools/bcftools/bcftools_call.xml
+++ b/tools/bcftools/bcftools_call.xml
@@ -1,9 +1,32 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@VERSION@.1">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@VERSION@.2">
     <description>SNP/indel variant calling from VCF/BCF</description>
     <macros>
         <token name="@EXECUTABLE@">call</token>
         <import>macros.xml</import>
+        <xml name="macro_novel_rate">
+            <param name="novel_rate_snp" type="float" label="Novel Rate SNP" value="" optional="true" 
+                   help="likelihood of novel mutation for constrained trio calling, see man page for details" />
+            <param name="novel_rate_del" type="float" label="Novel Rate Deletions" value="" optional="true" 
+                   help="likelihood of novel mutation for constrained trio calling, see man page for details" />
+            <param name="novel_rate_ins" type="float" label="Novel Rate Insertions" value="" optional="true" 
+                   help="likelihood of novel mutation for constrained trio calling, see man page for details" />
+        </xml>
+        <token name="@NOVEL_RATE@">
+            #set $novel_rate = []
+            #if $section.genotypes.novel_rate_snp:
+              $novel_rate.append(str($section.genotypes.novel_rate_snp))
+            #end if
+            #if $section.genotypes.novel_rate_del:
+              $novel_rate.append(str($section.genotypes.novel_rate_del))
+            #end if
+            #if $section.genotypes.novel_rate_ins:
+              $novel_rate.append(str($section.genotypes.novel_rate_ins))
+            #end if
+            #if len($novel_rate) > 0:
+               --novel-rate '#echo ','.join($novel_rate)#'
+            #end if
+        </token>
     </macros>
     <expand macro="requirements" />
     <expand macro="version_command" />
@@ -34,9 +57,7 @@ bcftools @EXECUTABLE@
  #else
    #if $section.genotypes.constrain == 'trio':
     --constrain trio
-    #if $section.genotypes.novel_rate:
-     --novel-rate '$section.genotypes.novel_rate'
-    #end if
+    @NOVEL_RATE@
    #end if
    #set $section = $sec_consensus_variant_calling.variant_calling.genotypes
    @TARGETS@
@@ -114,7 +135,7 @@ ${section.variants_only}
                         </when>
                         <when value="trio">
                             <expand macro="macro_targets" />
-                            <param name="novel_rate" type="float" label="Novel Rate" value="1e-8,1e-9,1e-9" optional="true" help="likelihood of novel mutation for constrained trio calling, see man page for details" />
+                            <expand macro="macro_novel_rate" />
                         </when>
                     </conditional>
                     <param name="gvcf" type="integer" label="gvcf" optional="True" help="group non-variant sites into gVCF blocks by minimum per-sample DP" />
@@ -128,7 +149,7 @@ ${section.variants_only}
                         <when value="none">
                         </when>
                         <when value="trio">
-                            <param name="novel_rate" type="float" label="Novel Rate" value="1e-8,1e-9,1e-9" optional="true" help="likelihood of novel mutation for constrained trio calling, see man page for details" />
+                            <expand macro="macro_novel_rate" />
                         </when>
                     </conditional>
                     <expand macro="macro_targets" />

--- a/tools/bcftools/bcftools_call.xml
+++ b/tools/bcftools/bcftools_call.xml
@@ -14,14 +14,14 @@
         </xml>
         <token name="@NOVEL_RATE@">
             #set $novel_rate = []
-            #if $section.genotypes.novel_rate_snp:
-              $novel_rate.append(str($section.genotypes.novel_rate_snp))
+            #if str($section.genotypes.novel_rate_snp):
+              #silent $novel_rate.append(str($section.genotypes.novel_rate_snp))
             #end if
-            #if $section.genotypes.novel_rate_del:
-              $novel_rate.append(str($section.genotypes.novel_rate_del))
+            #if str($section.genotypes.novel_rate_del):
+              #silent $novel_rate.append(str($section.genotypes.novel_rate_del))
             #end if
-            #if $section.genotypes.novel_rate_ins:
-              $novel_rate.append(str($section.genotypes.novel_rate_ins))
+            #if str($section.genotypes.novel_rate_ins):
+              #silent $novel_rate.append(str($section.genotypes.novel_rate_ins))
             #end if
             #if len($novel_rate) > 0:
                --novel-rate '#echo ','.join($novel_rate)#'

--- a/tools/bcftools/bcftools_plugin_counts.xml
+++ b/tools/bcftools/bcftools_plugin_counts.xml
@@ -28,7 +28,8 @@ bcftools plugin @EXECUTABLE@
 ]]>
     </command>
     <configfiles>
-        <configfile name="transform">
+        <configfile name="transform"><![CDATA[
+from __future__ import print_function
 import sys
 header = []
 value = []
@@ -38,6 +39,7 @@ for line in sys.stdin:
   value.append(v)
 print( '#%s' % '\t'.join(header) )
 print( '%s' % '\t'.join(value) )
+]]>
         </configfile>
     </configfiles>
     <inputs>

--- a/tools/bcftools/bcftools_plugin_counts.xml
+++ b/tools/bcftools/bcftools_plugin_counts.xml
@@ -36,8 +36,8 @@ for line in sys.stdin:
   h,v = line.strip().split()
   header.append(h)
   value.append(v)
-print >> sys.stdout, '#%s\n' % '\t'.join(header)
-print >> sys.stdout, '%s\n' % '\t'.join(value)
+print( '#%s' % '\t'.join(header) )
+print( '%s' % '\t'.join(value) )
         </configfile>
     </configfiles>
     <inputs>

--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -14,7 +14,9 @@
       <requirement type="package" version="1.3">bcftools</requirement>
       <!-- conda dependency -->
       <requirement type="package" version="1.3">htslib</requirement>
+      <!-- htslib provides tabix and bgzip
       <requirement type="package" version="0.2.6">tabix</requirement>
+      -->
       <requirement type="package" version="1.2">samtools</requirement>
     </requirements>
   </xml>


### PR DESCRIPTION
The optional —novel-rate can take 1 to 3 floats (comma separated) as
arguments.