### PR TITLE
Remove --foldenrichment option from macs2

### DIFF
--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -66,8 +66,6 @@
             #if str($cutoff_options.pvalue).strip() != '':
                 --pvalue "${ cutoff_options.pvalue }"
             #end if
-        #else:
-            --foldenrichment "${ cutoff_options.foldenrichment }"
         #end if
 
         ## model options
@@ -121,7 +119,6 @@
             <param name="cutoff_options_selector" type="select" label="Peak detection based on" help="default uses q-value">
                 <option value="qvalue" selected="true">q-value</option>
                 <option value="pvalue">p-value</option>
-                <option value="foldenrichment">foldenrichment</option>
             </param>
             <when value="pvalue">
                 <param name="pvalue" type="float" value="" label="p-value cutoff for peak detection"
@@ -130,10 +127,6 @@
             <when value="qvalue">
                 <param name="qvalue" type="float" value="0.05" label="Minimum FDR (q-value) cutoff for peak detection"
                     help="default: 0.05 (--qvalue)"/>
-            </when>
-            <when value="foldenrichment">
-                <param name="foldenrichment" value="" type="integer" label="Foldenrichment cutoff for peak detection"
-                    help="(--foldenrichment)"/>
             </when>
         </conditional>
 


### PR DESCRIPTION
This option hasn't existed in a few years. Macs2 uses a q-value cutoff of 0.05 by default, so neither `--pvalue` nor `--qvalue` need to be explicitly specified.