### PR TITLE
Jbrowse fixes

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -435,8 +435,9 @@ class JbrowseConnector(object):
         cmd = ['ln', data, dest]
         self.subprocess_check_call(cmd)
 
+        url = os.path.join('raw', trackData['label'] + '.bw')
         trackData.update({
-            "urlTemplate": os.path.join('..', dest),
+            "urlTemplate": url,
             "storeClass": "JBrowse/Store/SeqFeature/BigWig",
             "type": "JBrowse/View/Track/Wiggle/Density",
         })
@@ -460,8 +461,9 @@ class JbrowseConnector(object):
         cmd = ['ln', '-s', os.path.realpath(bam_index), dest + '.bai']
         self.subprocess_check_call(cmd)
 
+        url = os.path.join('raw', trackData['label'] + '.bam')
         trackData.update({
-            "urlTemplate": os.path.join('..', dest),
+            "urlTemplate": url,
             "type": "JBrowse/View/Track/Alignments2",
             "storeClass": "JBrowse/Store/SeqFeature/BAM",
         })
@@ -487,8 +489,9 @@ class JbrowseConnector(object):
         cmd = ['tabix', '-p', 'vcf', dest + '.gz']
         self.subprocess_check_call(cmd)
 
+        url = os.path.join('raw', trackData['label'] + '.vcf')
         trackData.update({
-            "urlTemplate": os.path.join('..', dest + '.gz'),
+            "urlTemplate": url,
             "type": "JBrowse/View/Track/HTMLVariants",
             "storeClass": "JBrowse/Store/SeqFeature/VCFTabix",
         })

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -158,7 +158,7 @@ class ColorScaling(object):
         return r, g, b
 
     def parse_menus(self, track):
-        trackConfig = {'menuTemplate': [{}, {}, {}]}
+        trackConfig = {'menuTemplate': [{}, {}, {}, {}]}
 
         if 'menu' in track['menus']:
             menu_list = [track['menus']['menu']]

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -564,8 +564,9 @@ class JbrowseConnector(object):
                 else:
                     outputTrackConfig[key] = colourOptions[key]
 
-            menus = self.cs.parse_menus(track['conf']['options'])
-            outputTrackConfig.update(menus)
+            if 'menus' in track['conf']['options']:
+                menus = self.cs.parse_menus(track['conf']['options'])
+                outputTrackConfig.update(menus)
 
             # import pprint; pprint.pprint(track)
             # import sys; sys.exit()

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -1,4 +1,4 @@
-<tool id="jbrowse" name="JBrowse" version="@WRAPPER_VERSION@">
+<tool id="jbrowse" name="JBrowse" version="@WRAPPER_VERSION@.1">
   <description>genome browser</description>
   <macros>
     <import>macros.xml</import>


### PR DESCRIPTION
3 little fixes for jbrowse:

- parse menus in xml file only when applicable (fixes tool error with bam track for example)

- add another placeholder in the generated menuTemplate: this is needed because apollo have 4 default menu items by default instead of 3 for jbrowse. (on jbrowse there will be an empty line in the menu, but couldn't find a better way)

- I also changed the urlTemplate for bam/vcf/wig tracks: it generated urls like http://jbrowse/data/../data/ that worked well most of the time, but failed with https://github.com/galaxy-genome-annotation/galaxy-tools/blob/master/tools/jbrowse/jbrowse_to_container.xml

ping @erasche I think :)