### PR TITLE
JBrowse: Add --type option for htmlfeature

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -424,6 +424,10 @@ class JbrowseConnector(object):
                '--trackType', 'JBrowse/View/Track/CanvasFeatures'
                ]
 
+        # className in --clientConfig is ignored, it needs to be set with --className
+        if 'className' in trackData['style']:
+            cmd += ['--className', trackData['style']['className']]
+
         self.subprocess_check_call(cmd)
         os.unlink(gff3)
 
@@ -505,6 +509,10 @@ class JbrowseConnector(object):
             '--trackLabel', trackData['label'],
             '--key', trackData['key']
         ]
+
+        # className in --clientConfig is ignored, it needs to be set with --className
+        if 'className' in trackData['style']:
+            cmd += ['--className', trackData['style']['className']]
 
         config = copy.copy(trackData)
         clientConfig = trackData['style']

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -528,6 +528,9 @@ class JbrowseConnector(object):
                 config['subParts'] = gffOpts['subParts']
             if 'impliedUTRs' in gffOpts and gffOpts['impliedUTRs']:
                 config['impliedUTRs'] = gffOpts['impliedUTRs']
+        elif trackType == 'JBrowse/View/Track/HTMLFeatures':
+            if 'transcriptType' in gffOpts and gffOpts['transcriptType']:
+                cmd += ['--type', gffOpts['transcriptType']]
 
         cmd += [
             '--trackType', gffOpts['trackType']

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -227,6 +227,10 @@ $trackxml &&
                     #if str($track.data_format.track_config.canvas_options.impliedUTRs) != "false":
                     <impliedUTRs>${track.data_format.track_config.canvas_options.impliedUTRs}</impliedUTRs>
                     #end if
+                  #else if $track.data_format.track_config.track_class == 'JBrowse/View/Track/HTMLFeatures':
+                    #if str($track.data_format.track_config.html_options.transcriptType) != "":
+                    <transcriptType>${track.data_format.track_config.html_options.transcriptType}</transcriptType>
+                    #end if
                   #end if
                   #if $track.data_format.match_part.match_part_select:
                     <match>${track.data_format.match_part.name}</match>
@@ -420,7 +424,16 @@ $trackxml &&
                                    help="Check this your input files does not contain UTR features, but the UTR can be 'implied' from the difference between the exon and CDS boundaries"/>
                        </section>
                    </when>
-                   <when value="JBrowse/View/Track/HTMLFeatures" />
+                   <when value="JBrowse/View/Track/HTMLFeatures">
+                       <section name="html_options" title="HTMLFeatures Options [Advanced]" expanded="false">
+                           <param label="Transcript type"
+                                  name="transcriptType"
+                                  type="text"
+                                  value=""
+                                  help="If your input files represents transcripts, give the name of the corresponding features here (e.g. 'mRNA' or 'transcript')"
+                                  optional="True"/>
+                      </section>
+                   </when>
                 </conditional>
                 <expand macro="track_styling" />
                 <expand macro="color_selection" />


### PR DESCRIPTION
As discussed in https://github.com/GMOD/Apollo/issues/1483, added the --type option when selecting HTMLFeature track type