### PR TITLE
Fix broken data_manager_humann2_database_downloader

### DIFF
--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -7,10 +7,10 @@
         <exit_code range=":-1"  level="fatal" description="Error: Cannot open file" />
         <exit_code range="1:"  level="fatal" description="Error" />
     </stdio>
-    <command interpreter="python">
-        data_manager_humann2_download.py
+    <command>
+        python '$__tool_directory__/data_manager_humann2_download.py'
             --database '$db.database'
-            --build '$db.build'
+            --build $db.build
             '${out_file}'
     </command>
     <inputs>
@@ -38,19 +38,16 @@
         </conditional>
     </inputs>
     <outputs>
-           <data name="out_file" format="data_manager_json" label="${tool.name}"/>
+        <data name="out_file" format="data_manager_json" label="${tool.name}" />
     </outputs>
     <tests>
     </tests>
     <help>
-
 This tool downloads the HUMAnN2 databases.
 
-`Read more about the tool <http://huttenhower.sph.harvard.edu/humann2/manual>`_.
-
+Read more about the tool at http://huttenhower.sph.harvard.edu/humann2/manual .
     </help>
     <citations>
         <citation type="doi">10.1371/journal.pcbi.1003153</citation>
-        <yield />
     </citations>
 </tool>


### PR DESCRIPTION
```
$ planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error data_managers/data_manager_humann2_database_downloader/
Linting repository /usr/users/ga002/soranzon/software/galaxyproject_tools-iuc/data_managers/data_manager_humann2_database_downloader
Error loading tool with path /tmp/planemo_tmp_yfUlf1/83901c99b429ead8a454823bbaa1c331/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/galaxyproject_planemo/.venv/local/lib/python2.7/site-packages/galaxy/tools/loader_directory.py", line 107, in _load_tools_from_path
    tool_element = loader_func(possible_tool_file)
ParseError: not well-formed (invalid token): line 49, column 32
+Linting tool /usr/users/ga002/soranzon/software/galaxyproject_tools-iuc/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
Could not lint /tmp/planemo_tmp_yfUlf1/83901c99b429ead8a454823bbaa1c331/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml due to malformed xml.
Failed linting
```

Also drop deprecated `interpreter` attribute of `<command>`.