### PR TITLE
fixed handling of guide gtf in stringtie merge

### DIFF
--- a/tools/stringtie/stringtie_merge.xml
+++ b/tools/stringtie/stringtie_merge.xml
@@ -10,7 +10,7 @@
     <![CDATA[
         stringtie --merge
         -p \${GALAXY_SLOTS:-1}
-        #if str($guide_gff) != "":
+        #if $guide_gff:
             -G "$guide_gff"
         #end if
         -m $min_len
@@ -25,7 +25,7 @@
     ]]>
     </command>
     <inputs>
-        <param type="data" name="input_gtf" multiple="true" format="gtf,gff3" />
+        <param type="data" name="input_gtf" multiple="True" format="gtf,gff3" />
         <param type="data" name="guide_gff" optional="True" format="gtf,gff3" />
         <param argument="-m" type="integer" name="min_len" value="50" help="Minimum input transcript length to include in the merge" />
         <param argument="-c" type="integer" name="min_cov" value="0" help="Minimum input transcript coverage to include in the merge" />
@@ -48,6 +48,14 @@
             <param ftype="gtf" name="input_gtf" value="stringtie_merge_in1.gtf,stringtie_merge_in2.gtf" />
             <param ftype="gtf" name="guide_gff" value="stringtie_merge_in3.gtf" />
             <output file="stringtie_merge_out2.gtf" ftype="gtf" lines_diff="2" name="out_gtf" />
+        </test>
+        <test>
+            <param ftype="gtf" name="input_gtf" value="stringtie_merge_in1.gtf,stringtie_merge_in2.gtf" />
+            <output ftype="gtf" name="out_gtf">
+                <assert_contents>
+                    <has_text text="stringtie --merge" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
stringtie-merge did not handle case for absent guide file. If was consistently giving the following error:

```
Fatal error: Exit code 1 ()
Error: reference annotation file (None) not found
```
this commit fixes this and adds appropriate test