### PR TITLE
Trinity: bump version forgotten

### DIFF
--- a/tools/trinity/run_de_analysis.xml
+++ b/tools/trinity/run_de_analysis.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_run_de_analysis" name="Differential expression analysis" version="@WRAPPER_VERSION@.1">
+<tool id="trinity_run_de_analysis" name="Differential expression analysis" version="@WRAPPER_VERSION@.2">
     <description>using a Trinity assembly</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
I have forgotten to bump the wrapper version of tool run_de_analysis in #1178
Fixed.