### PR TITLE
Additional (critical) MACS2 fixes

### DIFF
--- a/tools/macs2/macs2_bdgbroadcall.xml
+++ b/tools/macs2/macs2_bdgbroadcall.xml
@@ -4,7 +4,7 @@
         <import>macs2_macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="4.1.0">gnu_awk</requirement>
+        <requirement type="package" version="4.1.3">gawk</requirement>
     </expand>
     <expand macro="stdio" />
     <expand macro="version_command" />

--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -29,7 +29,7 @@
 
         @effective_genome_size@
 
-        --bw '${$band_width}'
+        --bw '${band_width}'
         @mfold_command@
 
         ## advanced options
@@ -74,7 +74,7 @@
             --extsize '${ nomodel_type.extsize }'
         #end if
 
-        2> $temp_stderr)
+        2>&1 > $temp_stderr)
         #if "peaks_tabular" in str($outputs).split(','):
             &&
             cp MACS2_peaks.xls '${ output_tabular }'
@@ -95,8 +95,8 @@
             then
                 mkdir '${ output_extra_files.files_path }' &&
                 cp MACS2* '${ output_extra_files.files_path }' &&
-                python '$__tool_directory__/dir2html.py' 
-                    '${ output_extra_files.files_path }' $temp_stderr > '${ output_extra_files }'
+                python '$__tool_directory__/dir2html.py'
+                    '${ output_extra_files.files_path }' $temp_stderr > '${ output_extra_files }';
             fi;
             )
         #end if
@@ -251,7 +251,7 @@
             <param name="cutoff_options_selector" value="qvalue"/>
             <param name="qvalue" value="0.05"/>
             <param name="band_width" value="300"/>
-            <param name="outputs" value="peaks_tabular,bdg"/>
+            <param name="outputs" value="peaks_tabular,bdg,html"/>
             <param name="effective_genome_size_options_selector" value="user_defined" />
             <param name="gsize" value="3300000000" />
             <param name="lower" value="5" />
@@ -259,6 +259,12 @@
             <output name="output_control_lambda" compare="contains" file="callpeak_control_part.bdg" lines_diff="1"/>
             <output name="output_treat_pileup" compare="contains" file="callpeak_treatment_part.bdg" lines_diff="1"/>
             <output name="output_tabular" compare="contains" file="callpeak_part.tabular" lines_diff="1"/>
+            <output name="output_extra_files">
+                <assert_contents>
+                    <has_text text="Additional output created by MACS2" />
+                </assert_contents>
+            </output>
+
         </test>
         <test>
             <param name="input_control_file" value="Control_200K.bed" ftype="bed"/>


### PR DESCRIPTION
Fixed several things: 
- html generation part of the `<command>` tag was missing `;`
- fixed error noticed by @nsoranzo 
- made sure stderr gets printed when tool fails
- added test for presence of html report