### PR TITLE
Fix compressed input into FastQC

### DIFF
--- a/tools/fastqc/.shed.yml
+++ b/tools/fastqc/.shed.yml
@@ -1,7 +1,7 @@
 categories:
 - Fastq Manipulation
 description: Read QC reports using FastQC
-homepage_url: http://www.bioinformatics.bbsrc.ac.uk/projects/fastqc/
+homepage_url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 long_description: |
   FastQC aims to provide a simple way to do some quality control
   checks on raw sequence data coming from high throughput sequencing pipelines. It

--- a/tools/fastqc/rgFastQC.py
+++ b/tools/fastqc/rgFastQC.py
@@ -52,19 +52,19 @@ class FastQCRunner(object):
         trimext = False
         # decompression at upload currently does NOT remove this now bogus ending - fastqc will barf
         # patched may 29 2013 until this is fixed properly
-        type = mimetypes.guess_type(self.opts.input)
-        if linf.endswith('.gz') or linf.endswith('.gzip') or type[-1] == "gzip" or informat.endswith('.gz'):
+        ftype = mimetypes.guess_type(self.opts.input)
+        if linf.endswith('.gz') or linf.endswith('.gzip') or ftype[-1] == "gzip" or informat.endswith('.gz'):
             f = gzip.open(self.opts.input)
             try:
                 f.readline()
-                type = ['gzip']
+                ftype = ['gzip']
             except:
                 trimext = True
             f.close()
         elif linf.endswith('bz2') or informat.endswith('.bz2'):
             f = bz2.BZ2File(self.opts.input, 'r')
             try:
-                type = ['bzip2']
+                ftype = ['bzip2']
                 f.readline()
             except:
                 trimext = True
@@ -98,9 +98,9 @@ class FastQCRunner(object):
             command_line.append('--limits %s' % self.opts.limits)
         command_line.append('--quiet')
         command_line.append('--extract')  # to access the output text file
-        if type[-1] == 'gzip':
+        if ftype[-1] == 'gzip':
             self.fastqinfilename += '.gz'
-        elif type[-1] == 'bzip2':
+        elif ftype[-1] == 'bzip2':
             self.fastqinfilename += '.bz2'
         else:
             command_line.append('-f %s' % self.opts.informat)

--- a/tools/fastqc/rgFastQC.py
+++ b/tools/fastqc/rgFastQC.py
@@ -48,20 +48,23 @@ class FastQCRunner(object):
         # This prevents uncompression of already uncompressed files
         infname = self.opts.inputfilename
         linf = infname.lower()
+        informat = self.opts.informat
         trimext = False
         # decompression at upload currently does NOT remove this now bogus ending - fastqc will barf
         # patched may 29 2013 until this is fixed properly
         type = mimetypes.guess_type(self.opts.input)
-        if linf.endswith('.gz') or linf.endswith('.gzip') or type[-1] == "gzip":
+        if linf.endswith('.gz') or linf.endswith('.gzip') or type[-1] == "gzip" or informat.endswith('.gz'):
             f = gzip.open(self.opts.input)
             try:
                 f.readline()
+                type = ['gzip']
             except:
                 trimext = True
             f.close()
-        elif linf.endswith('bz2'):
+        elif linf.endswith('bz2') or informat.endswith('.bz2'):
             f = bz2.BZ2File(self.opts.input, 'r')
             try:
+                type = ['bzip2']
                 f.readline()
             except:
                 trimext = True
@@ -95,10 +98,12 @@ class FastQCRunner(object):
             command_line.append('--limits %s' % self.opts.limits)
         command_line.append('--quiet')
         command_line.append('--extract')  # to access the output text file
-        if type[-1] != "gzip":
-            command_line.append('-f %s' % self.opts.informat)
+        if type[-1] == 'gzip':
+            self.fastqinfilename += '.gz'
+        elif type[-1] == 'bzip2':
+            self.fastqinfilename += '.bz2'
         else:
-            self.fastqinfilename += ".gz"
+            command_line.append('-f %s' % self.opts.informat)
         command_line.append(self.fastqinfilename)
         self.command_line = ' '.join(command_line)
 

--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -124,7 +124,7 @@ The tool produces a basic text and a HTML output file that contain all of the re
 - Kmer Content
 
 All except Basic Statistics and Overrepresented sequences are plots.
- .. _FastQC: http://www.bioinformatics.bbsrc.ac.uk/projects/fastqc/
+ .. _FastQC: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/
  .. _Picard-tools: http://picard.sourceforge.net/index.shtml
     </help>
     <citations>

--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -1,4 +1,4 @@
-<tool id="fastqc" name="FastQC" version="0.67">
+<tool id="fastqc" name="FastQC" version="0.68">
     <description>Read Quality reports</description>
     <requirements>
         <requirement type="package" version="0.11.5">fastqc</requirement>


### PR DESCRIPTION
Xref: #1128 

Compressed input into the current FastQC wrapper only works if the history item's name ends in `.gz`. That will generally work for uploaded or linked in files (assuming people don't change the names) but won't if you run FastQC on trimmed data. I've now modified the python script to pay closer attention to whether the input datatype is `fastq.gz` (or `fastq.bz2`). This fixes things locally for me at least.