### PR TITLE
Make.contigs - Combo mode

### DIFF
--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -9,14 +9,19 @@
     <command><![CDATA[
         @SHELL_OPTIONS@
 
-        ## create symlinks to input datasets
-        #if $input_type.type == 'collection'
-            ln -s '$input_type.fastq_pair.forward' ffastq.dat &&
-            ln -s '$input_type.fastq_pair.reverse' rfastq.dat &&
+        ## Symlinks creation or On the fly creation of a combo file
+        #if $input_type.type == 'list_collection'
+            #for $pair in $input_type.list_paired_collection:
+                echo -e "${pair.name}\t${pair.forward}\t${pair.reverse}" >> combo_fastq.dat &&
+            #end for
+        #elif $input_type.type == 'simple_collection'
+            ln -s '$input_type.paired_collection.forward' ffastq.dat &&
+            ln -s '$input_type.paired_collection.reverse' rfastq.dat &&
         #else
             ln -s '$input_type.forward_fastq' ffastq.dat &&
             ln -s '$input_type.reverse_fastq' rfastq.dat &&
         #end if
+
         #if $oligo.add == "yes":
             ln -s '$oligo.oligos' oligo.oligos.dat &&
             ln -s '$oligo.findex' oligo.findex.dat &&
@@ -24,8 +29,12 @@
         #end if
 
         echo 'make.contigs(
-            ffastq=ffastq.dat,
-            rfastq=rfastq.dat,
+            #if $input_type.type == 'list_collection':
+                file=combo_fastq.dat,
+            #else:
+                ffastq=ffastq.dat,
+                rfastq=rfastq.dat,
+            #end if
             align=$align,
             #if $oligo.add == "yes":
                 oligos=oligo.oligos.dat,

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -51,17 +51,20 @@
     ]]></command>
     <inputs>
         <conditional name="input_type">
-            <param name="type" type="select" label="Select type of fasta input" help="">
-                <option value="collection" selected="true">Paired collection</option>
-                <option value="regular">Two files (forward and reverse)</option>
+            <param name="type" type="select" label="Select a way to provide forward and reverse fastq files ?" help="">
+                <option value="regular" selected="true">Two simple fastq files (forward and reverse)</option>
+                <option value="simple_collection">One pair (paired collection)</option>
+                <option value="list_collection">Multiple pairs - Combo mode (list:paired collection)</option>
             </param>
-            <when value="collection">
-                <param name="fastq_pair" type="data_collection" format="fastq" collection_type="paired"
-                    label="Fastq pairs" help="paired collection of your forward and reverse fastq file"/>
-            </when>
             <when value="regular">
                 <param name="forward_fastq" type="data" format="fastq" label="Forward reads"/>
                 <param name="reverse_fastq" type="data" format="fastq" label="Reverse reads"/>
+            </when>
+            <when value="simple_collection">
+                <param name="paired_collection" type="data_collection" format="fastq" collection_type="paired" label="Fastq pair (collection)" help="Dataset collection made from a single pair of fastq files (forward + reverse)"/>
+            </when>
+            <when value="list_collection">
+                <param name="list_paired_collection" type="data_collection" format="fastq" collection_type="list:paired" label="Fastq pairs (collection)" help="Dataset collection made from multiple pairs of fastq files" />
             </when>
         </conditional>
         <param name="align" type="select" label="align - Select a pairwise alignment method" help="">

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -104,11 +104,11 @@
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="fasta" format="fasta" from_work_dir="ffastq*.trim.*.fasta" label="${tool.name} on ${on_string}: trim.contigs.fasta"/>
-        <data name="qual" format="qual" from_work_dir="ffastq*.trim.*.qual" label="${tool.name} on ${on_string}: trim.contigs.qual"/>
-        <data name="scrapfasta" format="fasta" from_work_dir="ffastq*.scrap.*.fasta" label="${tool.name} on ${on_string}: scrap.contigs.fasta"/>
-        <data name="scrapqual" format="qual" from_work_dir="ffastq*.scrap.*.qual" label="${tool.name} on ${on_string}: scrap.contigs.qual"/>
-        <data name="report" format="txt" from_work_dir="ffastq*.contigs.report" label="${tool.name} on ${on_string}: report"/>
+        <data name="fasta" format="fasta" from_work_dir="*fastq.trim.*.fasta" label="${tool.name} on ${on_string}: trim.contigs.fasta"/>
+        <data name="qual" format="qual" from_work_dir="*fastq*.trim.*.qual" label="${tool.name} on ${on_string}: trim.contigs.qual"/>
+        <data name="scrapfasta" format="fasta" from_work_dir="*fastq*.scrap.*.fasta" label="${tool.name} on ${on_string}: scrap.contigs.fasta"/>
+        <data name="scrapqual" format="qual" from_work_dir="*fastq*.scrap.*.qual" label="${tool.name} on ${on_string}: scrap.contigs.qual"/>
+        <data name="report" format="txt" from_work_dir="*fastq*.contigs.report" label="${tool.name} on ${on_string}: report"/>
     </outputs>
     <tests>
         <test><!-- test with collection input -->

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -111,34 +111,45 @@
         <data name="report" format="txt" from_work_dir="*fastq*.contigs.report" label="${tool.name} on ${on_string}: report"/>
     </outputs>
     <tests>
-        <test><!-- test with collection input -->
-            <param name="fastq_pair">
-                <collection type="paired">
-                    <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
-                    <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
-                </collection>
-            </param>
+        <!-- Test with two regular files as input -->
+        <test>
+            <conditional name="input_type">
+                <param name="type" value="regular"/>
+                <param name="forward_fastq" value="Mock_S280_L001_R1_001_small.fastq" ftype="fastq"/>
+                <param name="reverse_fastq" value="Mock_S280_L001_R2_001_small.fastq" ftype="fastq"/>
+            </conditional>
             <output name="fasta" file="Mock_S280_L001_R1_001_small.trim.contigs.fasta" ftype="fasta"/>
             <output name="qual" file="Mock_S280_L001_R1_001_small.trim.contigs.qual" ftype="qual"/>
             <output name="report" file="Mock_S280_L001_R1_001_small.contigs.report" ftype="txt"/>
             <expand macro="logfile-test"/>
         </test>
-        <test><!-- test with two regular files as input -->
-            <param name="type" value="regular"/>
-            <param name="forward_fastq" value="Mock_S280_L001_R1_001_small.fastq" ftype="fastq"/>
-            <param name="reverse_fastq" value="Mock_S280_L001_R2_001_small.fastq" ftype="fastq"/>
+        <!-- Test with a simple paired collection as input -->
+        <test>
+            <conditional name="input_type">
+                <param name="type" value="simple_collection"/>
+                <param name="paired_collection">
+                    <collection type="paired">
+                        <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
+                        <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
+                    </collection>
+                </param>
+            </conditional>
             <output name="fasta" file="Mock_S280_L001_R1_001_small.trim.contigs.fasta" ftype="fasta"/>
             <output name="qual" file="Mock_S280_L001_R1_001_small.trim.contigs.qual" ftype="qual"/>
             <output name="report" file="Mock_S280_L001_R1_001_small.contigs.report" ftype="txt"/>
             <expand macro="logfile-test"/>
         </test>
-        <test><!-- test with extra parameters set -->
-            <param name="fastq_pair">
-                <collection type="paired">
-                    <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
-                    <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
-                </collection>
-            </param>
+        <!-- Test with a simple paired collection as input + extra parameters specified -->
+        <test>
+            <conditional name="input_type">
+                <param name="type" value="simple_collection"/>
+                <param name="paired_collection">
+                    <collection type="paired">
+                        <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
+                        <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
+                    </collection>
+                </param>
+            </conditional>
             <param name="align" value="gotoh"/>
             <param name="match" value="2"/>
             <param name="mismatch" value="-2"/>
@@ -147,6 +158,32 @@
             <output name="fasta" md5="48e32c65bd9f064c5c0b4ea7695cabe9" ftype="fasta"/>
             <output name="qual" md5="1e7778cee0d86bfa2759a07bb4356165" ftype="qual"/>
             <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt"/>
+            <expand macro="logfile-test"/>
+        </test>
+        <!-- Test with a list:paired collection as input -->
+        <test>
+            <conditional name="input_type">
+                <param name="type" value="list_collection"/>
+                <param name="list_paired_collection">
+                    <collection type="list:paired">
+                        <element name="Pair1">
+                            <collection type="paired">
+                                <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
+                                <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
+                            </collection>
+                        </element>
+                        <element name="Pair2">
+                            <collection type="paired">
+                                <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
+                                <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
+                            </collection>
+                        </element>
+                    </collection>
+                </param>
+            </conditional>
+            <output name="fasta" md5="dab69a0e36f718b55d8defad26ec469b" ftype="fasta"/>
+            <output name="qual" md5="cdba5409e4f87e3cd093a4e51084d616" ftype="qual"/>
+            <output name="report" md5="80b992abd7e4d6a5e89fa70011ef2384" ftype="txt"/>
             <expand macro="logfile-test"/>
         </test>
     </tests>


### PR DESCRIPTION
This Pull Request concern an update of the make.contigs wrapper (as discussed previously with @shiltemann)

The wrapper has been modified so that the end user can use make.contigs in combo mode (i.e. make it process more than one pair of fastq files at a time).

The end user can now select a list:paired collection as input.

If such a collection is selected, the wrapper will create a valid combo file "on the fly" and use it in the make.contigs command line through the "file" option.

My goal here was to avoid forcing the end user to run many make.contigs in batch mode and then use several tools (merge.files, make.group) to merge all the result files (since make.contigs is already able to do it by itself).

The new test added in the <tests> section use md5 checksums to avoid having more test files in the test-data folder.

The wrapper syntax has been checked with "planemo lint".

The correct execution of the tool has been tested with "planemo test" and "planemo serve".