### PR TITLE
QIIME: re-enable alpha diversity test

### DIFF
--- a/tools/qiime/qiime_core/core_diversity_analyses.xml
+++ b/tools/qiime/qiime_core/core_diversity_analyses.xml
@@ -98,6 +98,25 @@
                 </assert_contents>
             </output>
         </test>
+        <test><!-- test alpha diversity -->
+             <param name="input_biom_fp" value="core_diversity_analyses/otu_table.biom"/>
+             <param name="mapping_fp" value="core_diversity_analyses/map.txt"/>
+             <param name="parameter_fp" value="core_diversity_analyses/alpha_diversity_params.txt"/>
+             <param name="sampling_depth" value="22"/>
+             <param name="parallel" value="--parallel"/>
+             <param name="nonphylogenetic_diversity" value="--nonphylogenetic_diversity"/>
+             <param name="suppress_taxa_summary" value="--suppress_taxa_summary"/>
+             <param name="suppress_beta_diversity" value="--suppress_beta_diversity"/>
+             <param name="suppress_alpha_diversity" value=""/>
+             <param name="suppress_group_significance" value="--suppress_group_significance"/>
+             <output name="html_report">
+                 <assert_contents>
+                     <has_text text="Filtered BIOM table (minimum sequence count: 22)"/>
+                     <has_text text="rarefied BIOM table (sampling depth: 22)"/>
+                     <has_text text="Alpha rarefaction plots"/>
+                 </assert_contents>
+             </output>
+        </test>
         <test><!-- test suppressing all -->
             <param name="input_biom_fp" value="core_diversity_analyses/otu_table.biom"/>
             <param name="mapping_fp" value="core_diversity_analyses/map.txt"/>


### PR DESCRIPTION
this test can be re-enabled again now that we have the extended log output timeout limit in travis.