### PR TITLE
Check that changed_tools_chunk.list is also not empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,31 +35,31 @@ install:
   - |
       planemo ci_find_repos --exclude_from .tt_blacklist \
                             --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
-                            --output changed_repositories_chunk.list
-  - | 
-    if [ -s changed_repositories_chunk.list ]; then  
+                            --output changed_repositories.list
+  - |
+    if [ -s changed_repositories.list ]; then
         planemo ci_find_tools --exclude data_managers \
                               --exclude packages \
                               --chunk_count 4 --chunk "${CHUNK}" \
                               --output changed_tools_chunk.list \
-                              $(cat changed_repositories_chunk.list)
+                              $(cat changed_repositories.list)
         cat changed_tools_chunk.list
     fi
-  - cat changed_repositories_chunk.list
-  
+  - cat changed_repositories.list
+
 script:
   - set -e
   - cd "$TRAVIS_BUILD_DIR" && flake8 --exclude=.git .
-  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR"; done < changed_repositories_chunk.list
-  - while read -r DIR; do planemo conda_install "$DIR"; done < changed_repositories_chunk.list
+  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR"; done < changed_repositories.list
   - |
-    if [ -e changed_tools_chunk.list ]; then
+    if [ -s changed_tools_chunk.list ]; then
+        while read -r DIR; do planemo conda_install "$DIR"; done < changed_repositories.list
         planemo test --conda_dependency_resolution --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
     fi
 
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
-      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
+      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
     fi


### PR DESCRIPTION
It may be empty in some chunk. Reported by @nekrut.
Also:
- rename `changed_repositories_chunk.list` to `changed_repositories.list`
- run `planemo conda_install` only if `planemo test` will be run

Even with these fixes, a few things remain broken:
- `planemo shed_lint` is run on all changed repositories in each job; it should probably be split in a separate job together with `flake8`
- `planemo conda_install` is run for all changed repositories instead of the repos whose tools are going to be tested in the job (i.e. the ones in `changed_repositories_chunk.list`)
- `planemo shed_update` is badly broken on PR merge because multiple jobs may be trying to update the same repo, this one needs to be fixed ASAP (maybe using staged builds proposed by @peterjc).