### PR TITLE
bcftools concat - add naive option

### DIFF
--- a/tools/bcftools/bcftools_concat.xml
+++ b/tools/bcftools/bcftools_concat.xml
@@ -43,7 +43,7 @@ ${section.compact_PS}
 ## Primary Input/Outputs
 @INPUT_FILES@ 
 #if $sec_default.mode.naive == "yes" and $output_type == 'v':
-| bcftools view -O v -o '$output_file' -.gz
+> output.gz && bcftools index output.gz && bcftools view -O v -o '$output_file' output.gz
 #else:
 > '$output_file'
 #end if
@@ -112,7 +112,18 @@ ${section.compact_PS}
                     <has_text_matching expression="3\t192"/>
                 </assert_contents>
             </output>
-        </test>
+       </test>
+       <test>
+            <param name="input_files" ftype="vcf" value="concat.1.b.vcf,concat.1.a.vcf" />
+            <param name="naive" value="yes" />
+            <param name="output_type" value="v" />
+            <output name="output_file">
+                <assert_contents>
+                    <has_text_matching expression="1\t100"/>
+                    <has_text_matching expression="3\t192"/>
+                </assert_contents>
+            </output>
+       </test>
        <test>
             <param name="input_files" ftype="vcf" value="concat.2.b.vcf,concat.2.a.vcf" />
             <param name="allow_overlaps" value="yes" />

--- a/tools/bcftools/bcftools_concat.xml
+++ b/tools/bcftools/bcftools_concat.xml
@@ -24,7 +24,7 @@ bcftools @EXECUTABLE@
   #if $section.mode.overlaps.allow_overlaps == 'yes':
     --allow-overlaps
     #if $section.mode.overlaps.rm_dups:
-      --rm-dups $section.overlaps.rm_dups
+      --rm-dups $section.mode.overlaps.rm_dups
     #end if
   #end if
   ${section.mode.ligate}

--- a/tools/bcftools/bcftools_concat.xml
+++ b/tools/bcftools/bcftools_concat.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@VERSION@.0">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@VERSION@.1">
     <description>Concatenate or combine VCF/BCF files</description>
     <macros>
         <token name="@EXECUTABLE@">concat</token>
@@ -18,13 +18,17 @@ bcftools @EXECUTABLE@
 ## Default section
 #set $section = $sec_default
 
-#if $section.overlaps.allow_overlaps == 'yes':
-  --allow-overlaps
-  #if $section.overlaps.rm_dups:
-    --rm-dups $section.overlaps.rm_dups
+#if $section.mode.naive == "yes":
+  --naive
+#else: 
+  #if $section.mode.overlaps.allow_overlaps == 'yes':
+    --allow-overlaps
+    #if $section.mode.overlaps.rm_dups:
+      --rm-dups $section.overlaps.rm_dups
+    #end if
   #end if
+  ${section.mode.ligate}
 #end if
-${section.ligate}
 ${section.compact_PS}
 #if $section.min_PQ:
   --min-PQ "${section.min_PQ}"
@@ -38,7 +42,11 @@ ${section.compact_PS}
 
 ## Primary Input/Outputs
 @INPUT_FILES@ 
+#if $sec_default.mode.naive == "yes" and $output_type == 'v':
+| bcftools view -O v -o '$output_file' -.gz
+#else:
 > '$output_file'
+#end if
 ]]>
     </command>
     <inputs>
@@ -47,31 +55,43 @@ ${section.compact_PS}
             <expand macro="macro_regions" />
         </section>
         <section name="sec_default" expanded="true" title="Concat Options">
-            <conditional name="overlaps">
-                <param name="allow_overlaps" type="select" label="Allow Overlaps">   
-                    <help>
-                    First coordinate of the next file can precede last record of the current file. 
-                    </help>
-                    <option value="yes">Yes </option>
+            <conditional name="mode">
+                <param name="naive" type="select" label="naive concat">   
+                    <help><![CDATA[
+--naive concatenates VCF or BCF files without recompression. This can be used used to combine results that were generated separately for each chromosome.  This is very fast but requires that all files are of the same type (all VCF or all BCF) and have the same headers. This is because all tags and chromosome names in the BCF body rely on the implicit order of the contig and tag definitions in the header. Currently no sanity checks are in place. Dangerous, use with caution. 
+                    ]]></help>
                     <option value="no">No </option>
+                    <option value="yes">Yes </option>
                 </param>
-                <when value="yes">
-                    <param name="rm_dups" type="select" label="Remove duplicate" optional="True" >
-                        <help><![CDATA[
-                         Output duplicate records present in multiple files only once: 
-                           rm-dups <snps|indels|both|all|none>
-                        ]]></help>
-                        <option value="snps">snps - SNP records</option>
-                        <option value="indels">indels - indel records</option>
-                        <option value="both">both - both SNP and indel records</option>
-                        <option value="all">all - records</option>
-                        <option value="none">none - output multiple records instead</option>
-                    </param>
+                <when value="yes"/>
+                <when value="no">
+                    <conditional name="overlaps">
+                        <param name="allow_overlaps" type="select" label="Allow Overlaps">   
+                            <help>
+                            First coordinate of the next file can precede last record of the current file. 
+                            </help>
+                            <option value="yes">Yes </option>
+                            <option value="no">No </option>
+                        </param>
+                        <when value="yes">
+                            <param name="rm_dups" type="select" label="Remove duplicate" optional="True" >
+                                <help><![CDATA[
+                                 Output duplicate records present in multiple files only once: 
+                                   rm-dups <snps|indels|both|all|none>
+                                ]]></help>
+                                <option value="snps">snps - SNP records</option>
+                                <option value="indels">indels - indel records</option>
+                                <option value="both">both - both SNP and indel records</option>
+                                <option value="all">all - records</option>
+                                <option value="none">none - output multiple records instead</option>
+                            </param>
+                        </when>
+                        <when value="no"/>
+                    </conditional>
+                    <param name="ligate" type="boolean" truevalue="--ligate" falsevalue="" label="Ligate" 
+                           help="Ligate phased VCFs by matching phase at overlapping haplotypes" />
                 </when>
-                <when value="no"/>
             </conditional>
-            <param name="ligate" type="boolean" truevalue="--ligate" falsevalue="" label="Ligate" 
-                   help="Ligate phased VCFs by matching phase at overlapping haplotypes" />
             <param name="compact_PS" type="boolean" truevalue="--compact-PS" falsevalue="" label="Compact Ps" 
                    help="Do not output PS tag at each site, only at the start of a new phase set block." />
             <param name="min_PQ" type="integer" label="Min Pq" value="30" optional="True" 
@@ -122,6 +142,12 @@ ${section.compact_PS}
 =====================================
 
 Concatenate or combine VCF/BCF files. All source files must have the same sample columns appearing in the same order. The program can be used, for example, to concatenate chromosome VCFs into one VCF, or combine a SNP VCF and an indel VCF into one. The input files must be sorted by chr and position. The files must be given in the correct order to produce sorted VCF on output unless the -a, --allow-overlaps option is specified.
+
+
+Naive concatenation is useful when using a galaxy workflow that splits a BAM file by chromosome, processes each in parallel, then bcftools concat merges the results into a single VCF file: 
+
+BAM -> bamtools split => bcftools mpileup => bcftools call => bcftools concat -> VCF
+
 
 @REGIONS_HELP@
 


### PR DESCRIPTION
naive option needed for merging vcf files generated per chromosome:
HISAT2 -> bamtools split -reference => bcftools mpileup => bcftools
call => bcftools concat (naive) ->