### PR TITLE
Fixed infinite loop error in data_manager_gatk_picard_index_builder

### DIFF
--- a/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.py
+++ b/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.py
@@ -131,7 +131,7 @@ def _sort_fasta_gatk( fasta_filename ):
         sorted_names = ["chr%s" % x for x in sorted_names]
     else:
         sorted_names.insert( 0, "MT" )
-    sorted_names.extend( "%s_random" % x for x in sorted_names )
+    sorted_names.extend( [ "%s_random" % x for x in sorted_names ] )
 
     existing_sorted_names = []
     for name in sorted_names:


### PR DESCRIPTION
The sorted_names list was extended ad infinitum. Not only did it append "_random" to all items in the list, but it kept adding it, creating an infinite list of x_random_random_random(etc.) items.
This would eat all memory until the Linux kernel would kill the process, resulting in a failure to run the data manager.

The fix makes sure the extension is evaluated after it is complete, not during completion.
