### PR TITLE
Condafy seqtk

### DIFF
--- a/tools/seqtk/.shed.yml
+++ b/tools/seqtk/.shed.yml
@@ -1,10 +1,9 @@
 categories:
 - Sequence Analysis
 description:  Toolkit for processing sequences in FASTA/Q formats
+homepage_url: https://github.com/lh3/seqtk
 long_description: |
   Sequence Analysis toolkit provies several small utilities for working with FastA and FastQ data.
-
-  https://github.com/lh3/seqtk
 name: seqtk
 owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/seqtk

--- a/tools/seqtk/macros.xml
+++ b/tools/seqtk/macros.xml
@@ -1,37 +1,36 @@
 <?xml version="1.0"?>
 <macros>
-  <xml name="requirements">
-    <requirements>
-      <requirement type="package" version="1.2">seqtk</requirement>
-      <yield/>
-    </requirements>
-  </xml>
-  <token name="@WRAPPER_VERSION@">1.2</token>
-  <xml name="stdio">
-    <stdio>
-      <!-- Anything other than zero is an error -->
-      <exit_code range="1:"/>
-      <exit_code range=":-1"/>
-      <!-- In case the return code has not been set propery check stderr too -->
-      <regex match="Error:"/>
-      <regex match="Exception:"/>
-    </stdio>
-  </xml>
-  <xml name="in_fq">
-    <param name="in_file" type="data" format="fastq" label="Input FASTQ file"/>
-  </xml>
-  <xml name="in_faq">
-    <param name="in_file" type="data" format="fasta,fastq" label="Input FASTA/Q file"/>
-  </xml>
-  <token name="@ATTRIBUTION@"><![CDATA[
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="1.2">seqtk</requirement>
+            <yield/>
+        </requirements>
+    </xml>
+    <token name="@WRAPPER_VERSION@">1.2</token>
+    <xml name="stdio">
+        <stdio>
+            <!-- Anything other than zero is an error -->
+            <exit_code range="1:"/>
+            <exit_code range=":-1"/>
+            <!-- In case the return code has not been set propery check stderr too -->
+            <regex match="Error:"/>
+            <regex match="Exception:"/>
+        </stdio>
+    </xml>
+    <xml name="in_fq">
+        <param name="in_file" type="data" format="fastq" label="Input FASTQ file"/>
+    </xml>
+    <xml name="in_faq">
+        <param name="in_file" type="data" format="fasta,fastq" label="Input FASTA/Q file"/>
+    </xml>
+    <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**
 
 This Galaxy tool relies on the seqtk toolkit from  `lh3/seqtk
 <https://github.com/lh3/seqtk/>`_, developed by Heng Li at the Broad Institute
-  ]]>
-  </token>
-  <xml name="citation">
-      <citations>
-      </citations>
-  </xml>
+    ]]></token>
+    <xml name="citation">
+        <citations>
+        </citations>
+    </xml>
 </macros>

--- a/tools/seqtk/seqtk_comp.xml
+++ b/tools/seqtk/seqtk_comp.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0"?>
 <tool id="seqtk_comp" name="seqtk_comp" version="@WRAPPER_VERSION@.0">
-  <description>get the nucleotide composition of FASTA/Q</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk comp
+    <description>get the nucleotide composition of FASTA/Q</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk comp
 #if $in_bed:
--r $in_bed
+    -r '$in_bed'
 #end if
-
-$in_file | awk 'BEGIN{print "#chr\tlength\t#A\t#C\t#G\t#T\t#2\t#3\t#4\t#CpG\t#tv\t#ts\t#CpG-ts"}1'
-
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <param name="in_bed" optional="True" type="data" format="bed" label="bed file"/>
-  </inputs>
-  <outputs>
-    <data format="tabular" hidden="false" name="default" label="Nucleotide composition of $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_comp.fa" ftype="fasta"/>
-      <output name="default" file="seqtk_comp.out" ftype="tabular"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file' | awk 'BEGIN{print "#chr\tlength\t#A\t#C\t#G\t#T\t#2\t#3\t#4\t#CpG\t#tv\t#ts\t#CpG-ts"}1'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <param name="in_bed" type="data" format="bed" optional="true" label="BED file"/>
+    </inputs>
+    <outputs>
+        <data name="default" format="tabular" label="Nucleotide composition of $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_comp.fa" ftype="fasta"/>
+            <output name="default" file="seqtk_comp.out" ftype="tabular"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Reports composition of fasta/fastq sequences. For an example sequence like
@@ -46,8 +46,7 @@ The seqtk tool will report:
     test0      11     4  2  2  2  0  0  1  0    0   0   0
     ambig_ref  15     1  2  3  4  0  4  1  4    0   0   0
 
-
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_cutN.xml
+++ b/tools/seqtk/seqtk_cutN.xml
@@ -1,33 +1,36 @@
 <?xml version="1.0"?>
 <tool id="seqtk_cutN" name="seqtk_cutN" version="@WRAPPER_VERSION@.0">
-  <description>cut sequence at long N</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk cutN -n $n
+    <description>cut sequence at long N</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk cutN
+-n $n
 -p $p
 $g
-$in_file
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <param label="min size of N tract" help="(-n)" name="n" type="integer" value="1000"/>
-    <param label="penalty for a non-N" help="(-p)" name="p" type="integer" value="10"/>
-    <param checked="false" label="print gaps only, no sequence" help="(-g)" name="g" type="boolean" falsevalue="" truevalue="-g"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="$in_file.name split on N runs longer than $n"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_cutn.fa"/>
-      <param name="n" value="1"/>
-      <output name="default" file="seqtk_cutn.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <param argument="-n" type="integer" value="1000" label="Minimum size of N tract" />
+        <param argument="-p" type="integer" value="10" label="Penalty for a non-N" />
+        <param argument="-g" type="boolean" truevalue="-g" falsevalue="" checked="false" label="Print gaps only, no sequence" />
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="$in_file.name split on N runs longer than $n"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_cutn.fa"/>
+            <param name="n" value="1"/>
+            <output name="default" file="seqtk_cutn.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Splits long sequences with runs of Ns
@@ -46,8 +49,7 @@ This will be split into the component sequences without the ambiguity.
     >test:29-33
     ACATG
 
-
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_dropse.xml
+++ b/tools/seqtk/seqtk_dropse.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0"?>
 <tool id="seqtk_dropse" name="seqtk_dropse" version="@WRAPPER_VERSION@.0">
-  <description>drop unpaired from interleaved Paired End FASTA/Q</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk dropse
-      $in_file
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="Only paired-end reads from $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_dropse.fq"/>
-      <output name="default" file="seqtk_dropse.out" ftype="fastq"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <description>drop unpaired from interleaved Paired End FASTA/Q</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk dropse
+'$in_file'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="Only paired-end reads from $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_dropse.fq"/>
+            <output name="default" file="seqtk_dropse.out" ftype="fastq"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Remove unpaired reads in an interleaved paired-end FASTA/Q file. Given a fastq file with unpaired reads:
@@ -70,8 +72,7 @@ This tool will remove the offending reads (test-4/1), leaving just the paired da
     +
     ?=?*?A?<?@
 
-
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_fqchk.xml
+++ b/tools/seqtk/seqtk_fqchk.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0"?>
 <tool id="seqtk_fqchk" name="seqtk_fqchk" version="@WRAPPER_VERSION@.0">
-  <description>fastq QC (base/quality summary)</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk fqchk
+    <description>fastq QC (base/quality summary)</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk fqchk
 -q $q
-$in_file | awk '{if(NR<4){print "#"$0}else{print $0}}'
-> $default]]></command>
-  <inputs>
-    <expand macro="in_fq"/>
-    <param name="q" type="integer" value="20" label="quality values" help="use 0 to get the distribution of all quality values (-q)"/>
-  </inputs>
-  <outputs>
-    <data format="tabular" hidden="false" name="default" label="Quality information for $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_fqchk.fq"/>
-      <output name="default" file="seqtk_fqchk.out" ftype="tabular"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file' | awk '{if(NR<4){print "#"$0}else{print $0}}'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_fq"/>
+        <param argument="-q" type="integer" value="20" label="Quality values" help="Use 0 to get the distribution of all quality values"/>
+    </inputs>
+    <outputs>
+        <data name="default" format="tabular" label="Quality information for $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_fqchk.fq"/>
+            <output name="default" file="seqtk_fqchk.out" ftype="tabular"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Returns quality score information base-by-base.
@@ -54,6 +56,6 @@ each based is examined individually and information reported:
     10    1       0.0    0.0   0.0    100.0  0.0  9.0   9.0   100.0  0.0
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_hety.xml
+++ b/tools/seqtk/seqtk_hety.xml
@@ -1,33 +1,36 @@
 <?xml version="1.0"?>
 <tool id="seqtk_hety" name="seqtk_hety" version="@WRAPPER_VERSION@.0">
-  <description>regional heterozygosity</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk hety -w $w
+    <description>regional heterozygosity</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk hety
+-w $w
 -t $t
 $m
-$in_file | awk 'BEGIN{print "#chr\tstart\tend\tA\tB\tnum_het"}1'
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <param label="window size" help="(-w)" name="w" type="integer" value="50000"/>
-    <param label="# start positions in a window" help="(-t)" name="t" type="integer" value="5"/>
-    <param checked="false" label="treat lowercases as masked" help="(-m)" name="m" type="boolean" falsevalue="" truevalue="-m"/>
-  </inputs>
-  <outputs>
-    <data format="tabular" hidden="false" name="default" label="Heterozygous regions in $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_hety.fa"/>
-      <param name="w" value="8"/>
-      <output name="default" file="seqtk_hety.out" ftype="tabular"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file' | awk 'BEGIN{print "#chr\tstart\tend\tA\tB\tnum_het"}1'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <param argument="-w" type="integer" value="50000" label="Window size" />
+        <param argument="-t" type="integer" value="5" label="# start positions in a window" />
+        <param argument="-m" type="boolean" truevalue="-m" falsevalue="" checked="false" label="Treat lowercases as masked" />
+    </inputs>
+    <outputs>
+        <data name="default" format="tabular" label="Heterozygous regions in $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_hety.fa"/>
+            <param name="w" value="8"/>
+            <output name="default" file="seqtk_hety.out" ftype="tabular"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Reports on heterozygosity over a region
@@ -69,6 +72,6 @@ As can be seen in the following output:
 If you know what A and B are measures of, please `submit an issue <https://github.com/galaxyproject/tools-iuc/issues>`__ and it will be corrected
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_listhet.xml
+++ b/tools/seqtk/seqtk_listhet.xml
@@ -1,25 +1,29 @@
 <?xml version="1.0"?>
 <tool id="seqtk_listhet" name="seqtk_listhet" version="@WRAPPER_VERSION@.0">
-  <description>extract the position of each het</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk listhet $in_file  | awk 'BEGIN{print "#chr\tposition\tbase"}1' > $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-  </inputs>
-  <outputs>
-    <data format="tabular" hidden="false" name="default" label="Positions of heterozygous bases in $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_listhet.fa"/>
-      <output name="default" file="seqtk_listhet.out" ftype="tabular"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <description>extract the position of each het</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk listhet
+'$in_file'  | awk 'BEGIN{print "#chr\tposition\tbase"}1'
+> '$default'
+]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+    </inputs>
+    <outputs>
+        <data name="default" format="tabular" label="Positions of heterozygous bases in $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_listhet.fa"/>
+            <output name="default" file="seqtk_listhet.out" ftype="tabular"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Lists regions of heterozygosity.
@@ -43,6 +47,6 @@ The seqtk suite recognises MRWSYK:
 
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_mergefa.xml
+++ b/tools/seqtk/seqtk_mergefa.xml
@@ -1,47 +1,48 @@
 <?xml version="1.0"?>
 <tool id="seqtk_mergefa" name="seqtk_mergefa" version="@WRAPPER_VERSION@.0">
-  <description>merge two FASTA/Q files</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk mergefa -q $q
+    <description>merge two FASTA/Q files</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk mergefa
+-q $q
 $i
 $m
 $r
 $h
-
-$in_fa1
-$in_fa2
-
-> $default]]></command>
-  <inputs>
-    <param name="in_fa1" type="data" format="fasta,fastq" label="Input FASTA/Q file #1"/>
-    <param name="in_fa2" type="data" format="fasta,fastq" label="Input FASTA/Q file #2"/>
-    <param label="quality threshold" help="(-q)" name="q" type="integer" value="0"/>
-    <param checked="false" label="take intersection" help="(-i)" name="i" type="boolean" falsevalue="" truevalue="-i"/>
-    <param checked="false" label="convert to lowercase when one of the input base is N" help="(-m)" name="m" type="boolean" falsevalue="" truevalue="-m"/>
-    <param checked="false" label="pick a random allele from het" help="(-r)" name="r" type="boolean" falsevalue="" truevalue="-r"/>
-    <param checked="false" label="suppress hets in the input" help="(-h)" name="h" type="boolean" falsevalue="" truevalue="-h"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_fa1" hidden="false" name="default" label="Merger of $in_fa1.name and $in_fa2.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_fa1" value="seqtk_mergefa1.fa"/>
-      <param name="in_fa2" value="seqtk_mergefa2.fa"/>
-      <output name="default" file="seqtk_mergefa.out" ftype="fasta"/>
-    </test>
-    <test>
-      <param name="in_fa1" value="seqtk_mergefa1.fa"/>
-      <param name="in_fa2" value="seqtk_mergefa2.fa"/>
-      <param name="m" value="True" />
-      <output name="default" file="seqtk_mergefa2.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_fa1'
+'$in_fa2'
+> '$default'
+    ]]></command>
+    <inputs>
+        <param name="in_fa1" type="data" format="fasta,fastq" label="Input FASTA/Q file #1"/>
+        <param name="in_fa2" type="data" format="fasta,fastq" label="Input FASTA/Q file #2"/>
+        <param argument="-q" type="integer" value="0" label="Quality threshold"/>
+        <param argument="-i" type="boolean" truevalue="-i" falsevalue="" checked="false" label="Take intersection" />
+        <param argument="-m" type="boolean" truevalue="-m" falsevalue="" checked="false" label="Convert to lowercase when one of the input base is N" />
+        <param argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false" label="Pick a random allele from het" />
+        <param argument="-h" type="boolean" truevalue="-h" falsevalue="" checked="false" label="Suppress hets in the input" />
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_fa1" label="Merger of $in_fa1.name and $in_fa2.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_fa1" value="seqtk_mergefa1.fa"/>
+            <param name="in_fa2" value="seqtk_mergefa2.fa"/>
+            <output name="default" file="seqtk_mergefa.out" ftype="fasta"/>
+        </test>
+        <test>
+            <param name="in_fa1" value="seqtk_mergefa1.fa"/>
+            <param name="in_fa2" value="seqtk_mergefa2.fa"/>
+            <param name="m" value="True" />
+            <output name="default" file="seqtk_mergefa2.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Merges two fasta files, using ambiguity codes
@@ -64,6 +65,6 @@ In the following the `-m` option has been set to highlight seqtk-mergefa's featu
     ACTGACTGxxa
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_mergepe.xml
+++ b/tools/seqtk/seqtk_mergepe.xml
@@ -1,30 +1,32 @@
 <?xml version="1.0"?>
 <tool id="seqtk_mergepe" name="seqtk_mergepe" version="@WRAPPER_VERSION@.0">
-  <description>interleave two unpaired FASTA/Q files for a paired-end file</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk mergepe
-      $in_fq1
-      $in_fq2
-> $default]]></command>
-  <inputs>
-    <param name="in_fq1" type="data" format="fasta,fastq" label="Input FASTA/Q file #1"/>
-    <param name="in_fq2" type="data" format="fasta,fastq" label="Input FASTA/Q file #2"/>
-  </inputs>
-  <outputs>
-      <data format_source="in_fq1" hidden="false" name="default" label="$in_fq1.name and $in_fq2.name as interleaved paired-end"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_fq1" value="paired_dat1.fq"/>
-      <param name="in_fq2" value="paired_dat2.fq"/>
-      <output name="default" file="paired_dat.fq" ftype="fastq"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <description>interleave two unpaired FASTA/Q files for a paired-end file</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk mergepe
+'$in_fq1'
+'$in_fq2'
+> '$default'
+    ]]></command>
+    <inputs>
+        <param name="in_fq1" type="data" format="fasta,fastq" label="Input FASTA/Q file #1"/>
+        <param name="in_fq2" type="data" format="fasta,fastq" label="Input FASTA/Q file #2"/>
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_fq1" label="$in_fq1.name and $in_fq2.name as interleaved paired-end"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_fq1" value="paired_dat1.fq"/>
+            <param name="in_fq2" value="paired_dat2.fq"/>
+            <output name="default" file="paired_dat.fq" ftype="fastq"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Merge two files which constitute a paired-end file into a single, interleaved, paired-end FASTA/Q file
@@ -89,6 +91,6 @@ These will be interleaved as
     @r-4/2
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_mutfa.xml
+++ b/tools/seqtk/seqtk_mutfa.xml
@@ -1,29 +1,32 @@
 <?xml version="1.0"?>
 <tool id="seqtk_mutfa" name="seqtk_mutfa" version="@WRAPPER_VERSION@.0">
-  <description>point mutate FASTA at specified positions</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk mutfa
-      $in_file $in_snp
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <param name="in_snp" type="data" format="tabular" label="Input SNP file"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="Mutated $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_mutfa.fa"/>
-      <param name="in_snp" value="seqtk_mutfa.snp"/>
-      <output name="default" file="seqtk_mutfa.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <description>point mutate FASTA at specified positions</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk mutfa
+'$in_file'
+'$in_snp'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <param name="in_snp" type="data" format="tabular" label="Input SNP file"/>
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="Mutated $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_mutfa.fa"/>
+            <param name="in_snp" value="seqtk_mutfa.snp"/>
+            <output name="default" file="seqtk_mutfa.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 the SNP inputs consist of 4 columns: chromosome, 1-based-pos, any, base-changed-to.
@@ -47,6 +50,6 @@ This will effect the desired mutations in the output file
     GCTAACTGAA
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_randbase.xml
+++ b/tools/seqtk/seqtk_randbase.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0"?>
 <tool id="seqtk_randbase" name="seqtk_randbase" version="@WRAPPER_VERSION@.0">
-  <description>choose a random base from hets</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk randbase
-      $in_file
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="Unambiguous $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_randbase.fa"/>
-      <output name="default" file="seqtk_randbase.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <description>choose a random base from hets</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk randbase
+'$in_file'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="Unambiguous $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_randbase.fa"/>
+            <output name="default" file="seqtk_randbase.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Randomly resolves ambiguous bases
@@ -41,6 +43,6 @@ results in
     ACGTCGTGTT
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_sample.xml
+++ b/tools/seqtk/seqtk_sample.xml
@@ -1,39 +1,42 @@
 <?xml version="1.0"?>
 <tool id="seqtk_sample" name="seqtk_sample" version="@WRAPPER_VERSION@.0">
     <description>random subsample of fasta or fastq sequences</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk sample -s $s
-      $in_file
-      $subsample_size
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq" />
-    <param label="RNG seed" help="The seed used for the random number generator. Manually specifying a number here is useful for reproducing the same subsampling over time (-s)." name="s" type="integer" value="4"/>
-    <param label="Subsample (decimal fraction or number)" name="subsample_size" type="float" value="100"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="Subsample of reads from $in_file.name"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_sample.fa"/>
-      <param name="subsample_size" value="4"/>
-      <param name="s" value="4"/>
-      <output name="default" file="seqtk_sample.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk sample
+-s $s
+'$in_file'
+$subsample_size
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq" />
+        <param argument="-s" type="integer" value="4" label="RNG seed" help="The seed used for the random number generator. Manually specifying a number here is useful for reproducing the same subsampling over time" />
+        <param name="subsample_size" type="float" value="100" label="Subsample (decimal fraction or number)" />
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="Subsample of reads from $in_file.name"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_sample.fa"/>
+            <param name="subsample_size" value="4"/>
+            <param name="s" value="4"/>
+            <output name="default" file="seqtk_sample.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
-Takes a random subsample of fasta or fastq sequences. The RNG is seedable to allow for reproducible results, and defaults to `4 <http://xkcd.com/221/>`__.
+Takes a random subsample of FASTA or FASTQ sequences. The RNG is seedable to allow for reproducible results, and defaults to `4 <http://xkcd.com/221/>`__.
 
 The subsample size can be a decimal fraction <=1, where 1 implies 100% of the reads should be used. If a number >1 is provided, that many reads will be taken from the dataset.
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_seq.xml
+++ b/tools/seqtk/seqtk_seq.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0"?>
-<tool id="seqtk_seq" name="seqtk_seq" version="@WRAPPER_VERSION@.1">
-  <description>common transformation of FASTA/Q</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk seq -q $q
+<tool id="seqtk_seq" name="seqtk_seq" version="@WRAPPER_VERSION@.2">
+    <description>common transformation of FASTA/Q</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk seq -q $q
 -X $X
-#if $n and $n != "None" and $n is not None and $n != "":
--n "$n"
+#if $n:
+    -n '$n'
 #end if
 -l $l
 -Q $Q
 -s $s
 -f $f
-#if $M and $M != "None" and $M is not None and $M != "":
--M "$M"
+#if $M:
+    -M '$M'
 #end if
 -L $L
 $c
@@ -27,52 +28,51 @@ $N
 $x1
 $x2
 #if $in_file.is_of_type('fastqillumina')
- -V
+    -V
 #end if
-
-$in_file
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <param label="mask bases with quality lower than INT" help="(-q)" name="q" type="integer" value="0"/>
-    <param label="mask bases with quality higher than INT" help="(-X)" name="X" type="integer" value="255"/>
-    <param area="false" value="0" label="masked bases converted to CHAR; 0 for lowercase" help="(-n)" name="n" type="text"/>
-    <param label="number of residues per line; 0 for 2^32-1" help="(-l)" name="l" type="integer" value="0"/>
-    <param label="quality shift: ASCII-INT gives base quality" help="(-Q)" name="Q" type="integer" value="33"/>
-    <param label="random seed" help="effective with -f (-s)" name="s" type="integer" value="11"/>
-    <param label="sample fraction of sequences" help="(-f)" name="f" type="float" value="1"/>
-    <param area="false" value="null" label="mask regions in BED or name list FILE" help="(-M)" name="M" type="text"/>
-    <param label="drop sequences with length shorter than INT" help="(-L)" name="L" type="integer" value="0"/>
-    <param checked="false" label="mask complement region" help="effective with -M (-c)" name="c" type="boolean" falsevalue="" truevalue="-c"/>
-    <param checked="false" label="reverse complement" help="(-r)" name="r" type="boolean" falsevalue="" truevalue="-r"/>
-    <param checked="false" label="force FASTA output (discard quality)" help="(-A)" name="A" type="boolean" falsevalue="" truevalue="-A"/>
-    <param checked="false" label="drop comments at the header lines" help="(-C)" name="C" type="boolean" falsevalue="" truevalue="-C"/>
-    <param checked="false" label="drop sequences containing ambiguous bases" help="(-N)" name="N" type="boolean" falsevalue="" truevalue="-N"/>
-    <param checked="false" label="output the 2n-1 reads only" help="(-1)" name="x1" type="boolean" falsevalue="" truevalue="-1"/>
-    <param checked="false" label="output the 2n reads only" help="(-2)" name="x2" type="boolean" falsevalue="" truevalue="-2"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default"/>
-  </outputs>
-  <tests>
-    <test>
-      <!-- This is a sorry excuse for a test for a tool which does way more
-           than it should, but upstream decided to put a TON of functionality
-           into a single tool rather than using the single responsibility
-           principle. -->
-      <param name="in_file" value="seqtk_seq.fa"/>
-      <param name="r" value="True"/>
-      <param name="n" value=""/>
-      <param name="M" value=""/>
-      <output name="default" file="seqtk_seq_revcom.fa" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <param argument="-q" type="integer" value="0" label="Mask bases with quality lower than INT" />
+        <param argument="-X" type="integer" value="255" label="Mask bases with quality higher than INT" />
+        <param argument="-n" type="text" value="0" label="Masked bases converted to CHAR; 0 for lowercase" />
+        <param argument="-l" type="integer" value="0" label="Number of residues per line; 0 for 2^32-1" />
+        <param argument="-Q" type="integer" value="33" label="Quality shift: ASCII-INT gives base quality" />
+        <param argument="-s" type="integer" value="11" label="Random seed" help="Effective with -f" />
+        <param argument="-f" type="float" value="1" label="Sample fraction of sequences" />
+        <param argument="-M" type="data" format="bed,txt" optional="true" label="Mask regions in BED or name list file" />
+        <param argument="-L" type="integer" value="0" label="Drop sequences with length shorter than INT" />
+        <param argument="-c" type="boolean" truevalue="-c" falsevalue="" checked="false" label="Mask complement region" help="Effective with -M" />
+        <param argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false" label="Reverse complement" />
+        <param argument="-A" type="boolean" truevalue="-A" falsevalue="" checked="false" label="Force FASTA output (discard quality)" />
+        <param argument="-C" type="boolean" truevalue="-C" falsevalue="" checked="false" label="Drop comments at the header lines" />
+        <param argument="-N" type="boolean" truevalue="-N" falsevalue="" checked="false" label="Drop sequences containing ambiguous bases" />
+        <param name="x1" argument="-1" type="boolean" truevalue="-1" falsevalue="" checked="false" label="Output the 2n-1 reads only" />
+        <param name="x2" argument="-2" type="boolean" truevalue="-2" falsevalue="" checked="false" label="Output the 2n reads only" />
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" />
+    </outputs>
+    <tests>
+        <!-- This is a sorry excuse for a test for a tool which does way more
+             than it should, but upstream decided to put a TON of functionality
+             into a single tool rather than using the single responsibility
+             principle. -->
+        <test>
+            <param name="in_file" value="seqtk_seq.fa"/>
+            <param name="r" value="True"/>
+            <param name="n" value=""/>
+            <output name="default" file="seqtk_seq_revcom.fa" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Various utilities for transforming FASTA/Q data
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_subseq.xml
+++ b/tools/seqtk/seqtk_subseq.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0"?>
 <tool id="seqtk_subseq" name="seqtk_subseq" version="@WRAPPER_VERSION@.0">
-  <description>extract subsequences from FASTA/Q files</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk subseq $t
+    <description>extract subsequences from FASTA/Q files</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk subseq
+$t
 -l $l
-$in_file
-
+'$in_file'
 #if $source.type == 'bed':
-  $in_bed
+    '$in_bed'
 #else
-  $name_list
+    '$name_list'
 #end if
-
 #if $t == '-t':
- | awk 'BEGIN{print "chr\tunknown\tseq"}1'
+    | awk 'BEGIN{print "chr\tunknown\tseq"}1'
 #end if
-
-> $default]]></command>
-  <inputs>
-    <param name="in_file" type="data" format="fasta,fastq" label="Input fasta/q file"/>
-    <conditional name="source">
-      <param name="type" type="select" label="Select source of sequence choices">
-        <option value="bed">BED</option>
-        <option value="name">FASTA/Q ID list</option>
-      </param>
-      <when value="bed">
-        <param name="in_bed" type="data" format="bed" label="Input BED file"/>
-      </when>
-      <when value="name">
-        <param name="name_list" type="data" format="txt" label="Input ID list"/>
-      </when>
-    </conditional>
-    <param label="TAB delimited output" help="(-t)" name="t" type="boolean" falsevalue="" truevalue="-t"/>
-    <param label="sequence line length" help="(-l)" name="l" type="integer" value="0"/>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="Selected sequences from $in_file.name">
-      <change_format>
-        <when input="t" value="-t" format="tabular"/>
-      </change_format>
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_subseq.fa"/>
-      <param name="type" value="name"/>
-      <param name="t" value="False" />
-      <param name="name_list" value="seqtk_subseq_list.txt"/>
-      <output name="default" file="seqtk_subseq.out" ftype="fasta"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <conditional name="source">
+            <param name="type" type="select" label="Select source of sequence choices">
+                <option value="bed">BED</option>
+                <option value="name">FASTA/Q ID list</option>
+            </param>
+            <when value="bed">
+                <param name="in_bed" type="data" format="bed" label="Input BED file"/>
+            </when>
+            <when value="name">
+                <param name="name_list" type="data" format="txt" label="Input ID list"/>
+            </when>
+        </conditional>
+        <param argument="-t" type="boolean" truevalue="-t" falsevalue="" label="TAB delimited output" />
+        <param argument="-l" type="integer" value="0" label="Sequence line length" />
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="Selected sequences from $in_file.name">
+            <change_format>
+                <when input="t" value="-t" format="tabular"/>
+            </change_format>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_subseq.fa"/>
+            <param name="type" value="name"/>
+            <param name="t" value="False" />
+            <param name="name_list" value="seqtk_subseq_list.txt"/>
+            <output name="default" file="seqtk_subseq.out" ftype="fasta"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Given a list of newline separated IDs from a fasta file, this will extract those named fasta sequences from the input file.
@@ -79,6 +79,6 @@ results in
     ACGTMRWSYK
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/seqtk_trimfq.xml
+++ b/tools/seqtk/seqtk_trimfq.xml
@@ -1,63 +1,65 @@
 <?xml version="1.0"?>
 <tool id="seqtk_trimfq" name="seqtk_trimfq" version="@WRAPPER_VERSION@.0">
-  <description>trim FASTQ using the Phred algorithm</description>
-  <macros>
-    <import>macros.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <expand macro="stdio"/>
-  <command><![CDATA[seqtk trimfq
+    <description>trim FASTQ using the Phred algorithm</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <command><![CDATA[
+seqtk trimfq
 #if $mode.mode_select == "quality":
--q $mode.q
--l $mode.l
+    -q $mode.q
+    -l $mode.l
 #else:
--b $mode.b
--e $mode.e
+    -b $mode.b
+    -e $mode.e
 #end if
-$in_file
-> $default]]></command>
-  <inputs>
-    <expand macro="in_faq"/>
-    <conditional name="mode">
-        <param name="mode_select" type="select" label="Mode for trimming FASTQ File">
-            <option value="quality">Quality</option>
-            <option value="position">Length/Position</option>
-        </param>
-        <when value="quality">
-            <param label="error rate threshold" help="(-q)" name="q" type="float" value="0.05"/>
-            <param label="maximally trim down to INT bp" help="(-l)" name="l" type="integer" value="30"/>
-        </when>
-        <when value="position">
-            <param label="trim INT bp from left" help="(-b)" name="b" type="integer" value="0"/>
-            <param label="trim INT bp from right" help="(-e)" name="e" type="integer" value="0"/>
-        </when>
-    </conditional>
-  </inputs>
-  <outputs>
-    <data format_source="in_file" hidden="false" name="default" label="$in_file.name trimmed"/>
-  </outputs>
-  <tests>
-    <test>
-      <param name="in_file" value="seqtk_trimfq.fq"/>
-      <param name="mode_select" value="quality"/>
-      <param name="q" value="0.05"/>
-      <param name="l" value="30"/>
-      <output name="default" file="seqtk_trimfq_default.fq" ftype="fastq"/>
-    </test>
-    <test>
-      <param name="in_file" value="seqtk_trimfq.fq"/>
-      <param name="mode_select" value="position"/>
-      <param name="b" value="5"/>
-      <param name="e" value="5"/>
-      <output name="default" file="seqtk_trimfq_be.fq" ftype="fastq"/>
-    </test>
-  </tests>
-  <help><![CDATA[
+'$in_file'
+> '$default'
+    ]]></command>
+    <inputs>
+        <expand macro="in_faq"/>
+        <conditional name="mode">
+            <param name="mode_select" type="select" label="Mode for trimming FASTQ File">
+                <option value="quality">Quality</option>
+                <option value="position">Length/Position</option>
+            </param>
+            <when value="quality">
+                <param argument="-q" type="float" value="0.05" label="Error rate threshold" />
+                <param argument="-l" type="integer" value="30" label="Maximally trim down to INT bp" />
+            </when>
+            <when value="position">
+                <param argument="-b" type="integer" value="0" label="Trim INT bp from left" />
+                <param argument="-e" type="integer" value="0" label="Trim INT bp from right" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="default" format_source="in_file" label="$in_file.name trimmed"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="in_file" value="seqtk_trimfq.fq"/>
+            <param name="mode_select" value="quality"/>
+            <param name="q" value="0.05"/>
+            <param name="l" value="30"/>
+            <output name="default" file="seqtk_trimfq_default.fq" ftype="fastq"/>
+        </test>
+        <test>
+            <param name="in_file" value="seqtk_trimfq.fq"/>
+            <param name="mode_select" value="position"/>
+            <param name="b" value="5"/>
+            <param name="e" value="5"/>
+            <output name="default" file="seqtk_trimfq_be.fq" ftype="fastq"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 **What it does**
 
 Trim a fastq file based on Phred scores, or by length
 
 @ATTRIBUTION@
-]]></help>
-  <expand macro="citation" />
+    ]]></help>
+    <expand macro="citation" />
 </tool>

--- a/tools/seqtk/tool_dependencies.xml
+++ b/tools/seqtk/tool_dependencies.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-  <package name="seqtk" version="1.2">
-    <repository name="package_seqtk_1_2" owner="iuc"/>
-  </package>
-</tool_dependency>


### PR DESCRIPTION
Remove `tool_dependencies.xml`

Also:
- Fix `seqtk_seq` `-M` param to be of type `data`
- Single quotes around data and text params in `<command>`
- Consistent 4-spaces indentation
- Use `argument` attribute