### PR TITLE
Use 3 build stages for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ jobs:
         - set -e
         - |
           if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-            while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
-            while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
           fi
 
 before_install:
@@ -66,29 +66,41 @@ install:
   - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?
   - |
     if [ "$GIT_DIFF_EXIT_CODE" -gt 1 ] ; then
-      git remote set-branches --add origin master;
-      git fetch;
-      TRAVIS_COMMIT_RANGE=origin/master...;
+        git remote set-branches --add origin master
+        git fetch
+        TRAVIS_COMMIT_RANGE=origin/master...
     fi
   - echo $TRAVIS_COMMIT_RANGE
   - |
-      planemo ci_find_repos --exclude_from .tt_blacklist \
-                            --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
-                            --output changed_repositories.list
+    planemo ci_find_repos --exclude data_managers \
+                          --exclude packages \
+                          --exclude_from .tt_blacklist \
+                          --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
+                          --output changed_repositories.list
+  - touch changed_repositories_chunk.list changed_tools_chunk.list
   - |
     if [ -s changed_repositories.list ]; then
-        planemo ci_find_tools --exclude data_managers \
-                              --exclude packages \
-                              --chunk_count 3 --chunk "${CHUNK}" \
-                              --output changed_tools_chunk.list \
-                              $(cat changed_repositories.list)
-        cat changed_tools_chunk.list
+        if [ $(wc -l < changed_repositories.list) -eq 1 ]; then
+            planemo ci_find_tools --chunk_count 3 --chunk "${CHUNK}" \
+                                  --output changed_tools_chunk.list \
+                                  $(cat changed_repositories.list)
+        else
+            planemo ci_find_repos --chunk_count 3 --chunk "${CHUNK}" \
+                                  --output changed_repositories_chunk.list \
+                                  $(cat changed_repositories.list)
+        fi
     fi
   - cat changed_repositories.list
+  - cat changed_repositories_chunk.list
+  - cat changed_tools_chunk.list
 
 script:
   - set -e
   - |
     if [ -s changed_tools_chunk.list ]; then
         planemo test --conda_dependency_resolution --conda_auto_install --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
+    elif [ -s changed_repositories_chunk.list ]; then
+        while read -r DIR; do
+            planemo test --conda_dependency_resolution --conda_auto_install --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"
+        done < changed_repositories_chunk.list
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,55 @@
 # 'sudo required' will give os 7,5 GB memory, but has slower startup times, as we start a VM instead of a Container
 sudo: required
 language: python
+cache: pip
+
 python: 2.7
 
-# This is a big repository so break Travis CI work into 2 CI jobs.
-env:
-  - CHUNK=0
-  - CHUNK=1
-  - CHUNK=2
-  - CHUNK=3
+jobs:
+  include:
+    - stage: lint
+      before_install: skip
+      install:
+        - pip install flake8 flake8-import-order planemo
+        - planemo --version
+        - echo $TRAVIS_COMMIT_RANGE
+        - |
+          planemo ci_find_repos --exclude_from .tt_blacklist \
+                                --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
+                                --output changed_repositories.list
+        - cat changed_repositories.list
+      script:
+        - set -e
+        - cd "$TRAVIS_BUILD_DIR" && flake8 --exclude=.git .
+        - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR"; done < changed_repositories.list
+
+    - stage: test
+      env: CHUNK=0
+
+    - stage: test
+      env: CHUNK=1
+
+    - stage: test
+      env: CHUNK=2
+
+    - stage: deploy
+      before_install: skip
+      install:
+        - pip install planemo
+        - planemo --version
+        - echo $TRAVIS_COMMIT_RANGE
+        - |
+          planemo ci_find_repos --exclude_from .tt_blacklist \
+                                --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
+                                --output changed_repositories.list
+        - cat changed_repositories.list
+      script:
+        - set -e
+        - |
+          if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
+            while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+            while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+          fi
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
@@ -17,11 +58,9 @@ before_install:
   - unset JAVA_HOME
 
 install:
-  - pip install flake8 flake8-import-order planemo
+  - pip install planemo
   - planemo conda_init
   - export PATH="$PLANEMO_CONDA_PREFIX/bin:$PATH"
-  - conda create -y -q -c bioconda --name iuc_conda samtools=0.1.19 bcftools
-  - . activate iuc_conda
   - planemo --version
   - conda --version
   - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?
@@ -40,7 +79,7 @@ install:
     if [ -s changed_repositories.list ]; then
         planemo ci_find_tools --exclude data_managers \
                               --exclude packages \
-                              --chunk_count 4 --chunk "${CHUNK}" \
+                              --chunk_count 3 --chunk "${CHUNK}" \
                               --output changed_tools_chunk.list \
                               $(cat changed_repositories.list)
         cat changed_tools_chunk.list
@@ -49,17 +88,7 @@ install:
 
 script:
   - set -e
-  - cd "$TRAVIS_BUILD_DIR" && flake8 --exclude=.git .
-  - while read -r DIR; do planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR"; done < changed_repositories.list
   - |
     if [ -s changed_tools_chunk.list ]; then
-        while read -r DIR; do planemo conda_install "$DIR"; done < changed_repositories.list
-        planemo test --conda_dependency_resolution --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
-    fi
-
-after_success:
-  - |
-    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-      while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
-      while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+        planemo test --conda_dependency_resolution --conda_auto_install --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
     fi

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_color_space_index_builder.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_color_space_index_builder.xml
@@ -1,32 +1,33 @@
-<tool id="bowtie_color_space_index_builder_data_manager" name="Bowtie Color index" tool_type="manage_data" version="0.0.3">
+<tool id="bowtie_color_space_index_builder_data_manager" name="Bowtie Color index" tool_type="manage_data" version="1.2.0">
     <description>builder</description>
     <requirements>
-        <requirement type="package" version="1.1.2">bowtie</requirement>
+        <requirement type="package" version="1.2.0">bowtie</requirement>
     </requirements>
-    <command interpreter="python">
-        bowtie_index_builder.py
-            "${out_file}"
-            --fasta_filename "${all_fasta_source.fields.path}"
-            --fasta_dbkey "${all_fasta_source.fields.dbkey}"
-            --fasta_description "${all_fasta_source.fields.name}"
-            --data_table_name "bowtie_indexes_color"
-            --color_space
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+python '$__tool_directory__/bowtie_index_builder.py'
+'${out_file}'
+--fasta_filename '${all_fasta_source.fields.path}'
+--fasta_dbkey '${all_fasta_source.fields.dbkey}'
+--fasta_description '${all_fasta_source.fields.name}'
+--data_table_name bowtie_indexes_color
+--color_space
+    ]]></command>
     <inputs>
         <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
             <options from_data_table="all_fasta"/>
         </param>
-        <param type="text" name="sequence_name" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
-        <param type="text" name="sequence_id" value="" label="ID for sequence" help="Leave blank to use all_fasta id" />
+        <param name="sequence_name" type="text" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
+        <param name="sequence_id" type="text" value="" label="ID for sequence" help="Leave blank to use all_fasta id" />
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>
     </outputs>
-    <help>
-
+    <help><![CDATA[
 .. class:: infomark
 
-**Notice:** If you leave name, description, or id blank, it will be generated automatically. 
-
-    </help>
+**Notice:** If you leave name, description, or id blank, it will be generated automatically.
+    ]]></help>
+    <citations>
+        <citation type="doi">10.1186/gb-2009-10-3-r25</citation>
+    </citations>
 </tool>

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import json
 import optparse
 import os
@@ -42,7 +44,7 @@ def build_bowtie_index( data_manager_dict, fasta_filename, params, target_direct
     if return_code:
         tmp_stderr.flush()
         tmp_stderr.seek(0)
-        print >> sys.stderr, "Error building index:"
+        print("Error building index:", file=sys.stderr)
         while True:
             chunk = tmp_stderr.read( CHUNK_SIZE )
             if not chunk:
@@ -62,7 +64,6 @@ def _add_data_table_entry( data_manager_dict, data_table_name, data_table_entry 
 
 
 def main():
-    # Parse Command Line
     parser = optparse.OptionParser()
     parser.add_option( '-f', '--fasta_filename', dest='fasta_filename', action='store', type="string", default=None, help='fasta_filename' )
     parser.add_option( '-d', '--fasta_dbkey', dest='fasta_dbkey', action='store', type="string", default=None, help='fasta_dbkey' )

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
@@ -1,31 +1,32 @@
-<tool id="bowtie_index_builder_data_manager" name="Bowtie index" tool_type="manage_data" version="0.0.3">
+<tool id="bowtie_index_builder_data_manager" name="Bowtie index" tool_type="manage_data" version="1.2.0">
     <description>builder</description>
     <requirements>
-        <requirement type="package" version="1.1.2">bowtie</requirement>
+        <requirement type="package" version="1.2.0">bowtie</requirement>
     </requirements>
-    <command interpreter="python">
-        bowtie_index_builder.py
-            "${out_file}"
-            --fasta_filename "${all_fasta_source.fields.path}"
-            --fasta_dbkey "${all_fasta_source.fields.dbkey}"
-            --fasta_description "${all_fasta_source.fields.name}"
-            --data_table_name "bowtie_indexes"
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+python '$__tool_directory__/bowtie_index_builder.py'
+'${out_file}'
+--fasta_filename '${all_fasta_source.fields.path}'
+--fasta_dbkey '${all_fasta_source.fields.dbkey}'
+--fasta_description '${all_fasta_source.fields.name}'
+--data_table_name bowtie_indexes
+    ]]></command>
     <inputs>
         <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
             <options from_data_table="all_fasta"/>
         </param>
-        <param type="text" name="sequence_name" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
-        <param type="text" name="sequence_id" value="" label="ID for sequence" help="Leave blank to use all_fasta id "/>
+        <param name="sequence_name" type="text" value="" label="Name of sequence" help="Leave blank to use all_fasta name" />
+        <param name="sequence_id" type="text" value="" label="ID for sequence" help="Leave blank to use all_fasta id" />
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>
     </outputs>
-    <help>
-
+    <help><![CDATA[
 .. class:: infomark
 
-**Notice:** If you leave name, description, or id blank, it will be generated automatically. 
-
-    </help>
+**Notice:** If you leave name, description, or id blank, it will be generated automatically.
+    ]]></help>
+    <citations>
+        <citation type="doi">10.1186/gb-2009-10-3-r25</citation>
+    </citations>
 </tool>

--- a/tools/bcftools/.shed.yml
+++ b/tools/bcftools/.shed.yml
@@ -15,6 +15,5 @@ suite:
   description: "A suite of Galaxy tools designed to work with version 1.3 of the bcftools package."
   type: repository_suite_definition
 exclude:
-    - bcftools1.3.help
     - bcftools_plugin_color_chrs.xml
     - bcftools_plugin_frameshifts.xml


### PR DESCRIPTION
The 3 stages are:
- lint (1 job) for `flake8` and `planemo shed_lint`
- test (3 jobs) for `planemo test`
- deploy (1 job) for `planemo shed_update` to TTS and MTS

Also:
- Cache pip files
- Use `--conda_auto_install` option of `planemo test` instead of running
  `planemo conda_install` beforehand. This will install only the tool
  dependencies required by the tools tested in the job

xref. https://github.com/galaxyproject/tools-iuc/pull/1316#issue-230036801

Fix https://github.com/galaxyproject/tools-iuc/issues/1308.