### PR TITLE
Better visualisation of bam tracks in apollo

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -472,6 +472,11 @@ class JbrowseConnector(object):
             "storeClass": "JBrowse/Store/SeqFeature/BAM",
         })
 
+        # Apollo will only switch to the (prettier) 'bam-read' className if it's not set explicitly in the track config
+        # So remove the default 'feature' value for these bam tracks
+        if 'className' in trackData['style'] and trackData['style']['className'] == 'feature':
+            del trackData['style']['className']
+
         self._add_track_json(trackData)
 
         if bamOpts.get('auto_snp', 'false') == 'true':


### PR DESCRIPTION
I noticed that bam tracks generated using the jbrowse tools, once loaded into an apollo instance are not using the prettier default apollo track style.
So a little patch to fix this.

Before the patch:
![pr_bam_before](https://user-images.githubusercontent.com/238755/26944122-0d583a98-4c88-11e7-802e-b20e6c3c252b.png)
And after:
![pr_bam_after](https://user-images.githubusercontent.com/238755/26944133-1499f18e-4c88-11e7-830f-064f2ee62897.png)

