### PR TITLE
Fix a wrong database name in HUMAnN2 data manager

### DIFF
--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
@@ -15,7 +15,7 @@ HUMANN2_REFERENCE_DATA = {
     "uniref50_diamond": "Full UniRef50",
     "uniref50_ec_filtered_diamond": "EC-filtered UniRef50",
     "uniref50_GO_filtered_rapsearch2": "GO filtered UniRef50 for rapsearch2",
-    "uniref90_diamond": "Full UniRef50",
+    "uniref90_diamond": "Full UniRef90",
     "uniref90_ec_filtered_diamond": "EC-filtered UniRef90",
     "DEMO_diamond": "Demo"
 }

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import optparse
 import os
+import shutil
 import subprocess
 import sys
 
@@ -116,9 +117,7 @@ def download_humann2_db(data_tables, table_name, database, build, target_dir):
                                                      build,
                                                      db_target_dir)
     subprocess.check_call(cmd, shell=True)
-    print(os.listdir(db_target_dir))
-    os.rename(os.path.join(db_target_dir, database), build_target_dir)
-    print(os.listdir(db_target_dir))
+    shutil.move(os.path.join(db_target_dir, database), build_target_dir)
     add_data_table_entry(
         data_tables,
         table_name,

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -1,7 +1,10 @@
-<tool id="data_manager_humann2_download" name="HUMAnN2 download" version="0.9.9" tool_type="manage_data">
+<tool id="data_manager_humann2_download" name="HUMAnN2 download" version="@VERSION@.1" tool_type="manage_data">
     <description>Download HUMAnN2 database</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
     <requirements>
-        <requirement type="package" version="0.9.9">humann2</requirement>
+        <requirement type="package" version="@VERSION@">humann2</requirement>
     </requirements>
     <stdio>
         <exit_code range=":-1"  level="fatal" description="Error: Cannot open file" />

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -33,7 +33,7 @@
                     <option value="uniref50_diamond">Full UniRef50</option>
                     <option value="uniref50_ec_filtered_diamond">EC-filtered UniRef50</option>
                     <option value="uniref50_GO_filtered_rapsearch2">GO filtered UniRef50 for rapsearch2</option>
-                    <option value="uniref90_diamond" selected="true">Full UniRef50</option>
+                    <option value="uniref90_diamond" selected="true">Full UniRef90</option>
                     <option value="uniref90_ec_filtered_diamond">EC-filtered UniRef90</option>
                     <option value="DEMO_diamond">Demo</option>
                 </param>

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -1,7 +1,7 @@
 <tool id="data_manager_humann2_download" name="HUMAnN2 download" version="@VERSION@.0" tool_type="manage_data">
     <description>Download HUMAnN2 database</description>
     <macros>
-        <import>macros.xml</import>
+        <token name="@VERSION@">0.9.9</token>
     </macros>
     <requirements>
         <requirement type="package" version="@VERSION@">humann2</requirement>

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_humann2_download" name="HUMAnN2 download" version="@VERSION@.1" tool_type="manage_data">
+<tool id="data_manager_humann2_download" name="HUMAnN2 download" version="@VERSION@.0" tool_type="manage_data">
     <description>Download HUMAnN2 database</description>
     <macros>
         <import>macros.xml</import>

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/macros.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/macros.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<macros>
-    <token name="@VERSION@">0.9.9</token>
-</macros>

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/macros.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/macros.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<macros>
+    <token name="@VERSION@">0.9.9</token>
+</macros>


### PR DESCRIPTION
Hi,

There were a duplication of a database name in the tool data table generated by the HUMAnN2 data manager.
I fixed it  and I increased the version number.

Bérénice