### PR TITLE
Qiime data manager: fix value column value

### DIFF
--- a/data_managers/data_manager_qiime_database_downloader/data_manager/data_manager_qiime_download.py
+++ b/data_managers/data_manager_qiime_database_downloader/data_manager/data_manager_qiime_download.py
@@ -229,7 +229,7 @@ def move_file(input_filepath, filename, name, data_tables, target_dir, filetype)
         "qiime_%s" % (filetype),
         dict(
             dbkey=filename,
-            value="1.0",
+            value=os.path.splitext(filename)[0],
             name=name,
             path=output_filepath))
 


### PR DESCRIPTION
ping @bebatut 

I had a problem with the `value` column always being `1.0` for every entry in the loc file:

```
value 	name 	dbkey 	path
1.0 	greengenes (13_8) - 79_otus 	greengenes_13_8_79_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_79_otus.fasta
1.0 	greengenes (13_8) - 76_otus 	greengenes_13_8_76_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_76_otus.fasta
1.0 	greengenes (13_8) - 70_otus 	greengenes_13_8_70_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_70_otus.fasta
```

now if you select one of these in a tool (for instance `qiime_pick_closed_reference_otus`) it would always pass all files (as a comma separated list) to qiime, because all entries matched on this. I changed it so the value colum now looks like:

```
value 	name 	dbkey 	path
greengenes_13_8_79_otus 	greengenes (13_8) - 79_otus 	greengenes_13_8_79_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_79_otus.fasta
greengenes_13_8_76_otus 	greengenes (13_8) - 76_otus 	greengenes_13_8_76_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_76_otus.fasta
greengenes_13_8_70_otus 	greengenes (13_8) - 70_otus 	greengenes_13_8_70_otus.fasta 	/data/galaxy/galaxy-dist/tool-data/qiime_rep_set/greengenes_13_8_70_otus.fasta
```

so it only passes the selected file on to qiime