### PR TITLE
Update Jbrowse to 1.12.3

### DIFF
--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -2,7 +2,7 @@
 <macros>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.12.1">jbrowse</requirement>
+      <requirement type="package" version="1.12.3">jbrowse</requirement>
       <requirement type="package" version="2.7">python</requirement>
       <requirement type="package" version="1.66">biopython</requirement>
       <requirement type="package" version="0.6.2">bcbiogff</requirement>
@@ -12,7 +12,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">0.5.2</token>
+  <token name="@WRAPPER_VERSION@">0.5.3</token>
   <xml name="stdio">
     <stdio>
       <exit_code range="1:"/>


### PR DESCRIPTION
Updating to the latest jbrowse version 
@erasche do you prefer to merge it before or after gcc? the "name store" error message should be gone with this new version, but I haven't tested all the options