### PR TITLE
Fix high memory consumption when downloading genomes with data_manage…

### DIFF
--- a/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
+++ b/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
@@ -205,7 +205,12 @@ def _sort_fasta_custom(fasta_filename, params):
 def _download_file(start, fh):
     tmp = tempfile.NamedTemporaryFile()
     tmp.write(start)
-    tmp.write(fh.read())
+    while True:
+        data = fh.read(CHUNK_SIZE)
+        if data:
+            tmp.write(data)
+        else:
+            break
     tmp.flush()
     tmp.seek(0)
     return tmp


### PR DESCRIPTION
…r_fetch_genome_all_fasta

I hope that fixes #1244. I have tested this locally by downloading ce11 and hg19 on my laptop,
the memory was constantly low.