### PR TITLE
Change the STAR index builder DM's sample tool_data_table_conf.xml `withGTF` column to `with-gtf` to match the tool

### DIFF
--- a/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
@@ -6,7 +6,7 @@
     </table>
     <!-- Locations of indexes in the BWA mapper format -->
     <table name="rnastar_index2" comment_char="#" allow_duplicate_entries="False">
-        <columns>value, dbkey, name, path, withGTF</columns>
+        <columns>value, dbkey, name, path, with-gtf</columns>
         <file path="tool-data/rnastar_index2.loc" />
     </table>
 </tables>


### PR DESCRIPTION
The column in the [rgrnastar tool_data_table_conf.xml.sample](https://github.com/galaxyproject/tools-iuc/blob/a831282140ce160035a4ce984f48cc20198ed0a1/tools/rgrnastar/tool_data_table_conf.xml.sample) is `with-gtf`. The conflicting names prevents Galaxy from being able to merge the data tables on startup (and it therefore fails to start).

Ping @dpryan79 