### PR TITLE
GDCWebApp: Asynchronous Data Source

### DIFF
--- a/tools/gdcwebapp/.shed.yml
+++ b/tools/gdcwebapp/.shed.yml
@@ -1,0 +1,14 @@
+name: gdcwebapp
+owner: iuc
+categories:
+  - Data Source
+  - Convert Formats
+description: GDCWebApp automatically filter, extract, and convert genomic data from the Genomic Data Commons portal to BED format
+long_description: |
+  GDCWebApp is a web service to automatically query, filter, extract and convert genomic data and clinical 
+  information from the Genomic Data Commons portal (GDC) to BED format. It is able to operate on all data 
+  types for each programs (TCGA and TARGET) available on GDC. 
+  The service is available at http://bioinf.iasi.cnr.it/gdcwebapp/
+remote_repository_url: https://github.com/fabio-cumbo/GDCWebApp4Galaxy
+homepage_url: http://bioinf.iasi.cnr.it/gdcwebapp/
+type: unrestricted

--- a/tools/gdcwebapp/gdcwebapp.xml
+++ b/tools/gdcwebapp/gdcwebapp.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<tool name="GDCWebApp" id="data_source_gdcwebapp" tool_type="data_source_async" hidden="False" display_interface="False" version="1.0.0" force_history_refresh="True">
+    <description>an intuitive interface to filter, extract, and convert Genomic Data Commons experiments</description>
+    <requirements>
+        <requirement type="package" version="2.7.10">python</requirement>
+        <requirement type="package" version="1.0.1">json_collect_data_source</requirement>
+    </requirements>
+    <command detect_errors="exit_code">json_collect_data_source.py '${__app__.config.output_size_limit}' --json_param_file '${output1}' --path '.' --appdata 'tmp'</command>
+    <inputs check_values="False" action="http://bioinf.iasi.cnr.it/gdcwebapp/app.php">
+        <display>Go to GDCWebApp service $GALAXY_URL</display>
+        <param name="GALAXY_URL" type="baseurl" value="/async/data_source_gdcwebapp" />
+    </inputs>
+    <outputs>
+        <collection name="list_output" type="list:list" label="${tool.name} Output Collection">
+            <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)_(?P&lt;ext&gt;[^_]+)_(?P&lt;dbkey&gt;[^_]+)" ext="auto" visible="False" directory="tmp" />
+        </collection>
+        <data name="output1" format="auto" label="${tool.name} Output Data" />
+    </outputs>
+    <options sanitize="False" refresh="True" />
+</tool>

--- a/tools/gdcwebapp/gdcwebapp.xml
+++ b/tools/gdcwebapp/gdcwebapp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="GDCWebApp" id="data_source_gdcwebapp" tool_type="data_source_async" hidden="False" display_interface="False" version="1.0.0" force_history_refresh="True">
+<tool name="GDCWebApp" id="data_source_gdcwebapp" tool_type="data_source_async" hidden="False" display_interface="False" version="1.0.0" force_history_refresh="True" profile="17.09">
     <description>an intuitive interface to filter, extract, and convert Genomic Data Commons experiments</description>
     <requirements>
         <requirement type="package" version="2.7.10">python</requirement>


### PR DESCRIPTION
Galaxy tool for the GDCWebApp asynchronous data source. A detailed description of the service is reported on [https://github.com/fabio-cumbo/GDCWebApp4Galaxy](https://github.com/fabio-cumbo/GDCWebApp4Galaxy). This tool requires the improvement of the *async.py* [#4198](https://github.com/galaxyproject/galaxy/pull/4198) to work properly. It exploits the [*json_collect_data_source*](https://github.com/fabio-cumbo/galaxy-json-collect-data-source) BioConda package [#5034](https://github.com/bioconda/bioconda-recipes/pull/5034) to import and optionally organize data (in collections) into the Galaxy History.