### PR TITLE
Finish withGTF -> with-gtf changes in the STAR datamanager

### DIFF
--- a/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.py
+++ b/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.py
@@ -22,7 +22,7 @@ def main():
     if options.withGTF:
         withGTF = "1"
 
-    data_manager_dict = {'data_tables': {options.data_table: [dict( value=options.value, dbkey=options.dbkey, name=options.name, path=options.subdir, withGTF=withGTF )]}}
+    data_manager_dict = {'data_tables': {options.data_table: [dict({"value": options.value, "dbkey": options.dbkey, "name": options.name, "path": options.subdir, "with-gtf": withGTF} )]}}
     open( options.config_file, 'wb' ).write( json.dumps( data_manager_dict ) )
 
 

--- a/data_managers/data_manager_star_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_star_index_builder/data_manager_conf.xml
@@ -17,7 +17,7 @@
                     <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${dbkey}/rnastar_index2/${value}/${path}</value_translation>
                     <value_translation type="function">abspath</value_translation>
                 </column>
-                <column name="withGTF" />
+                <column name="with-gtf" />
             </output>
         </data_table>
     </data_manager>

--- a/data_managers/data_manager_star_index_builder/tool-data/rnastar_index2.loc.sample
+++ b/data_managers/data_manager_star_index_builder/tool-data/rnastar_index2.loc.sample
@@ -5,9 +5,9 @@
 #the directories in which those files are stored. The rnastar_index2.loc
 #file has this format (longer white space characters are TAB characters):
 #
-#<unique_build_id>   <dbkey>   <display_name>   <file_base_path>	<withGTF>
+#<unique_build_id>   <dbkey>   <display_name>   <file_base_path>	<with-gtf>
 #
-#The <with_gtf> column should be 1 or 0, indicating whether the index was made
+#The <with-gtf> column should be 1 or 0, indicating whether the index was made
 #with an annotation (i.e., --sjdbGTFfile and --sjdbOverhang were used) or not,
 #respecively.
 #

--- a/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_star_index_builder/tool_data_table_conf.xml.sample
@@ -6,7 +6,7 @@
     </table>
     <!-- Locations of indexes in the BWA mapper format -->
     <table name="rnastar_index2" comment_char="#" allow_duplicate_entries="False">
-        <columns>value, dbkey, name, path, withGTF</columns>
+        <columns>value, dbkey, name, path, with-gtf</columns>
         <file path="tool-data/rnastar_index2.loc" />
     </table>
 </tables>


### PR DESCRIPTION
Xref: https://github.com/galaxyproject/tools-iuc/pull/1379

I remember now why I preferred `withGTF`, it made creating the dict easier since you can keep the `dict()` function call, which won't allow strings as keywords.