### PR TITLE
HUMAnN2 data manager - Disable the update of the configuration file

### DIFF
--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
@@ -113,9 +113,10 @@ def download_humann2_db(data_tables, table_name, database, build, target_dir):
     db_target_dir = os.path.join(target_dir, database)
     build_target_dir = os.path.join(db_target_dir, build)
     os.makedirs(build_target_dir)
-    cmd = "humann2_databases --download %s %s %s" % (database,
-                                                     build,
-                                                     db_target_dir)
+    cmd = "humann2_databases --download %s %s %s --update-config no" % (
+        database,
+        build,
+        db_target_dir)
     subprocess.check_call(cmd, shell=True)
     shutil.move(os.path.join(db_target_dir, database), build_target_dir)
     add_data_table_entry(


### PR DESCRIPTION
Hi,

We had an issue on the Freiburg instance that the data manager tried to update the HUMAnN2 configuration file to define the downloaded database as the reference database. But it could not access. We do not need this feature as the databases as to be always defined in the wrapper.
I hope this change will fix the issue: I just disable the update of the configuration file.

I tested the data manager in a Galaxy Docker.

Bérénice

