### PR TITLE
Condafy and rewrite raxml

### DIFF
--- a/tools/raxml/.shed.yml
+++ b/tools/raxml/.shed.yml
@@ -3,13 +3,12 @@ owner: iuc
 categories:
 - Phylogenetics
 description: RAxML - A Maximum Likelihood based phylogenetic inference
+homepage_url: http://www.exelixis-lab.org/web/software/raxml/
 long_description: |
   Phylogenies are increasingly used in all fields of medical and biological research.
   Moreover, because of the next generation sequencing revolution, datasets used
   for conducting phylogenetic analyses grow at an unprecedented pace.
   RAxML (Randomized Axelerated Maximum Likelihood) is a popular program for phylogenetic analyses
   of large datasets under maximum likelihood.
-
-  http://sco.h-its.org/exelixis/web/software/raxml/
-remote_repository_url: https://github.com/stamatak/standard-RAxML
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/raxml
 type: unrestricted

--- a/tools/raxml/raxml.py
+++ b/tools/raxml/raxml.py
@@ -6,14 +6,6 @@ For use with RAxML version 8.2.4
 import fnmatch
 import glob
 import optparse
-import os
-import subprocess
-import sys
-
-
-def stop_err(msg):
-    sys.stderr.write("%s\n" % msg)
-    sys.exit()
 
 
 def getint(name):
@@ -24,347 +16,90 @@ def getint(name):
 
 
 def __main__():
-    usage = "usage: %prog -T <threads> -s <input> -n <output> -m <model> [optional arguments]"
-
     # Parse the primary wrapper's command line options
-    parser = optparse.OptionParser(usage=usage)
-    # raxml binary name, hardcoded in the xml file
-    parser.add_option("--binary", action="store", type="string", dest="binary", help="Command to run")
-    # (-a)
-    parser.add_option("--weightfile", action="store", type="string", dest="weightfile", help="Column weight file")
-    # (-A)
-    parser.add_option("--secondary_structure_model", action="store", type="string", dest="secondary_structure_model", help="Secondary structure model")
+    parser = optparse.OptionParser()
     # (-b)
-    parser.add_option("--bootseed", action="store", type="int", dest="bootseed", help="Bootstrap random number seed")
-    # (-c)
-    parser.add_option("--numofcats", action="store", type="int", dest="numofcats", help="Number of distinct rate categories")
-    # (-d)
-    parser.add_option("--search_complete_random_tree", action="store_true", dest="search_complete_random_tree", help="Search with a complete random starting tree")
-    # (-D)
-    parser.add_option("--ml_search_convergence", action="store_true", dest="ml_search_convergence", help="ML search onvergence criterion")
-    # (-e)
-    parser.add_option("--model_opt_precision", action="store", type="float", dest="model_opt_precision", help="Model Optimization Precision (-e)")
-    # (-E)
-    parser.add_option("--excludefile", action="store", type="string", dest="excludefile", help="Exclude File Name")
-    # (-f)
-    parser.add_option("--search_algorithm", action="store", type="string", dest="search_algorithm", help="Search Algorithm")
-    # (-F)
-    parser.add_option("--save_memory_cat_model", action="store_true", dest="save_memory_cat_model", help="Save memory under CAT and GTRGAMMA models")
-    # (-g)
-    parser.add_option("--groupingfile", action="store", type="string", dest="groupingfile", help="Grouping File Name")
-    # (-G)
-    parser.add_option("--enable_evol_heuristics", action="store_true", dest="enable_evol_heuristics", help="Enable evol algo heuristics")
-    # (-i)
-    parser.add_option("--initial_rearrangement_setting", action="store", type="int", dest="initial_rearrangement_setting", help="Initial Rearrangement Setting")
-    # (-I)
-    parser.add_option("--posterior_bootstopping_analysis", action="store", type="string", dest="posterior_bootstopping_analysis", help="Posterior bootstopping analysis")
-    # (-J)
-    parser.add_option("--majority_rule_consensus", action="store", type="string", dest="majority_rule_consensus", help="Majority rule consensus")
-    # (-k)
-    parser.add_option("--print_branch_lengths", action="store_true", dest="print_branch_lengths", help="Print branch lengths")
-    # (-K)
-    parser.add_option("--multistate_sub_model", action="store", type="string", dest="multistate_sub_model", help="Multistate substitution model")
-    # (-m)
-    parser.add_option("--model_type", action="store", type="string", dest="model_type", help="Model Type")
-    parser.add_option("--base_model", action="store", type="string", dest="base_model", help="Base Model")
-    parser.add_option("--aa_empirical_freq", action="store_true", dest="aa_empirical_freq", help="Use AA Empirical base frequences")
-    parser.add_option("--aa_search_matrix", action="store", type="string", dest="aa_search_matrix", help="AA Search Matrix")
-    # (-n)
-    parser.add_option("--name", action="store", type="string", dest="name", help="Run Name")
+    parser.add_option("--bootseed", action="store", type="int", dest="bootseed", help="Random number for non-parametric bootstrapping")
     # (-N/#)
-    parser.add_option("--number_of_runs", action="store", type="int", dest="number_of_runs", help="Number of alternative runs")
-    parser.add_option("--number_of_runs_bootstop", action="store", type="string", dest="number_of_runs_bootstop", help="Number of alternative runs based on the bootstop criteria")
-    # (-M)
-    parser.add_option("--estimate_individual_branch_lengths", action="store_true", dest="estimate_individual_branch_lengths", help="Estimate individual branch lengths")
-    # (-o)
-    parser.add_option("--outgroup_name", action="store", type="string", dest="outgroup_name", help="Outgroup Name")
-    # (-O)
-    parser.add_option("--disable_undetermined_seq_check", action="store_true", dest="disable_undetermined_seq_check", help="Disable undetermined sequence check")
-    # (-p)
-    parser.add_option("--random_seed", action="store", type="int", dest="random_seed", help="Random Number Seed")
-    # (-P)
-    parser.add_option("--external_protein_model", action="store", type="string", dest="external_protein_model", help="External Protein Model")
+    parser.add_option("--number_of_runs", action="store", type="int", dest="number_of_runs", default=1, help="Number of alternative runs")
     # (-q)
     parser.add_option("--multiple_model", action="store", type="string", dest="multiple_model", help="Multiple Model File")
-    # (-r)
-    parser.add_option("--constraint_file", action="store", type="string", dest="constraint_file", help="Constraint File")
-    # (-R)
-    parser.add_option("--bin_model_parameter_file", action="store", type="string", dest="bin_model_parameter_file", help="Constraint File")
-    # (-s)
-    parser.add_option("--source", action="store", type="string", dest="source", help="Input file")
-    # (-S)
-    parser.add_option("--secondary_structure_file", action="store", type="string", dest="secondary_structure_file", help="Secondary structure file")
-    # (-t)
-    parser.add_option("--starting_tree", action="store", type="string", dest="starting_tree", help="Starting Tree")
-    # (-T)
-    parser.add_option("--threads", action="store", type="int", dest="threads", help="Number of threads to use")
-    # (-u)
-    parser.add_option("--use_median_approximation", action="store_true", dest="use_median_approximation", help="Use median approximation")
-    # (-U)
-    parser.add_option("--save_memory_gappy_alignments", action="store_true", dest="save_memory_gappy_alignments", help="Save memory in large gapped alignments")
-    # (-V)
-    parser.add_option("--disable_rate_heterogeneity", action="store_true", dest="disable_rate_heterogeneity", help="Disable rate heterogeneity")
-    # (-W)
-    parser.add_option("--sliding_window_size", action="store", type="string", dest="sliding_window_size", help="Sliding window size")
     # (-x)
     parser.add_option("--rapid_bootstrap_random_seed", action="store", type="int", dest="rapid_bootstrap_random_seed", help="Rapid Boostrap Random Seed")
-    # (-y)
-    parser.add_option("--parsimony_starting_tree_only", action="store_true", dest="parsimony_starting_tree_only", help="Generate a parsimony starting tree only")
-    # (-z)
-    parser.add_option("--file_multiple_trees", action="store", type="string", dest="file_multiple_trees", help="Multiple Trees File")
 
     (options, args) = parser.parse_args()
-    cmd = []
-
-    # Required parameters
-    binary = options.binary
-    cmd.append(binary)
-    # Threads
-    if options.threads > 1:
-        threads = "-T %d" % options.threads
-        cmd.append(threads)
-    # Source
-    source = "-s %s" % options.source
-    cmd.append(source)
-    # Hardcode to "galaxy" first to simplify the output part of the wrapper
-    # name = "-n %s" % options.name
-    name = "-n galaxy"
-    cmd.append(name)
-    # Model
-    model_type = options.model_type
-    base_model = options.base_model
-    aa_search_matrix = options.aa_search_matrix
-    aa_empirical_freq = options.aa_empirical_freq
-    if model_type == 'aminoacid':
-        model = "-m %s%s" % (base_model, aa_search_matrix)
-        if aa_empirical_freq:
-            model = "-m %s%s%s" % (base_model, aa_search_matrix, 'F')
-        # (-P)
-        if options.external_protein_model:
-            external_protein_model = "-P %s" % options.external_protein_model
-            cmd.append(external_protein_model)
-    else:
-        model = "-m %s" % base_model
-    cmd.append(model)
-    if model == "GTRCAT":
-        # (-c)
-        if options.numofcats:
-            numofcats = "-c %d" % options.numofcats
-            cmd.append(numofcats)
-    # Optional parameters
-    if options.number_of_runs_bootstop:
-        number_of_runs_bootstop = "-N %s" % options.number_of_runs_bootstop
-        cmd.append(number_of_runs_bootstop)
-    else:
-        number_of_runs_bootstop = ''
-    if options.number_of_runs:
-        number_of_runs_opt = "-N %d" % options.number_of_runs
-        cmd.append(number_of_runs_opt)
-    else:
-        number_of_runs_opt = 0
-    # (-a)
-    if options.weightfile:
-        weightfile = "-a %s" % options.weightfile
-        cmd.append(weightfile)
-    # (-A)
-    if options.secondary_structure_model:
-        secondary_structure_model = "-A %s" % options.secondary_structure_model
-        cmd.append(secondary_structure_model )
-    # (-b)
-    if options.bootseed:
-        bootseed = "-b %d" % options.bootseed
-        cmd.append(bootseed)
-    else:
-        bootseed = 0
-    # -C - doesn't work in pthreads version, skipped
-    if options.search_complete_random_tree:
-        cmd.append("-d")
-    if options.ml_search_convergence:
-        cmd.append("-D" )
-    if options.model_opt_precision:
-        model_opt_precision = "-e %f" % options.model_opt_precision
-        cmd.append(model_opt_precision)
-    if options.excludefile:
-        excludefile = "-E %s" % options.excludefile
-        cmd.append(excludefile)
-    if options.search_algorithm:
-        search_algorithm = "-f %s" % options.search_algorithm
-        cmd.append(search_algorithm)
-    if options.save_memory_cat_model:
-        cmd.append("-F")
-    if options.groupingfile:
-        groupingfile = "-g %s" % options.groupingfile
-        cmd.append(groupingfile)
-    if options.enable_evol_heuristics:
-        enable_evol_heuristics = "-G %f" % options.enable_evol_heuristics
-        cmd.append(enable_evol_heuristics )
-    if options.initial_rearrangement_setting:
-        initial_rearrangement_setting = "-i %s" % options.initial_rearrangement_setting
-        cmd.append(initial_rearrangement_setting)
-    if options.posterior_bootstopping_analysis:
-        posterior_bootstopping_analysis = "-I %s" % options.posterior_bootstopping_analysis
-        cmd.append(posterior_bootstopping_analysis)
-    if options.majority_rule_consensus:
-        majority_rule_consensus = "-J %s" % options.majority_rule_consensus
-        cmd.append(majority_rule_consensus)
-    if options.print_branch_lengths:
-        cmd.append("-k")
-    if options.multistate_sub_model:
-        multistate_sub_model = "-K %s" % options.multistate_sub_model
-        cmd.append(multistate_sub_model)
-    if options.estimate_individual_branch_lengths:
-        cmd.append("-M")
-    if options.outgroup_name:
-        outgroup_name = "-o %s" % options.outgroup_name
-        cmd.append(outgroup_name)
-    if options.disable_undetermined_seq_check:
-        cmd.append("-O")
-    if options.random_seed:
-        random_seed = "-p %d" % options.random_seed
-        cmd.append(random_seed)
-    multiple_model = None
-    if options.multiple_model:
-        multiple_model = "-q %s" % options.multiple_model
-        cmd.append(multiple_model)
-    if options.constraint_file:
-        constraint_file = "-r %s" % options.constraint_file
-        cmd.append(constraint_file)
-    if options.bin_model_parameter_file:
-        bin_model_parameter_file_name = "RAxML_binaryModelParameters.galaxy"
-        os.symlink(options.bin_model_parameter_file, bin_model_parameter_file_name )
-        bin_model_parameter_file = "-R %s" % options.bin_model_parameter_file
-        # Needs testing. Is the hardcoded name or the real path needed?
-        cmd.append(bin_model_parameter_file)
-    if options.secondary_structure_file:
-        secondary_structure_file = "-S %s" % options.secondary_structure_file
-        cmd.append(secondary_structure_file)
-    if options.starting_tree:
-        starting_tree = "-t %s" % options.starting_tree
-        cmd.append(starting_tree)
-    if options.use_median_approximation:
-        cmd.append("-u")
-    if options.save_memory_gappy_alignments:
-        cmd.append("-U")
-    if options.disable_rate_heterogeneity:
-        cmd.append("-V")
-    if options.sliding_window_size:
-        sliding_window_size = "-W %d" % options.sliding_window_size
-        cmd.append(sliding_window_size)
-    if options.rapid_bootstrap_random_seed:
-        rapid_bootstrap_random_seed = "-x %d" % options.rapid_bootstrap_random_seed
-        cmd.append(rapid_bootstrap_random_seed)
-    else:
-        rapid_bootstrap_random_seed = 0
-    if options.parsimony_starting_tree_only:
-        cmd.append("-y")
-    if options.file_multiple_trees:
-        file_multiple_trees = "-z %s" % options.file_multiple_trees
-        cmd.append(file_multiple_trees)
-
-    print "cmd list: ", cmd, "\n"
-
-    full_cmd = " ".join(cmd)
-    print "Command string: %s" % full_cmd
-
-    try:
-        proc = subprocess.Popen(args=full_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except Exception as err:
-        sys.stderr.write("Error invoking command: \n%s\n\n%s\n" % (cmd, err))
-        sys.exit(1)
-    stdout, stderr = proc.communicate()
-    return_code = proc.returncode
-    if return_code:
-        sys.stdout.write(stdout)
-        sys.stderr.write(stderr)
-        sys.stderr.write("Return error code %i from command:\n" % return_code)
-        sys.stderr.write("%s\n" % cmd)
-    else:
-        sys.stdout.write(stdout)
-        sys.stdout.write(stderr)
 
     # Multiple runs - concatenate
-    if number_of_runs_opt > 0:
-        if (bootseed == 0) and (rapid_bootstrap_random_seed == 0 ):
+    if options.number_of_runs > 1:
+        if options.bootseed is None and options.rapid_bootstrap_random_seed is None:
             runfiles = glob.glob('RAxML*RUN*')
             runfiles.sort(key=getint)
-        # Logs
-            outfile = open('RAxML_log.galaxy', 'w')
-            for filename in runfiles:
-                if fnmatch.fnmatch(filename, 'RAxML_log.galaxy.RUN.*'):
-                    infile = open(filename, 'r')
-                    filename_line = "%s\n" % filename
-                    outfile.write(filename_line)
-                    for line in infile:
-                        outfile.write(line)
-                    infile.close()
-            outfile.close()
-        # Parsimony Trees
-            outfile = open('RAxML_parsimonyTree.galaxy', 'w')
-            for filename in runfiles:
-                if fnmatch.fnmatch(filename, 'RAxML_parsimonyTree.galaxy.RUN.*'):
-                    infile = open(filename, 'r')
-                    filename_line = "%s\n" % filename
-                    outfile.write(filename_line)
-                    for line in infile:
-                        outfile.write(line)
-                    infile.close()
-            outfile.close()
-        # Results
-            outfile = open('RAxML_result.galaxy', 'w')
-            for filename in runfiles:
-                if fnmatch.fnmatch(filename, 'RAxML_result.galaxy.RUN.*'):
-                    infile = open(filename, 'r')
-                    filename_line = "%s\n" % filename
-                    outfile.write(filename_line)
-                    for line in infile:
-                        outfile.write(line)
-                    infile.close()
-            outfile.close()
+            # Logs
+            with open('RAxML_log.galaxy', 'w') as outfile:
+                for filename in runfiles:
+                    if fnmatch.fnmatch(filename, 'RAxML_log.galaxy.RUN.*'):
+                        with open(filename, 'r') as infile:
+                            filename_line = "%s\n" % filename
+                            outfile.write(filename_line)
+                            for line in infile:
+                                outfile.write(line)
+            # Parsimony Trees
+            with open('RAxML_parsimonyTree.galaxy', 'w') as outfile:
+                for filename in runfiles:
+                    if fnmatch.fnmatch(filename, 'RAxML_parsimonyTree.galaxy.RUN.*'):
+                        with open(filename, 'r') as infile:
+                            filename_line = "%s\n" % filename
+                            outfile.write(filename_line)
+                            for line in infile:
+                                outfile.write(line)
+            # Results
+            with open('RAxML_result.galaxy', 'w') as outfile:
+                for filename in runfiles:
+                    if fnmatch.fnmatch(filename, 'RAxML_result.galaxy.RUN.*'):
+                        with open(filename, 'r') as infile:
+                            filename_line = "%s\n" % filename
+                            outfile.write(filename_line)
+                            for line in infile:
+                                outfile.write(line)
     # Multiple Model Partition Files
-    if multiple_model:
+    if options.multiple_model:
         files = glob.glob('RAxML_bestTree.galaxy.PARTITION.*')
         if len(files) > 0:
             files.sort(key=getint)
-            outfile = open('RAxML_bestTreePartitions.galaxy', 'w')
             # Best Tree Partitions
-            for filename in files:
-                if fnmatch.fnmatch(filename, 'RAxML_bestTree.galaxy.PARTITION.*'):
-                    infile = open(filename, 'r')
-                    filename_line = "%s\n" % filename
-                    outfile.write(filename_line)
-                    for line in infile:
-                        outfile.write(line)
-                    infile.close()
-            outfile.close()
+            with open('RAxML_bestTreePartitions.galaxy', 'w') as outfile:
+                for filename in files:
+                    if fnmatch.fnmatch(filename, 'RAxML_bestTree.galaxy.PARTITION.*'):
+                        with open(filename, 'r') as infile:
+                            filename_line = "%s\n" % filename
+                            outfile.write(filename_line)
+                            for line in infile:
+                                outfile.write(line)
         else:
-            outfile = open('RAxML_bestTreePartitions.galaxy', 'w')
-            outfile.write("No partition files were produced.\n")
-            outfile.close()
+            with open('RAxML_bestTreePartitions.galaxy', 'w') as outfile:
+                outfile.write("No partition files were produced.\n")
 
         # Result Partitions
         files = glob.glob('RAxML_result.galaxy.PARTITION.*')
         if len(files) > 0:
             files.sort(key=getint)
-            outfile = open('RAxML_resultPartitions.galaxy', 'w')
-            for filename in files:
-                if fnmatch.fnmatch(filename, 'RAxML_result.galaxy.PARTITION.*'):
-                    infile = open(filename, 'r')
-                    filename_line = "%s\n" % filename
-                    outfile.write(filename_line)
-                    for line in infile:
-                        outfile.write(line)
-                    infile.close()
-            outfile.close()
+            with open('RAxML_resultPartitions.galaxy', 'w') as outfile:
+                for filename in files:
+                    if fnmatch.fnmatch(filename, 'RAxML_result.galaxy.PARTITION.*'):
+                        with open(filename, 'r') as infile:
+                            filename_line = "%s\n" % filename
+                            outfile.write(filename_line)
+                            for line in infile:
+                                outfile.write(line)
         else:
-            outfile = open('RAxML_resultPartitions.galaxy', 'w')
-            outfile.write("No partition files were produced.\n")
-            outfile.close()
+            with open('RAxML_resultPartitions.galaxy', 'w') as outfile:
+                outfile.write("No partition files were produced.\n")
 
     # DEBUG options
-    infof = open('RAxML_info.galaxy', 'a')
-    infof.write('\nOM: CLI options DEBUG START:\n')
-    infof.write(options.__repr__())
-    infof.write('\nOM: CLI options DEBUG END\n')
+    with open('RAxML_info.galaxy', 'a') as infof:
+        infof.write('\nOM: CLI options DEBUG START:\n')
+        infof.write(options.__repr__())
+        infof.write('\nOM: CLI options DEBUG END\n')
 
 
 if __name__ == "__main__":

--- a/tools/raxml/raxml.xml
+++ b/tools/raxml/raxml.xml
@@ -1,197 +1,146 @@
-<tool id="raxml" name="Phyogenetic reconstruction with RaXML" version="1.0.2">
+<tool id="raxml" name="Phyogenetic reconstruction with RaXML" version="8.2.4">
     <description>- Maximum Likelihood based inference of large phylogenetic trees</description>
     <requirements>
-        <requirement type='package' version="8.2.4">raxml</requirement>
+        <requirement type="package" version="8.2.4">raxml</requirement>
     </requirements>
-    <command interpreter="python">raxml.py
-    ## Required parameters 
-    ## binary is hard-coded to the pthreads enabled raxml executable if threads > 1
-    ## (-T)
-    ## Cannot have --threads 1
-    #set $slots = $getVar('GALAXY_SLOTS', 1)
-    #if $slots == 1:
-        --binary "raxmlHPC"
-        --threads 1
+    <command detect_errors="exit_code"><![CDATA[
+## binary is hard-coded to the pthreads enabled raxml executable if threads > 1
+#set $slots = $getVar('GALAXY_SLOTS', 1)
+#if $slots == 1:
+    raxmlHPC
+    ## Cannot have -T 1
+#else:
+    raxmlHPC-PTHREADS
+    -T $slots
+#end if
+-s '$infile'
+-n galaxy
+#if $search_model_selector.model_type == 'aminoacid':
+    -m ${search_model_selector.base_model}${search_model_selector.aa_search_matrix}${search_model_selector.aa_model_empirical_base_frequencies}
+#else:
+    -m $search_model_selector.base_model
+#end if
+-p $random_seed
+
+#if $selExtraOpts.extraOptions == 'full':
+    #if $selExtraOpts.number_of_runs_conditional.number_of_runs_selector == 'by_number_of_runs':
+        -N $selExtraOpts.number_of_runs_conditional.number_of_runs
     #else:
-        --binary "raxmlHPC-PTHREADS"
-        --threads $slots
+        -N $selExtraOpts.number_of_runs_conditional.number_of_runs_bootstop
     #end if
-    ## (-s)
-    --source "$infile"
-    ## (-m)
-    --model_type $search_model_selector.model_type
-    --base_model $search_model_selector.base_model
-    #if str( $search_model_selector.model_type ) == 'aminoacid':
-        $search_model_selector.aa_model_empirical_base_frequencies
-        #if $search_model_selector.aa_search_matrix:
-            --aa_search_matrix $search_model_selector.aa_search_matrix
-        #end if
+    #if $selExtraOpts.weightfile:
+        -a '$selExtraOpts.weightfile'
     #end if
-
-    ## Optional parameters
-
-    #if str( $selExtraOpts.extraOptions ) == 'full':
-        ## (-N/#)
-        #if $selExtraOpts.number_of_runs:
-            --number_of_runs $selExtraOpts.number_of_runs
-        #end if
-        #if $selExtraOpts.number_of_runs_bootstop:
-            --number_of_runs_bootstop $selExtraOpts.number_of_runs_bootstop
-        #end if
-        ## (-a)
-        #if $selExtraOpts.weightfile:
-            --weightfile "$selExtraOpts.weightfile"
-        #end if
-        ## (-b)
-        #if str ($selExtraOpts.secondary_structure_model) != "":
-            --secondary_structure_model $selExtraOpts.secondary_structure_model
-        #end if
-        ## (-b)
-        #if str($selExtraOpts.bootseed):
-            --bootseed $selExtraOpts.bootseed
-        #end if
-        ## (-c)
-        #if $selExtraOpts.numofcats:
-            --numofcats $selExtraOpts.numofcats
-        #end if
-        ## (-d)
-        $selExtraOpts.search_complete_random_tree
-        ## (-D)
-        $selExtraOpts.ml_search_convergence
-        ## (-e)
-        #if $selExtraOpts.model_opt_precision:
-            --model_opt_precision $selExtraOpts.model_opt_precision
-        #end if
-        ## (-E)
-        #if $selExtraOpts.excludefile:
-            --excludefile "$selExtraOpts.excludefile"
-        #end if
-        ## (-f)
-        #if $selExtraOpts.search_algorithm:
-            --search_algorithm $selExtraOpts.search_algorithm
-        #end if
-        ## (-F)
-        $selExtraOpts.save_memory_cat_model
-        ## (-g)
-        #if $selExtraOpts.groupingfile:
-            --groupingfile "$selExtraOpts.groupingfile"
-        #end if
-        ## (-G)
-        #if $selExtraOpts.enable_evol_heuristics:
-            --enable_evol_heuristics $selExtraOpts.enable_evol_heuristics
-        #end if
-        ## (-i)
-        #if $selExtraOpts.initial_rearrangement_setting:
-            --initial_rearrangement_setting $selExtraOpts.initial_rearrangement_setting
-        #end if
-        ## (-I)
-        #if $selExtraOpts.posterior_bootstopping_analysis:
-            --posterior_bootstopping_analysis $selExtraOpts.posterior_bootstopping_analysis
-        #end if
-        ## (-J)
-        #if $selExtraOpts.majority_rule_consensus:
-            --majority_rule_consensus $selExtraOpts.majority_rule_consensus
-        #end if
-        ## (-k)
-        $selExtraOpts.print_branch_lengths
-        ## (-K)
-        #if str ($selExtraOpts.multistate_sub_model) != "":
-            --multistate_sub_model $selExtraOpts.multistate_sub_model
-        #end if
-        ## (-m) - see elsewhere
-        ## (-M)
-        $selExtraOpts.estimate_individual_branch_lengths
-        ## (-n) - see elsewhere
-        ## (-o)
-        #if $selExtraOpts.outgroup_name:
-            --outgroup_name "$selExtraOpts.outgroup_name"
-        #end if
-        ## (-O)
-        $selExtraOpts.disable_undetermined_seq_check
-        ## (-P)
-        #if $selExtraOpts.external_protein_model:
-            --external_protein_model "$selExtraOpts.external_protein_model"
-        #end if
-        ## (-q)
-        #if $selExtraOpts.multiple_model:
-            --multiple_model "$selExtraOpts.multiple_model"
-        #end if
-        ## (-r)
-        #if $selExtraOpts.constraint_file:
-            --constraint_file "$selExtraOpts.constraint_file"
-        #end if
-        ## (-R)
-        #if $selExtraOpts.bin_model_parameter_file:
-            --bin_model_parameter_file "$selExtraOpts.bin_model_parameter_file"
-        #end if
-        ## (-S)
-        #if $selExtraOpts.secondary_structure_file:
-            --secondary_structure_file "$selExtraOpts.secondary_structure_file"
-        #end if
-        ## (-t)
-        #if $selExtraOpts.start_tree_file:
-            --starting_tree "$selExtraOpts.start_tree_file"
-        #end if
-        ## (-T) see elsewhere
-        ## (-u)
-        $selExtraOpts.use_median_approximation
-        ## (-U)
-        $selExtraOpts.save_memory_gappy_alignments
-        ## (-V)
-        $selExtraOpts.disable_rate_heterogeneity
-        ## (-W)
-        #if $selExtraOpts.sliding_window_size:
-            --sliding_window_size $selExtraOpts.sliding_window_size
-        #end if
-        ## (-x)
-        #if str($selExtraOpts.rapid_bootstrap_random_seed):
-            --rapid_bootstrap_random_seed $selExtraOpts.rapid_bootstrap_random_seed
-        #end if
-        ## (-y)
-        $selExtraOpts.parsimony_starting_tree_only
-        ## (-z)
-        #if $selExtraOpts.file_multiple_trees:
-            --file_multiple_trees "$selExtraOpts.file_multiple_trees"
-        #end if
-
-        ## (-p)
-        #if $selExtraOpts.random_seed:
-            --random_seed $selExtraOpts.random_seed
-        #else
-            --random_seed 1234567890
-        #end if
-
-    #else:
-        --random_seed 1234567890
+    #if $selExtraOpts.secondary_structure_model:
+        -A $selExtraOpts.secondary_structure_model
     #end if
-    </command>
+    #if str($selExtraOpts.bootseed):
+        -b $selExtraOpts.bootseed
+    #end if
+    -B $selExtraOpts.cutoff_threshold
+    -c $selExtraOpts.numofcats
+    $selExtraOpts.search_complete_random_tree
+    $selExtraOpts.ml_search_convergence
+    #if $selExtraOpts.model_opt_precision:
+        -e $selExtraOpts.model_opt_precision
+    #end if
+    #if $selExtraOpts.excludefile:
+        -E '$selExtraOpts.excludefile'
+    #end if
+    #if $selExtraOpts.search_algorithm:
+        -f $selExtraOpts.search_algorithm
+    #end if
+    $selExtraOpts.save_memory_cat_model
+    #if $selExtraOpts.groupingfile:
+        -g '$selExtraOpts.groupingfile'
+    #end if
+    #if $selExtraOpts.enable_evol_heuristics:
+        -G $selExtraOpts.enable_evol_heuristics
+    #end if
+    #if str($selExtraOpts.initial_rearrangement_setting):
+        -i $selExtraOpts.initial_rearrangement_setting
+    #end if
+    #if $selExtraOpts.posterior_bootstopping_analysis:
+        -I $selExtraOpts.posterior_bootstopping_analysis
+    #end if
+    #if $selExtraOpts.majority_rule_consensus:
+        -J $selExtraOpts.majority_rule_consensus
+    #end if
+    $selExtraOpts.print_branch_lengths
+    -K $selExtraOpts.multistate_sub_model
+    $selExtraOpts.estimate_individual_branch_lengths
+    #if $selExtraOpts.outgroup_name:
+        -o '$selExtraOpts.outgroup_name'
+    #end if
+    $selExtraOpts.disable_undetermined_seq_check
+    #if $selExtraOpts.external_protein_model:
+        -P '$selExtraOpts.external_protein_model'
+    #end if
+    #if $selExtraOpts.multiple_model:
+        -q '$selExtraOpts.multiple_model'
+    #end if
+    #if $selExtraOpts.constraint_file:
+        -r '$selExtraOpts.constraint_file'
+    #end if
+    #if $selExtraOpts.bin_model_parameter_file:
+        -R '$selExtraOpts.bin_model_parameter_file'
+    #end if
+    #if $selExtraOpts.secondary_structure_file:
+        -S '$selExtraOpts.secondary_structure_file'
+    #end if
+    #if $selExtraOpts.start_tree_file:
+        -t '$selExtraOpts.start_tree_file'
+    #end if
+    $selExtraOpts.use_median_approximation
+    $selExtraOpts.save_memory_gappy_alignments
+    $selExtraOpts.disable_rate_heterogeneity
+    -W $selExtraOpts.sliding_window_size
+    #if str($selExtraOpts.rapid_bootstrap_random_seed):
+        -x $selExtraOpts.rapid_bootstrap_random_seed
+    #end if
+    $selExtraOpts.parsimony_starting_tree_only
+#end if
+&& python '$__tool_directory__/raxml.py'
+#if $selExtraOpts.extraOptions == 'full':
+    #if str($selExtraOpts.bootseed):
+        --bootseed $selExtraOpts.bootseed
+    #end if
+    #if str($selExtraOpts.rapid_bootstrap_random_seed):
+        --rapid_bootstrap_random_seed $selExtraOpts.rapid_bootstrap_random_seed
+    #end if
+    #if $selExtraOpts.number_of_runs_conditional.number_of_runs_selector == 'by_number_of_runs':
+        --number_of_runs $selExtraOpts.number_of_runs_conditional.number_of_runs
+    #end if
+    #if $selExtraOpts.multiple_model:
+        --multiple_model '$selExtraOpts.multiple_model'
+    #end if
+#end if
+    ]]></command>
     <inputs>
-        <param type="data" format="fasta,phylip" name="infile" label="Source file" help="(-s)"/> 
+        <param name="infile" argument="-s" type="data" format="fasta,phylip" label="Source file" />
         <conditional name="search_model_selector">
-            <param name="model_type" type="select" label="Model Type" help="(--model_type)">
+            <param name="model_type" type="select" label="Model type">
                 <option value="nucleotide" selected="true">Nucleotide</option>
                 <option value="aminoacid">Amino Acid</option>
                 <option value="binary">Binary</option>
                 <option value="multistate">Multistate</option>
             </param>
             <when value="nucleotide">
-                <param name="base_model" type="select" label="Substitution Model" help="--base-model">
-                    <option value="GTRCAT">GTRCAT</option> 
-                    <option value="GTRCATI">GTRCATI</option> 
+                <param name="base_model" type="select" label="Substitution model">
+                    <option value="GTRCAT">GTRCAT</option>
+                    <option value="GTRCATI">GTRCATI</option>
                     <option value="GTRGAMMA" selected="true">GTRGAMMA</option>
                     <option value="GTRGAMMAI">GTRGAMMAI</option>
                 </param>
             </when>
             <when value="aminoacid">
-                <param name="aa_model_empirical_base_frequencies"
-                    type="boolean" checked="no" truevalue="--aa_empirical_freq" falsevalue="" display="checkboxes" label="Use empirical base frequencies in AA models" />
-                <param name="base_model" type="select" label="Substitution Model (--base_model)">
+                <param name="base_model" type="select" label="Substitution model">
                     <option value="PROTCAT" selected="true">PROTCAT</option>
                     <option value="PROTCATI">PROTCATI</option>
                     <option value="PROTGAMMA">PROTGAMMA</option>
                     <option value="PROTGAMMAI">PROTGAMMAI</option>
                 </param>
-                <param name="aa_search_matrix" type="select" label="Matrix" help="(--aa_search_matrix)">
+                <param name="aa_search_matrix" type="select" label="Matrix">
                     <option value="DAYHOFF" selected="true">DAYHOFF</option>
                     <option value="DCMUT">DCMUT</option>
                     <option value="JTT">JTT</option>
@@ -215,24 +164,26 @@
                     <option value="GTR_UNLINKED">GTR_UNLINKED</option>
                     <option value="GTR">GTR</option>
                 </param>
+                <param name="aa_model_empirical_base_frequencies" type="boolean" truevalue="F" falsevalue="" checked="no" display="checkboxes" label="Use empirical base frequencies in AA models" />
             </when>
             <when value="binary">
-                <param name="base_model" type="select" label="Substitution Model" help="(--base_model)">
-                    <option value="BINCAT">BINCAT</option> 
-                    <option value="BINCATI">BINCATI</option> 
-                    <option value="BINGAMMA">BINGAMMA</option> 
-                    <option value="BINGAMMAI">BINGAMMAI</option> 
+                <param name="base_model" type="select" label="Substitution model">
+                    <option value="BINCAT">BINCAT</option>
+                    <option value="BINCATI">BINCATI</option>
+                    <option value="BINGAMMA">BINGAMMA</option>
+                    <option value="BINGAMMAI">BINGAMMAI</option>
                 </param>
             </when>
             <when value="multistate">
-                <param name="base_model" type="select" label="Substitution Model">
-                    <option value="MULTICAT">MULTICAT</option> 
-                    <option value="MULTICATI">MULTICATI</option> 
-                    <option value="MULTIGAMMA">MULTIGAMMA</option> 
-                    <option value="MULTIGAMMAI">MULTIGAMMAI</option> 
+                <param name="base_model" type="select" label="Substitution model">
+                    <option value="MULTICAT">MULTICAT</option>
+                    <option value="MULTICATI">MULTICATI</option>
+                    <option value="MULTIGAMMA">MULTIGAMMA</option>
+                    <option value="MULTIGAMMAI">MULTIGAMMAI</option>
                 </param>
             </when>
         </conditional>
+        <param name="random_seed" argument="-p" type="integer" value="1234567890" label="Random seed used for the parsimony inferences" />
         <conditional name="selExtraOpts">
             <param name="extraOptions" type="select" label="RAxML options to use"
                 help="The required minimal settings are the input file and the
@@ -242,26 +193,26 @@
             </param>
             <when value="required" />
             <when value="full">
-                <param name="number_of_runs" type="integer" value=""
-                    label="Number of runs" help="Specify the number of
-                    alternative runs (-N|#) on distinct starting trees In combination
-                    with the '-b' option will invoke a multiple boostrap analysis.
-                    You can add the bootstopping criteria by choosing the autoMR,
-                    autoMRE, autoMRE_IGN, or autoFC value in a menu below instead of
-                    providing a number here. Bootstopping will only work in
-                    combination with '-x' or '-b'."
-                    optional="True" />
-                <param name="number_of_runs_bootstop" type="select" label="Use bootstopping criteria for number of runs" optional="True" help="--number_of_runs_bootstop">
-                    <option value="" selected="yes"></option>
-                    <option value="autoMR">autoMR</option>
-                    <option value="autoMRE">autoMRE</option>
-                    <option value="autoMRE_IGN">autoMRE_IGN</option>
-                    <option value="autoFC">autoFC</option>
-                </param>
-                <param format="txt" name="weightfile" type="data" label="Column weight file" optional="True" help="(-a)" />
-                <param name="secondary_structure_model" type="select" label="Secondary structure substitution model" optional="True"
-                    help="(--secondary_structure_model)">
-                    <option value="" selected="yes"></option>
+                <conditional name="number_of_runs_conditional">
+                    <param name="number_of_runs_selector" type="select" label="Multiple boostrap specification">
+                        <option value="by_number_of_runs">By number of runs</option>
+                        <option value="by_bootstopping">By bootstopping criteria</option>
+                    </param>
+                    <when value="by_number_of_runs">
+                        <param name="number_of_runs" argument="-N" type="integer" value="1" label="Number of alternative runs on distinct starting trees"
+                            help="In combination with the '-b' option, this will invoke a multiple boostrap analysis" />
+                    </when>
+                    <when value="by_bootstopping">
+                        <param name="number_of_runs_bootstop" argument="-N" type="select" label="Bootstopping criteria" help="Bootstopping will only work in combination with '-x' or '-b'">
+                            <option value="autoMR">autoMR</option>
+                            <option value="autoMRE">autoMRE</option>
+                            <option value="autoMRE_IGN">autoMRE_IGN</option>
+                            <option value="autoFC">autoFC</option>
+                        </param>
+                    </when>
+                </conditional>
+                <param name="weightfile" argument="-a" type="data" format="txt" optional="true" label="Column weight file" />
+                <param name="secondary_structure_model" argument="-A" type="select" optional="true" label="Secondary structure substitution model">
                     <option value="S6A">S6A</option>
                     <option value="S6B">S6B</option>
                     <option value="S6C">S6C</option>
@@ -277,27 +228,29 @@
                     <option value="S16A">S16A</option>
                     <option value="S16B">S16B</option>
                 </param>
-                <param name="bootseed" type="integer" value="" label="Random number for non-parametric bootstrapping" optional="True" help="(--bootseed)"/>
-                <param name="rapid_bootstrap_random_seed" type="integer" value='' label="Rapid bootstrapping random seed" optional="True"
-                    help="Specify a random seed and turn on rapid bootstrapping. CAUTION: unlike in version 7.0.4 RAxML will conduct rapid BS replicates under the model of rate heterogeneity you specified via '-m' and not by default under CAT. (-x)" />
-                <param name="cutoff_threshold" type="float" label="MR Cutoff threshold" value=""
-                    help="Cutoff threshold for the MR-based bootstopping criteria, recommended value is 0.1. (-B)" optional="True"/>
-                <param name="numofcats" type="integer" label="Number of Rate Categories for GTRCAT/GTRMIX" optional="True" help="(-c)" />
+                <param name="bootseed" argument="-b" type="integer" value="" optional="true" label="Random seed for non-parametric bootstrapping"
+                    help="Specifying a value turns on bootstrapping" />
+                <param name="rapid_bootstrap_random_seed" argument="-x" type="integer" value="" optional="true" label="Random seed for rapid bootstrapping"
+                    help="Specifying a value turns on rapid bootstrapping. CAUTION: unlike in version 7.0.4 RAxML will conduct rapid BS replicates under the model of rate heterogeneity you specified via '-m' and not by default under CAT" />
+                <param name="cutoff_threshold" argument="-B" type="float" value="0.03" min="0" max="1" label="MR cutoff threshold"
+                    help="Cutoff threshold for the MR-based bootstopping criteria" />
+                <param name="numofcats" argument="-c" type="integer" value="25" label="Number of Rate Categories for GTRCAT/GTRMIX" />
                 <!-- (-C) Conduct model parameter optimization doesn't work in the pthreads version. Skip for now. -->
-                <param name="search_complete_random_tree" type="boolean" checked="False" truevalue="--search_complete_random_tree" falsevalue=""
-                    display="checkboxes" label="Start ML optimization from a complete random starting tree" help="(--search_complete_random_tree)"/>
-                <param name="ml_search_convergence" type="boolean" checked="False" truevalue="--ml_search_convergence" falsevalue=""
-                    label="ML search convergence criterion" help="(--ml_search_convergence)" />
-                <param name="model_opt_precision" type="float" label="Model optimization precision" value=""
-                    help="Set model optimization precision in log likelihood units when MIX/MIXI or GAMMA/GAMMAI models are used (--model_opt_precision)" optional="True" />
-                <param format="txt" name="excludefile" type="data" label="Exclude file" optional="True" help="(-E)" />
-                <param name="search_algorithm" type="select" label="Algorithm to execute" help="(-f)" optional="True">
+                <param name="search_complete_random_tree" argument="-d" type="boolean" truevalue="-d" falsevalue=""
+                    label="Start ML optimization from a complete random starting tree" />
+                <param name="ml_search_convergence" argument="-D" type="boolean" truevalue="-D" falsevalue=""
+                    label="ML search convergence criterion" help="This will break off ML searches if the relative Robinson-Foulds distance between the trees obtained from two consecutive lazy SPR cycles is smaller or equal to 1%. Usage recommended for very large datasets in terms of taxa. On trees with more than 500 taxa this will yield execution time improvements of approximately 50% while yielding only slightly worse trees" />
+                <param name="model_opt_precision" argument="-e" type="float" label="Model optimization precision" value="" optional="true"
+                    help="Set model optimization precision in log likelihood units for final optimization of tree topology" />
+                <param name="excludefile" argument="-E" type="data" format="txt" optional="true" label="Exclude file" help="Should contain a specification of alignment positions you wish to exclude" />
+                <param name="search_algorithm" argument="-f" type="select" label="Algorithm to execute" optional="true">
                     <option value="a">Rapid bootstrap and best ML tree search (a)</option>
                     <option value="A">Compute marginal ancestral states (A)</option>
                     <option value="b">Draw bipartition information (b)</option>
                     <option value="c">Check if the alignment can be read (c)</option>
-                    <option value="d" selected="true">Hill-climbing ML Search (d) (default)</option>
-                    <option value="e">Optimize GAMMA/GAMMAI model/branches (e)</option>
+                    <option value="d" selected="true">New rapid hill-climbing (d)</option>
+                    <option value="D">Rapid hill-climbing with RELL bootstraps (D)</option>
+                    <option value="e">Optimize model+branch lengths under GAMMA/GAMMAI only (e)</option>
                     <option value="g">Compute per-site log likelihoods for -z trees (g)</option>
                     <option value="h">Compute log likelihood test for -t / -z trees (h)</option>
                     <option value="j">Generate bootstrapped alignment files (j)</option>
@@ -318,71 +271,69 @@
                     <option value="x">Compute GAMMA model pair-wise ML distances on a tree (x)</option>
                     <option value="y">Classify environmental sequences into a reference tree (y)</option>
                 </param>
-                <param name="save_memory_cat_model" type="boolean" checked="no" truevalue="--save_memory_cat_model" falsevalue=""
-                    display="checkboxes" label="ML tree searches under CAT model" optional="True"
-                    help="ML tree searches under CAT model for very large trees without switching to GAMMA in the end (saves memory) and no thorough optimization under GAMMA (--save_memory_cat_model)" />
-                <param name="groupingfile" format="txt" type="data" label="Multifurcating constraint tree" optional="True" help="(-g)" />
-                <param name="enable_evol_heuristics" type="float" label="Enable the ML-based evolutionary placement algorithm heuristics"
-                    help="Enable the ML-based evolutionary placement algorithm heuristics by specifiyng a threshold value (fraction of insertion branches to be evaluated using slow insertions under ML). (--enable_evol_heuristics)" optional="True" >
-                    <validator type="in_range" message="0.0 &lt;= fraction &lt;= 1.0" min="0.0" max="1.0"/>
-                </param>
-                <param name="initial_rearrangement_setting" type="integer" value="" label="Initial rearrangement setting" optional="True" help="(-i)"/>
-                <param name="posterior_bootstopping_analysis" type="select" label="Posterior bootstopping analysis" optional="True" help="(-I)">
-                    <option value="" selected="True"></option>
+                <param name="save_memory_cat_model" argument="-F" type="boolean" truevalue="-F" falsevalue=""
+                    label="ML tree searches under CAT model"
+                    help="ML tree searches under CAT model for very large trees without switching to GAMMA in the end (saves memory) and no thorough optimization under GAMMA" />
+                <param name="groupingfile" argument="-g" type="data" format="txt" optional="true" label="Multifurcating constraint tree" help="This tree does not need to be comprehensive, i.e. does not have to contain all taxa" />
+                <param name="enable_evol_heuristics" argument="-G" type="float" min="0.0" max="1.0" optional="true"
+                    label="Enable the ML-based evolutionary placement algorithm heuristics"
+                    help="By specifying a threshold value (fraction of insertion branches to be evaluated using slow insertions under ML)" />
+                <param name="initial_rearrangement_setting" argument="-i" type="integer" value="" optional="true" label="Initial rearrangement setting for the subsequent application of topological changes phase" />
+                <param name="posterior_bootstopping_analysis" argument="-I" type="select" optional="true" label="A posteriori bootstopping analysis">
                     <option value="autoFC">Frequency-based criterion (autoFC)</option>
                     <option value="autoMR">Majority-rule consensus tree criterion (autoMR)</option>
                     <option value="autoMRE">Extended majority-rule consensus tree criterion (autoMRE)</option>
                     <option value="autoMRE_IGN">Extended MR consensus tree criterion with bipartitions (autoMRE_IGN)</option>
                 </param>
                 <!-- (-j) - EMPTY - we cannot handle intermediate tree files in Galaxy -->
-                <param name="majority_rule_consensus" type="select" label="Compute consensus tree" optional="True" help="(-J)">
-                    <option value="" selected="True"></option>
+                <param name="majority_rule_consensus" argument="-J" type="select" optional="true" label="Compute consensus tree">
                     <option value="MR">Majority-rule consensus tree (MR)</option>
                     <option value="MRE">Extended majority-rule consensus tree (MRE)</option>
                     <option value="STRICT">Strict consensus tree (STRICT)</option>
                     <option value="STRICT_DROP">Identify strict dropsets (STRICT_DROP)</option>
                     <option value="MR_DROP">Identify majority-rule dropsets (MR_DROP)</option>
                 </param>
-                <param name="print_branch_lengths" type="boolean" checked="no" truevalue="--print_branch_lengths" falsevalue="" display="checkboxes" label="Print bootstrapped trees with branch lengths" help="Specifies that bootstrapped trees should be printed with branch lengths. The bootstraps will run a bit longer, because model parameters will be optimized at the end of each run under GAMMA or GAMMA+P-Invar respectively. (-k)" optional="True" />
-                <param name="multistate_sub_model" type="select" optional="True" label="Specify a multi-state substitution model" help="(-K)">
-                    <option value="" selected="true"></option>
-                    <option value="GTR">GTR</option>
+                <param name="print_branch_lengths" argument="-k" type="boolean" truevalue="-k" falsevalue=""
+                    label="Print bootstrapped trees with branch lengths"
+                    help="The bootstraps will run a bit longer, because model parameters will be optimized at the end of each run under GAMMA or GAMMA+P-Invar respectively" />
+                <param name="multistate_sub_model" argument="-K" type="select" label="Specify a multi-state substitution model">
+                    <option value="GTR" selected="true">GTR</option>
                     <option value="ORDERED">ORDERED</option>
                     <option value="MK">MK</option>
                 </param>
-                <param name="estimate_individual_branch_lengths" type="boolean" checked="no"
-                    truevalue="--estimate_individual_branch_lengths" falsevalue="" display="checkboxes"
-                    label="Estimate individual per-partition branch lengths" help="Only has effect with a partition file (-M)." optional="True" />
-                <param name="outgroup_name" type="text" value="" label="Outgroup name"
-                    help="E.g. Mouse or Mouse,Rat. No spaces between taxon names are allowed. (-o)" optional="True" />
-                <param name="disable_undetermined_seq_check" type="boolean" checked="no"
-                    truevalue="--disable_undertermined_seq_check" falsevalue="" display="checkboxes" label="Disable check for completely undetermined sequence in alignment" optional="True" help="Disable the check for completely undetermined sequence in alignment. The program will not exit with an error message when '-O' is specified." />
-                <param name="external_protein_model" format="txt" type="data" label="External AA substitution model"
-                    help="Specify the file name of a user-defined AA (Protein) substitution model. This file must contain 420 entries, the first 400 being the AA substitution rates (this must be a symmetric matrix) and the last 20 are the empirical base frequencies. (--external_protein_model)" optional="True" />
-                <param name="multiple_model" format="txt" type="data" label="Multiple model assignment to alignment partitions" optional="True"
-                    help="Specify the file name which contains the assignment of models to alignment partitions for multiple models of substitution. For the syntax of this file please consult the manual. (--multiple_model)" />
-                <param name="constraint_file" format="txt" type="data" label="Binary constraint tree" optional="True"
-                    help="Specify the file name of a binary constraint tree. This tree does not need to be comprehensive, i.e. must not contain all taxa. (--constrain_file)" />
-                <param name="bin_model_parameter_file" format="txt" type="data" label="Binary model parameter file" optional="True"
-                    help="Specify the file name of a binary model parameter file that has previously been generated with RAxML using the '-f e' tree evaluation option. (-R)" />
-                <param name="secondary_structure_file" format="txt" type="data" label="Secondary structure file" optional="True"
-                    help="Specify the name of a secondary structure file. The file can contain '.' for alignment columns that do not form part of a stem and characters '()&lt;&gt;[]{}' to define stem regions and pseudoknots. (-S)"/>
-                <param name="start_tree_file" format="txt" type="data" label="Starting tree file" optional="True"
-                    help="Specify a user starting tree file name in Newick format. (-t)" />
-                <param name="use_median_approximation" type="boolean" checked="no" truevalue="--use_median_approximation" falsevalue="" display="checkboxes" label="Use the median for the discrete approximation"
-                    help="Use the median for the discrete approximation of the GAMMA model of rate heterogeneity. (-T)" optional="True" />
-                <param name="save_memory_gappy_alignments" type="boolean" checked="no" truevalue="--save_memory_gappy_alignments" falsevalue="" display="checkboxes" label="Save memory on large gappy alignments"
-                    help="Try to save memory by using SEV-based implementation for gap columns on large gappy alignments. (-U)" optional="True" />
-                <param name="disable_rate_heterogeneity" type="boolean" checked="no" truevalue="--disable_raite_heterogeneity" falsevalue="" display="checkboxes" label="Disable rate heterogeneity" help="Disable rate heterogeneity among sites model and use one without rate heterogeneity instead. Only works if you specify the CAT model of rate heterogeneity. (_V)" optional="True" />
-                <param name="sliding_window_size" type="integer" value="" label="Sliding window size" optional="True"
-                    help="Sliding window size for leave-one-out site-specific placement bias algorithm. Only effective when used in combination with '-f S'. Default is '100 sites' (-W)" />
-                <param name="parsimony_starting_tree_only" type="boolean" checked="no" truevalue="--parsimony_starting_tree_only" falsevalue="" display="checkboxes"
-                    label="Compute a randomized parsimony starting tree only" optional="True"
-                    help="If you want to only compute a parsimony starting tree with RAxML specify '-y'. The program will exit after computation of the starting tree." />
-                <param name="file_multiple_trees" format="txt" type="data" label="Multiple trees file"
-                    help="Specify the file name of a file containing multiple trees e.g. from a bootstrap that shall be used to draw bipartition values onto a tree provided with '-t', It can also be used to compute per site log likelihoods in combination with '-f g' and to read a bunch of trees for '-f h', '-f m' and '-f n'. (-z)" optional="True" />
-                <param name="random_seed" type="integer" value="1234567890" label="Random
-                    seed used for the parsimony inferences" help="(--random_seed)"/>
+                <param name="estimate_individual_branch_lengths" argument="-M" type="boolean" truevalue="-M" falsevalue=""
+                    label="Estimate individual per-partition branch lengths" help="Only has effect with a partition file. A weighted average of the branch lengths is computed by using the respective partition lengths" />
+                <param name="outgroup_name" argument="-o" type="text" value="" optional="true" label="Outgroup name"
+                    help="E.g. Mouse or Mouse,Rat. No spaces between taxon names are allowed" />
+                <param name="disable_undetermined_seq_check" argument="-O" type="boolean" truevalue="-O" falsevalue=""
+                    label="Disable check for completely undetermined sequence in alignment"
+                    help="The program will not exit with an error message when '-O' is specified." />
+                <param name="external_protein_model" argument="-P" type="data" format="txt" optional="true" label="External AA (Protein) substitution model"
+                    help="This file must contain 420 entries, the first 400 being the AA substitution rates (this must be a symmetric matrix) and the last 20 are the empirical base frequencies" />
+                <param name="multiple_model" argument="-q" type="data" format="txt" optional="true"
+                    label="Assignment of models to alignment partitions for multiple models of substitution"
+                    help="For the syntax of this file please consult the RaXML manual" />
+                <param name="constraint_file" argument="-r" type="data" format="txt" optional="true" label="Binary constraint tree"
+                    help="This tree does not need to be comprehensive, i.e. does not have to contain all taxa" />
+                <param name="bin_model_parameter_file" argument="-R" type="data" format="txt" optional="true" label="Binary model parameter file"
+                    help="This parameter file can be generated with RAxML using the '-f e' tree evaluation option" />
+                <param name="secondary_structure_file" argument="-S" type="data" format="txt" optional="true" label="Secondary structure file"
+                    help="The file can contain '.' for alignment columns that do not form part of a stem and characters '()&lt;&gt;[]{}' to define stem regions and pseudoknots" />
+                <param name="start_tree_file" argument="-t" type="data" format="nhx" optional="true" label="Starting tree file" help="In Newick format" />
+                <param name="use_median_approximation" argument="-u" type="boolean" truevalue="-u" falsevalue=""
+                    label="Use the median for the discrete approximation of the GAMMA model of rate heterogeneity" />
+                <param name="save_memory_gappy_alignments" argument="-U" type="boolean" truevalue="-U" falsevalue=""
+                    label="Save memory on large gappy alignments"
+                    help="Try to save memory by using SEV-based implementation for gap columns on large gappy alignments. This will only work for DNA and/or PROTEIN data" />
+                <param name="disable_rate_heterogeneity" argument="-V" type="boolean" truevalue="-V" falsevalue=""
+                    label="Disable rate heterogeneity among sites model and use one without rate heterogeneity instead"
+                    help="Only works if you specify the CAT model of rate heterogeneity" />
+                <param name="sliding_window_size" argument="-W" type="integer" min="1" value="100"
+                    label="Sliding window size for leave-one-out site-specific placement bias algorithm"
+                    help="Only effective when used in combination with '-f S'" />
+                <param name="parsimony_starting_tree_only" argument="-y" type="boolean" truevalue="-y" falsevalue=""
+                    label="Compute a randomized parsimony starting tree only"
+                    help="The program will exit after computation of the starting tree" />
             </when>
         </conditional>
     </inputs>
@@ -390,15 +341,15 @@
         <data format="txt" name="info" from_work_dir="RAxML_info.galaxy" label="Info" />
         <!-- REQUIRED -->
         <data format="txt" name="logReq" from_work_dir="RAxML_log.galaxy" label="Log">
-            <filter>(selExtraOpts['extraOptions'] == 'required')</filter>
+            <filter>selExtraOpts['extraOptions'] == 'required'</filter>
             <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
         </data>
         <data format="nhx" name="parsimonyTreeReq" from_work_dir="RAxML_parsimonyTree.galaxy" label="Parsimony Tree">
-            <filter>(selExtraOpts['extraOptions'] == 'required')</filter>
+            <filter>selExtraOpts['extraOptions'] == 'required'</filter>
             <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
         </data>
         <data format="nhx" name="resultReq" from_work_dir="RAxML_result.galaxy" label="Result">
-            <filter>(selExtraOpts['extraOptions'] == 'required')</filter>
+            <filter>selExtraOpts['extraOptions'] == 'required'</filter>
             <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
         </data>
         <!-- ADVANCED -->
@@ -407,49 +358,49 @@
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
         </data>
         <data format="nhx" name="bestTree" from_work_dir="RAxML_bestTree.galaxy" label="Best-scoring ML Tree">
-            <!--    <filter>(selExtraOpts['extraOptions'] == 'full')</filter> -->
-            <!-- <filter>(selExtraOpts['search_algorithm'] != 'b')</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == '')</filter> -->
+            <!--    <filter>selExtraOpts['extraOptions'] == 'full'</filter> -->
+            <!-- <filter>selExtraOpts['search_algorithm'] != 'b'</filter>
+            <filter>not selExtraOpts['majority_rule_consensus']</filter> -->
         </data>
         <data format="nhx" name="bestTreeMultipleModel" from_work_dir="RAxML_bestTree.galaxy" label="Best-scoring ML Tree">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
-            <filter>(selExtraOpts['multiple_model'] != '')</filter>
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
+            <filter>selExtraOpts['multiple_model'] != ''</filter>
         </data>
         <data format="txt" name="bestTreeMultipleModelPartitions" from_work_dir="RAxML_bestTreePartitions.galaxy" label="Best-scoring ML Tree Partitions">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
             <filter>selExtraOpts['multiple_model'] is not None </filter>
         </data>
         <data format="txt" name="log" from_work_dir="RAxML_log.galaxy" label="Log">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
-            <filter>(selExtraOpts['rapid_bootstrap_random_seed'] == '')</filter>
-            <filter>(selExtraOpts['bootseed'] == '')</filter> 
-            <filter>(selExtraOpts['search_algorithm'] != 'a')</filter>
-            <filter>(selExtraOpts['search_algorithm'] != 'b')</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == '') </filter>
-        </data>
-        <data format="nhx" name="result" from_work_dir="RAxML_result.galaxy" label="Result">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
-            <filter>(selExtraOpts['rapid_bootstrap_random_seed'] == '')</filter>
-            <filter>selExtraOpts['bootseed'] == ''</filter> 
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
+            <filter>selExtraOpts['rapid_bootstrap_random_seed'] == ''</filter>
+            <filter>selExtraOpts['bootseed'] == ''</filter>
             <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
             <filter>selExtraOpts['search_algorithm'] != 'b'</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == '') </filter>
+            <filter>not selExtraOpts['majority_rule_consensus']</filter>
+        </data>
+        <data format="nhx" name="result" from_work_dir="RAxML_result.galaxy" label="Result">
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
+            <filter>selExtraOpts['rapid_bootstrap_random_seed'] == ''</filter>
+            <filter>selExtraOpts['bootseed'] == ''</filter>
+            <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
+            <filter>selExtraOpts['search_algorithm'] != 'b'</filter>
+            <filter>not selExtraOpts['majority_rule_consensus']</filter>
         </data>
         <data format="txt" name="resultMultipleModelPartitions" from_work_dir="RAxML_resultPartitions.galaxy" label="Result Partitions">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
-            <filter>(selExtraOpts['multiple_model'] is not None)</filter>
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
+            <filter>selExtraOpts['multiple_model'] is not None</filter>
         </data>
         <data format="nhx" name="parsimonyTree" from_work_dir="RAxML_parsimonyTree.galaxy" label="Parsimony Tree">
-            <filter>(selExtraOpts['extraOptions'] == "full")</filter>
+            <filter>selExtraOpts['extraOptions'] == "full"</filter>
         <!--
-            <filter>(selExtraOpts['rapid_bootstrap_random_seed'] == '')</filter>
-            <filter>(selExtraOpts['bootseed'] == '')</filter> 
-            <filter>(selExtraOpts['search_algorithm'] != 'a')</filter>
-            <filter>(selExtraOpts['constraint_file'] is None)</filter>
-            <filter>(selExtraOpts['groupingfile'] is None)</filter>
-            <filter>(selExtraOpts['search_complete_random_tree'] is False)</filter>
-            <filter>(selExtraOpts['start_tree_file'] is None)</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == '') </filter>
+            <filter>selExtraOpts['rapid_bootstrap_random_seed'] == ''</filter>
+            <filter>selExtraOpts['bootseed'] == ''</filter>
+            <filter>selExtraOpts['search_algorithm'] != 'a'</filter>
+            <filter>selExtraOpts['constraint_file'] is None</filter>
+            <filter>selExtraOpts['groupingfile'] is None</filter>
+            <filter>selExtraOpts['search_complete_random_tree'] is False</filter>
+            <filter>selExtraOpts['start_tree_file'] is None</filter>
+            <filter>not selExtraOpts['majority_rule_consensus'] == ''</filter>
         -->
         </data>
         <data format="nhx" name="bootstrap" from_work_dir="RAxML_bootstrap.galaxy" label="Final Bootstrap Trees">
@@ -458,24 +409,24 @@
             <filter>selExtraOpts['rapid_bootstrap_random_seed'] != '' or selExtraOpts['bootseed'] != ''</filter>
         </data>
         <data format="txt" name="bipartitions" from_work_dir="RAxML_bipartitions.galaxy" label="Bipartitions">
-            <filter>(selExtraOpts['search_algorithm'] == 'b') or ((selExtraOpts['search_algorithm'] == 'a') and (selExtraOpts['rapid_bootstrap_random_seed'] != '')) </filter>
+            <filter>selExtraOpts['search_algorithm'] == 'b' or (selExtraOpts['search_algorithm'] == 'a' and selExtraOpts['rapid_bootstrap_random_seed'] != '') </filter>
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
         </data>
         <data format="txt" name="bipartitionsBranchLabels" from_work_dir="RAxML_bipartitionsBranchLabels.galaxy" label="Bipartitions Branch Labels">
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
-            <filter>(selExtraOpts['search_algorithm'] == 'b') or ((selExtraOpts['search_algorithm'] == 'a') and (selExtraOpts['rapid_bootstrap_random_seed'] != '')) </filter>
+            <filter>selExtraOpts['search_algorithm'] == 'b' or (selExtraOpts['search_algorithm'] == 'a' and selExtraOpts['rapid_bootstrap_random_seed'] != '') </filter>
         </data>
         <data format="nhx" name="strictConsensusTree" from_work_dir="RAxML_StrictConsensusTree.galaxy" label="Strict Consensus Tree">
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == 'STRICT') </filter>
+            <filter>selExtraOpts['majority_rule_consensus'] == 'STRICT'</filter>
         </data>
         <data format="nhx" name="majorityRuleConsensusTree" from_work_dir="RAxML_MajorityRuleConsensusTree.galaxy" label="Majority Rule Consensus Tree">
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == 'MR')</filter>
+            <filter>selExtraOpts['majority_rule_consensus'] == 'MR'</filter>
         </data>
         <data format="nhx" name="majorityRuleExtendedConsensusTree" from_work_dir="RAxML_MajorityRuleExtendedConsensusTree.galaxy" label="Majority Rule Extended Consensus Tree">
             <filter>selExtraOpts['extraOptions'] == "full"</filter>
-            <filter>(selExtraOpts['majority_rule_consensus'] == 'MRE')</filter>
+            <filter>selExtraOpts['majority_rule_consensus'] == 'MRE'</filter>
         </data>
         <data format="txt" name="bipartitionFreq" from_work_dir="RAxML_bipartitionFrequences.galaxy" label="Pair-wise bipartition frequences.">
             <filter>selExtraOpts['search_algorithm'] == 'm' </filter>
@@ -523,22 +474,18 @@
             </output>
         </test>
     </tests>
-    <help>
-
+    <help><![CDATA[
 RAxML_ (Randomized Axelerated Maximum Likelihood) is a program for Maximum Likelihood-based inference of large phylogenetic
 trees. The program is explicitly being developed to efficiently infer trees for
 extremely large datasets, either in terms of the number of taxa and/or the
 sequence length.
 
-
-.. _RAxML: http://www.exelixis-lab.org/
-
+.. _RAxML: http://www.exelixis-lab.org/web/software/raxml/
 
 **Tool development**:
 
 Oleksandr Moskalenko with adaptations from Tiago Antao.
-
-    </help>
+    ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btu033</citation>
     </citations>

--- a/tools/raxml/tool_dependencies.xml
+++ b/tools/raxml/tool_dependencies.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-    <package name="raxml" version="8.2.4">
-        <repository name="package_raxml_8_2_4" owner="iuc" />
-    </package>
-</tool_dependency>


### PR DESCRIPTION
- Remove most of the duplication in the Python script
- Remove deprecated `interpreter` attribute of `<command>`
- Use single quotes in `<command>`
- IUC code style and indentation fixes
- Use `with` statement to open/close files
- Various fixes