### PR TITLE
Require Python 2 for genetrack

### DIFF
--- a/tools/genetrack/genetrack.xml
+++ b/tools/genetrack/genetrack.xml
@@ -5,18 +5,18 @@
         <import>genetrack_macros.xml</import>
     </macros>
     <expand macro="requirements" />
-    <command>
-        python $__tool_directory__/genetrack.py
-        --input_format $input_format_cond.input_format
-        #for $i in $input_format_cond.input:
-            --input "${i}" "${i.hid}"
-        #end for
-        --sigma $sigma
-        --exclusion $exclusion
-        --up_width $up_width
-        --down_width $down_width
-        --filter $filter
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+python '$__tool_directory__/genetrack.py'
+--input_format $input_format_cond.input_format
+#for $i in $input_format_cond.input:
+    --input '${i}' '${i.hid}'
+#end for
+--sigma $sigma
+--exclusion $exclusion
+--up_width $up_width
+--down_width $down_width
+--filter $filter
+    ]]></command>
     <inputs>
         <conditional name="input_format_cond">
             <param name="input_format" type="select" label="Format of files for conversion">

--- a/tools/genetrack/genetrack_macros.xml
+++ b/tools/genetrack/genetrack_macros.xml
@@ -3,16 +3,9 @@
     <token name="@WRAPPER_VERSION@">1.0</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="1.11.3">numpy</requirement>
+            <requirement type="package" version="2.7.13">python</requirement>
+            <requirement type="package" version="1.13.0">numpy</requirement>
         </requirements>
-    </xml>
-    <xml name="stdio">
-        <stdio>
-            <exit_code range="1:"/>
-            <exit_code range=":-1"/>
-            <regex match="Error:"/>
-            <regex match="Exception:"/>
-        </stdio>
     </xml>
     <xml name="citations">
         <citations>

--- a/tools/genetrack/genetrack_macros.xml
+++ b/tools/genetrack/genetrack_macros.xml
@@ -3,8 +3,8 @@
     <token name="@WRAPPER_VERSION@">1.0</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="2.7.13">python</requirement>
             <requirement type="package" version="1.13.0">numpy</requirement>
+            <requirement type="package" version="1.10.0">six</requirement>
         </requirements>
     </xml>
     <xml name="citations">

--- a/tools/genetrack/genetrack_util.py
+++ b/tools/genetrack/genetrack_util.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 
+from six import Iterator
 import numpy
 
 GFF_EXT = 'gff'
@@ -41,7 +42,7 @@ def convert_data(data, in_fmt, out_fmt):
     return data
 
 
-class ChromosomeManager(object):
+class ChromosomeManager(Iterator):
     """
     Manages a CSV reader of an index file to only load one chrom at a time
     """
@@ -53,8 +54,8 @@ class ChromosomeManager(object):
         self.current_index = 0
         self.next_valid()
 
-    def next(self):
-        self.line = self.reader.next()
+    def __next__(self):
+        self.line = next(self.reader)
 
     def is_valid(self, line):
         if len(line) not in [4, 5, 9]:
@@ -77,10 +78,10 @@ class ChromosomeManager(object):
         """
         Advance to the next valid line in the reader
         """
-        self.line = self.reader.next()
+        self.line = next(self.reader)
         s = 0
         while not self.is_valid(self.line):
-            self.line = self.reader.next()
+            self.line = next(self.reader)
             s += 1
         if s > 0:
             # Skip initial line(s) of file
@@ -115,7 +116,7 @@ class ChromosomeManager(object):
                 self.current_index = read[0]
                 self.add_read(read)
             try:
-                self.next()
+                next(self)
             except StopIteration:
                 self.done = True
                 break
@@ -271,7 +272,7 @@ def normal_array(width, sigma, normalize=True):
         return math.exp(-x * x / (2 * sigma2))
 
     # width is the half of the distribution
-    values = map(normal_func, range(-width, width))
+    values = list(map(normal_func, range(-width, width)))
     values = numpy.array(values, numpy.float)
     # normalization
     if normalize:

--- a/tools/genetrack/genetrack_util.py
+++ b/tools/genetrack/genetrack_util.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 import tempfile
 
-from six import Iterator
 import numpy
+from six import Iterator
 
 GFF_EXT = 'gff'
 SCIDX_EXT = 'scidx'


### PR DESCRIPTION
and apply recent standards to command line.  It turns out the default numpy install now uses Python 3 but the genetrack code currently supports only Python 2. 