### PR TITLE
Require Python 2 for cwpair

### DIFF
--- a/tools/cwpair2/cwpair2.xml
+++ b/tools/cwpair2/cwpair2.xml
@@ -5,26 +5,24 @@
         <import>cwpair2_macros.xml</import>
     </macros>
     <expand macro="requirements" />
-    <command detect_errors="aggressive">
-        <![CDATA[
-            python $__tool_directory__/cwpair2.py
-            #for $i in $input:
-                 --input "${i}" "${i.hid}"
-            #end for
-            --up_distance $up_distance
-            --down_distance $down_distance
-            --method $method
-            --binsize $binsize
-            --threshold_format $threshold_format_cond.threshold_format
-            #if str($threshold_format_cond.threshold_format) == "absolute_threshold":
-                --absolute_threshold $threshold_format_cond.absolute_threshold
-            #elif str($threshold_format_cond.threshold_format) == "relative_threshold":
-                --relative_threshold $threshold_format_cond.relative_threshold
-            #end if
-            --output_files $output_files
-            --statistics_output "$statistics_output"
-        ]]>
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+python '$__tool_directory__/cwpair2.py'
+#for $i in $input:
+     --input '${i}' '${i.hid}'
+#end for
+--up_distance $up_distance
+--down_distance $down_distance
+--method $method
+--binsize $binsize
+--threshold_format $threshold_format_cond.threshold_format
+#if str($threshold_format_cond.threshold_format) == "absolute_threshold":
+    --absolute_threshold $threshold_format_cond.absolute_threshold
+#elif str($threshold_format_cond.threshold_format) == "relative_threshold":
+    --relative_threshold $threshold_format_cond.relative_threshold
+#end if
+--output_files $output_files
+--statistics_output '$statistics_output'
+    ]]></command>
     <inputs>
         <param  name="input" type="data" format="gff" multiple="True" label="Find matched pairs on" />
         <param name="up_distance" type="integer" value="50" min="0" label="Distance upstream from a peak to allow a pair" help="The maximum distance upstream or 5’ to the primary peak"/>

--- a/tools/cwpair2/cwpair2_macros.xml
+++ b/tools/cwpair2/cwpair2_macros.xml
@@ -3,16 +3,9 @@
     <token name="@WRAPPER_VERSION@">1.1</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="1.5.3">matplotlib</requirement>
+            <requirement type="package" version="2.7.13">python</requirement>
+            <requirement type="package" version="2.0.2">matplotlib</requirement>
         </requirements>
-    </xml>
-    <xml name="stdio">
-        <stdio>
-            <exit_code range="1:"/>
-            <exit_code range=":-1"/>
-            <regex match="Error:"/>
-            <regex match="Exception:"/>
-        </stdio>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Like numpy, it turns out the default install for matplotlib from conda uses Python 3, but the cwpair2 tool currently supports only Python 2.  This PR also applies recent standards to the command line.