### PR TITLE
Set "--defline-qual '+'" option

### DIFF
--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -32,7 +32,7 @@
     export HOME=\$PWD &&
     vdb-config --restore-defaults &&
     #if $input.input_select == "file":
-        fastq-dump --log-level fatal --accession '${input.file.name}'
+        fastq-dump --defline-qual '+' --log-level fatal --accession '${input.file.name}'
     #else:
         vdb-config -s "/repository/user/main/public/root=\$PWD" &&
         ## Do not use prefetch if region is specified, to avoid downloading
@@ -45,7 +45,7 @@
             ## dump command.
             vdb-config -s "/repository/user/main/public/root=\$PWD" &&
         #end if
-        fastq-dump --accession "\$acc"
+        fastq-dump --defline-qual '+' --accession "\$acc"
         --split-files
     #end if
     --defline-seq '@\$sn[_\$rn]/\$ri'


### PR DESCRIPTION
The default quality header line from `fastq-dump` produces a problem of [inconsistent identifiers](https://galaxyproject.org/support/ncbi-sra-fastq/). This PR adds a `--defline-qual '+'` option which sets the quality header line to '+', the suggested solution for the identifier problem. 

(The other option would be to harmonise the `--defline-seq` and `--defline-qual` options but that doesn't seem necessary.)