### PR TITLE
fixing krona warnings

### DIFF
--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -85,8 +85,6 @@
 This tool renders results of a metagenomic profiling as a zoomable pie chart using Krona_.
 
 
-.. _Krona: https://github.com/marbl/Krona/wiki
-
 ------
 
 **Krona options**

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -76,7 +76,7 @@
       <param name="max_rank" value="Genus"/>
       <param name="root_name" value="Root"/>
       <param name="combine_inputs" value="False"/>
-      <output name="output" file="krona_test1.html" ftype="html" lines_diff="100"/>
+      <output name="output" file="krona_test1.html" ftype="html" lines_diff="102"/>
     </test>
   </tests>
   <help>


### PR DESCRIPTION
<string>:4: (ERROR/3) Duplicate target name, cannot be used as a unique reference: "krona".