### PR TITLE
Fix HUMAnN2 data manager

### DIFF
--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
@@ -112,7 +112,6 @@ def download_humann2_db(data_tables, table_name, database, build, target_dir):
     value = "%s-%s-%s" % (database, build, datetime.date.today().isoformat())
     db_target_dir = os.path.join(target_dir, database)
     build_target_dir = os.path.join(db_target_dir, build)
-    os.makedirs(build_target_dir)
     cmd = "humann2_databases --download %s %s %s --update-config no" % (
         database,
         build,


### PR DESCRIPTION
The current HUMAnN2 data manager is broken: the downloaded files are moved into a subdirectory and HUMAnN2 can not find them. It was because the destination directory was created before. I fixed it and tested it via the TestToolShed