### PR TITLE
Small fixes for limma-voom output

### DIFF
--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -156,7 +156,7 @@ factPath <- as.character(argv[15])
 # Process factors
 if (as.character(argv[16])=="None") {
     factorData <- read.table(factPath, header=TRUE, sep="\t")
-    factors <- factorData[,-1]
+    factors <- factorData[,-1, drop=FALSE]
 }  else { 
     factorData <- list()
     for (i in 16:length(argv)) {
@@ -570,10 +570,13 @@ cata("<tr>\n")
 TableHeadItem("SampleID")
 TableHeadItem(names(factors)[1]," (Primary Factor)")
 
-for (i in names(factors)[2:length(names(factors))]) {
-  TableHeadItem(i)
-}
-cata("</tr>\n")
+  if (ncol(factors) > 1) {
+
+    for (i in names(factors)[2:length(names(factors))]) {
+      TableHeadItem(i)
+    }
+    cata("</tr>\n")
+  }
 
 for (i in 1:nrow(factors)) {
   cata("<tr>\n")

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -66,7 +66,7 @@ $normCounts
 mkdir ./output_dir
 
 &&
-mv '$outReport.files_path'/*.tsv output_dir/
+cp '$outReport.files_path'/*.tsv output_dir/
     ]]></command>
 
     <inputs>


### PR DESCRIPTION
This PR has two changes

- in the output html report if only one factor was input the sample check table had extra empty columns, this fixes it to have just the single factor column that it should

-  reverting a suggested change from the previous review, reverting back to using cp instead of the suggested mv as otherwise, on downloading the report or exporting the history, the tsv files are missing, so changing back from mv to: 
`cp '$outReport.files_path'/*.tsv output_dir/ `