### PR TITLE
Jbrowse small fixes

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -566,7 +566,24 @@ class JbrowseConnector(object):
             'category': track['category'],
         }
 
+        mapped_chars = {
+            '>': '__gt__',
+            '<': '__lt__',
+            "'": '__sq__',
+            '"': '__dq__',
+            '[': '__ob__',
+            ']': '__cb__',
+            '{': '__oc__',
+            '}': '__cc__',
+            '@': '__at__',
+            '#': '__pd__'
+        }
+
         for i, (dataset_path, dataset_ext, track_human_label) in enumerate(track['trackfiles']):
+            # Unsanitize labels (element_identifiers are always sanitized by Galaxy)
+            for key, value in mapped_chars.items():
+                track_human_label = track_human_label.replace(value, key)
+
             log.info('Processing %s / %s', track['category'], track_human_label)
             outputTrackConfig['key'] = track_human_label
             hashData = [dataset_path, track_human_label, track['category']]

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -436,7 +436,7 @@ class JbrowseConnector(object):
 
     def add_bigwig(self, data, trackData, wiggleOpts, **kwargs):
         dest = os.path.join('data', 'raw', trackData['label'] + '.bw')
-        cmd = ['ln', data, dest]
+        cmd = ['ln', '-s', data, dest]
         self.subprocess_check_call(cmd)
 
         url = os.path.join('raw', trackData['label'] + '.bw')

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -1,4 +1,4 @@
-<tool id="jbrowse" name="JBrowse" version="@WRAPPER_VERSION@.1">
+<tool id="jbrowse" name="JBrowse" version="@WRAPPER_VERSION@.2">
   <description>genome browser</description>
   <macros>
     <import>macros.xml</import>


### PR DESCRIPTION
Hey,
Just 2 quick fixes for the jbrowse tool:
- create symlinks instead of hardlinks for bigwig (otherwise it fails on my setup because you can't create hardlinks between different filesystems)
- unsanitize the track labels (as they come from element_identifier which are always sanitized by galaxy)