### PR TITLE
Update samtools dependency for sam_fasta_index_builder dm

### DIFF
--- a/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.xml
+++ b/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.xml
@@ -1,7 +1,7 @@
 <tool id="sam_fasta_index_builder" name="SAM FASTA index" tool_type="manage_data" version="0.0.2">
     <description>builder</description>
     <requirements>
-        <requirement type="package" version="0.1.19">samtools</requirement>
+        <requirement type="package" version="1.5">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/data_manager_sam_fasta_index_builder.py'


### PR DESCRIPTION
I've worked on testing data manager installation and table reloads in galaxy and I would like to include an integration test case that fetches a rhinovirus genome and then uses this datamanager to create an index, but samtools 0.1.19 is broken on OSX.