### PR TITLE
fix hisat2 extra outputs

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -290,11 +290,9 @@ hisat2
     --summary-file summary.txt
 #end if
 
-
 ## Convert SAM output to sorted BAM
 
 | samtools sort - -@ \${GALAXY_SLOTS:-1} -l 6 -o '${output_alignments}'
-
 
 ## Rename any output fastq files
 
@@ -540,12 +538,12 @@ hisat2
 
         <!-- Unaligned fastq (L) -->
         <data name="output_unaligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: unaligned reads (L)">
-            <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True)</filter>
+            <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True</filter>
         </data>
 
         <!-- Aligned fastq (L) -->
         <data name="output_aligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: aligned reads (L)">
-            <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True)</filter>
+            <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True</filter>
         </data>
 
         <!-- Unaligned fastq (R) -->
@@ -567,8 +565,8 @@ hisat2
 
     <!-- Define tests -->
 
-    <tests>
-        <test><!-- Ensure bam output works -->
+    <tests><!-- Ensure bam output works -->
+        <test expect_num_outputs="1" >
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -576,14 +574,16 @@ hisat2
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure built-in reference works -->
+        <!-- Ensure built-in reference works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="indexed" />
             <param name="input_1" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_reverse.fastq" />
             <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure trimming works -->
+        <!-- Ensure trimming works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -594,7 +594,8 @@ hisat2
             <param name="input_2" ftype="fastqsanger" value="hisat_input_2_reverse.fastq" />
             <output name="output_alignments" file="hisat_output_2.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure paired options works -->
+        <!-- Ensure paired options works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -608,18 +609,19 @@ hisat2
             <param name="no_discordant" value="True" />
             <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure unaligned output works -->
+        <!-- Ensure single unaligned output works -->
+        <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="output_options_selector" value="advanced" />
             <param name="unaligned_file" value="true" />
-            <param name="aligned_file" value="true" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fasta" value="test_unaligned_reads.fasta" />
             <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
         </test>
-        <test><!-- Ensure paired unaligned output works -->
+        <!-- Ensure paired unaligned/aligned output works -->
+        <test expect_num_outputs="5">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="output_options_selector" value="advanced" />
@@ -631,7 +633,8 @@ hisat2
             <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
             <output name="output_unaligned_reads_r" file="test_unaligned_reads.fasta" />
         </test>
-        <test><!-- Ensure fastqsanger.gz works -->
+        <!-- Ensure fastqsanger.gz works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -645,7 +648,8 @@ hisat2
             <param name="no_discordant" value="True" />
             <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure fastqsanger.bz2 works -->
+        <!-- Ensure fastqsanger.bz2 works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -659,7 +663,8 @@ hisat2
             <param name="no_discordant" value="True" />
             <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure paired strandness works -->
+        <!-- Ensure paired strandness works -->
+        <test expect_num_outputs="1">
             <param name="type" value="paired" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
@@ -668,7 +673,8 @@ hisat2
             <param name="rna_strandness" value="FR" />
             <output name="output_alignments" file="hisat_output_4.bam" ftype="bam" lines_diff="2" />
         </test>
-        <test><!-- Ensure summary file output works -->
+        <!-- Ensure summary file output works -->
+        <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -565,7 +565,8 @@ hisat2
 
     <!-- Define tests -->
 
-    <tests><!-- Ensure bam output works -->
+    <tests>
+        <!-- Ensure bam output works -->
         <test expect_num_outputs="1" >
             <param name="type" value="paired" />
             <param name="source" value="history" />


### PR DESCRIPTION
Sorry to be bringing hisat2 back again! but I just discovered that I accidentally left in a bracket that means that it's producing outputs that should be filtered out 😮 I left in the last bracket here: 

`<filter>(library['type'] == 'paired' or library['type'] == 'paired_collection') and (adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True) </filter>`

I fixed it here. I also learnt that I can include <test expect_num_outputs="num"> to check that the correct number of outputs are produced so I've added that in.

(a slightly weird thing to me is that nothing complained about the stray bracket, not planemo lint, test or travis. I was wondering if something should or if I really do need to get myself some better 👀!)