### PR TITLE
mothur: make.shared cat logs instead of move

### DIFF
--- a/tools/mothur/make.shared.xml
+++ b/tools/mothur/make.shared.xml
@@ -38,7 +38,6 @@
         | tee mothur.out.log &&
 
         ## move output files to correct destination
-	cat mothur.*.logfile > "$logfile" &&
         #if $intype.infile == 'otulist' and $intype.groups:
             mv intype_otu*.groups "$groupout"
         #else

--- a/tools/mothur/make.shared.xml
+++ b/tools/mothur/make.shared.xml
@@ -38,7 +38,7 @@
         | tee mothur.out.log &&
 
         ## move output files to correct destination
-        mv mothur.*.logfile "$logfile" &&
+	cat mothur.*.logfile > "$logfile" &&
         #if $intype.infile == 'otulist' and $intype.groups:
             mv intype_otu*.groups "$groupout"
         #else


### PR DESCRIPTION
Make.shared seems to produce multiple log files in the working directory: e.g. 
`mothur.1507547483.logfile  mothur.1507547484.logfile  mothur.out.log`. Hence `mv *log outfile` gives an error: 

```
Fatal error: Exit code 1 ()
mv: target `/gpfs1/data/galaxy_server/galaxy/jobs_dir/001/1248/galaxy_dataset_2683.dat' is not a directory
```

Using cat instead works. 

Question is: is make.shared supposed to produce more than one log file? And maybe: are we interested in all? 