### PR TITLE
Allow STAR to use (some) --limit options

### DIFF
--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -1,4 +1,4 @@
-<tool id="rna_star" name="RNA STAR" version="2.5.2b-0" profile="17.01">
+<tool id="rna_star" name="RNA STAR" version="2.5.2b-1" profile="17.01">
     <description>Gapped-read mapper for RNA-seq data</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -159,6 +159,13 @@
                 --chimScoreJunctionNonGTAG "$params.chim.chimScoreJunctionNonGTAG"
                 --chimJunctionOverhangMin "$params.chim.chimJunctionOverhangMin"
             #end if
+
+            ## Limits
+            --limitBAMsortRAM "$params.limit.limitBAMsortRAM"
+            --limitOutSJoneRead "$params.limit.limitOutSJoneRead"
+            --limitOutSJcollapsed "$params.limit.limitOutSJcollapsed"
+            --limitSjdbInsertNsj "$params.limit.limitSjdbInsertNsj"
+
         #end if
 
     ## Convert chimeric reads.
@@ -285,7 +292,7 @@
 
         <!-- Other parameter settings. -->
         <conditional name="params">
-            <param name="settingsType" type="select" label="Other parameters (seed, alignment, and chimeric alignment)">
+            <param name="settingsType" type="select" label="Other parameters (seed, alignment, limits and chimeric alignment)">
                 <option value="default" selected="true">Use Defaults</option>
                 <option value="star_fusion">Use parameters suggested for STAR-Fusion</option>
                 <option value="full">Extended parameter list</option>
@@ -316,6 +323,13 @@
                     <param argument="--alignTranscriptsPerWindowNmax" type="integer" min="1" value="100" label="Maximum number of transcripts per window"/>
                     <param argument="--alignTranscriptsPerReadNmax" type="integer" min="1" value="10000" label="Maximum number of different alignments per read to consider"/>
                     <param argument="--alignEndsType" type="boolean" truevalue="EndToEnd" falsevalue="Local" checked="false" label="Use end-to-end read alignments, with no soft-clipping?"/>
+                </section>
+
+                <section name="limits" title="Limits" expand="False">
+                    <param argument="--limitBAMsortRAM" type="integer" min="0" value="0" label="Maximum available RAM (in bytes) for sorting" help="If 0, this will be set to the genome index size. This is typically only changed in cases where an error is produced." />
+	            <param argument="--limitOutSJoneRead" type="integer" min="1" value="1000" label="Maximum number of junctions for one read (including all multimappers)" />
+	            <param argument="--limitOutSJcollapsed" type="integer" min="1" value="1000000" label="Maximum number of collapsed junctions" />
+	            <param argument="--limitSjdbInsertNsj" type="integer" min="0" value="1000000" label="Maximum number of inserts to be inserted into the genome on the fly." />
                 </section>
     
                 <conditional name="chim">

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -161,10 +161,10 @@
             #end if
 
             ## Limits
-            --limitBAMsortRAM "$params.limit.limitBAMsortRAM"
-            --limitOutSJoneRead "$params.limit.limitOutSJoneRead"
-            --limitOutSJcollapsed "$params.limit.limitOutSJcollapsed"
-            --limitSjdbInsertNsj "$params.limit.limitSjdbInsertNsj"
+            --limitBAMsortRAM "$params.limits.limitBAMsortRAM"
+            --limitOutSJoneRead "$params.limits.limitOutSJoneRead"
+            --limitOutSJcollapsed "$params.limits.limitOutSJcollapsed"
+            --limitSjdbInsertNsj "$params.limits.limitSjdbInsertNsj"
 
         #end if
 

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -325,7 +325,7 @@
                     <param argument="--alignEndsType" type="boolean" truevalue="EndToEnd" falsevalue="Local" checked="false" label="Use end-to-end read alignments, with no soft-clipping?"/>
                 </section>
 
-                <section name="limits" title="Limits" expand="False">
+                <section name="limits" title="Limits" expanded="False">
                     <param argument="--limitBAMsortRAM" type="integer" min="0" value="0" label="Maximum available RAM (in bytes) for sorting" help="If 0, this will be set to the genome index size. This is typically only changed in cases where an error is produced." />
 	            <param argument="--limitOutSJoneRead" type="integer" min="1" value="1000" label="Maximum number of junctions for one read (including all multimappers)" />
 	            <param argument="--limitOutSJcollapsed" type="integer" min="1" value="1000000" label="Maximum number of collapsed junctions" />


### PR DESCRIPTION
This fixes #1511 and adds a couple other `--limit*` options that people might occasionally want to tweak. The defaults in the wrapper match those from the command line.