### PR TITLE
fix for #1322

### DIFF
--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -8,9 +8,6 @@
     <expand macro="version_command" />
     <command><![CDATA[
         mkdir -p ./special_de_output/sample1/ &&
-        #if str($guide.use_guide) == 'yes':
-            ln -s '$guide.guide_gff' ./special_de_output/sample1/guide.gtf &&
-        #end if
 
         #if $input_bam.metadata.ftype == 'sam':
             samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' | stringtie
@@ -47,11 +44,13 @@
 
         #if str($guide.use_guide) == 'yes':
             #if $guide.special_outputs.special_outputs_select == 'deseq2':
+                && 
+                ln -s '$output_gtf' ./special_de_output/sample1/output.gtf
                 &&
                 prepDE.py
                     -i ./special_de_output/
-                    -g gene_cout_matrix.tsv
-                    -t transcripts_count_matrix.tsv
+                    -g ./gene_counts.tsv
+                    -t ./transcript_counts.tsv
                     -l $guide.special_outputs.read_length
                     #if str($option_set.options) == 'advanced':
                         -s '$option_set.name_prefix'
@@ -59,15 +58,25 @@
                     #if $guide.special_outputs.clustering:
                         -c
                         --legend ./legend.tsv
-
                         &&
                         sed -i.bak 's/,/\t/g' ./legend.tsv
-
+                        &&
+                        sed -i.bak 's/\r//g' ./legend.tsv
+                        &&
+                        mv -T ./legend.tsv "$legend"
                     #end if
                 &&
-                sed -i.bak 's/,/\t/g' transcripts_count_matrix.tsv
+                sed -i.bak 's/,/\t/g' ./transcript_counts.tsv
                 &&
-                sed -i.bak 's/,/\t/g' gene_cout_matrix.tsv
+                sed -i.bak 's/\r//g' ./transcript_counts.tsv
+                &&
+                mv -T ./transcript_counts.tsv "$transcript_counts"
+                &&
+                sed -i.bak 's/,/\t/g' ./gene_counts.tsv
+                &&
+                sed -i.bak 's/\r//g' ./gene_counts.tsv
+                &&
+                mv -T ./gene_counts.tsv "$gene_counts"
             #end if
         #end if
     ]]></command>
@@ -155,16 +164,13 @@
             label="${tool.name} on ${on_string}: intron to transcript mapping">
             <filter>guide['use_guide'] == 'yes' and guide['special_outputs']['special_outputs_select'] == 'ballgown'</filter>
         </data>
-        <data name="gene_counts" format="tabular" from_work_dir="gene_cout_matrix.tsv"
-            label="${tool.name} on ${on_string}: Gene counts">
+        <data name="gene_counts" format="tabular" label="${tool.name} on ${on_string}: Gene counts">
             <filter>guide['use_guide'] == 'yes' and guide['special_outputs']['special_outputs_select'] == 'deseq2'</filter>
         </data>
-        <data name="transcript_counts" format="tabular" from_work_dir="transcripts_count_matrix.tsv"
-            label="${tool.name} on ${on_string}: Transcript counts">
+        <data name="transcript_counts" format="tabular" label="${tool.name} on ${on_string}: Transcript counts">
             <filter>guide['use_guide'] == 'yes' and guide['special_outputs']['special_outputs_select'] == 'deseq2'</filter>
         </data>
-        <data name="legend" format="tabular" from_work_dir="legend.tsv"
-            label="${tool.name} on ${on_string}: legend">
+        <data name="legend" format="tabular" label="${tool.name} on ${on_string}: legend">
             <filter>guide['use_guide'] == 'yes' and guide['special_outputs']['special_outputs_select'] == 'deseq2' and guide['special_outputs']['clustering'] is True</filter>
         </data>
     </outputs>

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -63,20 +63,20 @@
                         &&
                         sed -i.bak 's/\r//g' ./legend.tsv
                         &&
-                        mv -T ./legend.tsv "$legend"
+                        mv ./legend.tsv "$legend"
                     #end if
                 &&
                 sed -i.bak 's/,/\t/g' ./transcript_counts.tsv
                 &&
                 sed -i.bak 's/\r//g' ./transcript_counts.tsv
                 &&
-                mv -T ./transcript_counts.tsv "$transcript_counts"
+                mv ./transcript_counts.tsv "$transcript_counts"
                 &&
                 sed -i.bak 's/,/\t/g' ./gene_counts.tsv
                 &&
                 sed -i.bak 's/\r//g' ./gene_counts.tsv
                 &&
-                mv -T ./gene_counts.tsv "$gene_counts"
+                mv ./gene_counts.tsv "$gene_counts"
             #end if
         #end if
     ]]></command>


### PR DESCRIPTION
Thanks @mblue9 for the pdfs. So here is my current version of the updated stringtie.xml that should fix the error described in #1322.
Compared to my last post I've added some 'cosmetic' changes regarding the temp-files. Please test if these changes work for you.

Maybe some last idea:
If someone has a project with several samples the outputs of the stringtie/prepDE combination have to be merged before feeding the table to DESeq. This means a lot of clicks.
prepDE.py is designed to handle .gtf input files from several samples and create one single table in which the samples are represented in the columns and the genes/transcripts are shown in the rows.
In order to use the full power of this tool it should get an own .xml-wrapper as the medium-term consideration.