### PR TITLE
DexSeq and get_length_and_gc_content update of requirement versions

### DIFF
--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -1,7 +1,7 @@
 <tool id="dexseq" name="DEXSeq" version="1.20.1">
     <description>Determines differential exon usage from count tables</description>
     <requirements>
-        <requirement type="package" version="1.20.1">bioconductor-dexseq</requirement>
+        <requirement type="package" version="1.22.0">bioconductor-dexseq</requirement>
         <requirement type="package" version="1.20.0">r-getopt</requirement>
         <requirement type="package" version="0.2.15">r-rjson</requirement>
     </requirements>

--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -1,7 +1,7 @@
 <tool id="dexseq_count" name="DEXSeq-Count" version="1.20.1">
     <description>Prepare and count exon abundancies from RNA-seq data</description>
     <requirements>
-        <requirement type="package" version="1.20.1">bioconductor-dexseq</requirement>
+        <requirement type="package" version="1.22.0">bioconductor-dexseq</requirement>
         <requirement type="package" version="0.6.1.post1">htseq</requirement>
     </requirements>
     <stdio>

--- a/tools/length_and_gc_content/get_length_and_gc_content.xml
+++ b/tools/length_and_gc_content/get_length_and_gc_content.xml
@@ -2,9 +2,9 @@
     <description>from GTF file</description>
     <requirements>
         <requirement type="package" version="1.3.2">r-optparse</requirement>
-        <requirement type="package" version="1.4.1">r-reshape2</requirement>
-        <requirement type="package" version="1.9.6">r-data.table</requirement>
-        <requirement type="package" version="1.34.1">bioconductor-rtracklayer</requirement>
+        <requirement type="package" version="1.4.2">r-reshape2</requirement>
+        <requirement type="package" version="1.10.4">r-data.table</requirement>
+        <requirement type="package" version="1.34.2">bioconductor-rtracklayer</requirement>
     </requirements>
     <stdio>
         <regex match="Execution halted"

--- a/tools/length_and_gc_content/get_length_and_gc_content.xml
+++ b/tools/length_and_gc_content/get_length_and_gc_content.xml
@@ -21,12 +21,14 @@
                description="An undefined error occured, please check your input carefully and contact your administrator." />
     </stdio>
     <command><![CDATA[
-        Rscript '$__tool_directory__'/get_length_and_gc_content.r --gtf '$gtf'
         #if $fastaSource.genomeSource == 'indexed':
-            --fasta '$fastaSource.fasta_pre_installed.fields.path'
+            ln -s '$fastaSource.fasta_pre_installed.fields.path' fasta
         #else:
-            --fasta '$fastaSource.fasta_history'
+            ln -s '$fastaSource.fasta_history' fasta
         #end if
+        &&
+        Rscript '$__tool_directory__'/get_length_and_gc_content.r --gtf '$gtf'
+        --fasta fasta
         --length '$length'
         --gc_content '$gc_content'
     ]]></command>


### PR DESCRIPTION
The version update is necessary to be able to install the DexSeq package at all. 

With the old version I run in several conda / bioconda related problems which make it impossible to install: 

- conda is unable to resolve the dependencies (https://github.com/conda/conda/issues/5536). I aborted it after 3days. With the new version the installation is successful after minutes. 
- some dependencies imply R 3.3.1 which seems impossible to install (https://github.com/conda/conda/issues/6175). I do not understand the explanation in the issue discussion, but the update solves the problem. 

Problems: 
- The DexSeq test yields different results. The question is: is it sufficient to update the test-data?
