### PR TITLE
CrossMap: cached chain file selection dbkey sensitive

### DIFF
--- a/tools/crossmap/crossmap_bam.xml
+++ b/tools/crossmap/crossmap_bam.xml
@@ -50,7 +50,7 @@ $optional_tags
         <test>
             <param name="index_source" value="cached"/>
 
-            <param name="input" value="test_bam_01_input_a.bam" ftype="bam"/>
+            <param name="input" value="test_bam_01_input_a.bam" ftype="bam" dbkey="hg18"/>
             <param name="include_fails" value="False"/>
 
             <output name="output" file="test_bam_01_output_a.bam" compare="diff" lines_diff="8"/>

--- a/tools/crossmap/crossmap_bed.xml
+++ b/tools/crossmap/crossmap_bed.xml
@@ -91,7 +91,7 @@ CrossMap.py bed
         </test>
 
         <test><!-- clone of first test: tests cached reference chain file -->
-            <param name="input" value="test_bed_01_input_a.bed" ftype="bed"/>
+            <param name="input" value="test_bed_01_input_a.bed" ftype="bed" dbkey="hg18"/>
             <param name="index_source" value="cached"/>
             <param name="merge_unmapped_entries" value="false" />
 

--- a/tools/crossmap/crossmap_bigwig.xml
+++ b/tools/crossmap/crossmap_bigwig.xml
@@ -35,7 +35,7 @@ CrossMap.py bigwig
             <output name="output" file="test_bigwig_01_output_a.bw"/>
         </test>
         <test><!-- cached chain file -->
-            <param name="input" value="test_bigwig_01_input_a.bw" ftype="bigwig"/>
+            <param name="input" value="test_bigwig_01_input_a.bw" ftype="bigwig" dbkey="hg18"/>
             <param name="index_source" value="cached"/>
 
             <output name="output" file="test_bigwig_01_output_a.bw"/>

--- a/tools/crossmap/crossmap_gff.xml
+++ b/tools/crossmap/crossmap_gff.xml
@@ -49,7 +49,7 @@ CrossMap.py gff
             <output name="output" file="test_gff_01_output_a__all.gtf"/>
         </test>
         <test><!-- cached chain file -->
-            <param name="input" value="test_gff_01_input_a.gtf" ftype="gtf"/>
+            <param name="input" value="test_gff_01_input_a.gtf" ftype="gtf" dbkey="hg18"/>
             <param name="index_source" value="cached"/>
             <param name="include_fails" value="True"/>
 

--- a/tools/crossmap/crossmap_vcf.xml
+++ b/tools/crossmap/crossmap_vcf.xml
@@ -14,9 +14,9 @@ CrossMap.py vcf
 
 #if $seq_source.index_source_s == "cached"
     ## This is the 2nd dbkey, and the corresponding value has to be looked up
-    "${filter(lambda x: str( x[1] ) == str($chain_source.input_chain ), $__app__.tool_data_tables['liftOver'].get_fields())[0][2] }"
+    "${filter(lambda x: str( x[1] ) == str($seq_source.chain_source.input_chain ), $__app__.tool_data_tables['liftOver'].get_fields())[0][2] }"
 #else
-    '${chain_source.input_chain}'
+    '${seq_source.chain_source.input_chain}'
 #end if
 
 '${input_file}'
@@ -45,14 +45,17 @@ CrossMap.py vcf
                 <param name="input_fasta" type="select" label="Lift Over To (FASTA file)" help="The FASTA file must be on the same build (dbkey) as the LiftOver chain file">
                     <options from_data_table="all_fasta"/>
                 </param>
+
+                <expand macro="chain" />
             </when>
 
             <when value="history">
                 <param name="input" type="data" format="vcf" label="VCF file"/>
                 <param name="input_fasta" type="data" format="fasta" label="Full genome FASTA file"/>
+
+                <expand macro="chain" />
             </when>
         </conditional>
-        <expand macro="chain" />
     </inputs>
 
     <outputs>

--- a/tools/crossmap/crossmap_wig.xml
+++ b/tools/crossmap/crossmap_wig.xml
@@ -38,8 +38,8 @@ CrossMap.py wig
             <output name="output2" file="test_wig_01_output_a.sorted.bgr"/>
         </test>
 
-        <test>
-            <param name="input" value="test_wig_01_input_a.wig" ftype="wig"/>
+        <test><!-- cached refernece genome -->
+            <param name="input" value="test_wig_01_input_a.wig" ftype="wig" dbkey="hg18" />
             <param name="index_source" value="cached"/>
 
             <output name="output" file="test_wig_01_output_a.bw"/>

--- a/tools/crossmap/crossmap_wig.xml
+++ b/tools/crossmap/crossmap_wig.xml
@@ -38,7 +38,7 @@ CrossMap.py wig
             <output name="output2" file="test_wig_01_output_a.sorted.bgr"/>
         </test>
 
-        <test><!-- cached refernece genome -->
+        <test><!-- cached reference genome -->
             <param name="input" value="test_wig_01_input_a.wig" ftype="wig" dbkey="hg18" />
             <param name="index_source" value="cached"/>
 

--- a/tools/crossmap/macros.xml
+++ b/tools/crossmap/macros.xml
@@ -28,9 +28,7 @@ CrossMap.py 2>&1 | head -n 1 | grep -E --only-matching 'CrossMap.*'
             <when value="cached">
                 <param name="input_chain" type="select" label="Lift Over To">
                     <options from_data_table="liftOver">
-                        <!--
                         <filter type="data_meta" ref="input" key="dbkey" column="0"/>
-                        -->
                     </options>
                 </param>
             </when>

--- a/tools/crossmap/test-data/cached_locally/liftOver.loc
+++ b/tools/crossmap/test-data/cached_locally/liftOver.loc
@@ -29,4 +29,4 @@
 #anoCar1	hg18	/depot/data2/galaxy/anoCar1/liftOver/anoCar1ToHg18.over.chain
 #...etc...
 
-A	B	${__HERE__}/aToB.over.chain
+hg18	hg19	${__HERE__}/aToB.over.chain


### PR DESCRIPTION
As requested (https://biostar.usegalaxy.org/p/24086/#25011) 
It may be handier to limit the number of possible cached chain files in the dropdown to those that match the input file's dbkey.