### PR TITLE
SnpEff: Remove unused data tables. Update to 4.3r

### DIFF
--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
@@ -1,7 +1,7 @@
-<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3k" tool_type="manage_data">
+<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3r" tool_type="manage_data">
     <description>Read the list of available SnpEff databases</description>
     <requirements>
-        <requirement type="package" version="4.3k">snpeff</requirement>
+        <requirement type="package" version="4.3.1r">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python '$__tool_directory__/data_manager_snpEff_databases.py' '$out_file'

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
@@ -93,8 +93,6 @@ def download_database(data_manager_dict, target_directory, genome_version, organ
         sys.exit( return_code )
     # search data_dir/genome_version for files
     regulation_pattern = 'regulation_(.+).bin'
-    #  annotation files that are included in SnpEff by a flag
-    annotations_dict = {'nextProt.bin': '-nextprot', 'motif.bin': '-motif', 'interactions.bin': '-interaction'}
     genome_path = os.path.join(data_dir, genome_version)
     snpeff_version = getSnpeffVersion()
     key = snpeff_version + '_' + genome_version
@@ -112,11 +110,6 @@ def download_database(data_manager_dict, target_directory, genome_version, organ
                         name = m.groups()[0]
                         data_table_entry = dict(key=key, version=snpeff_version, genome=genome_version, value=name, name=name)
                         _add_data_table_entry( data_manager_dict, 'snpeffv_regulationdb', data_table_entry )
-                    elif fname in annotations_dict:
-                        value = annotations_dict[fname]
-                        name = value.lstrip('-')
-                        data_table_entry = dict(key=key, version=snpeff_version, genome=genome_version, value=value, name=name)
-                        _add_data_table_entry( data_manager_dict, 'snpeffv_annotations', data_table_entry )
     return data_manager_dict
 
 

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
@@ -1,7 +1,7 @@
-<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3k" tool_type="manage_data">
+<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3r" tool_type="manage_data">
     <description>Download a new database</description>
     <requirements>
-        <requirement type="package" version="4.3k">snpeff</requirement>
+        <requirement type="package" version="4.3.1r">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python '$__tool_directory__/data_manager_snpEff_download.py'
@@ -25,15 +25,14 @@ python '$__tool_directory__/data_manager_snpEff_download.py'
                     <!-- Check that a genome was added -->
                     <has_text text="GRCh38.76" />
                     <has_text text="snpeffv_regulationdb" />
-                    <has_text text="snpeffv_annotations" />
                 </assert_contents>
             </output>
         </test>
     </tests>
     <help><![CDATA[
-This tool downloads a SnpEff database and populates the data tables: snpeffv_genomedb, snpeffv_regulationdb, and snpeffv_annotations.
+This tool downloads a SnpEff database and populates the data tables: snpeffv_genomedb, snpeffv_regulationdb.
 
-To see the list of available SnpEff genomes run the "SnpEff Databases" data manager which records the available genome databases in data table: snpeff4_databases
+To see the list of available SnpEff genomes, run the "SnpEff Databases" data manager which records the available genome databases in data table: snpeffv_databases.
 
 The SnpEff genome databases are at: http://sourceforge.net/projects/snpeff/files/databases/
 

--- a/data_managers/data_manager_snpeff/data_manager_conf.xml
+++ b/data_managers/data_manager_snpeff/data_manager_conf.xml
@@ -35,16 +35,5 @@
         <column name="name" />  <!-- columns that are going to be specified by the Data Manager Tool -->
       </output>
     </data_table>
-    <data_table name="snpeffv_annotations">  <!-- Defines a Data Table to be modified. -->
-      <output> <!-- Handle the output of the Data Manager Tool -->
-        <column name="key" /> <!-- columns that are going to be specified by the Data Manager Tool -->
-        <column name="version" /> <!-- columns that are going to be specified by the Data Manager Tool -->
-        <column name="genome" /> <!-- columns that are going to be specified by the Data Manager Tool -->
-        <column name="value" /> <!-- columns that are going to be specified by the Data Manager Tool -->
-        <column name="name" />  <!-- columns that are going to be specified by the Data Manager Tool -->
-      </output>
-    </data_table>
   </data_manager>
 </data_managers>
-
-

--- a/data_managers/data_manager_snpeff/tool-data/snpeffv_annotations.loc.sample
+++ b/data_managers/data_manager_snpeff/tool-data/snpeffv_annotations.loc.sample
@@ -1,5 +1,0 @@
-## Regulation Databases for SnpEff 
-## These are from the list on: http://snpeff.sourceforge.net/download.html
-#key	snpeff_version	genome	annotation_name description
-#SnpEff4.0_GRCh37.75	SnpEff4.0	GRCh37.75	nextprot	nextprot
-#SnpEff4.0_GRCh38.76	SnpEff4.1	GRCh38.76	motif	motif

--- a/data_managers/data_manager_snpeff/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_snpeff/tool_data_table_conf.xml.sample
@@ -7,10 +7,6 @@
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_regulationdb.loc" />
     </table>
-    <table name="snpeffv_annotations" comment_char="#" allow_duplicate_entries="False">
-        <columns>key, version, genome, value, name</columns>
-        <file path="tool-data/snpeffv_annotations.loc" />
-    </table>
     <table name="snpeffv_databases" comment_char="#" allow_duplicate_entries="False">
         <columns>key, version, value, name</columns>
         <file path="tool-data/snpeffv_databases.loc" />

--- a/tool_collections/snpeff/readme.rst
+++ b/tool_collections/snpeff/readme.rst
@@ -13,8 +13,8 @@ You can fill this file by running the following command:
 
 There are 2 datamanagers to download and install prebuilt SnpEff genome databases:
 
-* data_manager_snpeff_databases: generates a list of available SnpEff genome databases into the ``tool-data/snpeff_databases.loc`` file
-* data_manager_snpeff_download: downloads a SnpEff genome database selected from ``tool-data/snpeff_databases.loc`` and adds entries to ``snpeff_genomedb.loc``, ``snpeff_regulationdb.loc`` and ``snpeff_annotations.loc``
+* data_manager_snpeff_databases: generates a list of available SnpEff genome databases into the ``tool-data/snpeffv_databases.loc`` file
+* data_manager_snpeff_download: downloads a SnpEff genome database selected from ``tool-data/snpeffv_databases.loc`` and adds entries to ``snpeffv_genomedb.loc`` and ``snpeffv_regulationdb.loc`` .
 
 SnpEff citation: |Cingolani2012program|_.
 

--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -218,7 +218,7 @@
             <option value="-noNextProt">Disable NextProt annotations</option>
             <option value="-noInteraction">Disable interaction annotations</option>
             <option value="-cancer">Perform 'cancer' comparisons (somatic vs. germline)</option>
-            <!--  onlyReg option results in ifrequent exceptions with version 4.3k
+            <!--  onlyReg option results in frequent exceptions with version 4.3k
             <option value="-onlyReg">Only use regulation tracks</option>
             -->
         </param>

--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="4.3k">snpeff</requirement>
+            <requirement type="package" version="4.3r">snpeff</requirement>
         </requirements>
     </xml>
   <xml name="stdio">
@@ -15,7 +15,7 @@
 snpEff -version
     ]]></version_command>
   </xml>
-  <token name="@WRAPPER_VERSION@">4.3k</token>
+  <token name="@WRAPPER_VERSION@">4.3r</token>
   <token name="@SNPEFF_VERSION@">SnpEff4.3</token>
   <token name="@SNPEFF_DATABASE_URL@">https://sourceforge.net/projects/snpeff/files/databases/v4_3/</token>
   <token name="@EXTERNAL_DOCUMENTATION@">

--- a/tool_collections/snpeff/tool-data/snpeffv_annotations.loc.sample
+++ b/tool_collections/snpeff/tool-data/snpeffv_annotations.loc.sample
@@ -1,5 +1,0 @@
-## Regulation Databases for SnpEff 
-## These are from the list on: http://snpeff.sourceforge.net/download.html
-#key	snpeff_version	genome	annotation_name description
-#SnpEff4.0_GRCh37.75	SnpEff4.0	GRCh37.75	nextprot	nextprot
-#SnpEff4.0_GRCh38.76	SnpEff4.1	GRCh38.76	motif	motif

--- a/tool_collections/snpeff/tool-data/snpeffv_databases.loc.sample
+++ b/tool_collections/snpeff/tool-data/snpeffv_databases.loc.sample
@@ -1,5 +1,0 @@
-## Available Databases for SnpEff 
-## These are from the list on: http://snpeff.sourceforge.net/download.html
-## the Description field in this sample is "Genome : Version" 
-#key	snpeff_version	Version	Description
-#SnpEff4.0_GRCh37.75	SnpEff4.0	GRCh37.75	Homo sapiens : GRCh37.75

--- a/tool_collections/snpeff/tool_data_table_conf.xml.sample
+++ b/tool_collections/snpeff/tool_data_table_conf.xml.sample
@@ -7,13 +7,4 @@
         <columns>key, version, genome, value, name</columns>
         <file path="tool-data/snpeffv_regulationdb.loc" />
     </table>
-    <table name="snpeffv_annotations" comment_char="#" allow_duplicate_entries="False">
-        <columns>key, version, genome, value, name</columns>
-        <file path="tool-data/snpeffv_annotations.loc" />
-    </table>
-    <table name="snpeffv_databases" comment_char="#" allow_duplicate_entries="False">
-        <columns>key, version, value, name</columns>
-        <file path="tool-data/snpeffv_databases.loc" />
-    </table>
 </tables>
-

--- a/tool_collections/snpsift/snpsift/snpSift_annotate.xml
+++ b/tool_collections/snpsift/snpsift/snpSift_annotate.xml
@@ -10,7 +10,7 @@
     <expand macro="stdio" />
     <expand macro="version_command" />
     <command><![CDATA[
-SnpSift annotate
+SnpSift -Xmx8G annotate
 #if $annotate.id == 'id':
     -id
 #elif str($annotate.info_ids).strip() != '':
@@ -20,7 +20,7 @@ SnpSift annotate
     ]]></command>
     <inputs>
         <param name="input" type="data" format="vcf" label="Variant input file in VCF format"/>
-        <param name="dbSnp" type="data" format="vcf" label="VCF File with ID field annotated (e.g. dnSNP.vcf)"
+        <param name="dbSnp" type="data" format="vcf" label="VCF File with ID field annotated (e.g. dbSNP.vcf)"
             help="The ID field for a variant in input will be assigned from a matching variant in this file."/>
         <conditional name="annotate">
             <param name="id" type="select" label="Fields to annotate">


### PR DESCRIPTION
Also increase JVM maximum memory allocation to 8GB for `SnpSift annotate` tool.