### PR TITLE
Fix bugs in Trinity genome guided mode

### DIFF
--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -1,11 +1,15 @@
-<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@.1">
+<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@.2">
     <description>de novo assembly of RNA-Seq data</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="aggressive"><![CDATA[
-       Trinity --no_version_check
+        #if $additional_params.guided.is_guided == "yes":
+            ln -s '${$additional_params.guided.genome_guided_bam}' 'localbam.bam' &&
+            ln -s '${$additional_params.guided.genome_guided_bam.metadata.bam_index}' 'localbam.bam.bai' &&
+        #end if
+        Trinity --no_version_check
 
         ## Inputs.
         #if $inputs.paired_or_single == "paired":
@@ -59,7 +63,7 @@
             --long_reads $additional_params.long_reads
         #end if
         #if $additional_params.guided.is_guided == "yes":
-            --genome_guided_bam $additional_params.guided.genome_guided_bam
+            --genome_guided_bam 'localbam.bam'
 
             #if $additional_params.guided.genome_guided_min_coverage:
                 --genome_guided_min_coverage $additional_params.guided.genome_guided_min_coverage
@@ -67,6 +71,10 @@
 
             #if $additional_params.guided.genome_guided_min_reads_per_partition:
                 --genome_guided_min_reads_per_partition $additional_params.guided.genome_guided_min_reads_per_partition
+            #end if
+
+            #if $additional_params.guided.genome_guided_max_intron:
+                --genome_guided_max_intron $additional_params.guided.genome_guided_max_intron
             #end if
 
         #end if
@@ -125,7 +133,8 @@
                 <when value="no">
                 </when>
                 <when value="yes">
-                    <param name="genome_guided_bam" argument="--genome_guided_bam" type="data" format="bam" label="Coordinate-sorted BAM file" />
+                    <param format="bam" name="genome_guided_bam" argument="--genome_guided_bam" type="data" label="Coordinate-sorted BAM file" />
+                    <param name="genome_guided_max_intron" argument="--genome_guided_max_intron" type="integer" value="" min="1" label="Maximum allowed intron length (also maximum fragment span on genome)"/>
                     <param name="genome_guided_min_coverage" argument="--genome_guided_min_coverage" type="integer" optional="true" value="1" min="1" label="Minimum read coverage for identifying an expressed region of the genome"/>
                     <param name="genome_guided_min_reads_per_partition" argument="--genome_guided_min_reads_per_partition" type="integer" optional="true" value="10" min="1" label="Minimum number of reads per partition"/>
                 </when>


### PR DESCRIPTION
Added missing require parameter `genome_guided_max_intron`
Link bam file so it has a `.bam` extension which seems to be required by
Trinity's `ensure_coord_sorted_sam.pl` script.