### PR TITLE
Use no_ref option for CRAM output in minimap2

### DIFF
--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="minimap2" name="Map with minimap2" version="2.4" profile="17.01">
+<tool id="minimap2" name="Map with minimap2" version="2.4.1" profile="17.01">
     <description>A fast pairwise aligner for genomic and spliced nucleotide sequences</description>
     <requirements>
         <requirement type="package" version="2.4">minimap2</requirement>
@@ -106,6 +106,7 @@
     -O $io_options.output_format
     #if $io_options.output_format == 'CRAM':
         --reference reference.fa
+        --output-fmt-option no_ref
     #end if
     -o '$alignment_output'
 ]]>


### PR DESCRIPTION
This avoids reference-based compression (otherwise alignments against custom
references cannot be uncompressed).