### PR TITLE
Fix Docutils errors in Mothur tools

### DIFF
--- a/tools/mothur/get.otulabels.xml
+++ b/tools/mothur/get.otulabels.xml
@@ -87,6 +87,7 @@
 
 The get.otulabels_ command selects otu labels from the output from classify.otu_, corr.axes_ and otu.association_. This can be useful especially with subsampled datasets or when groups have been selected.
 
+.. _get.otulabels: https://www.mothur.org/w/index.php?search=get.otulabels
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
 .. _otu.association: https://www.mothur.org/wiki/Otu.association

--- a/tools/mothur/hcluster.xml
+++ b/tools/mothur/hcluster.xml
@@ -126,12 +126,14 @@
 
 The hcluster_ command assign sequences to OTUs (Operational Taxonomy Unit).  The assignment is based on a phylip-formatted_distance_matrix_ or a  column-formatted_distance_matrix_ and name_ file.  It generates a list_, a sabund_ (Species Abundance), and a rabund_ (Relative Abundance) file.
 
+.. _hcluster: https://www.mothur.org/w/index.php?search=hcluster
 .. _phylip-formatted_distance_matrix: https://www.mothur.org/wiki/Phylip-formatted_distance_matrix
 .. _column-formatted_distance_matrix: https://www.mothur.org/wiki/Column-formatted_distance_matrix
 .. _name: https://www.mothur.org/wiki/Name_file
 .. _list: https://www.mothur.org/wiki/List_file
-.. _rabund: https://www.mothur.org/wiki/Rabund_file
 .. _sabund: https://www.mothur.org/wiki/Sabund_file
+.. _rabund: https://www.mothur.org/wiki/Rabund_file
+
 
 ]]>
     </help>

--- a/tools/mothur/list.otulabels.xml
+++ b/tools/mothur/list.otulabels.xml
@@ -78,12 +78,13 @@
 The list.otulabels_ command lists otu labels from shared_ or relabund_ file. This list can be used especially with subsampled datasets when used with output from classify.otu_, otu.association_, or corr.axes_ to select specific otus using the get.otulabels_ or remove.otulabels_ commands.
 
 .. _list.otulabels: https://www.mothur.org/wiki/List.otulabels
+.. _shared: https://www.mothur.org/wiki/Shared_file
+.. _relabund: https://www.mothur.org/wiki/Get.relabund
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _otu.association: https://www.mothur.org/wiki/Otu.association
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
-.. _remove.otulabels: https://www.mothur.org/wiki/Remove.otulabels
-.. _shared: https://www.mothur.org/wiki/Shared_file
-.. _relabund: https://www.mothur.org/wiki/Get.relabund
+.. _get.otulabels: https://www.mothur.org/w/index.php?search=get.otulabels
+.. _remove.otulabels: https://www.mothur.org/w/index.php?search=remove.otulabels
 
 v.1.27.0: Updated to mothur 1.33, added list file for otu
 ]]>

--- a/tools/mothur/mimarks.attributes.xml
+++ b/tools/mothur/mimarks.attributes.xml
@@ -1,4 +1,4 @@
-<tool profile="16.07" id="mothur_mimarks_attributes" name="Get.mimarkspackage" version="@WRAPPER_VERSION@.0">
+<tool profile="16.07" id="mothur_mimarks_attributes" name="Mimarks.attributes" version="@WRAPPER_VERSION@.0">
     <description>Reads bioSample Attributes xml and generates source for get.mimarkspackage command</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/mothur/mimarks.attributes.xml
+++ b/tools/mothur/mimarks.attributes.xml
@@ -44,7 +44,11 @@
 
 **Command Documentation**
 
-The mimarks.attributes_ Reads bioSample Attributes xml and generates source for make.sra command.
+The mimarks.attributes_ command reads `BioSample Attributes`_ xml and generates source for get.mimarkspackage_ command.
+
+.. _mimarks.attributes: https://www.mothur.org/w/index.php?search=mimarks.attributes
+.. _BioSample Attributes: https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/
+.. _get.mimarkspackage: https://www.mothur.org/wiki/Get.mimarkspackage
 
 ]]>
     </help>

--- a/tools/mothur/remove.otulabels.xml
+++ b/tools/mothur/remove.otulabels.xml
@@ -86,10 +86,11 @@
 
 The remove.otulabels_ command removes otu labels from the output from classify.otu_, corr.axes_ and otu.association_. This can be useful especially with subsampled datasets or when groups have been selected.
 
+.. _remove.otulabels: https://www.mothur.org/w/index.php?search=remove.otulabels
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
 .. _otu.association: https://www.mothur.org/wiki/Otu.association
-.. _remove.otulabels: https://www.mothur.org/wiki/Remove.otulabels
+
 ]]>
     </help>
     <expand macro="citations"/>


### PR DESCRIPTION
Hi everyone,

I recently updated one of my Galaxy instance from Galaxy 17.05 (master) to Galaxy 17.09 (master) and, as I a consequence, I paid more attention to warnings and error messages that could appear at the instance startup.

I quickly noticed that several warnings were popping up in the log files and were triggering Docutils error messages visible on the parameter selection pages of several Mothur wrappers.

All those warnings are generated because some links are missing in the Help sections of a few Mothur wrappers.

The first part of this PR is therefore a commit that add all the missing links in the appropriate files.

Please note that in some cases I've been forced to use the URL of a search result on the official Mothur wiki instead of a direct link to the page of the corresponding tool.

The reason behind this behavior is that the maintainer of the official Mothur wiki has fully deleted the pages of tools that have been removed in the lastest versions of Mothur itself (instead of just marking them as deprecated).

The current IUC wrappers for Mothur were made for Mothur 1.36.1 and since this version the following tools have been removed from Mothur:

- get.otulabels removed since v1.37
- remove.otulabels removed since v1.37
- hcluster removed since v1.38
- clear.memory removed since v1.38
- pds.pipeline removed since v1.38

I've created an Issue on Mothur's Github to ask its creator if he can restore the deleted pages and just mark/tag them as deprecated/obsolete so that users can still access all the informations about the Mothur version they are currently running:

https://github.com/mothur/mothur/issues/401

Unfortunatly, the answer is not positive at the moment so we might expect some links to become dead after the release of the next Mothur versions.

In addition, when I was fixing the links in the Mimarks.attributes wrapper I also noticed that the wrapper name was incorrect so I fixed it in the second commit of this PR.

I've used planemo lint/serve/test locally to check that the wrappers were still Ok after the updates and Travis did not issued any error when it run on the branch of my fork of the galaxyproject/tools-iuc repo.

Have a nice day :)

ping @shiltemann