### PR TITLE
Update featureCounts column name to use `element_identifer`

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,4 +1,4 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.0" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.0.1" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
         <requirement type="package" version="1.6.0">subread</requirement>
@@ -384,7 +384,7 @@
               label="${tool.name} on ${on_string}">
             <filter>format == "tabdel_medium"</filter>
             <actions>
-                <action name="column_names" type="metadata" default="Geneid,${alignment.name},Length" />
+                <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier},Length" />
             </actions>
         </data>
 
@@ -393,7 +393,7 @@
               label="${tool.name} on ${on_string}">
             <filter>format == "tabdel_short"</filter>
             <actions>
-                <action name="column_names" type="metadata" default="Geneid,${alignment.name}" />
+                <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier}" />
             </actions>
         </data>
 
@@ -402,7 +402,7 @@
               label="${tool.name} on ${on_string}: count table">
             <filter>format == "tabdel_full"</filter>
             <actions>
-                <action name="column_names" type="metadata" default="Geneid,Chr,Start,End,Strand,Length,${alignment.name}" />
+                <action name="column_names" type="metadata" default="Geneid,Chr,Start,End,Strand,Length,${alignment.element_identifier}" />
             </actions>
         </data>
 
@@ -411,7 +411,7 @@
               hidden="true"
               label="${tool.name} on ${on_string}: summary">
             <actions>
-                <action name="column_names" type="metadata" default="Status,${alignment.name}" />
+                <action name="column_names" type="metadata" default="Status,${alignment.element_identifier}" />
             </actions>
         </data>
 
@@ -428,7 +428,7 @@
               label="${tool.name} on ${on_string}: junction counts">
             <filter>extended_parameters['exon_exon_junction_read_counting_enabled']['count_exon_exon_junction_reads']</filter>
             <actions>
-                <action name="column_names" type="metadata" default="PrimaryGene,SecondaryGene,Site1_chr,Site1_location,Site1_strand,Site2_chr,Site2_location,Site2_strand,${alignment.name}" />
+                <action name="column_names" type="metadata" default="PrimaryGene,SecondaryGene,Site1_chr,Site1_location,Site1_strand,Site2_chr,Site2_location,Site2_strand,${alignment.element_identifier}" />
             </actions>
         </data>
     </outputs>


### PR DESCRIPTION
Metadata column names had been using `$dataset.name`. This was updated
to use the newer (and often clearer) `$dataset.element_identifier`.
Fixes #1582.