### PR TITLE
ngsutils filter: Don't rely on executable bit for python script

### DIFF
--- a/tools/ngsutils/bam_filter.xml
+++ b/tools/ngsutils/bam_filter.xml
@@ -10,7 +10,7 @@
 ## If the tool is executed with no filtering option,
 ## the default parameters simply copy over the input file
 if grep -q "\w" '${parameters}'; then
-    '$__tool_directory__/filter.py'
+    python '$__tool_directory__/filter.py'
     '$infile'
     '$outfile'
     `cat ${parameters}`;


### PR DESCRIPTION
Not all locations on our cluster support script execution.
Without this change the tool fails with:

```
tool_script.sh: line 18: /data/users/mvandenb/gx124/data/shed_tools/toolshed.g2.bx.psu.edu/repos/iuc/ngsutils_bam_filter/9b9ae5963d3c/ngsutils_bam_filter/filter.py: Permission denied
```