### PR TITLE
MEGAHIT: enable paired-end outside of paired-collection

### DIFF
--- a/tools/megahit/megahit_wrapper.xml
+++ b/tools/megahit/megahit_wrapper.xml
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool id="megahit" name="MEGAHIT" version="1.1.2.1">
-    <description>metagenomics assembly</description>
+<tool id="megahit" name="MEGAHIT" version="@VERSION@.2">
+    <description>for metagenomics assembly</description>
+    <macros>
+        <token name="@VERSION@">1.1.2</token>
+    </macros>
     <requirements>
-        <requirement type="package" version="1.1.2">megahit</requirement>
+        <requirement type="package" version="@VERSION@">megahit</requirement>
     </requirements>
     <version_command>megahit --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-
-    megahit
-
+megahit
     #if $input_option.choice == 'paired'
         -1 '${input_option.fastq_input1}'
         -2 '${input_option.fastq_input2}'
@@ -18,14 +19,12 @@
     #else
         -r '${input_option.single_files}'
     #end if
-
     ##basic assembly
     --min-count '${basic_section.min_count}'
     --k-min '${basic_section.k_min}'
     --k-max '${basic_section.k_max}'
     --k-step '${basic_section.k_step}'
     --min-contig-len '${basic_section.min_contig_len}'
-
     ##advanced assembly
     ${advanced_section.nomercy}
     --bubble-level '${advanced_section.bubble_level}'
@@ -108,7 +107,6 @@
             <output name="output" file="paired_result.fa"/>
         </test>
     </tests>
-
     <help><![CDATA[
 
 **What it does**

--- a/tools/megahit/megahit_wrapper.xml
+++ b/tools/megahit/megahit_wrapper.xml
@@ -10,6 +10,9 @@
     megahit
 
     #if $input_option.choice == 'paired'
+        -1 '${input_option.fastq_input1}'
+        -2 '${input_option.fastq_input2}'
+    #else if $input_option.choice == 'paired_collection'
         -1 ${ ','.join(['"%s"' % x.forward for x in $input_option.fastq_input1]) }
         -2 ${ ','.join(['"%s"' % x.reverse for x in $input_option.fastq_input1]) }
     #else
@@ -32,24 +35,23 @@
     --low-local-ratio '${advanced_section.low_local_ratio}'
     ${advanced_section.nolocal}
     ${advanced_section.kmin1pass}
-
-    &&
-
-    cat megahit_out/log
-
     ]]></command>
-
     <inputs>
         <conditional name="input_option">
             <param name="choice" type="select" label="Select your input option">
                 <option value="single" selected="true">Single</option>
                 <option value="paired">Paired-end</option>
+                <option value="paired_collection">Paired-end collection</option>
             </param>
-            <when value="paired">
-                <param name="fastq_input1" format="fastq,fastqsanger,fasta" type="data_collection" collection_type="list:paired" label="Select a paired collection"/>
-            </when>
             <when value="single">
-                <param name="single_files" multiple="true" format="fastq,fastqsanger,fasta" type="data" label="Single-end file(s)" help="FASTQ/FASTA/FASTQ.GZ files accepted" />
+                <param name="single_files" argument="-r" type="data" format="fastq,fastqsanger,fasta,fastq.gz,fastqsanger.gz" multiple="true" label="Single-end file(s)" help="FASTQ/FASTA/FASTQ.GZ files accepted" />
+            </when>
+            <when value="paired">
+                <param name="fastq_input1" argument="-1" type="data" format="fastq,fastqsanger,fasta,fastq.gz,fastqsanger.gz" multiple="true" label="Mate 1 input reads"/>
+                <param name="fastq_input2" argument="-2" type="data" format="fastq,fastqsanger,fasta,fastq.gz,fastqsanger.gz" multiple="true" label="Mate 2 input reads"/>
+            </when>
+            <when value="paired_collection">
+                <param name="fastq_input1" type="data_collection" format="fastq,fastqsanger,fasta,fastq.gz,fastqsanger.gz" collection_type="list:paired" label="Select a paired collection"/>
             </when>
         </conditional>
         <section name="basic_section" title="Basic assembly options" expanded="True">
@@ -84,6 +86,14 @@
         <test>
             <conditional name="input_option">
                 <param name="choice" value="paired"/>
+                <param name="fastq_input1" value="paired-fq1.fa"/>
+                <param name="fastq_input2" value="paired-fq2.fa"/>
+            </conditional>
+            <output name="output" file="paired_result.fa"/>
+        </test>
+        <test>
+            <conditional name="input_option">
+                <param name="choice" value="paired_collection"/>
                 <param name="fastq_input1">
                     <collection type="list:paired">
                         <element name="Pair1">

--- a/tools/megahit/megahit_wrapper.xml
+++ b/tools/megahit/megahit_wrapper.xml
@@ -34,6 +34,7 @@ megahit
     --low-local-ratio '${advanced_section.low_local_ratio}'
     ${advanced_section.nolocal}
     ${advanced_section.kmin1pass}
+&& cat megahit_out/log
     ]]></command>
     <inputs>
         <conditional name="input_option">


### PR DESCRIPTION
Hi,

This PR adds the possibility to run MEGAHIT on paired-end data that are not in a paired-collection.

Bérénice