### PR TITLE
MultiQC fixed misplaced brackets {}

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -279,11 +279,11 @@ mkdir multiqc_WDir &&
             mkdir $repeat_dir &&
             #if str($repeat2.type.type) == "log"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}_Log.final.out' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}_Log.final.out' &&
                 #end for
             #elif str($repeat2.type.type) == "genecounts"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}_ReadsPerGene.out.tab' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}_ReadsPerGene.out.tab' &&
                 #end for
             #end if
         #end for
@@ -300,19 +300,19 @@ mkdir multiqc_WDir &&
             mkdir $file_dir &&
             #if str($repeat2.type.type) == "relatedness2"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}.relatedness2' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}.relatedness2' &&
                 #end for
             #elif str($repeat2.type) == "tstv_by_count"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}.TsTv.count' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}.TsTv.count' &&
                 #end for
             #elif str($repeat2.type) == "tstv_by_qual"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}.TsTv.qual' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}.TsTv.qual' &&
                 #end for
             #elif str($repeat2.type) == "tstv_summary"
                 #for $file in $repeat2.type.input
-                    ln -s '$file' '${repeat_dir}/{$file.element_identifier}.TsTv.summary' &&
+                    ln -s '$file' '${repeat_dir}/${file.element_identifier}.TsTv.summary' &&
                 #end for
             #end if
         #end for


### PR DESCRIPTION
Having the brackets outside of the `$` allowed Cheetah to properly parse
the variable name, but it added the bracket characters (`{` and `}`) as
strings.