### PR TITLE
Colibread: fix symlink creation outside working dir

### DIFF
--- a/tools/colibread/discosnp_RAD.xml
+++ b/tools/colibread/discosnp_RAD.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="discosnp_rad" name="DiscoSnpRAD" version="@DISCOSNP_VERSION@">
-    <description>discovering polymorphism from raw unassembled RADSEQ NGS reads.</description>
+<tool profile="16.04" id="discosnp_rad" name="DiscoSnpRAD" version="@DISCOSNP_VERSION@.1">
+    <description>discovering polymorphism from raw unassembled RADSeq NGS reads.</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/colibread/discosnp_RAD.xml
+++ b/tools/colibread/discosnp_RAD.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="discosnp_rad" name="DiscoSnpRAD" version="@DISCOSNP_VERSION@.1">
+<tool profile="16.04" id="discosnp_rad" name="DiscoSnpRAD" version="@DISCOSNP_VERSION@">
     <description>discovering polymorphism from raw unassembled RADSeq NGS reads.</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/colibread/discosnp_pp.xml
+++ b/tools/colibread/discosnp_pp.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="discosnp_pp" name="DiscoSnp++" version="@DISCOSNP_VERSION@">
+<tool profile="16.04" id="discosnp_pp" name="DiscoSnp++" version="@DISCOSNP_VERSION@.1">
     <description>is an efficient tool for detecting SNPs without a reference genome.</description>
     <macros>
         <import>macros.xml</import>
@@ -19,7 +19,7 @@
         #end if
 
         #if str($VCF_option.mapping) == 'reference'
-            #set $reference_file = str($VCF_option.G) + "." + $VCF_option.G.ext
+            #set $reference_file = os.path.basename(str($VCF_option.G)) + "." + $VCF_option.G.ext
             ln -sf '${VCF_option.G}' '${reference_file}' &&
         #end if
 

--- a/tools/colibread/discosnp_pp.xml
+++ b/tools/colibread/discosnp_pp.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="discosnp_pp" name="DiscoSnp++" version="@DISCOSNP_VERSION@.1">
+<tool profile="16.04" id="discosnp_pp" name="DiscoSnp++" version="@DISCOSNP_VERSION@">
     <description>is an efficient tool for detecting SNPs without a reference genome.</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/colibread/kissplice.xml
+++ b/tools/colibread/kissplice.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="kissplice" name="KisSplice" version="2.4.0">
+<tool profile="16.04" id="kissplice" name="KisSplice" version="2.4.0.1">
     <description>is a local transcriptome assembler for SNPs, indels and AS events</description>
     <macros>
         <import>macros.xml</import>
@@ -14,7 +14,7 @@
         #set $samples = ""
 
         #for x in $list_reads
-            #set $filename = str($x) + "." + $x.ext
+            #set $filename = os.path.basename(str($x)) + "." + $x.ext
             ln -sf '${x}' '${filename}' &&
             #set $samples += " -r '" + $filename + "'"
         #end for

--- a/tools/colibread/kissplice.xml
+++ b/tools/colibread/kissplice.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="kissplice" name="KisSplice" version="2.4.0.1">
+<tool profile="16.04" id="kissplice" name="KisSplice" version="2.4.0">
     <description>is a local transcriptome assembler for SNPs, indels and AS events</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/colibread/macros.xml
+++ b/tools/colibread/macros.xml
@@ -9,7 +9,7 @@
 
     <token name="@discosnp_single_reads@"><![CDATA[
         #for $input in $input_type_options.list_reads
-            #set $filename = str($input) + "." + $input.ext
+            #set $filename = os.path.basename(str($input)) + "." + $input.ext
             ln -sf '${input}' '${filename}' &&
             echo '${filename}' >> input.lst &&
         #end for
@@ -18,10 +18,10 @@
     <token name="@discosnp_paired_reads@"><![CDATA[
         #for $i, $paired in enumerate( $input_type_options.list_paired_reads )
 
-            #set $filenameFWD = str($paired.forward) + "." + $paired.forward.ext
+            #set $filenameFWD = os.path.basename(str($paired.forward)) + "." + $paired.forward.ext
             ln -sf '${paired.forward}' '${filenameFWD}' &&
 
-            #set $filenameREV = str($paired.reverse) + "." + $paired.reverse.ext
+            #set $filenameREV = os.path.basename(str($paired.reverse)) + "." + $paired.reverse.ext
             ln -sf '${paired.reverse}' '${filenameREV}' &&
 
             echo '${filenameFWD}' > "paired_${i}.lst" &&

--- a/tools/colibread/mapsembler2.xml
+++ b/tools/colibread/mapsembler2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="mapsembler2" name="Mapsembler2" version="2.2.4">
+<tool profile="16.04" id="mapsembler2" name="Mapsembler2" version="2.2.4.1">
     <description>is a targeted assembly software</description>
     <macros>
         <import>macros.xml</import>
@@ -9,12 +9,12 @@
     </requirements>
     <command><![CDATA[
 
-        #set $starter_filename = str($s) + "." + $s.ext
+        #set $starter_filename = os.path.basename(str($s)) + "." + $s.ext
         ln -sf '${s}' '${starter_filename}' &&
 
         #set $samples = []
         #for $read in $r
-            #set $filename = str($read) + "." + $read.ext
+            #set $filename = os.path.basename(str($read)) + "." + $read.ext
             ln -sf '${read}' '${filename}' &&
             #silent $samples.append($filename)
         #end for

--- a/tools/colibread/mapsembler2.xml
+++ b/tools/colibread/mapsembler2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.04" id="mapsembler2" name="Mapsembler2" version="2.2.4.1">
+<tool profile="16.04" id="mapsembler2" name="Mapsembler2" version="2.2.4">
     <description>is a targeted assembly software</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/colibread/takeabreak.xml
+++ b/tools/colibread/takeabreak.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.0" id="takeabreak" name="TakeABreak" version="1.1.2">
+<tool profile="16.0" id="takeabreak" name="TakeABreak" version="1.1.2.1">
     <description>is a tool that can detect inversion breakpoints directly from raw NGS reads</description>
     <requirements>
         <requirement type="package" version="1.1.2">takeabreak</requirement>
@@ -13,7 +13,7 @@
         #if str( $input_type_option.input_type ) == "simple"
             #for $input in $input_type_option.reads
                 #if $input
-                    #set $filename = str($input)+ "." + $input.ext
+                    #set $filename = os.path.basename(str($input)) + "." + $input.ext
                     ln -sf '${input}' '${filename}' &&
                     echo "${filename}" >> input.fof &&
                 #end if
@@ -22,7 +22,7 @@
             ## if paired reads in a list
             #for $i, $list in enumerate( $input_type_option.reads_lists )
                 #for $read in $list.list_reads
-                    #set $filename = str($read) + "." + $read.ext
+                    #set $filename = os.path.basename(str($read)) + "." + $read.ext
                     ln -sf '${read}' '${filename}' &&
                     echo "${filename}" >> "indiv_${i}.fof" &&
                 #end for

--- a/tools/colibread/takeabreak.xml
+++ b/tools/colibread/takeabreak.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool profile="16.0" id="takeabreak" name="TakeABreak" version="1.1.2.1">
+<tool profile="16.0" id="takeabreak" name="TakeABreak" version="1.1.2">
     <description>is a tool that can detect inversion breakpoints directly from raw NGS reads</description>
     <requirements>
         <requirement type="package" version="1.1.2">takeabreak</requirement>


### PR DESCRIPTION
While looking at the failing test in #1600, I found out that the colibread tools are creating symlinks outside the working dir, so here's a fix for this problem
I still don't understand why the tests in #1600 failed, maybe it's related? Let's see if it goes green

ping @cmonjeau 