### PR TITLE
Fix a typo in the multiqc --version command

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -27,7 +27,7 @@
     <requirements>
        <requirement type="package" version="@WRAPPER_VERSION@">multiqc</requirement>
     </requirements>
-    <version_command>mulitqc --version</version_command>
+    <version_command>multiqc --version</version_command>
     <command detect_errors="aggressive">
 <![CDATA[
 die() { echo "$@" 1>&2 ; exit 1; } &&


### PR DESCRIPTION
Currently, it runs `mulitqc --version` rather than `multiqc --version`.