### PR TITLE
Change 'genome' to 'transcriptome'

### DIFF
--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="kallisto_pseudo" name="Kallisto pseudo" version="@VERSION@.0">
+<tool id="kallisto_pseudo" name="Kallisto pseudo" version="@VERSION@.1">
     <description>- run pseudoalignment on RNA-Seq transcripts</description>
     <macros>
         <import>macros.xml</import>
@@ -7,12 +7,12 @@
     <expand macro="requirements" />
     <command detect_errors="exit_code">
         <![CDATA[
-        #if $reference_genome.reference_genome_source == "history":
-            ln -s '$reference_genome.reference' reference.fa &&
+        #if $reference_transcriptome.reference_transcriptome_source == "history":
+            ln -s '$reference_transcriptome.reference' reference.fa &&
             kallisto index reference.fa -i reference.kallisto &&
             #set index_path = 'reference.kallisto'
         #else:
-            #set index_path = $reference_genome.index.fields.path
+            #set index_path = $reference_transcriptome.index.fields.path
         #end if
         kallisto pseudo -i '$index_path'
             #if $pseudobam:
@@ -67,23 +67,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
         </configfile>
     </configfiles>
     <inputs>
-        <conditional name="reference_genome">
-            <param name="reference_genome_source" type="select" label="Reference genome for pseudoalignment">
-                <option value="indexed" selected="true">Use a built-in genome</option>
-                <option value="history">Use a genome from history</option>
-            </param>
-            <when value="indexed">
-                <param name="index" type="select" label="Select a reference genome" help="If your genome of interest is not listed, contact your Galaxy administrator">
-                    <options from_data_table="kallisto_indexes">
-                        <filter type="sort_by" column="2" />
-                        <validator type="no_options" message="No genomes are available for the selected input dataset" />
-                    </options>
-                </param>
-            </when>
-            <when value="history">
-                <param name="reference" type="data" format="fasta" label="FASTA reference genome" />
-            </when>
-        </conditional>
+        <expand macro="reference_input" />
         <conditional name="single_paired">
             <param name="single_paired_selector" type="select" label="Single-end or paired reads">
                 <option value="single" selected="true">Single-end</option>
@@ -134,7 +118,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
     </outputs>
     <tests>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
@@ -148,7 +132,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             </output>
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="collection" />
@@ -165,7 +149,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             </output>
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="single" />
             <param name="collection_selector" value="collection" />
@@ -176,7 +160,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             </output>
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="felCat8_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
@@ -189,7 +173,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             </output>
         </test>
         <test>
-            <param name="reference_genome_source" value="cached" />
+            <param name="reference_transcriptome_source" value="cached" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
             <param name="pseudobam" value="true" />
@@ -202,7 +186,7 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             <output name="pseudobam_output" file="kallisto_pseudo_out5.bam" ftype="bam" />
         </test>
         <test>
-            <param name="reference_genome_source" value="cached" />
+            <param name="reference_transcriptome_source" value="cached" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
             <param name="umi" value="yes" />

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="kallisto_quant" name="Kallisto quant" version="@VERSION@.2">
+<tool id="kallisto_quant" name="Kallisto quant" version="@VERSION@.3">
     <description>- quantify abundances of RNA-Seq transcripts</description>
     <macros>
         <import>macros.xml</import>
@@ -7,12 +7,12 @@
     <expand macro="requirements" />
     <command detect_errors="exit_code">
         <![CDATA[
-        #if $reference_genome.reference_genome_source == "history":
-            ln -s '$reference_genome.reference' reference.fa &&
+        #if $reference_transcriptome.reference_transcriptome_source == "history":
+            ln -s '$reference_transcriptome.reference' reference.fa &&
             kallisto index reference.fa -i reference.kallisto &&
             #set index_path = 'reference.kallisto'
         #else:
-            #set index_path = $reference_genome.index.fields.path
+            #set index_path = $reference_transcriptome.index.fields.path
         #end if
         kallisto quant -i '$index_path'
             $bias --bootstrap-samples $bootstrap_samples --seed $seed $fusion $pseudobam
@@ -46,23 +46,7 @@
         ]]>
     </command>
     <inputs>
-        <conditional name="reference_genome">
-            <param name="reference_genome_source" type="select" label="Reference genome for quantification">
-                <option value="indexed" selected="true">Use a built-in genome</option>
-                <option value="history">Use a genome from history</option>
-            </param>
-            <when value="indexed">
-                <param name="index" type="select" label="Select a reference genome" help="If your genome of interest is not listed, contact your Galaxy administrator">
-                    <options from_data_table="kallisto_indexes">
-                        <filter type="sort_by" column="2" />
-                        <validator type="no_options" message="No genomes are available for the selected input dataset" />
-                    </options>
-                </param>
-            </when>
-            <when value="history">
-                <param name="reference" type="data" format="fasta" label="FASTA reference genome" />
-            </when>
-        </conditional>
+        <expand macro="reference_input" />
         <conditional name="single_paired">
             <param name="single_paired_selector" type="select" label="Single-end or paired reads">
                 <option value="single" selected="true">Single-end</option>
@@ -107,7 +91,7 @@
     </outputs>
     <tests>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
@@ -116,7 +100,7 @@
             <output name="abundance_tab" file="kallisto_quant_out1.tab" ftype="tabular" />
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="collection" />
@@ -129,7 +113,7 @@
             <output name="abundance_tab" file="kallisto_quant_out2.tab" ftype="tabular" />
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="single" />
             <param name="collection_selector" value="collection" />
@@ -137,7 +121,7 @@
             <output name="abundance_tab" file="kallisto_quant_out3.tab" ftype="tabular" />
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="felCat8_chrM.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
@@ -148,7 +132,7 @@
             <output name="pseudobam_output" file="kallisto_quant_out4.bam" ftype="bam" />
         </test>
         <test>
-            <param name="reference_genome_source" value="cached" />
+            <param name="reference_transcriptome_source" value="cached" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />
             <param name="pseudobam" value="true" />
@@ -158,7 +142,7 @@
             <output name="pseudobam_output" file="kallisto_quant_out5.bam" ftype="bam" />
         </test>
         <test>
-            <param name="reference_genome_source" value="history" />
+            <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="hg38_transcripts.fa" />
             <param name="single_paired_selector" value="paired" />
             <param name="collection_selector" value="datasets" />

--- a/tools/kallisto/macros.xml
+++ b/tools/kallisto/macros.xml
@@ -12,4 +12,23 @@
             <citation type="doi">doi:10.1038/nbt.3519</citation>
         </citations>
     </xml>
+    <xml name="reference_input">
+        <conditional name="reference_transcriptome">
+            <param name="reference_transcriptome_source" type="select" label="Reference transcriptome for quantification">
+                <option value="indexed" selected="true">Use a built-in transcriptome</option>
+                <option value="history">Use a transcriptome from history</option>
+            </param>
+            <when value="indexed">
+                <param name="index" type="select" label="Select a reference transcriptome" help="If your transcriptome of interest is not listed, contact your Galaxy administrator">
+                    <options from_data_table="kallisto_indexes">
+                        <filter type="sort_by" column="2" />
+                        <validator type="no_options" message="No transcriptomes are available for the selected input dataset" />
+                    </options>
+                </param>
+            </when>
+            <when value="history">
+                <param name="reference" type="data" format="fasta" label="FASTA reference transcriptome" />
+            </when>
+        </conditional>
+    </xml>
 </macros>


### PR DESCRIPTION
Per suggestion by @jxtx, it would be more accurate to refer to the reference input as a transcriptome.