### PR TITLE
Fix #1581, bump multiqc wrapper version

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,7 +1,7 @@
 <tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.0">
     <description>aggregate results from bioinformatics analyses into a single report</description>
     <macros>
-        <token name="@WRAPPER_VERSION@">1.2</token>
+        <token name="@WRAPPER_VERSION@">1.2.1</token>
         <token name="@LN_FILES@">
 <![CDATA[
 #for $file in $repeat.software_cond.input
@@ -107,12 +107,12 @@ mkdir multiqc_WDir &&
     #elif str($repeat.software_cond.software) == "featureCounts"
         #for $file in $repeat.software_cond.input
             #set file_prefix = $software_dir + '/' + str($file.element_identifier)
-            #if $file.metadata.column_names and $file.metadata.column_names.find(',') != -1
-                echo '$file.metadata.column_names.replace(',','\t').replace('__ob__u','').replace('u__sq__','').replace('__sq__','').replace('__cb__','')' >> '${file_prefix}.summary' &&
-                cat '$file' >> '${file_prefix}.summary' &&
-            #else
-                ln -s '$file' '${file_prefix}.summary' &&
-            #end if
+            if grep -qw Status '$file'; then
+                ln -s '$file' '${file_prefix}.summary';
+            else
+                echo -e 'Status\t$file.element_identifier' > '${file_prefix}.summary';
+                cat '$file' >> '${file_prefix}.summary';
+            fi &&
         #end for
     #elif str($repeat.software_cond.software) == "flexbar"
         #set $pattern = "flexible barcode and adapter removal"

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,7 +1,7 @@
-<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.0">
+<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.1">
     <description>aggregate results from bioinformatics analyses into a single report</description>
     <macros>
-        <token name="@WRAPPER_VERSION@">1.2.1</token>
+        <token name="@WRAPPER_VERSION@">1.2</token>
         <token name="@LN_FILES@">
 <![CDATA[
 #for $file in $repeat.software_cond.input


### PR DESCRIPTION
This primarily fixes #1581. The initial implementation of this wrapper had issues in part due to the `Status` line being stripped in the featureCounts wrapper (which is itself due to `featureCounts` not using the `element_identifier`). This PR does two things:

1. It uses the `element_identifier` if the `Status` line is empty. This respects whatever people have labeled things and plays well with dataset collections (at least in my test, since I'm using this now in our local installation).
2. If a user uploads a featureCounts summary file, then it leaves that untouched and all file names that the user originally used (outside of Galaxy) will still be displayed as normal.

Thankfully, the `featureCounts` wrapper in Galaxy doesn't run featureCounts on multiple files at once (hopefully it will never support this since it would also break the DESeq2 wrapper).