### PR TITLE
Trinity collection paired

### DIFF
--- a/tools/trinity/README.rst
+++ b/tools/trinity/README.rst
@@ -9,22 +9,22 @@ trinity requires a large amount of memory to perform the assembly: "roughly
 By default, this tool is configured to limit the memory consumption to 1G.
 You might need to lower this limit if the machine(s) executing the jobs have less memory available.
 If you have a lot of reads to assemble and a machine with enough memory, you can increase it.
-In both cases, you can set the TRINITY_MAX_MEMORY environmental variable in the destination section of the job_conf.xml file:
+In both cases, you can set the TRINITY_MAX_MEMORY environmental variable in the destination section of the job_conf.xml file::
 
-<?xml version="1.0"?>
-<!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
-<job_conf>
-    <plugins>
-        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
-    </plugins>
-    <handlers>
-        <handler id="main"/>
-    </handlers>
-    <destinations>
-        <destination id="local" runner="local">
-            <env id="TRINITY_MAX_MEMORY">1G</env>
-        </destination>
-    </destinations>
-</job_conf>
+    <?xml version="1.0"?>
+    <!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
+    <job_conf>
+        <plugins>
+            <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
+        </plugins>
+        <handlers>
+            <handler id="main"/>
+        </handlers>
+        <destinations>
+            <destination id="local" runner="local">
+                <env id="TRINITY_MAX_MEMORY">1G</env>
+            </destination>
+        </destinations>
+    </job_conf>
 
 

--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -9,6 +9,29 @@
 
     <token name="@WRAPPER_VERSION@">2.4.0</token>
 
+    <token name="@COMMAND_PAIRED_STRAND_JACCARD@">
+        #if $inputs.strand.is_strand_specific:
+            --SS_lib_type $inputs.strand.library_type
+        #end if
+
+        $inputs.jaccard_clip
+    </token>
+
+    <xml name="input_paired_strand_jaccard">
+        <conditional name="strand">
+            <param name="is_strand_specific" type="boolean" checked="false" label="Strand specific data"/>
+            <when value="false">
+            </when>
+            <when value="true">
+                <param name="library_type" argument="--SS_lib_type" type="select" label="Strand-specific Library Type">
+                    <option value="FR">Forward-Reverse</option>
+                    <option value="RF">Reverse-Forward</option>
+                </param>
+            </when>
+        </conditional>
+        <param name="jaccard_clip" argument="--jaccard_clip" type="boolean" truevalue="--jaccard_clip" falsevalue="" checked="false" label="Jaccard Clip options" help="set if you expect high gene density with UTR overlap"/>
+    </xml>
+
     <xml name="citation">
         <citations>
             <citation type="doi">10.1038/nbt.1883</citation>

--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -20,16 +20,15 @@
     <xml name="input_paired_strand_jaccard">
         <conditional name="strand">
             <param name="is_strand_specific" type="boolean" checked="false" label="Strand specific data"/>
-            <when value="false">
-            </when>
+            <when value="false" />
             <when value="true">
-                <param name="library_type" argument="--SS_lib_type" type="select" label="Strand-specific Library Type">
+                <param name="library_type" argument="--SS_lib_type" type="select" label="Strand-specific library type">
                     <option value="FR">Forward-Reverse</option>
                     <option value="RF">Reverse-Forward</option>
                 </param>
             </when>
         </conditional>
-        <param name="jaccard_clip" argument="--jaccard_clip" type="boolean" truevalue="--jaccard_clip" falsevalue="" checked="false" label="Jaccard Clip options" help="set if you expect high gene density with UTR overlap"/>
+        <param name="jaccard_clip" argument="--jaccard_clip" type="boolean" truevalue="--jaccard_clip" falsevalue="" checked="false" label="Jaccard Clip options" help="Set if you expect high gene density with UTR overlap"/>
     </xml>
 
     <xml name="citation">

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -20,11 +20,7 @@
                 --seqType fq
             #end if
 
-            #if $inputs.strand.is_strand_specific:
-                --SS_lib_type $inputs.strand.library_type
-            #end if
-
-            $inputs.jaccard_clip
+            @COMMAND_PAIRED_STRAND_JACCARD@
 
         #elif $readtype.single_or_paired == "collection"
             --left ${ ','.join(['"%s"' % x for x in $inputs.fastq_pair.forward]) }
@@ -37,11 +33,7 @@
                 --seqType fq
             #end if
 
-            #if $inputs.strand.is_strand_specific:
-                --SS_lib_type $inputs.strand.library_type
-            #end if
-
-            $inputs.jaccard_clip
+            @COMMAND_PAIRED_STRAND_JACCARD@
 
         #else:
             --single ${ ','.join(['"%s"' % x for x in $inputs.input]) }
@@ -98,18 +90,7 @@
             <when value="paired">
                 <param format="fasta,fastqsanger" argument="--left" name="left_input" multiple="true" type="data" label="Left/Forward strand reads" help=""/>
                 <param format="fasta,fastqsanger" argument="--right" name="right_input" multiple="true" type="data" label="Right/Reverse strand reads" help=""/>
-                <conditional name="strand">
-                    <param name="is_strand_specific" type="boolean" checked="false" label="Strand specific data"/>
-                    <when value="false">
-                    </when>
-                    <when value="true">
-                        <param name="library_type" argument="--SS_lib_type" type="select" label="Strand-specific Library Type">
-                            <option value="FR">Forward-Reverse</option>
-                            <option value="RF">Reverse-Forward</option>
-                        </param>
-                    </when>
-                </conditional>
-                <param name="jaccard_clip" argument="--jaccard_clip" type="boolean" truevalue="--jaccard_clip" falsevalue="" checked="false" label="Jaccard Clip options" help="set if you expect high gene density with UTR overlap"/>
+                <expand macro="input_paired_strand_jaccard" />
             </when>
             <when value="single">
                 <param format="fasta,fastqsanger" name="input" argument="--single" multiple="true" type="data" label="Single-end reads" help=""/>
@@ -126,7 +107,8 @@
                 </conditional>
             </when>
             <when value="collection">
-              <param name="fastq_pair" format="fasta,fastqsanger" type="data_collection" collection_type="paired" label="Select FASTQ dataset collection with R1/R2 pair" />
+               <param format="fasta,fastqsanger" name="fastq_pair" type="data_collection" collection_type="paired" label="Select FASTQ dataset collection with R1/R2 pair" />
+               <expand macro="input_paired_strand_jaccard" />
             </when>
         </conditional>
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -22,12 +22,12 @@
 
             @COMMAND_PAIRED_STRAND_JACCARD@
 
-        #elif $readtype.single_or_paired == "collection"
-            --left ${ ','.join(['"%s"' % x for x in $inputs.fastq_pair.forward]) }
+        #elif $inputs.paired_or_single == "collection"
+            --left ${ ','.join(['"%s"' % x.forward for x in $inputs.pair_input]) }
 
-            --right ${ ','.join(['"%s"' % x for x in $inputs.fastq_pair.reverse]) }
+            --right ${ ','.join(['"%s"' % x.reverse for x in $inputs.pair_input]) }
 
-            #if $inputs.fastq_pair[0].forward.is_of_type('fasta'):
+            #if $inputs.pair_input[0].forward.is_of_type('fasta'):
                 --seqType fa
             #else:
                 --seqType fq
@@ -107,7 +107,7 @@
                 </conditional>
             </when>
             <when value="collection">
-               <param format="fasta,fastqsanger" name="fastq_pair" type="data_collection" collection_type="paired" label="Select FASTQ dataset collection with R1/R2 pair" />
+               <param format="fasta,fastqsanger" name="pair_input" type="data_collection" collection_type="list:paired" label="Select FASTQ dataset collection with R1/R2 pair" />
                <expand macro="input_paired_strand_jaccard" />
             </when>
         </conditional>
@@ -161,16 +161,20 @@
         </test>
         <test>
             <param name="paired_or_single" value="collection"/>
-            <param name="fastq_pair">
-              <collection type="paired">
-                <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
-                <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
-              </collection>
+            <param name="pair_input">
+                <collection type="list:paired">
+                    <element name="Pair1">
+                        <collection type="paired">
+                            <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
+                            <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
+                        </collection>
+                    </element>
+                </collection>
             </param>
             <param name="is_strand_specific" value="true"/>
             <param name="norm" value="false"/>
             <param name="library_type" value="RF"/>
-            <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
+            <output name="assembled_transcripts" file="raw/Trinity.fasta" compare="sim_size" delta="500" />
         </test>
     </tests>
     <help>

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -22,7 +22,7 @@
 
             @COMMAND_PAIRED_STRAND_JACCARD@
 
-        #elif $inputs.paired_or_single == "collection"
+        #elif $inputs.paired_or_single == "paired_collection"
             --left ${ ','.join(['"%s"' % x.forward for x in $inputs.pair_input]) }
 
             --right ${ ','.join(['"%s"' % x.reverse for x in $inputs.pair_input]) }
@@ -83,17 +83,12 @@
     <inputs>
         <conditional name="inputs">
             <param name="paired_or_single" type="select" label="Paired or Single-end data?">
-                <option value="paired">Paired (two separate input files)</option>
-                <option value="single">Single</option>
-                <option value="collection">Paired (as collection)</option>
+                <option value="single">Single-end</option>
+                <option value="paired" selected="true">Paired-end</option>
+                <option value="paired_collection">Paired-end collection</option>
             </param>
-            <when value="paired">
-                <param format="fasta,fastqsanger" argument="--left" name="left_input" multiple="true" type="data" label="Left/Forward strand reads" help=""/>
-                <param format="fasta,fastqsanger" argument="--right" name="right_input" multiple="true" type="data" label="Right/Reverse strand reads" help=""/>
-                <expand macro="input_paired_strand_jaccard" />
-            </when>
             <when value="single">
-                <param format="fasta,fastqsanger" name="input" argument="--single" multiple="true" type="data" label="Single-end reads" help=""/>
+                <param name="input" argument="--single" type="data" format="fasta,fastqsanger" multiple="true" label="Single-end reads" help=""/>
                 <conditional name="strand">
                     <param name="is_strand_specific" type="boolean" checked="false" label="Strand specific data"/>
                     <when value="false">
@@ -106,9 +101,14 @@
                     </when>
                 </conditional>
             </when>
-            <when value="collection">
-               <param format="fasta,fastqsanger" name="pair_input" type="data_collection" collection_type="list:paired" label="fastq/fasta dataset collection with R1/R2 pair" help="Can be lists of pair dataset collection"/>
-               <expand macro="input_paired_strand_jaccard" />
+            <when value="paired">
+                <param name="left_input" argument="--left" type="data" format="fasta,fastqsanger" multiple="true" label="Left/Forward strand reads" />
+                <param name="right_input" argument="--right" type="data" format="fasta,fastqsanger" multiple="true" label="Right/Reverse strand reads" />
+                <expand macro="input_paired_strand_jaccard" />
+            </when>
+            <when value="paired_collection">
+                <param name="pair_input" type="data_collection" collection_type="list:paired" format="fasta,fastqsanger" label="FASTA/FASTQ dataset collection with R1/R2 pair" help="Can be lists of pair dataset collection"/>
+                <expand macro="input_paired_strand_jaccard" />
             </when>
         </conditional>
 
@@ -125,20 +125,19 @@
                 <when value="no">
                 </when>
                 <when value="yes">
-                    <param format="bam" name="genome_guided_bam" argument="--genome_guided_bam" type="data" label="Coordinate-sorted BAM file" />
+                    <param name="genome_guided_bam" argument="--genome_guided_bam" type="data" format="bam" label="Coordinate-sorted BAM file" />
                     <param name="genome_guided_min_coverage" argument="--genome_guided_min_coverage" type="integer" optional="true" value="1" min="1" label="Minimum read coverage for identifying an expressed region of the genome"/>
                     <param name="genome_guided_min_reads_per_partition" argument="--genome_guided_min_reads_per_partition" type="integer" optional="true" value="10" min="1" label="Minimum number of reads per partition"/>
                 </when>
             </conditional>
 
-            <param format="fasta" name="long_reads" argument="--long_reads" type="data" optional="true" label="Error-corrected or circular consensus (CCS) pac bio reads" help="Experimental feature! Long reads must be in the same orientation as short reads if they are strand specific"/>
+            <param name="long_reads" argument="--long_reads" type="data" format="fasta" optional="true" label="Error-corrected or circular consensus (CCS) pac bio reads" help="Experimental feature! Long reads must be in the same orientation as short reads if they are strand specific"/>
 
             <param name="min_kmer_cov" argument="--min_kmer_cov" type="integer" optional="true" value="1" min="1" label="Minimum count for K-mers to be assembled"/>
         </section>
     </inputs>
     <outputs>
-        <!--data format="txt" name="trinity_log" label="${tool.name} on ${on_string}: log" /-->
-        <data format="fasta" name="assembled_transcripts" label="${tool.name} on ${on_string}: Assembled Transcripts" from_work_dir="trinity_out_dir/Trinity.fasta"/>
+        <data name="assembled_transcripts" format="fasta" label="${tool.name} on ${on_string}: Assembled Transcripts" from_work_dir="trinity_out_dir/Trinity.fasta"/>
     </outputs>
     <tests>
         <test>
@@ -160,16 +159,16 @@
             <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
         </test>
         <test>
-            <param name="paired_or_single" value="collection"/>
+            <param name="paired_or_single" value="paired_collection"/>
             <param name="pair_input">
                 <collection type="list:paired">
-                    <element name="Pair1">
+                    <element name="pair1">
                         <collection type="paired">
                             <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
                             <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
                         </collection>
                     </element>
-                    <element name="Pair2">
+                    <element name="pair2">
                         <collection type="paired">
                             <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
                             <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
@@ -178,15 +177,15 @@
                 </collection>
             </param>
             <param name="is_strand_specific" value="true"/>
-            <param name="norm" value="yes"/>
+            <param name="norm" value="true"/>
             <param name="library_type" value="RF"/>
             <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
         </test>
     </tests>
     <help>
-        Trinity_ assembles transcript sequences from Illumina RNA-Seq data.
+Trinity_ assembles transcript sequences from Illumina RNA-Seq data.
 
-        .. _Trinity: http://trinityrnaseq.github.io
+.. _Trinity: http://trinityrnaseq.github.io
     </help>
 
     <expand macro="citation" />

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -83,9 +83,9 @@
     <inputs>
         <conditional name="inputs">
             <param name="paired_or_single" type="select" label="Paired or Single-end data?">
-                <option value="paired">Paired</option>
+                <option value="paired">Paired (two separate input files)</option>
                 <option value="single">Single</option>
-                <option value="collection">Paired-end (as collection)</option>
+                <option value="collection">Paired (as collection)</option>
             </param>
             <when value="paired">
                 <param format="fasta,fastqsanger" argument="--left" name="left_input" multiple="true" type="data" label="Left/Forward strand reads" help=""/>
@@ -107,7 +107,7 @@
                 </conditional>
             </when>
             <when value="collection">
-               <param format="fasta,fastqsanger" name="pair_input" type="data_collection" collection_type="list:paired" label="Select FASTQ dataset collection with R1/R2 pair" />
+               <param format="fasta,fastqsanger" name="pair_input" type="data_collection" collection_type="list:paired" label="fastq/fasta dataset collection with R1/R2 pair" help="Can be lists of pair dataset collection"/>
                <expand macro="input_paired_strand_jaccard" />
             </when>
         </conditional>
@@ -169,12 +169,18 @@
                             <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
                         </collection>
                     </element>
+                    <element name="Pair2">
+                        <collection type="paired">
+                            <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
+                            <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
+                        </collection>
+                    </element>
                 </collection>
             </param>
             <param name="is_strand_specific" value="true"/>
-            <param name="norm" value="false"/>
+            <param name="norm" value="yes"/>
             <param name="library_type" value="RF"/>
-            <output name="assembled_transcripts" file="raw/Trinity.fasta" compare="sim_size" delta="500" />
+            <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
         </test>
     </tests>
     <help>

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -1,4 +1,4 @@
-<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@.0">
+<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@.1">
     <description>de novo assembly of RNA-Seq data</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -76,6 +76,7 @@
             <param name="paired_or_single" type="select" label="Paired or Single-end data?">
                 <option value="paired">Paired</option>
                 <option value="single">Single</option>
+                <option value="collection">Paired-end (as collection)</option>
             </param>
             <when value="paired">
                 <param format="fasta,fastqsanger" argument="--left" name="left_input" multiple="true" type="data" label="Left/Forward strand reads" help=""/>
@@ -106,6 +107,9 @@
                         </param>
                     </when>
                 </conditional>
+            </when>
+            <when value="collection">
+              <param name="fastq_pair" format="fasta,fastqsanger" type="data_collection" collection_type="paired" label="Select FASTQ dataset collection with R1/R2 pair" />
             </when>
         </conditional>
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -26,6 +26,23 @@
 
             $inputs.jaccard_clip
 
+        #elif $readtype.single_or_paired == "collection"
+            --left ${ ','.join(['"%s"' % x for x in $inputs.fastq_pair.forward]) }
+
+            --right ${ ','.join(['"%s"' % x for x in $inputs.fastq_pair.reverse]) }
+
+            #if $inputs.fastq_pair[0].forward.is_of_type('fasta'):
+                --seqType fa
+            #else:
+                --seqType fq
+            #end if
+
+            #if $inputs.strand.is_strand_specific:
+                --SS_lib_type $inputs.strand.library_type
+            #end if
+
+            $inputs.jaccard_clip
+
         #else:
             --single ${ ','.join(['"%s"' % x for x in $inputs.input]) }
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -156,6 +156,19 @@
             <param name="library_type" value="RF"/>
             <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
         </test>
+        <test>
+            <param name="paired_or_single" value="collection"/>
+            <param name="fastq_pair">
+              <collection type="paired">
+                <element name="forward" value="reads.left.fq" ftype="fastqsanger" />
+                <element name="reverse" value="reads.right.fq" ftype="fastqsanger"/>
+              </collection>
+            </param>
+            <param name="is_strand_specific" value="true"/>
+            <param name="norm" value="false"/>
+            <param name="library_type" value="RF"/>
+            <output name="assembled_transcripts" file="norm/Trinity.fasta" compare="sim_size" delta="500" />
+        </test>
     </tests>
     <help>
         Trinity_ assembles transcript sequences from Illumina RNA-Seq data.


### PR DESCRIPTION
Those commits will allow Trinity to support Dataset Collections of the type list of pair as Trimmomatic, bowtie2 ...

I'm aware of those 2 ongoing PR : https://github.com/galaxyproject/tools-iuc/pull/1620 and  https://github.com/galaxyproject/tools-iuc/pull/1557 and with the issue with conda https://github.com/conda/conda/issues/5536#issuecomment-350067404. But I was not sure to get spare time at the moment when those PR will be merged. So sure, at some point, I will resolve the conflict :)

In my point of view, the next move will be to handle some `.gz`?
