### PR TITLE
Update some dependencies of Trinity tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ install:
   - pip install planemo
   - planemo conda_init
   - export PATH="$PLANEMO_CONDA_PREFIX/bin:$PATH"
+  - conda install -y conda=4.3.30
   - planemo --version
   - conda --version
   - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?

--- a/tools/trinity/abundance_estimates_to_matrix.xml
+++ b/tools/trinity/abundance_estimates_to_matrix.xml
@@ -1,12 +1,11 @@
-<tool id="trinity_abundance_estimates_to_matrix" name="Build expression matrix" version="@WRAPPER_VERSION@.1">
+<tool id="trinity_abundance_estimates_to_matrix" name="Build expression matrix" version="@WRAPPER_VERSION@.2">
     <description>for a de novo assembly of RNA-Seq data by Trinity</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="3.16.5">bioconductor-edger</requirement>
-        <!-- Cannot update to salmon 0.8.2 because in Bioconda it requires icu 58, while r-base 3.3.1 requires icu 54 -->
-        <requirement type="package" version="0.8.1">salmon</requirement>
+        <requirement type="package" version="3.20.1">bioconductor-edger</requirement>
+        <requirement type="package" version="0.9.1">salmon</requirement>
         <requirement type="package" version="0.43.1">kallisto</requirement>
     </expand>
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/trinity/align_and_estimate_abundance.xml
+++ b/tools/trinity/align_and_estimate_abundance.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_align_and_estimate_abundance" name="Align reads and estimate abundance" version="@WRAPPER_VERSION@.2">
+<tool id="trinity_align_and_estimate_abundance" name="Align reads and estimate abundance" version="@WRAPPER_VERSION@.3">
     <description>on a de novo assembly of RNA-Seq data</description>
     <macros>
         <import>macros.xml</import>
@@ -6,8 +6,7 @@
     <expand macro="requirements">
         <requirement type="package" version="1.3.0">rsem</requirement>
         <requirement type="package" version="1.5.1">express</requirement>
-        <!-- Cannot update to salmon 0.8.2 because in Bioconda it requires icu 58, while r-base 3.3.1 requires icu 54 -->
-        <requirement type="package" version="0.8.1">salmon</requirement>
+        <requirement type="package" version="0.9.1">salmon</requirement>
         <requirement type="package" version="0.43.1">kallisto</requirement>
     </expand>
     <command detect_errors="aggressive"><![CDATA[


### PR DESCRIPTION
This forces Conda to choose packages depending on r-base 3.4.1, which resolves 2 problems:
- the conda solver got stuck
- some old r-3.3.1 builds were not built with conda-build>2.0