### PR TITLE
Fix output type for compressed BCF

### DIFF
--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -254,7 +254,7 @@ $vcfs_list_file
   <xml name="macro_vcf_output">
       <data name="output_file" format="vcf">
         <change_format>
-          <when input="output_type" value="b" format="bcf" />
+          <when input="output_type" value="b" format="bcf_bgzip" />
           <when input="output_type" value="u" format="bcf" />
           <when input="output_type" value="z" format="vcf_bgzip" />
           <when input="output_type" value="v" format="vcf" />


### PR DESCRIPTION
Change format for compressed BCF to its corresponding extension of 'bcf_bgzip' Otherwise, you cannot output a compressed BCF at all.