### PR TITLE
bwa: added a regular expression to stdio

### DIFF
--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -45,6 +45,7 @@
             <exit_code range=":-1" />
             <regex match="Error:" />
             <regex match="Exception:" />
+            <regex match="[bns_restore_core] Parse error reading" />
         </stdio>
     </xml>
 

--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -45,7 +45,7 @@
             <exit_code range=":-1" />
             <regex match="Error:" />
             <regex match="Exception:" />
-            <regex match="[bns_restore_core] Parse error reading" />
+            <regex match="\[bns_restore_core\] Parse error reading" />
         </stdio>
     </xml>
 


### PR DESCRIPTION
This happens when unexpected input is provided. For instance a fa.tar file is used (I also read that spaces in the sequence may cause this message).