### PR TITLE
Featurecount: Add output option to keep header

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -24,13 +24,13 @@
             -s  $extended_parameters.strand_specificity
                 $extended_parameters.multimapping_enabled.multimapping_counts
 
-                #if str($extended_parameters.multimapping_enabled.multimapping_counts) == " -M"
+                #if str($extended_parameters.multimapping_enabled.multimapping_counts) == " -M":
                     $extended_parameters.multimapping_enabled.fraction
                 #end if
 
                 $extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads
-                #if str($extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads) == "-J"
-                    #if $extended_parameters.exon_exon_junction_read_counting_enabled.genome
+                #if str($extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads) == "-J":
+                    #if $extended_parameters.exon_exon_junction_read_counting_enabled.genome:
                         -G '$extended_parameters.exon_exon_junction_read_counting_enabled.genome'
                     #end if
                 #end if
@@ -48,18 +48,18 @@
                 $extended_parameters.primary
                 $extended_parameters.ignore_dup
 
-                #if str($extended_parameters.read_extension_5p) != "0"
+                #if str($extended_parameters.read_extension_5p) != "0":
                     --readExtension5 $extended_parameters.read_extension_5p
                 #end if
 
-                #if str($extended_parameters.read_extension_3p) != "0"
+                #if str($extended_parameters.read_extension_3p) != "0":
                     --readExtension3 $extended_parameters.read_extension_3p
                 #end if
 
                 $pe_parameters.fragment_counting_enabled.fragment_counting
-                #if str($pe_parameters.fragment_counting_enabled.fragment_counting) == " -p"
+                #if str($pe_parameters.fragment_counting_enabled.fragment_counting) == " -p":
                     $pe_parameters.fragment_counting_enabled.check_distance_enabled.check_distance
-                    #if str($pe_parameters.fragment_counting_enabled.check_distance_enabled.check_distance) == " -P"
+                    #if str($pe_parameters.fragment_counting_enabled.check_distance_enabled.check_distance) == " -P":
                         -d $pe_parameters.fragment_counting_enabled.check_distance_enabled.minimum_fragment_length
                         -D $pe_parameters.fragment_counting_enabled.check_distance_enabled.maximum_fragment_length
                     #end if
@@ -70,11 +70,16 @@
 
         '${alignment}'
 
-        ## Removal of comment and column-header line
-        && grep -v "^#" "output" | tail -n+2 > body.txt
-
+        ## Removal of comment 
+        && grep -v "^#" "output"
+        
+        #if $format.value == "tabdel_short_noheader":
+            ## and remove column-header line
+            | tail -n+2
+        #end if
+        > body.txt
         ## Set the right columns for the tabular formats
-        #if $format.value == "tabdel_medium"
+        #if $format.value == "tabdel_medium":
             && cut -f 1,7 body.txt > expression_matrix.txt
 
             ## Paste doesn't allow a non ordered list of columns: -f 1,7,8,6 will only return columns 1,7 and 8
@@ -82,23 +87,29 @@
             && cut -f 6 body.txt > gene_lengths.txt
             && paste expression_matrix.txt gene_lengths.txt > expression_matrix.txt.bak
             && mv -f expression_matrix.txt.bak '${output_medium}'
-        #elif $format.value == "tabdel_short"
+        #elif $format.value == "tabdel_short" or $format.value == "tabdel_short_noheader":
             && cut -f 1,7 body.txt > '${output_short}'
-        #else
+        #else:
             && cp body.txt '${output_full}'
         #end if
 
-
-        #if str($include_feature_length_file) == "true"
+        #if str($include_feature_length_file) == "true":
             && cut -f 1,6 body.txt > '${output_feature_lengths}'
         #end if
 
-        #if str($extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads) == "-J"
-            && tail -n+2 'output.jcounts' > '${output_jcounts}'
+        #if str($extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads) == "-J":
+            #if $format.value == "tabdel_short_noheader":
+              && tail -n+2 'output.jcounts' > '${output_jcounts}'
+            #else:
+              && mv 'output.jcounts' '${output_jcounts}'
+            #end if
         #end if
 
-        && tail -n+2 'output.summary' > '${output_summary}'
-
+        #if $format.value == "tabdel_short_noheader":
+            && tail -n+2 'output.summary' > '${output_summary}'
+        #else:
+            && mv 'output.summary' '${output_summary}'
+        #end if
     ]]></command>
     <inputs>
         <param name="alignment"
@@ -134,7 +145,8 @@
                type="select"
                label="Output format"
                help="The output format will be tabular, select the preferred columns here">
-            <option value="tabdel_short" selected="true">Gene-ID "\t" read-count (DESeq2 IUC wrapper compatible)</option>
+            <option value="tabdel_short_noheader" selected="true">Gene-ID "\t" read-count (DESeq2 IUC wrapper compatible)</option>
+            <option value="tabdel_short">Gene-ID "\t" read-count (MultiQC compatible, includes header in output)</option>
             <option value="tabdel_medium">Gene-ID "\t" read-count "\t" gene-length</option>
             <option value="tabdel_full">featureCounts 1.4.0+ default (includes regions provided by the GTF file)</option>
         </param>
@@ -391,7 +403,7 @@
         <data format="tabular"
               name="output_short"
               label="${tool.name} on ${on_string}">
-            <filter>format == "tabdel_short"</filter>
+            <filter>format == "tabdel_short_noheader" or format == "tabdel_short"</filter>
             <actions>
                 <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier}" />
             </actions>
@@ -436,7 +448,7 @@
         <test expect_num_outputs="4">
             <param name="alignment" value="featureCounts_input1.bam" ftype="bam" />
             <param name="reference_gene_sets" value="featureCounts_guide.gff" ftype="gff" />
-            <param name="format" value="tabdel_short" />
+            <param name="format" value="tabdel_short_noheader" />
             <param name="include_feature_length_file" value="true"/>
             <param name="ref_source" value="history" />
             <param name="count_exon_exon_junction_reads" value="-J"/>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -73,9 +73,12 @@
         ## Removal of comment 
         && grep -v "^#" "output"
         
-        #if $format.value == "tabdel_short_noheader":
+        #if $format.value != "tabdel_short":
             ## and remove column-header line
             | tail -n+2
+        #else
+            ## update header
+            | sed --expression='s|${alignment}|${alignment.element_identifier}|g'
         #end if
         > body.txt
         ## Set the right columns for the tabular formats
@@ -98,17 +101,18 @@
         #end if
 
         #if str($extended_parameters.exon_exon_junction_read_counting_enabled.count_exon_exon_junction_reads) == "-J":
-            #if $format.value == "tabdel_short_noheader":
+            #if $format.value != "tabdel_short":
               && tail -n+2 'output.jcounts' > '${output_jcounts}'
             #else:
-              && mv 'output.jcounts' '${output_jcounts}'
+              
+              && sed --expression='s|${alignment}|${alignment.element_identifier}|g' 'output.jcounts' > '${output_jcounts}'
             #end if
         #end if
 
-        #if $format.value == "tabdel_short_noheader":
+        #if $format.value != "tabdel_short":
             && tail -n+2 'output.summary' > '${output_summary}'
         #else:
-            && mv 'output.summary' '${output_summary}'
+            && sed --expression='s|${alignment}|${alignment.element_identifier}|g' 'output.summary' > '${output_summary}'
         #end if
     ]]></command>
     <inputs>
@@ -440,7 +444,8 @@
               label="${tool.name} on ${on_string}: junction counts">
             <filter>extended_parameters['exon_exon_junction_read_counting_enabled']['count_exon_exon_junction_reads']</filter>
             <actions>
-                <action name="column_names" type="metadata" default="PrimaryGene,SecondaryGene,Site1_chr,Site1_location,Site1_strand,Site2_chr,Site2_location,Site2_strand,${alignment.element_identifier}" />
+                <action name="column_names" type="metadata" 
+                    default="PrimaryGene,SecondaryGene,Site1_chr,Site1_location,Site1_strand,Site2_chr,Site2_location,Site2_strand,${alignment.element_identifier}" />
             </actions>
         </data>
     </outputs>
@@ -491,7 +496,23 @@
                 <metadata name="column_names" value="Feature,Length"/>
             </output>
         </test>
-
+        <test expect_num_outputs="4">
+            <param name="alignment" value="featureCounts_input1.bam" ftype="bam" />
+            <param name="reference_gene_sets" value="featureCounts_guide.gff" ftype="gff" />
+            <param name="format" value="tabdel_short" />
+            <param name="include_feature_length_file" value="true"/>
+            <param name="ref_source" value="history" />
+            <param name="count_exon_exon_junction_reads" value="-J"/>
+            <output name="output_short" file="output_1_short_with_header.tab">
+                <metadata name="column_names" value="Geneid,featureCounts_input1.bam"/>
+            </output>
+            <output name="output_summary" file="output_1_summary_with_header.tab">
+                <metadata name="column_names" value="Status,featureCounts_input1.bam"/>
+            </output>
+            <output name="output_jcounts" file="output_1_jcounts_with_header.tab">
+                <metadata name="column_names" value="PrimaryGene,SecondaryGene,Site1_chr,Site1_location,Site1_strand,Site2_chr,Site2_location,Site2_strand,featureCounts_input1.bam"/>
+            </output>
+        </test>
     </tests>
 
     <help><![CDATA[

--- a/tools/featurecounts/test-data/output_1_jcounts_with_header.tab
+++ b/tools/featurecounts/test-data/output_1_jcounts_with_header.tab
@@ -1,0 +1,1 @@
+PrimaryGene	SecondaryGenes	Site1_chr	Site1_location	Site1_strand	Site2_chr	Site2_location	Site2_strand	featureCounts_input1.bam

--- a/tools/featurecounts/test-data/output_1_short_with_header.tab
+++ b/tools/featurecounts/test-data/output_1_short_with_header.tab
@@ -1,0 +1,3 @@
+Geneid	featureCounts_input1.bam
+left	92
+right	66

--- a/tools/featurecounts/test-data/output_1_summary_with_header.tab
+++ b/tools/featurecounts/test-data/output_1_summary_with_header.tab
@@ -1,0 +1,13 @@
+Status	featureCounts_input1.bam
+Assigned	158
+Unassigned_Unmapped	0
+Unassigned_MappingQuality	0
+Unassigned_Chimera	0
+Unassigned_FragmentLength	0
+Unassigned_Duplicate	0
+Unassigned_MultiMapping	0
+Unassigned_Secondary	0
+Unassigned_Nonjunction	0
+Unassigned_NoFeatures	6078
+Unassigned_Overlapping_Length	0
+Unassigned_Ambiguity	0


### PR DESCRIPTION
For e.g. multiqc we need the column header in the output. However, in the current state this is always stripped. This adds another option to the output to keep it in.