### PR TITLE
macs2: modify inputs, outputs, help and add r-base 3.4 as requirement

### DIFF
--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_callpeak" name="MACS2 callpeak" version="@VERSION_STRING@.0">
+<tool id="macs2_callpeak" name="MACS2 callpeak" version="@VERSION_STRING@.1">
     <description>Call peaks from alignment results</description>
     <macros>
         <import>macs2_macros.xml</import>
@@ -7,25 +7,42 @@
     </expand>
     <expand macro="stdio" />
     <expand macro="version_command" />
-    <command>
-        <![CDATA[
+    <command><![CDATA[
         #set $temp_stderr = 'macs2_stderr'
         (macs2 callpeak
 
             --name 'MACS2'
-            -t ${ ' '.join( map( lambda x:'"%s"' % ( x ), $input_treatment_file ) ) }
 
-            #if str( $input_control_file ) != 'None':
-                -c ${ ' '.join( map( lambda x:'"%s"' % ( x ), $input_control_file ) ) }
-            #end if
+            ## Treatment File(s)
 
-        #for $ifile in $input_treatment_file:
-            #if $ifile.ext.upper() == "BAM" and $bampe:
-                --format BAMPE
+            #if str($treatment.t_multi_select) == "Yes":
+                -t ${ ' '.join( map( lambda x:'"%s"' % ( x ), '$treatment.input_treatment_file' ) ) }
+
+                #if '$treatment.input_treatment_file[0].ext.upper()' == "BAM" and $bampe:
+                    --format BAMPE
+                #else
+                    --format='$treatment.input_treatment_file[0].ext.upper()'
+                #end if
+
             #else
-                --format='$ifile.ext.upper()'
+                -t '$treatment.input_treatment_file'
+
+                #if '$treatment.input_treatment_file.ext.upper()' == "BAM" and $bampe:
+                    --format BAMPE
+                #else
+                    --format='$treatment.input_treatment_file.ext.upper()'
+                #end if
             #end if
-        #end for
+
+            ## Control File(s)
+
+            #if str($control.c_select) == "Yes":
+                #if str($control.c_multiple.c_multi_select) == "Yes":
+                    -c ${ ' '.join( map( lambda x:'"%s"' % ( x ), '$control.c_multiple.input_control_file' ) ) }
+                #else
+                    -c '$control.c_multiple.input_control_file'
+                #end if
+            #end if
 
         @effective_genome_size@
 
@@ -42,7 +59,7 @@
             #if $advanced_options.broad_options.broad_options_selector == "broad":
                 --broad
                 --broad-cutoff='${ advanced_options.broad_options.broad_cutoff }'
-            #else:
+            #else
                 $advanced_options.broad_options.call_summits
             #end if
 
@@ -104,13 +121,42 @@
         exit_code_for_galaxy=\$? &&
         cat $temp_stderr 2>&1 &&
         (exit \$exit_code_for_galaxy)
-        ]]>
-    </command>
+    ]]></command>
     <inputs>
-        <param name="input_treatment_file" type="data" format="bam,sam,bed" multiple="true"
-               label="ChIP-Seq Treatment File" />
-        <param name="input_control_file" type="data" format="bam,sam,bed" multiple="true" optional="True"
-               label="ChIP-Seq Control File" />
+        <conditional name="treatment">
+            <param name="t_multi_select" type="select" label="Are you pooling Treatment Files?" help="For more information, see Help section below" >
+                <option value="No" selected="True">No</option>
+                <option value="Yes">Yes</option>
+            </param>
+            <when value="No" >
+                <param name="input_treatment_file" argument="-t" type="data" format="bam,sam,bed" label="ChIP-Seq Treatment File" />
+            </when>
+            <when value="Yes">
+                <param name="input_treatment_file" argument="-t" type="data" format="bam,sam,bed" multiple="true" label="ChIP-Seq Treatment File" />
+            </when>
+        </conditional>
+
+        <conditional name="control">
+            <param name="c_select" type="select" label="Do you have a Control File?" >
+                <option value="Yes" selected="True">Yes</option>
+                <option value="No">No</option>
+            </param>
+            <when value="Yes">
+                <conditional name="c_multiple">
+                    <param name="c_multi_select" type="select" label="Are you pooling Control Files?" help="For more information, see Help section below" >
+                        <option value="No" selected="True">No</option>
+                        <option value="Yes">Yes</option>
+                    </param>
+                    <when value="No" >
+                        <param name="input_control_file" argument="-c" type="data" format="bam,sam,bed" label="ChIP-Seq Control File" />
+                    </when>
+                    <when value="Yes">
+                        <param name="input_control_file" argument="-c" type="data" format="bam,sam,bed" multiple="true" label="ChIP-Seq Control File" />
+                    </when>
+                </conditional>
+            </when>
+            <when value="No" />
+        </conditional>
 
         <param name="bampe" type="boolean" truevalue="--format BAMPE" falsevalue="" checked="False"
                label="Are your inputs Paired-end BAM files?"
@@ -141,20 +187,20 @@
             <when value="create_model"/>
             <when value="nomodel">
                 <param name="extsize" type="integer" value="200" label="Set extension size" help="The arbitrary extension size in bp. When nomodel is true, MACS will use this value as fragment size to extend each read towards 3-prime; end, then pile them up. It is exactly twice the number of obsolete SHIFTSIZE. In previous language, each read is moved 5-prime-to-3-prime direction to middle of fragment by 0.5 d, then extended to both direction with 0.5 d. This is equivalent to say each read is extended towards 5-prime-to-3-prime into a d size fragment. --extsize (this option) and --shift (the option below) can be combined when necessary. See --shift option below. Default = 200 (--extsize)."/>
-                <param name="shift" type="integer" value="0" label="Set shift size" help="(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion while setting it other than default value. When NOMODEL is set, MACS will use this value to move cutting ends (5-prime) towards 5-prime-to-3-prime  direction then apply EXTSIZE to extend them to fragments. When this value is negative, ends will be moved toward 3-prime-to-5-prime  direction. Recommended to keep it as default 0 for ChIP-Seq datasets, or -1 * 0.5 of --extsize (option above) together with --extsize option for detecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you can't set values other than 0 if format is BAMPE for paired-end data. Default = 0 (--shift)."/>
+                <param name="shift" type="integer" value="0" label="Set shift size" help="(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion while setting it other than default value. When NOMODEL is set, MACS will use this value to move cutting ends (5-prime) towards 5-prime-to-3-prime  direction then apply EXTSIZE to extend them to fragments. When this value is negative, ends will be moved toward 3-prime-to-5-prime  direction. Recommended to keep it as default 0 for ChIP-Seq datasets, or -1 * 0.5 of --extsize (option above) together with --extsize option for detecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you can't set values other than 0 if format is paired-end data (BAMPE). Default = 0 (--shift)."/>
             </when>
         </conditional>
 
-        <param name="outputs" type="select" display="checkboxes" multiple="True" optional="false" label="Outputs" help="PDF only created when model is build">
-            <option value="peaks_tabular" selected="True">Peaks as tabular file</option>
-            <option value="summits" selected="true">Peak summits</option>
-            <option value="bdg" selected="true">Scores in bedGraph files (--bdg)</option>
+        <param name="outputs" type="select" display="checkboxes" multiple="True" optional="True" label="Additional Outputs" help="PDF is only created when the model is built">
+            <option value="peaks_tabular">Peaks as tabular file</option>
+            <option value="summits">Peak summits</option>
+            <option value="bdg" >Scores in bedGraph files (--bdg)</option>
             <option value="html">Summary page (html)</option>
             <option value="pdf">Plot in PDF</option>
         </param>
 
         <conditional name="advanced_options">
-            <param name="advanced_options_selector" type="select" label="Advanced options">
+            <param name="advanced_options_selector" type="select" label="Advanced Options">
                 <option value="off" selected="true">Hide advanced options</option>
                 <option value="on">Display advanced options</option>
             </param>
@@ -195,7 +241,7 @@
     <outputs>
         <!--callpeaks output-->
         <data name="output_tabular" format="tabular" label="${tool.name} on ${on_string} (Peaks in tabular format)">
-            <filter>'peaks_tabular' in outputs</filter>
+            <filter> outputs and 'peaks_tabular' in outputs</filter>
         </data>
         <data name="output_broadpeaks" format="bed" from_work_dir="MACS2_peaks.broadPeak" label="${tool.name} on ${on_string} (broad Peaks)">
             <filter>
@@ -224,30 +270,31 @@
             </filter>
         </data>
         <data name="output_summits" format="bed" from_work_dir="MACS2_summits.bed" label="${tool.name} on ${on_string} (summits in BED)">
-            <filter>'summits' in outputs</filter>
+            <filter>outputs and 'summits' in outputs</filter>
         </data>
         <data name="output_plot" format="pdf" from_work_dir="MACS2_model.pdf" label="${tool.name} on ${on_string} (plot)">
             <filter>
             ((
-              'pdf' in outputs and
+              outputs and 'pdf' in outputs and
               nomodel_type['nomodel_type_selector'] == "create_model"
             ))
             </filter>
         </data>
         <data name="output_treat_pileup" format="bedgraph" from_work_dir="MACS2_treat_pileup.bdg" label="${tool.name} on ${on_string} (Bedgraph Treatment)">
-            <filter>'bdg' in outputs</filter>
+            <filter>outputs and 'bdg' in outputs</filter>
         </data>
         <data name="output_control_lambda" format="bedgraph" from_work_dir="MACS2_control_lambda.bdg" label="${tool.name} on ${on_string} (Bedgraph Control)">
-            <filter>'bdg' in outputs</filter>
+            <filter>outputs and 'bdg' in outputs</filter>
         </data>
         <data name="output_extra_files" format="html" label="${tool.name} on ${on_string} (html report)">
-            <filter>'html' in outputs</filter>
+            <filter>outputs and 'html' in outputs</filter>
         </data>
     </outputs>
     <tests>
-        <test>
-            <param name="input_control_file" value="Control_200K.bed" ftype="bed"/>
+        <test expect_num_outputs="5">
             <param name="input_treatment_file" value="ChIP_200K.bed" ftype="bed"/>
+            <param name="c_select" value="Yes"/>
+            <param name="input_control_file" value="Control_200K.bed" ftype="bed"/>
             <param name="cutoff_options_selector" value="qvalue"/>
             <param name="qvalue" value="0.05"/>
             <param name="band_width" value="300"/>
@@ -266,9 +313,11 @@
             </output>
 
         </test>
-        <test>
-            <param name="input_control_file" value="Control_200K.bed" ftype="bed"/>
+        <!-- Ensure pdf can be output -->
+        <test expect_num_outputs="2">
             <param name="input_treatment_file" value="ChIP_200K.bed" ftype="bed"/>
+            <param name="c_select" value="Yes"/>
+            <param name="input_control_file" value="Control_200K.bed" ftype="bed"/>
             <param name="cutoff_options_selector" value="qvalue"/>
             <param name="qvalue" value="0.05"/>
             <param name="band_width" value="300"/>
@@ -280,32 +329,244 @@
             <output name="output_plot" file="magic.pdf" ftype="pdf" compare="contains" />
         </test>
     </tests>
-    <help>
-        <![CDATA[
+    <help><![CDATA[
+
+.. class:: infomark
+
 **What it does**
 
-**callpeak** is the main function of the MACS2_ package. MACS identifies enriched binding sites in ChIP-seq experiments.
-It captures the influence of genome complexity to evaluate the significance of enriched ChIP regions,
-and improves the spatial resolution of binding sites through combining the information of both sequencing
-tag position and orientation. MACS can be used for ChIP-Seq data alone, or with control sample with the
-increase of specificity (recommended).
+**callpeak** is the main function of the MACS2_ package. MACS identifies enriched binding sites in ChIP-seq experiments. It captures the influence of genome complexity to evaluate the significance of enriched ChIP regions, and improves the spatial resolution of binding sites through combining the information of both sequencing tag position and orientation. 
 
 .. _MACS2: https://github.com/taoliu/MACS
 
+-----
+
+**Inputs**
+
+MACS can be used for ChIP-Seq data (Treatment) alone, or with a Control sample with the increase of specificity (recommended).
+
+A Treatment File is the only REQUIRED parameter for MACS. The file can be in BAM or BED format and this tool will autodetect the format using the first treatment file provided as input. If you have more than one alignment file per sample, you can select to pool them above. MACS can pool files together e.g. as `-t A B C` for treatment or `-c A B C` for control.
+
+Both single-end and paired-end mapping results can be input and you can specify if the data is from paired-end reads above. Paired-end mapping results can be input to MACS as a single BAM file, and just the left mate (5' end) tag will be automatically kept. However, when paired-end format (BAMPE) is specified, MACS will use the real fragments inferred from alignment results for reads pileup.
+
+-----
+
+**Outputs**
+
+This tool produces a BED file of narrowPeaks as default output. It can also produce additional outputs, which can be selected under the **Additional Outputs** option above. 
+
+    * **a BED file of peaks** (default)
+    * a tabular file of peaks
+    * a BED file of peak summits
+    * two bedGraph files of scores, for treatment pileup and control lambda
+    * a HTML summary page
+    * a PDF plot (if model is built)
+    * a BED file of broad peaks (if **Composite broad regions** is selected under Advanced Options)
+    * a BED file of gapped peaks (if **Composite broad regions** is selected under Advanced Options)
+
+**Peaks BED File**
+
+The default output is the narrowPeak BED file (BED6+4 format). This contains the peak locations, together with peak summit, pvalue and qvalue. You can load it to UCSC genome browser. 
+
+    Example:
+
+    ======= ========= ======= ============ ==== === ======= ======== ======= =======
+    1          2        3          4        5    6     7       8         9   **10**
+    ======= ========= ======= ============ ==== === ======= ======== ======= ======= 
+    chr1    840081    840400  MACS2_peak_1  69   .  4.89872 10.50944 6.91052 158
+    chr1    919419    919785  MACS2_peak_2  87   .  5.85158 12.44148 8.70936 130
+    chr1    937220    937483  MACS2_peak_3  66   .  4.87632 10.06728 6.61759 154
+    ======= ========= ======= ============ ==== === ======= ======== ======= =======
+
+    Columns contain the following data:
+
+* **1st**: chromosome name
+* **2nd**: start position of peak
+* **3rd**: end position of peak
+* **4th**: name of peak
+* **5th**: integer score for display in genome browser (e.g. UCSC)
+* **6th**: strand, either "." (=no strand) or "+" or "-"
+* **7th**: fold-change
+* **8th**: -log10pvalue
+* **9th**: -log10qvalue
+* **10th**: relative summit position to peak start
+
+
+**Peaks tabular File**
+
+A tabular file which contains information about called peaks. You can open it in Excel and sort/filter using Excel functions. 
+
+    Example:
+
+    ======= ========= ======= ========== ============== ========== ==================  =================== ================== =============
+    **chr** **start** **end** **length** **abs_summit** **pileup** **-log10(pvalue)**  **fold_enrichment** **-log10(qvalue)**  **name**
+    ======= ========= ======= ========== ============== ========== ==================  =================== ================== =============
+    chr1    840082    840400  319        840240         4.00       10.50944            4.89872             6.91052             MACS2_peak_1
+    chr1    919420    919785  366        919550         5.00       12.44148            5.85158             8.70936             MACS2_peak_2
+    chr1    937221    937483  263        937375         4.00       10.06728            4.87632             6.61759             MACS2_peak_3
+    ======= ========= ======= ========== ============== ========== ==================  =================== ================== =============
+
+    Columns contain the following data:
+
+* **chr**: chromosome name
+* **start**: start position of peak
+* **end**: end position of peak
+* **length**: length of peak region
+* **abs_summit**: absolute peak summit position
+* **pileup**: pileup height at peak summit
+* **-log10(pvalue)**: -log10(pvalue) for the peak summit (e.g. pvalue =1e-10, then this value should be 10)
+* **fold_enrichment**: fold enrichment for this peak summit against random Poisson distribution with local lambda
+* **-log10(qvalue)**: -log10(qvalue) at peak summit
+* **name**: name of peak
+
+*Note that these tabular file coordinates are 1-based which is different than the 0-based BED format (compare the start values in the BED and tabular Example above)*
+
+
+**Summits BED File**
+
+A BED file which contains the peak summits locations for every peaks. The 5th column in this file is -log10qvalue, the same as in the Peaks BED file. If you want to find the motifs at the binding sites, this file is recommended. The file can be loaded directly to UCSC genome browser. Remove the beginning track line if you want to analyze it by other tools.
+
+    Example:
+
+    ======= ========= ======= ============ ======= 
+    1          2        3          4        **5**
+    ======= ========= ======= ============ =======
+    chr1    840239    840240  MACS2_peak_1 6.91052
+    chr1    919549    919550  MACS2_peak_2 8.70936
+    chr1    937374    937375  MACS2_peak_3 6.61759
+    ======= ========= ======= ============ =======
+
+    Columns contain the following data:
+
+* **1st**: chromosome name
+* **2nd**: start position of peak
+* **3rd**: end position of peak
+* **4th**: name of peak
+* **5th**: -log10qvalue
+
+
+**BedGraph Files**
+
+MACS2 will output two kinds of bedGraph files if the --bdg option is selected under the Additional Outputs option above, which contain the scores for the treatment fragment pileup and control local lambda, respectively. BedGraph files can be imported into genome browsers, such as UCSC genome browser, or be converted into even smaller bigWig files. For more information on bedGraphs, see the `UCSC website here`_.
+
+
+Example:
+
+**Treatment pileup file**
+
+    ======= ========= ======= =======
+    1          2        3      **4**
+    ======= ========= ======= =======
+    chr1    840146    840147  3.00000
+    chr1    840147    840332  4.00000
+    chr1    840332    840335  3.00000
+    ======= ========= ======= =======
+
+
+**Control lambda file**
+
+    ======= ========= ======= =======
+    1          2        3      **4**
+    ======= ========= ======= =======
+    chr1    800953    801258  0.02536
+    chr1    801258    801631  0.25364
+    chr1    801631    801885  0.99858
+    ======= ========= ======= =======
+
+    Columns contain the following data:
+
+* **1st**: chromosome name
+* **2nd**: start position of peak
+* **3rd**: end position of peak
+* **4th**: treatment pileup score or control local lambda score
+
+
+**Broad peaks File**
+
+If the broad option (--broad) is selected unded Advanced Options above, MACS2 will output a broadPeaks file. When this flag is on, MACS will try to composite broad regions in BED12 ( a gene-model-like format ) by putting nearby highly enriched regions into a broad region with loose cutoff. The broad region is controlled by another cutoff through --broad-cutoff. The maximum length of broad region length is 4 times of d from MACS. The broad peaks file is in BED6+3 format which is similar to the narrowPeak file, except for missing the 10th column for annotating peak summits.
+
+    Example:
+
+    ======= ========= ======= ============ ==== === ======= ======= ======= 
+    1        2         3       4            5    6   7       8       9
+    ======= ========= ======= ============ ==== === ======= ======= ======= 
+    chr1    840081    840400  MACS2_peak_1  52   .  4.08790 8.57605 5.21506
+    chr1    919419    919785  MACS2_peak_2  56   .  4.37270 8.90436 5.60462
+    chr1    937220    937483  MACS2_peak_3  48   .  4.02343 8.06676 4.86861
+    ======= ========= ======= ============ ==== === ======= ======= ======= 
+
+
+Columns contain the following data:
+
+* **1st**: chromosome name
+* **2nd**: start position of peak
+* **3rd**: end position of peak
+* **4th**: name of peak
+* **5th**: integer score for display in genome browser (e.g. UCSC)
+* **6th**: strand, either "." (=no strand) or "+" or "-"
+* **7th**: fold-change
+* **8th**: -log10pvalue
+* **9th**: -log10qvalue
+
+
+**Gapped peaks File**
+
+If the broad option (--broad) is selected unded Advanced Options above, MACS2 will also output a gappedPeaks file. The gappedPeak file is in BED12+3 format and contains both the broad region and narrow peaks. The file can be loaded directly to UCSC genome browser.
+
+    Example:
+
+    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
+    1       2         3       4            5    6    7       8       9   10  11  12  13      14     15
+    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
+    chr1    840081    840400  MACS2_peak_1  52   .  840081  840400   0   1  319  0  4.08790 8.57605 5.21506
+    chr1    919419    919785  MACS2_peak_2  56   .  919419  919785   0   1  366  0  4.37270 8.90436 5.60462
+    chr1    937220    937483  MACS2_peak_3  48   .  937220  937483   0   1  263  0  4.02343 8.06676 4.86861
+    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
+
+Columns contain the following data:
+
+* **1st**: chromosome name
+* **2nd**: start position of peak
+* **3rd**: end position of peak
+* **4th**: name of peak
+* **5th**: 10*-log10qvalue, to be more compatible to show grey levels on UCSC browser
+* **6th**: strand, either "." (=no strand) or "+" or "-"
+* **7th**: start of the first narrow peak in the region 
+* **8th**: end of the peak
+* **9th**: RGB color key, default colour is 0 
+* **10th**: number of blocks, including the starting 1bp and ending 1bp of broad regions
+* **11th**: length of each block, comma-separated values if multiple
+* **12th**: start of each block, comma-separated values if multiple
+* **13th**: fold-change 
+* **14th**: -log10pvalue 
+* **15th**: -log10qvalue
+
+-----
+
+**More Information**
+
 MACS2 performs the following analysis steps:
 
- * Artificially extend reads to expected fragment length, and generate coverage map along genome.
- * Assume background reads are Poisson distributed. Mean of the Poisson is locally variable and is estimated from control experiment (if available) in 5Kbp or 10Kbp around examined location.
- * For a given location, do we see more reads than we would have expected from the Poisson (p < 0.00005)? If Yes, MACS2 calls a peak. 
+ * Artificially extends reads to expected fragment length, and generates coverage map along genome.
+ * Assumes background reads are Poisson distributed. Mean of the Poisson is locally variable and is estimated from control experiment (if available) in 5Kbp or 10Kbp around examined location.
+ * For a given location, asks do we see more reads than we would have expected from the Poisson (p < 0.00005)? If Yes, MACS2 calls a peak.
 
+
+**Tips of fine-tuning peak calling**
+
+Check out these other MACS2 tools:
+
+    * **MACS2 bdgcmp** can be used on the callpeak bedGraph files or bedGraph files from other resources to calculate score track.
+    * **MACS2 bdgpeakcall** can be used on the file generated from bdgcmp or bedGraph file from other resources to call peaks with given cutoff, maximum-gap between nearby mergable peaks and minimum length of peak. bdgbroadcall works similarly to bdgpeakcall, however it will output a broad peaks file in BED12 format.
+    * Differential calling tool **MACS2 bdgdiff**, can be used on 4 bedGraph files which are scores between treatment 1 and control 1, treatment 2 and control 2, treatment 1 and treatment 2, treatment 2 and treatment 1. It will output the consistent and unique sites according to parameter settings for minimum length, maximum gap and cutoff.
 
 .. class:: warningmark
 
-If MACS2 fails, it is usually because it cannot build the model for peaks.  You may want to extend **mfold** range by increasing the upper bound or play with **Build model** options.
+If MACS2 fails, it is usually because it cannot build the model for peaks. You may want to extend **mfold** range by increasing the upper bound or play with **Build model** options. For more information, see the MACS2_ website.
 
+.. _`UCSC website here`: https://genome.ucsc.edu/goldenPath/help/bedgraph.html
 
 @citation@
-]]>
-  </help>
+]]></help>
   <expand macro="citations" />
 </tool>

--- a/tools/macs2/macs2_macros.xml
+++ b/tools/macs2/macs2_macros.xml
@@ -4,6 +4,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@VERSION_STRING@">macs2</requirement>
+            <requirement type="package" version="3.4">r-base</requirement>
             <yield />
         </requirements>
     </xml>


### PR DESCRIPTION
This PR has suggested modifications for MACS2, mainly because I ran into the same issue as @zfrenchee here: https://github.com/galaxyproject/tools-iuc/issues/1501

The changes here are to:

- add conditionals for more flexible handling of treatment and control inputs
- add r-base 3.4 as requirement to macros.xml (to remove of some errors due to defaulting to use R 3.2)
- change to only produce narrowPeaks file as default output
- add more info to Help section
- increase wrapper version for callpeak

@zfrenchee what do you think of the changes here for the conditionals you wanted? (here: https://github.com/galaxyproject/tools-iuc/pull/1627)
I think this should allow MACS2 to accept as input:

- single treatment/control files
- equal length treatment/control collections
- treatment collection/single control

but would be great if you could check