### PR TITLE
fix for 'Read distribution from RSeQC' in MultiQC 

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -218,6 +218,9 @@ mkdir multiqc_WDir &&
             #elif str($repeat2.type.type) == "junction_annotation"
                 #set $pattern = "Group               Total_bases         Tag_count           Tags/Kb"
                 @LN_3_FILES@
+            #elif str($repeat2.type.type) == "read_distribution"
+                #set $pattern = "Group               Total_bases         Tag_count           Tags/Kb"
+                @LN_3_FILES@
             #elif str($repeat2.type.type) == "read_duplication_pos"
                 #for $k, $file in enumerate($repeat2.type.input)
                     ln -s '$file' '$repeat_dir/file_${k}.pos.DupRate.xls' &&


### PR DESCRIPTION
Hi Team, 
I am trying to use mulitiqc to summarise the outputs of 'Read Distribution from RSeQC'. I realised that this module is not working properly. The condition for 'read_distribution' is missing in the 'command' tag of multiqc.xml. I believe this pull request will fix this issue. 

  