### PR TITLE
added missing echo to version command

### DIFF
--- a/tools/enasearch/enasearch_retrieve_taxons.xml
+++ b/tools/enasearch/enasearch_retrieve_taxons.xml
@@ -61,6 +61,8 @@ enasearch
 **What it does**
 
 This tool retrieve ENA taxon data
+
+See also [command line documentation](http://bebatut.fr/enasearch/cli_usage.html#enasearch-retrieve-taxons)
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tools/enasearch/macros.xml
+++ b/tools/enasearch/macros.xml
@@ -2,7 +2,7 @@
 <macros>
     <token name="@WRAPPER_VERSION@">0.1.1</token>
     <xml name="version">
-        <version_command>@WRAPPER_VERSION@</version_command>
+        <version_command>echo @WRAPPER_VERSION@</version_command>
     </xml>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
the missing echo gives a `command not found` error on the info page of data sets created with enasearch. 