### PR TITLE
Bump bowtie2 version to 2.3.4

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,10 +1,10 @@
-<tool id="bowtie2" name="Bowtie2" version="2.3.3.1" profile="17.01">
+<tool id="bowtie2" name="Bowtie2" version="2.3.4" profile="17.01">
     <description>- map reads against reference genome</description>
     <macros>
         <import>bowtie2_macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="2.3.3.1">bowtie2</requirement>
+        <requirement type="package" version="2.3.4">bowtie2</requirement>
         <requirement type="package" version="1.6">samtools</requirement>
     </requirements>
     <version_command>bowtie2 --version</version_command>


### PR DESCRIPTION
This contains some important upstream bugfixes and a new  "continuous FASTA" input format (-F) for aligning all the k-mers in the sequences of a FASTA file (not implemented in the wrapper yet).