### PR TITLE
Use conda 4.3.33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
   - pip install planemo
   - planemo conda_init
   - export PATH="$PLANEMO_CONDA_PREFIX/bin:$PATH"
-  - conda install -y conda=4.3.30
+  - conda install -y -c conda-forge conda=4.3.33
   - planemo --version
   - conda --version
   - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?


### PR DESCRIPTION
The new [4.3.33 release](https://github.com/conda/conda/releases/tag/4.3.33) contains an important bugfix for the dependency resolver: https://github.com/conda/conda/pull/6766