### PR TITLE
Update to version 0.4.4

### DIFF
--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -1,9 +1,10 @@
-<tool id="unicycler" name="Create assemblies with Unicycler" version="@VERSION@.1">
+<tool id="unicycler" name="Create assemblies with Unicycler" version="@VERSION@.0">
     <macros>
-        <token name="@VERSION@">0.4.1</token>
+        <token name="@VERSION@">0.4.4</token>
     </macros>
     <requirements>
          <requirement type="package" version="@VERSION@">unicycler</requirement>
+         <requirement type="package" version="3.5">python</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 ## Preparing files

--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -4,7 +4,6 @@
     </macros>
     <requirements>
          <requirement type="package" version="@VERSION@">unicycler</requirement>
-         <requirement type="package" version="3.5">python</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 ## Preparing files


### PR DESCRIPTION
This release of unicycler introduces new option `--existing_long_read_assembly`. Unfortunately it cannot yet be used in our case because Racon bioconda package is in conflict with unicycler due to zlib version incompatibility. 