### PR TITLE
detection of insufficient memory for seqret (EMBOSS)

### DIFF
--- a/tools/emboss_5/emboss_seqret.xml
+++ b/tools/emboss_5/emboss_seqret.xml
@@ -4,6 +4,7 @@
     <import>macros.xml</import>
   </macros>
   <expand macro="requirements" />
+  <expand macro="stdio" />
   <code file="emboss_format_corrector.py" />
   <command>seqret -sequence '$input1' -outseq '$out_file1' -feature $feature -firstonly $firstonly -osformat2 $out_format1 -auto</command>
   <inputs>

--- a/tools/emboss_5/macros.xml
+++ b/tools/emboss_5/macros.xml
@@ -5,6 +5,12 @@
             <requirement type="package" version="@VERSION@">emboss</requirement>
         </requirements>
     </xml>
+    <xml name="stdio">
+        <stdio>
+	    <regex level="fatal_oom" match="insufficient memory available" source="both" />
+            <exit_code range="1:" />
+        </stdio>
+    </xml>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1016/S0168-9525(00)02024-2</citation>

--- a/tools/emboss_5/macros.xml
+++ b/tools/emboss_5/macros.xml
@@ -7,7 +7,7 @@
     </xml>
     <xml name="stdio">
         <stdio>
-	    <regex level="fatal_oom" match="insufficient memory available" source="both" />
+            <regex level="fatal_oom" match="insufficient memory available" source="both" />
             <exit_code range="1:" />
         </stdio>
     </xml>


### PR DESCRIPTION
I found that emboss' seqret gives a specific message on insufficient memory: `Uncaught exception:  Allocation failed, insufficient memory available, raised at ajstr.c:2089`

So I added a stdio tag that detects this. Could be added to all tools. Even if the emboss documentation suggests that the error code is always 0 this was not the case here. So I left the exit code 1: detection. I you think this is useful I could add it to all other tools of the suite.

Question is `<code file="emboss_format_corrector.py" />` used at all? When is this called? I could not find a corresponding call in the job directory. 