### PR TITLE
Add genomicfeatures to requirements

### DIFF
--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -3,6 +3,7 @@
     <requirements>
         <requirement type="package" version="1.18.1">bioconductor-deseq2</requirement>
         <requirement type="package" version="1.6.0">bioconductor-tximport</requirement>
+        <requirement type="package" version="1.30.0">bioconductor-genomicfeatures</requirement>
         <requirement type="package" version="0.6.5">r-ggrepel</requirement>
         <requirement type="package" version="1.0.8">r-pheatmap</requirement>
     </requirements>


### PR DESCRIPTION
this is required by out wrapper in https://github.com/galaxyproject/tools-iuc/blob/76065f751b678abf87e6c723be680fecaa8cb589/tools/deseq2/deseq2.R#L240, which is not always used, but it will be used for running deseq2 on salmon data.