### PR TITLE
Krona: make wording for text input more generic

### DIFF
--- a/tools/taxonomy_krona_chart/.shed.yml
+++ b/tools/taxonomy_krona_chart/.shed.yml
@@ -3,8 +3,7 @@ categories:
 description: Krona pie chart from taxonomic profile
 long_description: |
   This tool converts the standard result file of a metagenomic profiling in a zoomable pie chart using Krona.
-
-  http://sourceforge.net/projects/krona/
+homepage_url: http://sourceforge.net/projects/krona/
 name: taxonomy_krona_chart
 owner: crs4
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/taxonomy_krona_chart

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -28,9 +28,9 @@
   ]]></command>
   <inputs>
     <conditional name="type_of_data">
-      <param name="type_of_data_selector" type="select" label="What is the type of your input data" help="Choose between Galaxy Taxonomy and generic text format (e.g. from MetaPhlAn or mothur)">
+      <param name="type_of_data_selector" type="select" label="What is the type of your input data" help="Choose between Galaxy Taxonomy and generic table format (e.g. from MetaPhlAn or mothur)">
         <option value="taxonomy" selected="True">Taxonomy</option>
-        <option value="text">Text</option>
+        <option value="text">Tabular</option>
       </param>
       <when value="taxonomy">
         <param name="input" type="data" format="taxonomy" multiple="True" label="Input file" help="Select a taxonomy dataset" />

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -99,7 +99,7 @@ The Galaxy version supports the following options::
 
 **Input format**
 
-*Text* input format should be a tab-delimited file with the first column containing a count
+*Tabular* input format should be a tab-delimited file with the first column containing a count
 and the remaining columns describing the hierarchy. For example::
 
     2 Fats Saturated fat

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -28,9 +28,9 @@
   ]]></command>
   <inputs>
     <conditional name="type_of_data">
-      <param name="type_of_data_selector" type="select" label="What is the type of your input data" help="Select between Galaxy Taxonomy and MetaPhlAn Text">
+      <param name="type_of_data_selector" type="select" label="What is the type of your input data" help="Choose between Galaxy Taxonomy and generic text format (e.g. from MetaPhlAn or mothur)">
         <option value="taxonomy" selected="True">Taxonomy</option>
-        <option value="text">MetaPhlAn</option>
+        <option value="text">Text</option>
       </param>
       <when value="taxonomy">
         <param name="input" type="data" format="taxonomy" multiple="True" label="Input file" help="Select a taxonomy dataset" />
@@ -94,6 +94,26 @@ The Galaxy version supports the following options::
   -n   Name of the highest level.
   -c   Combine data from each file, rather than creating separate datasets within the chart.
   -d   Maximum depth of wedges to include in the chart.
+
+-----
+
+**Input format**
+
+*Text* input format should be a tab-delimited file with the first column containing a count
+and the remaining columns describing the hierarchy. For example::
+
+    2 Fats Saturated fat
+    3 Fats Unsaturated fat Monounsaturated fat
+    3 Fats Unsaturated fat Polyunsaturated fat
+    13 Carbohydrates Sugars
+    4 Carbohydrates Dietary fiber
+    21 Carbohydrates
+    5 Protein
+    4
+
+which would yield this `Krona plot`_.
+
+.. _Krona plot: https://marbl.github.io/Krona/examples/xml.krona.html
 
 -----
 


### PR DESCRIPTION
I made a tool to convert mothur taxonomy files to krona text input format, so it is no longer restricted to MetaPhlAn output, changed wording to reflect this.

ping @bebatut 