### PR TITLE
IWTomics: updating citations

### DIFF
--- a/tools/iwtomics/macros.xml
+++ b/tools/iwtomics/macros.xml
@@ -43,15 +43,7 @@
     <xml name="citations">
         <citations>
             <citation type="doi">10.1080/10485252.2017.1306627</citation>
-            <citation type="bibtex">
-                @MANUAL{
-                        iwtomics,
-                        author = {Cremona, M.A. and Pini, A. and Chiaromonte, F. and Vantini, S.},
-                        title = {IWTomics: Interval-Wise Testing for Omics Data},
-                        note = {R package version 1.0.0},
-                        year = {2017}
-                }
-            </citation>
+            <citation type="doi">10.1093/bioinformatics/bty090</citation>
         </citations>
     </xml>
 


### PR DESCRIPTION
The citation to the Bioconductor package has been replaced with the doi to the published article on [Bioinformatics](https://doi.org/10.1093/bioinformatics/bty090).