### PR TITLE
Give samtools sort information on available memory

### DIFF
--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -25,7 +25,7 @@
         samtools sort
             -O bam
             -@ \${GALAXY_SLOTS:-1}
-            -m ${GALAXY_MEMORY_MB:-768}M
+            -m \${GALAXY_MEMORY_MB:-768}M
             -o '$output1'
             -T temp
     ]]></command>

--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -25,6 +25,7 @@
         samtools sort
             -O bam
             -@ \${GALAXY_SLOTS:-1}
+            -m ${GALAXY_MEMORY_MB:-768}M
             -o '$output1'
             -T temp
     ]]></command>

--- a/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
+++ b/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
@@ -30,7 +30,7 @@
         -O bam
         -T sorted
         -@ \${GALAXY_SLOTS:-1}
-        -m ${GALAXY_MEMORY_MB:-768}M
+        -m \${GALAXY_MEMORY_MB:-768}M
         -o '${output_bam}'
         unsorted_output.bam
     ]]></command>

--- a/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
+++ b/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
@@ -30,6 +30,7 @@
         -O bam
         -T sorted
         -@ \${GALAXY_SLOTS:-1}
+        -m ${GALAXY_MEMORY_MB:-768}M
         -o '${output_bam}'
         unsorted_output.bam
     ]]></command>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -10,7 +10,7 @@
         samtools sort
             $sort_mode
             -@ \${GALAXY_SLOTS:-1}
-            -m ${GALAXY_MEMORY_MB:-768}M
+            -m \${GALAXY_MEMORY_MB:-768}M
             -o '${output1}'
             -O bam
             -T dataset

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -10,6 +10,7 @@
         samtools sort
             $sort_mode
             -@ \${GALAXY_SLOTS:-1}
+            -m ${GALAXY_MEMORY_MB:-768}M
             -o '${output1}'
             -O bam
             -T dataset

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -11,7 +11,7 @@
 <![CDATA[
 
         #if $input.extension == 'bam' and $option == "-bedpe":
-            samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n "${input}" ./input &&
+            samtools sort -@\${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -n "${input}" ./input &&
         #else
             ln -s "${input}" ./input.bam &&
         #end if

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -11,7 +11,7 @@
 <![CDATA[
 
         #if $input.extension == 'bam' and $option == "-bedpe":
-            samtools sort -n "${input}" ./input &&
+            samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n "${input}" ./input &&
         #else
             ln -s "${input}" ./input.bam &&
         #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -304,7 +304,7 @@ bowtie2
 
 ## output file
 #if ( str( $analysis_type.analysis_type_selector ) != "full" or str( $analysis_type.sam_opt ) != "true" ):
-    | samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$output'
+    | samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$output'
 #else
     > '$output_sam'
 #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -304,7 +304,7 @@ bowtie2
 
 ## output file
 #if ( str( $analysis_type.analysis_type_selector ) != "full" or str( $analysis_type.sam_opt ) != "true" ):
-    | samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$output'
+    | samtools sort -@\${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -O bam -o '$output'
 #else
     > '$output_sam'
 #end if

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -105,7 +105,7 @@ bwa mem
     '${fastq_input.fastq_input1}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
     ]]></command>
 
     <inputs>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -105,7 +105,7 @@ bwa mem
     '${fastq_input.fastq_input1}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
     ]]></command>
 
     <inputs>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -208,7 +208,7 @@
   '${reference_fasta_filename}' first.sai '${input_type.bam_input}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
 ]]>
     </command>
 

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -208,7 +208,7 @@
   '${reference_fasta_filename}' first.sai '${input_type.bam_input}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -O bam -o '$bam_output'
 ]]>
     </command>
 

--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -78,7 +78,7 @@
     #else:
         $read1 $read2
     #end if
-    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T tmp -O bam -o output.bam -
+    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-1}" -m ${GALAXY_MEMORY_MB:-768}M -T tmp -O bam -o output.bam -
 ]]>
     </command>
     <inputs>

--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -78,7 +78,7 @@
     #else:
         $read1 $read2
     #end if
-    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-1}" -m ${GALAXY_MEMORY_MB:-768}M -T tmp -O bam -o output.bam -
+    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-1}" -m \${GALAXY_MEMORY_MB:-768}M -T tmp -O bam -o output.bam -
 ]]>
     </command>
     <inputs>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -60,7 +60,7 @@
         mv $qc.files_path/hicQC.html $qc
         && mv $qc.files_path/*.log raw_qc
         && mv matrix.$outputFormat matrix
-        && samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M ./unsorted.bam -o sorted.bam
+        && samtools sort -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M ./unsorted.bam -o sorted.bam
        
 ]]>
     </command>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -60,7 +60,7 @@
         mv $qc.files_path/hicQC.html $qc
         && mv $qc.files_path/*.log raw_qc
         && mv matrix.$outputFormat matrix
-        && samtools sort ./unsorted.bam -o sorted.bam
+        && samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M ./unsorted.bam -o sorted.bam
        
 ]]>
     </command>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -296,7 +296,7 @@ hisat2
 
 ## Convert SAM output to sorted BAM
 
-samtools sort hisat_out.sam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_PERSLOT_MEMORY_MB:-768}M -l 6 -o '${output_alignments}'
+samtools sort hisat_out.sam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB_PER_SLOT:-768}M -l 6 -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -14,7 +14,13 @@
     </stdio>
     <version_command>hisat2 --version</version_command>
     <command><![CDATA[
-
+## memory requirements for samtools
+if [ -n "\$GALAXY_MEMORY_MB" ]; then
+    let GALAXY_PERSLOT_MEMORY_MB = \$GALAXY_MEMORY_MB / \${GALAXY_SLOTS:-1} &&
+else
+    set GALAXY_PERSLOT_MEMORY_MB = 768 &&
+fi
+    
 ## Prepare HISAT2 index
 
 #if $reference_genome.source == "history":
@@ -190,6 +196,9 @@ hisat2
 
 #end if
 
+## Output
+-S hisat_out.sam
+
 
 ## Specify strandedness of reads
 
@@ -290,9 +299,11 @@ hisat2
     --summary-file summary.txt
 #end if
 
+&& 
+
 ## Convert SAM output to sorted BAM
 
-| samtools sort - -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -l 6 -o '${output_alignments}'
+samtools sort hisat_out.sam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_PERSLOT_MEMORY_MB:-768}M -l 6 -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -292,7 +292,7 @@ hisat2
 
 ## Convert SAM output to sorted BAM
 
-| samtools sort - -@ \${GALAXY_SLOTS:-1} -l 6 -o '${output_alignments}'
+| samtools sort - -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -l 6 -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -14,13 +14,6 @@
     </stdio>
     <version_command>hisat2 --version</version_command>
     <command><![CDATA[
-## memory requirements for samtools
-if [ -n "\$GALAXY_MEMORY_MB" ]; then
-    let GALAXY_PERSLOT_MEMORY_MB = \$GALAXY_MEMORY_MB / \${GALAXY_SLOTS:-1} &&
-else
-    set GALAXY_PERSLOT_MEMORY_MB = 768 &&
-fi
-    
 ## Prepare HISAT2 index
 
 #if $reference_genome.source == "history":

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -32,9 +32,9 @@
     #end if
 
     #if $samfile.extension == 'bam':
-        samtools sort -n --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
+        samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
     #else
-        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
+        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
     #end if
 
     htseq-count
@@ -66,7 +66,7 @@
             && samtools view -Su
                 -t '${reference_fasta_filename}.fai'
                 '$__new_file_path__/${samoutfile.id}_tmp.sam'
-            | samtools sort -o '$samoutfile' -
+            | samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$samoutfile' -
         #end if
     #end if
     ]]>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -66,7 +66,7 @@
             && samtools view -Su
                 -t '${reference_fasta_filename}.fai'
                 '$__new_file_path__/${samoutfile.id}_tmp.sam'
-            | samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$samoutfile' -
+            | samtools sort -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -o '$samoutfile' -
         #end if
     #end if
     ]]>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -32,9 +32,9 @@
     #end if
 
     #if $samfile.extension == 'bam':
-        samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
+        samtools sort -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
     #else
-        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
+        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -n --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
     #end if
 
     htseq-count

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -40,7 +40,7 @@
                 #end if
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
             #end if
             && if [ -f run_info.json ] ; then cat run_info.json ; fi &&
             mkdir outputs &&

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -40,7 +40,7 @@
                 #end if
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
             #end if
             && if [ -f run_info.json ] ; then cat run_info.json ; fi &&
             mkdir outputs &&

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -40,7 +40,7 @@
                 $reads
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
             #end if
             && cat run_info.json
         ]]>

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -40,7 +40,7 @@
                 $reads
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$pseudobam_output' -
             #end if
             && cat run_info.json
         ]]>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -253,7 +253,7 @@
         --action:target=multiple
         --rdotplot=plot.r
         #if str( $output_format.out.format ) == "bam":
-            | samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '${output}' &&
+            | samtools sort -@\${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -O bam -o '${output}' &&
         #else:
             > '${output}' &&
         #end if

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -253,7 +253,7 @@
         --action:target=multiple
         --rdotplot=plot.r
         #if str( $output_format.out.format ) == "bam":
-            | samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '${output}' &&
+            | samtools sort -@\${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -O bam -o '${output}' &&
         #else:
             > '${output}' &&
         #end if

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -103,7 +103,8 @@
         '$fastq_input.fastq_input1.forward' '$fastq_input.fastq_input1.reverse'
     #end if
     | samtools sort
-    -@\${GALAXY_SLOTS:-2}
+    -@\${GALAXY_SLOTS:-1}
+    -m ${GALAXY_MEMORY_MB:-768}M 
     -O $io_options.output_format
     #if $io_options.output_format == 'CRAM':
         --reference reference.fa

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -103,8 +103,8 @@
         '$fastq_input.fastq_input1.forward' '$fastq_input.fastq_input1.reverse'
     #end if
     | samtools sort
-    -@\${GALAXY_SLOTS:-1}
-    -m ${GALAXY_MEMORY_MB:-768}M 
+    -@ \${GALAXY_SLOTS:-1}
+    -m \${GALAXY_MEMORY_MB:-768}M 
     -O $io_options.output_format
     #if $io_options.output_format == 'CRAM':
         --reference reference.fa

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -183,7 +183,7 @@
             -Shb Chimeric.out.sam |
         
         samtools sort
-            -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M - ChimericSorted
+            -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M - ChimericSorted
     #end if
     ]]></command>
 

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -179,11 +179,11 @@
     #if str($params.settingsType) == "star_fusion" or ( str($params.settingsType) == "full" and str($params.chim.chim_select) == "yes" and int($params.chim.chimSegmentMin) > 0 ):
         &&
         samtools view
-            -@ \${GALAXY_SLOTS:-4}
+            -@ \${GALAXY_SLOTS:-1}
             -Shb Chimeric.out.sam |
         
         samtools sort
-            -@ \${GALAXY_SLOTS:-4} - ChimericSorted
+            -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M - ChimericSorted
     #end if
     ]]></command>
 

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -20,7 +20,7 @@ mkdir -p ./special_de_output/sample1/ &&
 #end if
 
 #if $input_bam.metadata.ftype == 'sam':
-    samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M '$input_bam' | stringtie
+    samtools sort -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M '$input_bam' | stringtie
 #else
     stringtie '$input_bam'
 #end if

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -20,7 +20,7 @@ mkdir -p ./special_de_output/sample1/ &&
 #end if
 
 #if $input_bam.metadata.ftype == 'sam':
-    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' | stringtie
+    samtools sort -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M '$input_bam' | stringtie
 #else
     stringtie '$input_bam'
 #end if

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -34,7 +34,7 @@
                 --in-sam
             #end if
             -I '$input_file' -S deduped.bam &&
-            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
+            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to deduplicate in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -34,7 +34,7 @@
                 --in-sam
             #end if
             -I '$input_file' -S deduped.bam &&
-            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -o '$output' -O BAM
+            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to deduplicate in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -38,7 +38,7 @@
             #end if
             --output-bam
             -I '$input_file' -S grouped.bam &&
-            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
+            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -m \${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to group in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -38,7 +38,7 @@
             #end if
             --output-bam
             -I '$input_file' -S grouped.bam &&
-            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -o '$output' -O BAM
+            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -m ${GALAXY_MEMORY_MB:-768}M -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to group in SAM or BAM format" />


### PR DESCRIPTION
Problem: for huge alignments creates a large number of temporary files and is slow because of disk IO. 

The -m parameter gives `samtools sort` the information on how many memory it can use (default is 768M in all samtools versions) . 

I also changed the number of cores to 1 if this was different. 

I would also be willing to implement an alternative for the use of the pipe in these tools (https://github.com/galaxyproject/tools-iuc/issues/1733) .. but a consensus on the "best" solution would be needed. 