### PR TITLE
fixed input datatypes for lastz

### DIFF
--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_wrapper_2" name="LASTZ" version="1.4">
+<tool id="lastz_wrapper_2" name="LASTZ" version="1.3">
     <description>: align long sequences</description>
     <macros>
         <import>lastz_macros.xml</import>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_wrapper_2" name="LASTZ" version="1.3">
+<tool id="lastz_wrapper_2" name="LASTZ" version="1.4">
     <description>: align long sequences</description>
     <macros>
         <import>lastz_macros.xml</import>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -279,7 +279,7 @@
     </configfiles>
     <inputs>
         <expand macro="target_input"/>
-        <param name="query" format="fasta,fasta.gz,fastq.gz" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
+        <param name="query" format="fasta,fastq" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
 
         <section name="where_to_look" expanded="False" title="Where to look">
             <param name="strand" type="select" display="radio" label="which strand to search" argument="--strand" help="Search both strands or choose plus or minus">

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -20,7 +20,7 @@
     </command>
     <inputs>
         <expand macro="target_input"/>
-        <param name="query" format="fasta,fasta.gz,fastq.gz" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
+        <param name="query" format="fasta,fastq" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
         <param name="score_file" type="data" format="txt" optional="true" label="Control file for inference" argument="--inferonly[=control_file]" help="Optional controf file. If nothing is selected, LASTZ_D uses default described in the manual"/>
      </inputs>
     <outputs>

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_d_wrapper" name="LASTZ_D" version="1.4">
+<tool id="lastz_d_wrapper" name="LASTZ_D" version="1.3">
     <description>: estimate substitution scores matrix</description>
     <macros>
     	<import>lastz_macros.xml</import>

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_d_wrapper" name="LASTZ_D" version="1.3">
+<tool id="lastz_d_wrapper" name="LASTZ_D" version="1.4">
     <description>: estimate substitution scores matrix</description>
     <macros>
     	<import>lastz_macros.xml</import>

--- a/tools/lastz/lastz_macros.xml
+++ b/tools/lastz/lastz_macros.xml
@@ -19,7 +19,7 @@
                 </param>
             </when>
             <when value="history">
-                <param name="target" type="data" format="fasta,fasta.gz" label="Select a reference dataset" />
+                <param name="target" type="data" format="fasta" label="Select a reference dataset" />
             </when>
         </conditional>
     </xml>


### PR DESCRIPTION
Having `fasta.gz` and `fastq.gz` causes errors as these datatypes are not understood by `lastz`. The conversion will be taken care by implicit converted I previously added during lastz rewrite