### PR TITLE
renamed extract genomic dna tool

### DIFF
--- a/tools/extract_genomic_dna/extract_genomic_dna.xml
+++ b/tools/extract_genomic_dna/extract_genomic_dna.xml
@@ -1,4 +1,4 @@
-<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="3.0.3">
+<tool id="Extract genomic DNA" name="Extract Genomic DNA" version="3.0.3">
     <description>using coordinates from assembled/unassembled genomes</description>
     <requirements>
         <requirement type="package" version="0.7.1">bx-python</requirement>


### PR DESCRIPTION
The name was identical to the legacy tool. This has the side effect that the galaxy environment is preferred over the conda environment (because of preserve_python_environment = legacy_only in galaxy.in). 

(You won't believe how long I needed to find this out ...)