### PR TITLE
Update Msaboot to version 0.1.2 - support relaxed PHYLIP output

### DIFF
--- a/tools/msaboot/msaboot.xml
+++ b/tools/msaboot/msaboot.xml
@@ -2,7 +2,7 @@
 <tool id="msaboot" name="MSABOOT" version="@VERSION@">
     <description>Output PHYLIP file with bootstrapped multiple sequence alignment data</description>
     <macros>
-        <token name="@VERSION@">0.1.1</token>
+        <token name="@VERSION@">0.1.2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@VERSION@">msaboot</requirement>


### PR DESCRIPTION
Replaced use of AlignIO.write with custom implementation to output in relaxed PHYLIP format. I am updating the wrapper accordingly.