### PR TITLE
umi_tools extract: log2sterr fix

### DIFF
--- a/tools/umi_tools/umi-tools_whitelist.xml
+++ b/tools/umi_tools/umi-tools_whitelist.xml
@@ -57,6 +57,8 @@
                 --log='$out_log'
             #end if
 
+            --log2stderr    
+
             > '$out_whitelist' &&
 
             mkdir '${ out_html_report.files_path }' &&


### PR DESCRIPTION
Logs were bleeding into the whitelist output. Now it just prints to stderr.