### PR TITLE
Fix versioning for snpEff tools.

### DIFF
--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -13,7 +13,7 @@
 snpEff -version
     ]]></version_command>
   </xml>
-  <token name="@wrapper_version@">4.3.1t</token>
+  <token name="@wrapper_version@">4.3.1</token>
   <token name="@snpeff_version@">SnpEff4.3</token>
   <token name="@snpeff_database_url@">https://sourceforge.net/projects/snpeff/files/databases/v4_3/</token>
   <token name="@java_options@">-Xmx\${GALAXY_MEMORY_MB:-8192}m</token>
@@ -36,7 +36,7 @@ SnpEff relies on specially formatted databases to generate annotations. It will 
 
 **Pre-cached databases**
 
-Many standard (e.g., human, mouse, *Drosophila*) databases are likely pre-cached within a given Galaxy instance. You should be able to see them listed in **Genome** drop-down of **SbpEff eff** tool. 
+Many standard (e.g., human, mouse, *Drosophila*) databases are likely pre-cached within a given Galaxy instance. You should be able to see them listed in **Genome** drop-down of **SbpEff eff** tool.
 
 In you *do not see them* keep reading...
 
@@ -48,17 +48,17 @@ SnpEff project generates large numbers of pre-build databases. These are availab
   #. Use **SnpEff download** tool to download the database.
   #. Finally, use **SnpEff eff** by choosing the downloaded database from the history using *Downloaded snpEff database in your history* option of the **Genome source** parameter.
 
-Alternatively, you can specify the name of the database directly in **SnpEff eff** using the *Download on demand* option (again, **Genome source** parameter). In this case snpEff will download the database before performing annotation. 
+Alternatively, you can specify the name of the database directly in **SnpEff eff** using the *Download on demand* option (again, **Genome source** parameter). In this case snpEff will download the database before performing annotation.
 
 **Create your own database**
 
 In cases when you are dealing with bacterial or viral (or, frankly, any other) genomes it may be easier to create database yourself. For this you need:
 
- #. Download Genbank record corresponding to your genome of interest from from NCBI. 
- #. Use **SnpEff build** to create the database. 
+ #. Download Genbank record corresponding to your genome of interest from from NCBI.
+ #. Use **SnpEff build** to create the database.
  #. Use the database in **SnpEff eff** (using *Custom* option for **Genome source** parameter).
 
-Creating custom database has one benefit. The **SnpEff build** tool normally produces two outputs: (1) a SnpEff database and (2) FASTA file containing sequences from the Genbank file. If you are performing your experiment from the beginning by mapping reads against a genome and finding variants before annotating them with SnpEff you can use **this FASTA file** as a reference to map your reads against. This will guarantee that you will not have any issues related to reference sequence naming -- the most common source of SnpEff errors. 
+Creating custom database has one benefit. The **SnpEff build** tool normally produces two outputs: (1) a SnpEff database and (2) FASTA file containing sequences from the Genbank file. If you are performing your experiment from the beginning by mapping reads against a genome and finding variants before annotating them with SnpEff you can use **this FASTA file** as a reference to map your reads against. This will guarantee that you will not have any issues related to reference sequence naming -- the most common source of SnpEff errors.
 
 </token>
 


### PR DESCRIPTION
Also accidentally fixed trailing whitespace.

Old: `LegacyVersion('4.3.1t.1')`
New: `Version('4.3.1.1')`