### PR TITLE
Updated umi_tools whitelist, paired input

### DIFF
--- a/tools/umi_tools/umi-tools_whitelist.xml
+++ b/tools/umi_tools/umi-tools_whitelist.xml
@@ -108,11 +108,11 @@
             <when value="paired">
                 <param name="input_read1" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
                 <param name="input_read2" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
-                <expand name="barcode2_conditional" />
+                <expand macro="barcode2_conditional" />
             </when>
             <when value="paired_collection">
-                <param name="input_readpair" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
-                <expand name="barcode2_conditional" />
+                <param name="input_readpair" type="data_collection" collection_type="paired" format="fastq,fastq.gz" label="Reads in FASTQ format" />
+                <expand macro="barcode2_conditional" />
             </when>
         </conditional>
         <param name="bc_pattern" argument="--bc-pattern" type="text" label="Barcode pattern for first read"
@@ -171,6 +171,28 @@
             <param name="type" value="paired" />
             <param name="input_read1" value="t_R1.fastq.gz" ftype="fastq" />
             <param name="input_read2" value="t_R2.fastq.gz" ftype="fastq" />
+            <param name="barcode_select" value="both_reads" />
+            <param name="bc_pattern"  value="CCCNNNNNNNNXXXXX" />
+            <param name="bc_pattern2" value="CCCCCCCCNNNNNNNN" />
+            <param name="method" value="reads" />
+            <param name="prime3" value="false" />
+            <param name="use_cell_opts" value="advanced" />
+            <param name="expect_cells" value="5" />
+            <param name="error_correct_thresh" value="3" />
+            <param name="log" value="true" />
+            <output name="out_whitelist" file="out_wl_paired.txt" />
+            <output name="out_log" file="out_wl_paired.log" lines_diff="40" />
+            <output name="out_html_report" file="out_wl_paired.html" />
+            <output name="out_thresh" file="out_wl_paired.tresh.tab" />
+        </test>
+        <test expect_num_outputs="4"> <!-- As previous, identical outputs but paired collection input -->
+            <param name="type" value="paired_collection" />
+            <param name="input_readpair" >
+                <collection type="paired">
+                    <element name="forward" ftype="fastq.gz" value="t_R1.fastq.gz" />
+                    <element name="reverse" ftype="fastq.gz" value="t_R2.fastq.gz" />
+                </collection>
+            </param>
             <param name="barcode_select" value="both_reads" />
             <param name="bc_pattern"  value="CCCNNNNNNNNXXXXX" />
             <param name="bc_pattern2" value="CCCCCCCCNNNNNNNN" />

--- a/tools/umi_tools/umi-tools_whitelist.xml
+++ b/tools/umi_tools/umi-tools_whitelist.xml
@@ -2,6 +2,21 @@
     <description>Extract cell barcodes from FASTQ files</description>
     <macros>
         <import>macros.xml</import>
+        <macro name="barcode2_conditional" >
+            <conditional name="barcode">
+                <param name="barcode_select" argument="--split-barcode" type="select" label="Barcode on both reads?">
+                    <option value="first_read_only">Barcode on first read only</option>
+                    <option value="both_reads">Barcode on both reads</option>
+                </param>
+                <when value="first_read_only"/>
+                <when value="both_reads">
+                    <param name="bc_pattern2" argument="--bc-pattern2" type="text" value="" label="Barcode pattern for second read"
+                           help="Use this option to specify the format of the UMI/barcode for
+                                 the second read pair if required.">
+                    </param>
+                </when>
+            </conditional>
+        </macro>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
@@ -11,10 +26,16 @@
                 ln -s '$input_type.input_single' input_single.gz &&
                 #set $gz = True
             #end if
-        #else
+        #elif $input_type.type == 'paired':
             #if $input_type.input_read1.is_of_type("fastq.gz", "fastqsanger.gz"):
                 ln -s '$input_type.input_read1' input_read1.gz &&
                 ln -s '$input_type.input_read2' input_read2.gz &&
+                #set $gz = True
+            #end if
+        #else  ## paired_collection
+            #if $input_type.input_readpair.forward.is_of_type("fastq.gz", "fastqsanger.gz"):
+                ln -s '$input_type.input_readpair.forward' input_read1.gz &&
+                ln -s '$input_type.input_readpair.reverse' input_read2.gz &&
                 #set $gz = True
             #end if
         #end if
@@ -27,7 +48,7 @@
                 #else
                     --stdin='$input_type.input_single'
                 #end if
-            #else:
+            #else:  ## equally valid for both 'paired' and 'paired_collection'
                 #if $gz:
                     --stdin=input_read1.gz
                     --read2-in=input_read2.gz
@@ -57,7 +78,7 @@
                 --log='$out_log'
             #end if
 
-            --log2stderr    
+            --log2stderr
 
             > '$out_whitelist' &&
 
@@ -79,6 +100,7 @@
             <param name="type" type="select" label="Library type">
                 <option value="single">Single-end</option>
                 <option value="paired">Paired-end</option>
+                <option value="paired_collection">Paired-end Dataset Collection</option>
             </param>
             <when value="single">
                 <param name="input_single" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
@@ -86,19 +108,11 @@
             <when value="paired">
                 <param name="input_read1" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
                 <param name="input_read2" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
-                <conditional name="barcode">
-                    <param name="barcode_select" argument="--split-barcode" type="select" label="Barcode on both reads?">
-                        <option value="first_read_only">Barcode on first read only</option>
-                        <option value="both_reads">Barcode on both reads</option>
-                    </param>
-                    <when value="first_read_only"/>
-                    <when value="both_reads">
-                        <param name="bc_pattern2" argument="--bc-pattern2" type="text" value="" label="Barcode pattern for second read"
-                            help="Use this option to specify the format of the UMI/barcode for
-                                  the second read pair if required.">
-                        </param>
-                    </when>
-                </conditional>
+                <expand name="barcode2_conditional" />
+            </when>
+            <when value="paired_collection">
+                <param name="input_readpair" type="data" format="fastq,fastq.gz" label="Reads in FASTQ format" />
+                <expand name="barcode2_conditional" />
             </when>
         </conditional>
         <param name="bc_pattern" argument="--bc-pattern" type="text" label="Barcode pattern for first read"


### PR DESCRIPTION
Adds paired collection input.

Works better in conjunction with other demultiplexing tools such as Je, when feeding inputs inside a workflow