### PR TITLE
Also generate or append snpEff.config file.

### DIFF
--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -1,4 +1,4 @@
-<tool id="snpEff_build_gb" name="SnpEff build:" version="@wrapper_version@.galaxy1">
+<tool id="snpEff_build_gb" name="SnpEff build:" version="@wrapper_version@.galaxy2">
     <description> database from Genbank record</description>
     <macros>
         <import>snpEff_macros.xml</import>
@@ -29,7 +29,9 @@
         snpEff @java_options@ build -v
         -configOption '${genome_version}'.genome='${genome_version}'
         -configOption '${genome_version}'.codonTable='${codon_table}'
-        -genbank -dataDir '$snpeff_output.files_path' '$genome_version'
+        -genbank -dataDir '${snpeff_output.files_path}' '${genome_version}' &&
+        echo "${genome_version}.genome : ${genome_version}" >> '${snpeff_output.files_path}'/snpEff.config &&
+        echo "${genome_version}.codonTable : ${codon_table}" >> '${snpeff_output.files_path}'/snpEff.config
 
     ]]></command>
     <inputs>


### PR DESCRIPTION
Without this addition, snpEff will report the following error when using a custom-built database for annotating variants:

`java.lang.RuntimeException: Property: '$__DBKEY__.genome' not found
	at org.snpeff.interval.Genome.<init>(Genome.java:106)
	at org.snpeff.snpEffect.Config.readGenomeConfig(Config.java:681)
	at org.snpeff.snpEffect.Config.readConfig(Config.java:649)
	at org.snpeff.snpEffect.Config.init(Config.java:480)
	at org.snpeff.snpEffect.Config.<init>(Config.java:117)
	at org.snpeff.SnpEff.loadConfig(SnpEff.java:451)
	at org.snpeff.snpEffect.commandLine.SnpEffCmdEff.run(SnpEffCmdEff.java:1000)
	at org.snpeff.snpEffect.commandLine.SnpEffCmdEff.run(SnpEffCmdEff.java:984)
	at org.snpeff.SnpEff.run(SnpEff.java:1183)
	at org.snpeff.SnpEff.main(SnpEff.java:162)`