### PR TITLE
data_manager_manual: fix error on 18.01

### DIFF
--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.py
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.py
@@ -52,8 +52,11 @@ def exec_before_job( app, inp_data, out_data, param_dict, tool=None, **kwd ):
                 data_table_filename = data_table.get_filename_for_source( data_manager, None )
                 if not data_table_filename:
                     if tdtm is None:
-                        from tool_shed.tools import data_table_manager
-                        tdtm = data_table_manager.ToolDataTableManager( app )
+                        try:
+                            from tool_shed.tools.data_table_manager import ToolDataTableManager as ShedToolDataTableManager  # For Galaxy < 18.01
+                        except ImportError:
+                            from tool_shed.tools.data_table_manager import ShedToolDataTableManager  # For Galaxy >= 18.01
+                        tdtm = ShedToolDataTableManager( app )
                         target_dir, tool_path, relative_target_dir = tdtm.get_target_install_dir( tool_shed_repository )
                     # Dynamically add this data table
                     log.debug( "Attempting to dynamically create a missing Tool Data Table named %s." % data_table_name )

--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.xml
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.xml
@@ -10,22 +10,22 @@
         <repeat name="data_tables" title="Data Table to define" min="1">
             <param name="data_table_name" type="select" multiple="False" optional="False" label="Choose Desired Data Table"
                 dynamic_options="galaxy_code_get_available_data_tables( __trans__ )" refresh_on_change="True"/>
-        <repeat name="columns" title="Table Columns" min="1">
-            <param name="data_table_column_name" type="select" multiple="False" optional="False" label="Column Name"
-                dynamic_options="galaxy_code_get_available_data_table_columns( __trans__, data_table_name )" />
-            <!-- <param name="data_table_column_name" type="text" label="Column Name"/> -->
-            <param name="data_table_column_value" type="text" label="Value to use for data table column"/>
-            <conditional name="is_path">
-                <param name="is_path_selector" type="select" label="Value is a path">
-                    <option value="yes">Yes</option>
-                    <option value="no" selected="True">No</option>
-                </param>
-                <when value="yes">
-                    <param name="abspath" type="boolean" label="Apply abspath" checked="True" truevalue="abspath" falsevalue="" />
-                </when>
-                <when value="no"/>
-            </conditional>
-        </repeat>
+            <repeat name="columns" title="Table Columns" min="1">
+                <param name="data_table_column_name" type="select" multiple="False" optional="False" label="Column Name"
+                    dynamic_options="galaxy_code_get_available_data_table_columns( __trans__, data_table_name )" />
+                <!-- <param name="data_table_column_name" type="text" label="Column Name"/> -->
+                <param name="data_table_column_value" type="text" label="Value to use for data table column"/>
+                <conditional name="is_path">
+                    <param name="is_path_selector" type="select" label="Value is a path">
+                        <option value="yes">Yes</option>
+                        <option value="no" selected="True">No</option>
+                    </param>
+                    <when value="yes">
+                        <param name="abspath" type="boolean" label="Apply abspath" checked="True" truevalue="abspath" falsevalue="" />
+                    </when>
+                    <when value="no"/>
+                </conditional>
+            </repeat>
         </repeat>
         <repeat name="directory_content" title="Directory Content">
             <param name="subdir" type="text" label="Place in Subdirectory" value=""/>


### PR DESCRIPTION
Just a little fix for the manual data manager due to a class name change in 18.01 (https://github.com/galaxyproject/galaxy/commit/7df9dce63d635d66a0a9ce5045135ab49b7ef506)
With this patch + https://github.com/galaxyproject/galaxy/pull/5922 the data manager seems to work fine in the 18.01 docker image