### PR TITLE
MAGeCK: Also add single quotes in symlink in mageck count

### DIFF
--- a/tools/mageck/mageck_count.xml
+++ b/tools/mageck/mageck_count.xml
@@ -27,7 +27,7 @@
             #set infile = $name + ".bam"
         #end if
 
-        ln -s '${sample}' $infile &&
+        ln -s '${sample}' '$infile' &&
 
         #silent $files.append($infile)
         #silent $names.append($name)


### PR DESCRIPTION
Just found the new version of mageck count still fails if you run it on a "Tool on data N" file. I should have also added the quotes to the symlink! Fixed here.