### PR TITLE
Define and use @STD_BEDTOOLS_INPUTS@ token / allow bedgraph in most tools

### DIFF
--- a/tools/bedtools/annotateBed.xml
+++ b/tools/bedtools/annotateBed.xml
@@ -33,7 +33,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file" />
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file" />
         <!-- Additional files, if the user needs more -->
          <conditional name="names">
             <param name="names_select" type="select" label="Specify names for each file">

--- a/tools/bedtools/annotateBed.xml
+++ b/tools/bedtools/annotateBed.xml
@@ -33,7 +33,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file" />
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file" />
         <!-- Additional files, if the user needs more -->
          <conditional name="names">
             <param name="names_select" type="select" label="Specify names for each file">
@@ -73,7 +73,7 @@
 <![CDATA[
 **What it does**
 
-bedtools annotate, well, annotates one BED/VCF/GFF file with the coverage and number of overlaps observed from multiple other BED/VCF/GFF files. In this way, it allows one to ask to what degree one feature coincides with multiple other feature types with a single command.
+bedtools annotate, well, annotates one @STD_BEDTOOLS_INPUT_LABEL@ file with the coverage and number of overlaps observed from multiple other @STD_BEDTOOLS_INPUT_LABEL@ files. In this way, it allows one to ask to what degree one feature coincides with multiple other feature types with a single command.
 
 @REFERENCES@
 ]]>

--- a/tools/bedtools/bedToIgv.xml
+++ b/tools/bedtools/bedToIgv.xml
@@ -20,7 +20,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,gff,gff3,vcf" name="input" type="data" label="Create IGV batch script the following BED file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Create IGV batch script for this BED/GFF/VCF file"/>
         <param name="sort" type="select" label="Sort BAM file by" help="The type of BAM sorting you would like to apply to each image.">
             <option value="">No sorting at all (default)</option>
             <option value="base">base</option>

--- a/tools/bedtools/bedToIgv.xml
+++ b/tools/bedtools/bedToIgv.xml
@@ -20,7 +20,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Create IGV batch script for this BED/GFF/VCF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Create IGV batch script for this @STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="sort" type="select" label="Sort BAM file by" help="The type of BAM sorting you would like to apply to each image.">
             <option value="">No sorting at all (default)</option>
             <option value="base">base</option>
@@ -52,7 +52,7 @@
 <![CDATA[
 **What it does**
 
-Creates a batch script to create IGV images at each interval defined in a BED/GFF/VCF file.
+Creates a batch script to create IGV images at each interval defined in a @STD_BEDTOOLS_INPUT_LABEL@ file.
 
 **Notes**
 

--- a/tools/bedtools/bedpeToBam.xml
+++ b/tools/bedtools/bedpeToBam.xml
@@ -15,7 +15,7 @@
 ]]>
     </command>
     <inputs>
-        <param name="input" format="bed,gff,vcf" type="data" label="BED/VCF/GFF file"/>
+        <param name="input" format="bed,gff,vcf" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="input_conditional_genome_file" />
         <param name="mapq" type="integer" value="255"
             label="Set a mapping quality (SAM MAPQ field) value for all BED entries"

--- a/tools/bedtools/closestBed.xml
+++ b/tools/bedtools/closestBed.xml
@@ -30,11 +30,11 @@ $io
 > '$output'
     ]]></command>
     <inputs>
-        <param name="inputA" type="data" format="@STD_BEDTOOLS_INPUTS@" label="BED/VCF/GFF file"/>
+        <param name="inputA" type="data" format="@STD_BEDTOOLS_INPUTS@" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <!-- overlap with file (inputB) -->
         <conditional name="overlap_with">
-            <param name="source" type="select" label="Overlap with: will you select a BED/VCF/GFF file from your history or use a built-in GFF file?" help="Built-in GFF files contain full annotation of a reference genome">
-                <option value="history" selected="true">Use a BED/VCF/GFF file from the history</option>
+            <param name="source" type="select" label="Overlap with: will you select a @STD_BEDTOOLS_INPUT_LABEL@ file from your history or use a built-in GFF file?" help="Built-in GFF files contain full annotation of a reference genome">
+                <option value="history" selected="true">Use a @STD_BEDTOOLS_INPUT_LABEL@ file from the history</option>
                 <option value="data_table">Use a built-in GFF file</option>
             </param>
             <when value="data_table">
@@ -46,7 +46,7 @@ $io
                 </param>
             </when>
             <when value="history">
-                <param name="inputB" type="data" format="@STD_BEDTOOLS_INPUTS@" multiple="true" label="Select a BED/VCF/GFF file" />
+                <param name="inputB" type="data" format="@STD_BEDTOOLS_INPUTS@" multiple="true" label="Select a @STD_BEDTOOLS_INPUT_LABEL@ file" />
             </when>
         </conditional>
 

--- a/tools/bedtools/closestBed.xml
+++ b/tools/bedtools/closestBed.xml
@@ -30,7 +30,7 @@ $io
 > '$output'
     ]]></command>
     <inputs>
-        <param name="inputA" type="data" format="bed,vcf,gff,gff3" label="BED/VCF/GFF file"/>
+        <param name="inputA" type="data" format="@STD_BEDTOOLS_INPUTS@" label="BED/VCF/GFF file"/>
         <!-- overlap with file (inputB) -->
         <conditional name="overlap_with">
             <param name="source" type="select" label="Overlap with: will you select a BED/VCF/GFF file from your history or use a built-in GFF file?" help="Built-in GFF files contain full annotation of a reference genome">
@@ -46,7 +46,7 @@ $io
                 </param>
             </when>
             <when value="history">
-                <param name="inputB" type="data" format="bed,gff,vcf,gff3" multiple="true" label="Select a BED/VCF/GFF file" />
+                <param name="inputB" type="data" format="@STD_BEDTOOLS_INPUTS@" multiple="true" label="Select a BED/VCF/GFF file" />
             </when>
         </conditional>
 

--- a/tools/bedtools/clusterBed.xml
+++ b/tools/bedtools/clusterBed.xml
@@ -15,7 +15,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
         <param name="strand" type="boolean" checked="false" truevalue="-s" falsevalue="" label="Force strandedness."
             help="That is, only cluster features that are the same strand. By default, this is disabled." />
         <param name="distance" type="integer" value="0"

--- a/tools/bedtools/clusterBed.xml
+++ b/tools/bedtools/clusterBed.xml
@@ -15,7 +15,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="strand" type="boolean" checked="false" truevalue="-s" falsevalue="" label="Force strandedness."
             help="That is, only cluster features that are the same strand. By default, this is disabled." />
         <param name="distance" type="integer" value="0"

--- a/tools/bedtools/complementBed.xml
+++ b/tools/bedtools/complementBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="input_conditional_genome_file" />
     </inputs>
     <outputs>
@@ -32,7 +32,7 @@
 <![CDATA[
 **What it does**
 
-bedtools complement returns all intervals in a genome that are not covered by at least one interval in the input BED/GFF/VCF file.
+bedtools complement returns all intervals in a genome that are not covered by at least one interval in the input @STD_BEDTOOLS_INPUT_LABEL@ file.
 
 .. image:: $PATH_TO_IMAGES/complement-glyph.png
 

--- a/tools/bedtools/complementBed.xml
+++ b/tools/bedtools/complementBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <expand macro="input_conditional_genome_file" />
     </inputs>
     <outputs>

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -39,18 +39,18 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,bed,gff,gff3,vcf" name="inputA" type="data" label="File A (on which coverage is calculated)" help="BAM/BED/GFF/VCF format" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (on which coverage is calculated)" help="BAM/BED/GFF/VCF format" />
         <conditional name="reduce_or_iterate">
             <param name='reduce_or_iterate_selector' type='select' label='Combined or separate output files'>
                 <option value='iterate' selected='true'>One output file per 'input B' file</option>
                 <option value='reduce'>Single output containing results for all 'input B' files</option>
             </param>
             <when value='iterate'>
-                <param format="bam,bed,gff,gff3,vcf" name="inputB" type="data"
+                <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data"
                        label="File(s) B (for which coverage is calculated)" help="BAM/BED/GFF/VCF format"/>
             </when>
             <when value='reduce'>
-                <param format="bam,bed,gff,gff3,vcf" name="inputB" type="data" multiple="true"
+                <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" multiple="true"
                        label="File(s) B (for which coverage is calculated)" help="BAM/BED/GFF/VCF format"/>
             </when>
         </conditional>
@@ -69,14 +69,14 @@
             <sanitizer invalid_char="">
                 <valid initial="string.digits"><add value=",."/></valid>
             </sanitizer>
-	</param>
+        </param>
         <param name="overlap_b" type="text"
             label="Minimum overlap required as a fraction of B."
             help="Default is 1E-9 (i.e., 1bp). (-F)">
             <sanitizer invalid_char="">
                 <valid initial="string.digits"><add value=",."/></valid>
             </sanitizer>
-	</param>
+        </param>
         <param name="reciprocal_overlap" type="boolean" checked="false" truevalue="-r" falsevalue=""
             label="Require that the fraction overlap be reciprocal for A AND B."
             help="if -f is 0.90 and -r is used, this requires that B overlap 90% of A and A _also_ overlaps 90% of B (-r)" />

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -39,7 +39,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (on which coverage is calculated)" help="BAM/BED/GFF/VCF format" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (on which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format" />
         <conditional name="reduce_or_iterate">
             <param name='reduce_or_iterate_selector' type='select' label='Combined or separate output files'>
                 <option value='iterate' selected='true'>One output file per 'input B' file</option>
@@ -47,11 +47,11 @@
             </param>
             <when value='iterate'>
                 <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data"
-                       label="File(s) B (for which coverage is calculated)" help="BAM/BED/GFF/VCF format"/>
+                       label="File(s) B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
             </when>
             <when value='reduce'>
                 <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" multiple="true"
-                       label="File(s) B (for which coverage is calculated)" help="BAM/BED/GFF/VCF format"/>
+                       label="File(s) B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
             </when>
         </conditional>
         <expand macro="split" />

--- a/tools/bedtools/expandBed.xml
+++ b/tools/bedtools/expandBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="choose_columns" />
     </inputs>
     <outputs>

--- a/tools/bedtools/expandBed.xml
+++ b/tools/bedtools/expandBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <expand macro="choose_columns" />
     </inputs>
     <outputs>

--- a/tools/bedtools/fisherBed.xml
+++ b/tools/bedtools/fisherBed.xml
@@ -20,8 +20,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="input_conditional_genome_file" />
         <expand macro="strand2" />
         <expand macro="split" />

--- a/tools/bedtools/fisherBed.xml
+++ b/tools/bedtools/fisherBed.xml
@@ -20,8 +20,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="bed,gff,vcf,gff3" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
         <expand macro="input_conditional_genome_file" />
         <expand macro="strand2" />
         <expand macro="split" />

--- a/tools/bedtools/flankBed.xml
+++ b/tools/bedtools/flankBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="input_conditional_genome_file" />
         <param name="pct" type="boolean" checked="false" truevalue="-pct" falsevalue=""
             label="Define -l and -r as a fraction of the feature’s length"

--- a/tools/bedtools/flankBed.xml
+++ b/tools/bedtools/flankBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <expand macro="input_conditional_genome_file" />
         <param name="pct" type="boolean" checked="false" truevalue="-pct" falsevalue=""
             label="Define -l and -r as a fraction of the feature’s length"

--- a/tools/bedtools/genomeCoverageBed.xml
+++ b/tools/bedtools/genomeCoverageBed.xml
@@ -39,11 +39,11 @@
     <inputs>
         <conditional name="input_type">
             <param name="input_type_select" type="select" label="Input type">
-                <option value="bed">BED/VCF/GFF</option>
+                <option value="bed">@STD_BEDTOOLS_INPUT_LABEL@</option>
                 <option value="bam">BAM</option>
             </param>
             <when value="bed">
-                <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file" />
+                <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file" />
                 <expand macro="input_conditional_genome_file" />
             </when>
             <when value="bam">

--- a/tools/bedtools/genomeCoverageBed.xml
+++ b/tools/bedtools/genomeCoverageBed.xml
@@ -43,7 +43,7 @@
                 <option value="bam">BAM</option>
             </param>
             <when value="bed">
-                <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file" />
+                <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file" />
                 <expand macro="input_conditional_genome_file" />
             </when>
             <when value="bam">

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file" />
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file" />
         <conditional name="fasta_source">
             <param name="fasta_source_selector" type="select" label="Choose the source for the fasta file">
                 <option value="history" selected="True">History</option>

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file" />
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file" />
         <conditional name="fasta_source">
             <param name="fasta_source_selector" type="select" label="Choose the source for the fasta file">
                 <option value="history" selected="True">History</option>

--- a/tools/bedtools/groupbyBed.xml
+++ b/tools/bedtools/groupbyBed.xml
@@ -16,7 +16,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/GFF/VCF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="choose_columns" />
         <param name="group" type="text" value="1,2,3"
             label="Specifies which column(s) (1-based) should be used to group the input"

--- a/tools/bedtools/groupbyBed.xml
+++ b/tools/bedtools/groupbyBed.xml
@@ -16,7 +16,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed" name="inputA" type="data" label="BED file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/GFF/VCF file"/>
         <expand macro="choose_columns" />
         <param name="group" type="text" value="1,2,3"
             label="Specifies which column(s) (1-based) should be used to group the input"

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -37,7 +37,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A to intersect with B" help="BAM/BED/GFF/VCF format" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A to intersect with B" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format" />
         <conditional name="reduce_or_iterate">
             <param name='reduce_or_iterate_selector' type='select' label='Combined or separate output files'>
                 <option value='iterate' selected='true'>One output file per 'input B' file</option>
@@ -45,11 +45,11 @@
             </param>
             <when value='iterate'>
                 <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data"
-                       label="File(s) B to intersect with A" help="BAM/BED/GFF/VCF format"/>
+                       label="File(s) B to intersect with A" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
             </when>
             <when value='reduce'>
                 <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" multiple="true"
-                       label="File(s) B to intersect with A" help="BAM/BED/GFF/VCF format"/>
+                       label="File(s) B to intersect with A" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
             </when>
         </conditional>
         <expand macro="strand2" />
@@ -112,7 +112,7 @@
 <![CDATA[
 **What it does**
 
-By far, the most common question asked of two sets of genomic features is whether or not any of the features in the two sets “overlap” with one another. This is known as feature intersection. bedtools intersect allows one to screen for overlaps between two sets of genomic features. Moreover, it allows one to have fine control as to how the intersections are reported. bedtools intersect works with both BED/GFF/VCF and BAM files as input.
+By far, the most common question asked of two sets of genomic features is whether or not any of the features in the two sets “overlap” with one another. This is known as feature intersection. bedtools intersect allows one to screen for overlaps between two sets of genomic features. Moreover, it allows one to have fine control as to how the intersections are reported. bedtools intersect works with both @STD_BEDTOOLS_INPUT_LABEL@ and BAM files as input.
 
 .. image:: $PATH_TO_IMAGES/intersect-glyph.png
 

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -37,18 +37,18 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,bam,vcf,gff,gff3" name="inputA" type="data" label="File A to intersect with B" help="BAM/BED/GFF/VCF format" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A to intersect with B" help="BAM/BED/GFF/VCF format" />
         <conditional name="reduce_or_iterate">
             <param name='reduce_or_iterate_selector' type='select' label='Combined or separate output files'>
                 <option value='iterate' selected='true'>One output file per 'input B' file</option>
                 <option value='reduce'>Single output containing intersections of any 'input B' lines with A </option>
             </param>
             <when value='iterate'>
-                <param format="bam,bed,gff,gff3,vcf" name="inputB" type="data"
+                <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data"
                        label="File(s) B to intersect with A" help="BAM/BED/GFF/VCF format"/>
             </when>
             <when value='reduce'>
-                <param format="bam,bed,gff,gff3,vcf" name="inputB" type="data" multiple="true"
+                <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" multiple="true"
                        label="File(s) B to intersect with A" help="BAM/BED/GFF/VCF format"/>
             </when>
         </conditional>

--- a/tools/bedtools/jaccardBed.xml
+++ b/tools/bedtools/jaccardBed.xml
@@ -18,8 +18,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="overlap" />
         <expand macro="reciprocal" />
         <param name="strand" type="boolean" checked="false" truevalue="-s" falsevalue=""

--- a/tools/bedtools/jaccardBed.xml
+++ b/tools/bedtools/jaccardBed.xml
@@ -18,8 +18,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="bed,vcf,gff,gff3" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
         <expand macro="overlap" />
         <expand macro="reciprocal" />
         <param name="strand" type="boolean" checked="false" truevalue="-s" falsevalue=""

--- a/tools/bedtools/linksBed.xml
+++ b/tools/bedtools/linksBed.xml
@@ -16,7 +16,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="basename" type="text" value="http://genome.ucsc.edu"
             label="The 'basename' for the UCSC genome browser" />
         <param name="org" type="text" value="human" label="Organism name" help="e.g. mouse, human (-org)" />

--- a/tools/bedtools/linksBed.xml
+++ b/tools/bedtools/linksBed.xml
@@ -16,7 +16,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <param name="basename" type="text" value="http://genome.ucsc.edu"
             label="The 'basename' for the UCSC genome browser" />
         <param name="org" type="text" value="human" label="Organism name" help="e.g. mouse, human (-org)" />

--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -6,6 +6,7 @@
         </requirements>
     </xml>
     <token name="@WRAPPER_VERSION@">2.27.0</token>
+    <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf</token>
     <xml name="stdio">
         <stdio>
             <!-- Anything other than zero is an error -->

--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -7,6 +7,7 @@
     </xml>
     <token name="@WRAPPER_VERSION@">2.27.0</token>
     <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf</token>
+    <token name="@STD_BEDTOOLS_INPUT_LABEL@">bed,bedgraph,gff,vcf</token>
     <xml name="stdio">
         <stdio>
             <!-- Anything other than zero is an error -->
@@ -132,7 +133,7 @@
     <xml name="addition">
         <conditional name="addition">
             <param name="addition_select" type="select" label="Choose what you want to do">
-                <option value="b" selected="True">Increase the BED/GFF/VCF entry by the same number base pairs in each direction.</option>
+                <option value="b" selected="True">Increase the @STD_BEDTOOLS_INPUT_LABEL@ entry by the same number base pairs in each direction.</option>
                 <option value="lr">Increase by Start Coordinate and End Coordinate</option>
             </param>
             <when value="b">

--- a/tools/bedtools/makeWindowsBed.xml
+++ b/tools/bedtools/makeWindowsBed.xml
@@ -33,7 +33,7 @@
                 <option value="genome">Genome File</option>
             </param>
             <when value="bed">
-                <param  name="input" format="bed,vcf,gff,gff3" type="data" label="BED/VCF/GFF file"/>
+                <param  name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="BED/VCF/GFF file"/>
             </when>
             <when value="genome">
                 <expand macro="input_conditional_genome_file" />

--- a/tools/bedtools/makeWindowsBed.xml
+++ b/tools/bedtools/makeWindowsBed.xml
@@ -33,7 +33,7 @@
                 <option value="genome">Genome File</option>
             </param>
             <when value="bed">
-                <param  name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="BED/VCF/GFF file"/>
+                <param  name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
             </when>
             <when value="genome">
                 <expand macro="input_conditional_genome_file" />

--- a/tools/bedtools/mapBed.xml
+++ b/tools/bedtools/mapBed.xml
@@ -21,8 +21,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,bed,vcf,gff,gff3" name="inputA" type="data" label="File A (BAM/BED/VCF/GFF)" />
-        <param format="bam,bed,gff,vcf,gff3" name="inputB" type="data" label="File B (BAM/BED/VCF/GFF)" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (BAM/BED/VCF/GFF)" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="File B (BAM/BED/VCF/GFF)" />
         <expand macro="overlap" />
         <param name="reciprocal" type="boolean" checked="false" truevalue="-r" falsevalue=""
             label="Require reciprocal overlap"

--- a/tools/bedtools/mapBed.xml
+++ b/tools/bedtools/mapBed.xml
@@ -21,8 +21,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (BAM/BED/VCF/GFF)" />
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="File B (BAM/BED/VCF/GFF)" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="File A (BAM/@STD_BEDTOOLS_INPUT_LABEL@)" />
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="File B (BAM/@STD_BEDTOOLS_INPUT_LABEL@)" />
         <expand macro="overlap" />
         <param name="reciprocal" type="boolean" checked="false" truevalue="-r" falsevalue=""
             label="Require reciprocal overlap"

--- a/tools/bedtools/maskFastaBed.xml
+++ b/tools/bedtools/maskFastaBed.xml
@@ -17,7 +17,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param format="fasta" name="fasta" type="data" label="Fasta file"/>
         <param name="soft" type="boolean" checked="false" truevalue="-soft" falsevalue=""
             label="Soft-mask (that is, convert to lower-case bases) the FASTA sequence"

--- a/tools/bedtools/maskFastaBed.xml
+++ b/tools/bedtools/maskFastaBed.xml
@@ -17,7 +17,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <param format="fasta" name="fasta" type="data" label="Fasta file"/>
         <param name="soft" type="boolean" checked="false" truevalue="-soft" falsevalue=""
             label="Soft-mask (that is, convert to lower-case bases) the FASTA sequence"

--- a/tools/bedtools/mergeBed.xml
+++ b/tools/bedtools/mergeBed.xml
@@ -17,7 +17,7 @@
 ]]>
     </command>
     <inputs>
-        <param  name="input" format="bam,@STD_BEDTOOLS_INPUTS@" type="data" label="Sort the following BAM/BED/VCF/GFF file"/>
+        <param  name="input" format="bam,@STD_BEDTOOLS_INPUTS@" type="data" label="Sort the following BAM/@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="strand" type="select" label="Calculation based on strandedness?">
             <option value="" selected="True">Overlaps on either strand</option>
             <option value="-s">Force strandedness. That is, only merge features that are the same strand.</option>

--- a/tools/bedtools/mergeBed.xml
+++ b/tools/bedtools/mergeBed.xml
@@ -17,7 +17,7 @@
 ]]>
     </command>
     <inputs>
-        <param  name="input" format="bam,bed,gff,vcf" type="data" label="Sort the following BAM/BED/VCF/GFF file"/>
+        <param  name="input" format="bam,@STD_BEDTOOLS_INPUTS@" type="data" label="Sort the following BAM/BED/VCF/GFF file"/>
         <param name="strand" type="select" label="Calculation based on strandedness?">
             <option value="" selected="True">Overlaps on either strand</option>
             <option value="-s">Force strandedness. That is, only merge features that are the same strand.</option>

--- a/tools/bedtools/multiCov.xml
+++ b/tools/bedtools/multiCov.xml
@@ -30,7 +30,7 @@
 ]]>
     </command>
     <inputs>
-        <param name="input" format="bed" type="data" label="Sorted BED file" />
+        <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="Sorted BED file" />
         <!-- Additional files, if the user needs more -->
         <param name="bams" format="bam" type="data" multiple="True" label="BAM file" />
 

--- a/tools/bedtools/multiCov.xml
+++ b/tools/bedtools/multiCov.xml
@@ -30,7 +30,7 @@
 ]]>
     </command>
     <inputs>
-        <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="Sorted BED file" />
+        <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" label="Sorted @STD_BEDTOOLS_INPUT_LABEL@ file" />
         <!-- Additional files, if the user needs more -->
         <param name="bams" format="bam" type="data" multiple="True" label="BAM file" />
 

--- a/tools/bedtools/multiIntersectBed.xml
+++ b/tools/bedtools/multiIntersectBed.xml
@@ -38,11 +38,11 @@
                 <option value="custom">Enter custom name per file</option>
             </param>
             <when value="tag">
-                <param name="inputs" format="bed" type="data" multiple="True" label="BED files" />
+                <param name="inputs" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="BED/GFF/VCF files" />
             </when>
             <when value="custom">
                 <repeat name="beds" title="Add BED files" min="2" >
-                    <param name="input" format="bed" type="data" multiple="True" label="BED file" />
+                    <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="BED/GFF/VCF file" />
                     <param name="custom_name" type="text" area="false" label="Custom sample name" />
                 </repeat>
             </when>

--- a/tools/bedtools/multiIntersectBed.xml
+++ b/tools/bedtools/multiIntersectBed.xml
@@ -38,11 +38,11 @@
                 <option value="custom">Enter custom name per file</option>
             </param>
             <when value="tag">
-                <param name="inputs" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="BED/GFF/VCF files" />
+                <param name="inputs" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="@STD_BEDTOOLS_INPUT_LABEL@ files" />
             </when>
             <when value="custom">
                 <repeat name="beds" title="Add BED files" min="2" >
-                    <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="BED/GFF/VCF file" />
+                    <param name="input" format="@STD_BEDTOOLS_INPUTS@" type="data" multiple="True" label="@STD_BEDTOOLS_INPUT_LABEL@ file" />
                     <param name="custom_name" type="text" area="false" label="Custom sample name" />
                 </repeat>
             </when>

--- a/tools/bedtools/nucBed.xml
+++ b/tools/bedtools/nucBed.xml
@@ -20,7 +20,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param format="fasta" name="fasta" type="data" label="FASTA file"/>
 
         <param argument="-s" type="boolean" checked="false" truevalue="-s" falsevalue=""

--- a/tools/bedtools/nucBed.xml
+++ b/tools/bedtools/nucBed.xml
@@ -20,7 +20,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <param format="fasta" name="fasta" type="data" label="FASTA file"/>
 
         <param argument="-s" type="boolean" checked="false" truevalue="-s" falsevalue=""

--- a/tools/bedtools/overlapBed.xml
+++ b/tools/bedtools/overlapBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="cols" type="data_column" multiple="True" data_ref="input"
             label="Specify the columns for the starts and ends of the features for which you’d like to compute the overlap/distance"
             help="The columns must be listed in the following order: start1,end1,start2,end2" />

--- a/tools/bedtools/overlapBed.xml
+++ b/tools/bedtools/overlapBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="input" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF file"/>
         <param name="cols" type="data_column" multiple="True" data_ref="input"
             label="Specify the columns for the starts and ends of the features for which you’d like to compute the overlap/distance"
             help="The columns must be listed in the following order: start1,end1,start2,end2" />

--- a/tools/bedtools/reldist.xml
+++ b/tools/bedtools/reldist.xml
@@ -15,8 +15,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,bam,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
-        <param format="bed,gff,vcf,gff3" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
         <param name="detail" type="boolean" checked="false" truevalue="-detail" falsevalue=""
             label="Instead of a summary, report the relative distance for each interval in A" help="(-detail)" />
     </inputs>

--- a/tools/bedtools/reldist.xml
+++ b/tools/bedtools/reldist.xml
@@ -15,8 +15,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@/BAM file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="detail" type="boolean" checked="false" truevalue="-detail" falsevalue=""
             label="Instead of a summary, report the relative distance for each interval in A" help="(-detail)" />
     </inputs>

--- a/tools/bedtools/shuffleBed.xml
+++ b/tools/bedtools/shuffleBed.xml
@@ -29,7 +29,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="bedpe" type="boolean" label="The file is in BEDPE format" checked="False" truevalue="-bedpe" falsevalue="" />
         <expand macro="input_conditional_genome_file" />
         <param name="chrom" type="boolean" checked="False" truevalue="-chrom" falsevalue=""
@@ -106,7 +106,7 @@
 <![CDATA[
 **What it does**
 
-bedtools shuffle will randomly permute the genomic locations of a feature file among a genome defined in a genome file. One can also provide an “exclusions” BED/GFF/VCF file that lists regions where you do not want the permuted features to be placed. For example, one might want to prevent features from being placed in known genome gaps. shuffle is useful as a null basis against which to test the significance of associations of one feature with another.
+bedtools shuffle will randomly permute the genomic locations of a feature file among a genome defined in a genome file. One can also provide an “exclusions” @STD_BEDTOOLS_INPUT_LABEL@ file that lists regions where you do not want the permuted features to be placed. For example, one might want to prevent features from being placed in known genome gaps. shuffle is useful as a null basis against which to test the significance of associations of one feature with another.
 
 .. image:: $PATH_TO_IMAGES/shuffle-glyph.png
 

--- a/tools/bedtools/shuffleBed.xml
+++ b/tools/bedtools/shuffleBed.xml
@@ -29,7 +29,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
         <param name="bedpe" type="boolean" label="The file is in BEDPE format" checked="False" truevalue="-bedpe" falsevalue="" />
         <expand macro="input_conditional_genome_file" />
         <param name="chrom" type="boolean" checked="False" truevalue="-chrom" falsevalue=""

--- a/tools/bedtools/slopBed.xml
+++ b/tools/bedtools/slopBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
         <expand macro="input_conditional_genome_file" />
         <param name="pct" type="boolean" checked="false" truevalue="-pct" falsevalue=""
             label="Define -l and -r as a fraction of the feature’s length"

--- a/tools/bedtools/slopBed.xml
+++ b/tools/bedtools/slopBed.xml
@@ -23,7 +23,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="input_conditional_genome_file" />
         <param name="pct" type="boolean" checked="false" truevalue="-pct" falsevalue=""
             label="Define -l and -r as a fraction of the feature’s length"

--- a/tools/bedtools/sortBed.xml
+++ b/tools/bedtools/sortBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,gff,gff3,vcf" name="input" type="data" label="Sort the following BED file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Sort the following BED/GFF/VCF file"/>
         <param name="option" type="select" label="Sort by">
             <!-- sort -k 1,1 -k2,2 -n a.bed -->
             <option value="">chromosome, then by start position (asc)</option>

--- a/tools/bedtools/sortBed.xml
+++ b/tools/bedtools/sortBed.xml
@@ -14,7 +14,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Sort the following BED/GFF/VCF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="Sort the following @STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="option" type="select" label="Sort by">
             <!-- sort -k 1,1 -k2,2 -n a.bed -->
             <option value="">chromosome, then by start position (asc)</option>

--- a/tools/bedtools/spacingBed.xml
+++ b/tools/bedtools/spacingBed.xml
@@ -13,7 +13,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3,bam" name="input" type="data" label="BED/VCF/GFF/BAM file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF/BAM file"/>
     </inputs>
     <outputs>
         <data format_source="input" name="output" metadata_source="input" label="Spaces between intervals of ${input}"/>

--- a/tools/bedtools/spacingBed.xml
+++ b/tools/bedtools/spacingBed.xml
@@ -13,7 +13,7 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="BED/VCF/GFF/BAM file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="input" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@/BAM file"/>
     </inputs>
     <outputs>
         <data format_source="input" name="output" metadata_source="input" label="Spaces between intervals of ${input}"/>

--- a/tools/bedtools/subtractBed.xml
+++ b/tools/bedtools/subtractBed.xml
@@ -17,8 +17,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <expand macro="strand2" />
         <expand macro="overlap" />
         <param name="removeIfOverlap" type="select" label="Calculation based on strandedness?">

--- a/tools/bedtools/subtractBed.xml
+++ b/tools/bedtools/subtractBed.xml
@@ -17,8 +17,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF file"/>
-        <param format="bed,gff,vcf,gff3" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
         <expand macro="strand2" />
         <expand macro="overlap" />
         <param name="removeIfOverlap" type="select" label="Calculation based on strandedness?">

--- a/tools/bedtools/tagBed.xml
+++ b/tools/bedtools/tagBed.xml
@@ -20,7 +20,7 @@
     </command>
     <inputs>
         <param name="inputA" format="bam" type="data" label="BAM file"/>
-        <param name="inputB" format="@STD_BEDTOOLS_INPUTS@" multiple="True" type="data" label="BED/VCF/GFF file" />
+        <param name="inputB" format="@STD_BEDTOOLS_INPUTS@" multiple="True" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file" />
         <expand macro="strand2" />
         <expand macro="overlap" />
         <param name="tag" type="text" value="YB" label="Specify the tag to use" />
@@ -46,7 +46,7 @@
 <![CDATA[
 **What it does**
 
-Annotates a BAM file based on overlaps with multiple BED/GFF/VCF files on the intervals in an input bam file
+Annotates a BAM file based on overlaps with multiple @STD_BEDTOOLS_INPUT_LABEL@ files on the intervals in an input bam file
 
 @REFERENCES@
 ]]>

--- a/tools/bedtools/tagBed.xml
+++ b/tools/bedtools/tagBed.xml
@@ -20,7 +20,7 @@
     </command>
     <inputs>
         <param name="inputA" format="bam" type="data" label="BAM file"/>
-        <param name="inputB" format="bed,gff,vcf" multiple="True" type="data" label="BED/VCF/GFF file" />
+        <param name="inputB" format="@STD_BEDTOOLS_INPUTS@" multiple="True" type="data" label="BED/VCF/GFF file" />
         <expand macro="strand2" />
         <expand macro="overlap" />
         <param name="tag" type="text" value="YB" label="Specify the tag to use" />

--- a/tools/bedtools/windowBed.xml
+++ b/tools/bedtools/windowBed.xml
@@ -30,8 +30,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
-        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@/BAM file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="bed" type="boolean" checked="false" truevalue="-bed" falsevalue=""
             label="When using BAM input, write output as BED. The default is to write output in BAM when using a bam file"
             help="(-bed)" />

--- a/tools/bedtools/windowBed.xml
+++ b/tools/bedtools/windowBed.xml
@@ -30,8 +30,8 @@
 ]]>
     </command>
     <inputs>
-        <param format="bed,bam,vcf,gff,gff3" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
-        <param format="bed,gff,vcf,gff3" name="inputB" type="data" label="BED/VCF/GFF file"/>
+        <param format="bam,@STD_BEDTOOLS_INPUTS@" name="inputA" type="data" label="BED/VCF/GFF/BAM file"/>
+        <param format="@STD_BEDTOOLS_INPUTS@" name="inputB" type="data" label="BED/VCF/GFF file"/>
         <param name="bed" type="boolean" checked="false" truevalue="-bed" falsevalue=""
             label="When using BAM input, write output as BED. The default is to write output in BAM when using a bam file"
             help="(-bed)" />


### PR DESCRIPTION
Most bedtools tools take a standard set of bed/bedgraph/gff/vcf interval files. Using this token we can control this set in a single place.

In addition this commit allows bedgraph input in most commands without additional conversion and adds non-bed inputs in groupbybed, multicov, multiintersectbed and sortbed which all support these
additional formats (they can also take gzipped input ... if we'd want to toggle this in Galaxy).