### PR TITLE
fix htseq

### DIFF
--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -158,43 +158,43 @@
             </actions>
         </data>
         <data format="bam" name="samoutfile" metadata_source="samfile" label="${tool.name} on ${on_string} (BAM)">
-            <filter>samout_conditional['samout'] == "Yes"</filter>
+            <filter>advanced_options['advanced_options_selector'] == 'advanced' and  advanced_options['samout_conditional']['samout'] == "Yes"</filter>
         </data>
     </outputs>
 
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
             <param name="gfffile" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
             <param name="gfffile" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.bam" />
             <param name="gfffile" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
             <param name="gfffile" value="htseq-test.gff" />
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
             <param name="gfffile" value="htseq-test.gff" />
             <param name="samout" value="No" />
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="samfile" value="htseq-test.sam" />
             <param name="gfffile" value="htseq-test.gff" />
             <param name="advanced_options_selector" value="advanced" />
@@ -205,7 +205,7 @@
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
             <output name="samoutfile" file="htseq-test_samout.bam" />
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
             <param name="gfffile" value="htseq-test.gff" />
             <param name="advanced_options_selector" value="advanced" />


### PR DESCRIPTION
The old filter did not work and Galaxy produced an empty dataset, which Galaxy was trying to index and crashed (probably also a Galaxy bug).

But this should solve the htseq tool at least.