### PR TITLE
Fix default_identifier_source in macs2 to include conditional

### DIFF
--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -243,34 +243,34 @@
     </inputs>
     <outputs>
         <!--callpeaks output-->
-        <data name="output_tabular" format="tabular" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (Peaks in tabular format)">
+        <data name="output_tabular" format="tabular" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (Peaks in tabular format)">
             <filter> outputs and 'peaks_tabular' in outputs</filter>
         </data>
-        <data name="output_broadpeaks" format="bed" from_work_dir="MACS2_peaks.broadPeak" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (broad Peaks)">
+        <data name="output_broadpeaks" format="bed" from_work_dir="MACS2_peaks.broadPeak" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (broad Peaks)">
             <filter>
             ((
               advanced_options['broad_options']['broad_options_selector'] == "broad"
             ))
             </filter>
         </data>
-        <data name="output_gappedpeaks" format="bed" from_work_dir="MACS2_peaks.gappedPeak" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (gapped Peaks)">
+        <data name="output_gappedpeaks" format="bed" from_work_dir="MACS2_peaks.gappedPeak" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (gapped Peaks)">
             <filter>
             ((
               advanced_options['broad_options']['broad_options_selector'] == "broad"
             ))
             </filter>
         </data>
-        <data name="output_narrowpeaks" format="bed" from_work_dir="MACS2_peaks.narrowPeak" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (narrow Peaks)">
+        <data name="output_narrowpeaks" format="bed" from_work_dir="MACS2_peaks.narrowPeak" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (narrow Peaks)">
             <filter>
             ((
               advanced_options['broad_options']['broad_options_selector'] == "nobroad"
             ))
             </filter>
         </data>
-        <data name="output_summits" format="bed" from_work_dir="MACS2_summits.bed" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (summits in BED)">
+        <data name="output_summits" format="bed" from_work_dir="MACS2_summits.bed" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (summits in BED)">
             <filter>outputs and 'summits' in outputs</filter>
         </data>
-        <data name="output_plot" format="pdf" from_work_dir="MACS2_model.pdf" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (plot)">
+        <data name="output_plot" format="pdf" from_work_dir="MACS2_model.pdf" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (plot)">
             <filter>
             ((
               outputs and 'pdf' in outputs and
@@ -279,13 +279,13 @@
             ))
             </filter>
         </data>
-        <data name="output_treat_pileup" format="bedgraph" from_work_dir="MACS2_treat_pileup.bdg" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (Bedgraph Treatment)">
+        <data name="output_treat_pileup" format="bedgraph" from_work_dir="MACS2_treat_pileup.bdg" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (Bedgraph Treatment)">
             <filter>outputs and 'bdg' in outputs</filter>
         </data>
-        <data name="output_control_lambda" format="bedgraph" from_work_dir="MACS2_control_lambda.bdg" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (Bedgraph Control)">
+        <data name="output_control_lambda" format="bedgraph" from_work_dir="MACS2_control_lambda.bdg" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (Bedgraph Control)">
             <filter>outputs and 'bdg' in outputs</filter>
         </data>
-        <data name="output_extra_files" format="html" default_identifier_source="input_treatment_file" label="${tool.name} on ${on_string} (html report)">
+        <data name="output_extra_files" format="html" default_identifier_source="treatment|input_treatment_file" label="${tool.name} on ${on_string} (html report)">
             <filter>outputs and 'html' in outputs</filter>
         </data>
     </outputs>


### PR DESCRIPTION
Sorry that I didn't notice this right away @mblue9 !
I tested this a couple of times and this works correctly for me now.
Without the conditional prefix we're not finding the source in https://github.com/galaxyproject/galaxy/blob/release_18.01/lib/galaxy/tools/execute.py#L228. 