### PR TITLE
Fix sorting of rows in StringTie outputs

### DIFF
--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -103,9 +103,9 @@ $adv.multi_mapping
         #end if
         ## Sort count files on the first column
         &&
-        tail -n +2 gene_counts.csv | sort -t"\${TAB}" -k1 >> '$gene_counts'
+        tail -n +2 gene_counts.csv | sort -t"\${TAB}" -k1,1 >> '$gene_counts'
         &&
-        tail -n +2 transcript_counts.csv | sort -t"\${TAB}" -k1 >> '$transcript_counts'
+        tail -n +2 transcript_counts.csv | sort -t"\${TAB}" -k1,1 >> '$transcript_counts'
     #end if
 #end if
     ]]></command>


### PR DESCRIPTION
Sort only on the first column, otherwise an output count file may become something like:
```
G1000	2
G100	1
G1001	2
G1002	2
```
instead of:
```
G100	1
G1000	2
G1001	2
G1002	2
```