### PR TITLE
EdgeR: fixes and improvements to output with annotations, plots and report

### DIFF
--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -504,7 +504,7 @@ for (i in 1:length(contrastData)) {
     pdf(mdOutPdf[i])
     limma::plotMD(res, status=status,
                                 main=paste("MD Plot:", unmake.names(contrastData[i])), 
-                                col=alpha(c("firebrick", "blue"), 0.4), values=c("1", "-1"),
+                                hl.col=alpha(c("firebrick", "blue"), 0.4), values=c(1, -1),
                                 xlab="Average Expression", ylab="logFC")
     
     abline(h=0, col="grey", lty=2)
@@ -517,7 +517,7 @@ for (i in 1:length(contrastData)) {
     png(mdOutPng[i], height=600, width=600)
     limma::plotMD(res, status=status,
                                 main=paste("MD Plot:", unmake.names(contrastData[i])), 
-                                col=alpha(c("firebrick", "blue"), 0.4), values=c("1", "-1"),
+                                hl.col=alpha(c("firebrick", "blue"), 0.4), values=c(1, -1),
                                 xlab="Average Expression", ylab="logFC")
     
     abline(h=0, col="grey", lty=2)

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -622,7 +622,7 @@ cata("<ul>\n")
 
 if (filtCPM || filtSmpCount || filtTotCount) {
     if (filtCPM) {
-    tempStr <- paste("Genes without more than", opt$cmpReq,
+    tempStr <- paste("Genes without more than", opt$cpmReq,
                                      "CPM in at least", opt$sampleReq, "samples are insignificant",
                                      "and filtered out.")
     } else if (filtSmpCount) {

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -338,7 +338,9 @@ flatCount <- numeric()
 data <- list()
 data$counts <- counts
 if (haveAnno) {
-    data$genes <- geneanno
+  # order annotation by genes in counts (assumes gene ids are in 1st column of geneanno)
+  annoord <- geneanno[match(row.names(counts), geneanno[,1]), ]
+  data$genes <- annoord
 } else {
     data$genes <- data.frame(GeneID=row.names(counts))
 }

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -471,7 +471,7 @@ if (wantLRT) {
 if (wantNorm) { 
         normalisedCounts <- cpm(data, normalized.lib.sizes=TRUE, log=TRUE) 
         normalisedCounts <- data.frame(data$genes, normalisedCounts)
-        write.table (normalisedCounts, file=normOut, row.names=FALSE, sep="\t")
+        write.table (normalisedCounts, file=normOut, row.names=FALSE, sep="\t", quote=FALSE)
         linkData <- rbind(linkData, c("edgeR_normcounts.tsv", "edgeR_normcounts.tsv"))
 }
 
@@ -494,7 +494,7 @@ for (i in 1:length(contrastData)) {
                                              
     # Write top expressions table
     top <- topTags(res, n=Inf, sort.by="PValue")
-    write.table(top, file=topOut[i], row.names=FALSE, sep="\t")
+    write.table(top, file=topOut[i], row.names=FALSE, sep="\t", quote=FALSE)
     
     linkName <- paste0("edgeR_", contrastData[i], ".tsv")
     linkAddr <- paste0("edgeR_", contrastData[i], ".tsv")

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -419,7 +419,7 @@ imageData[1, ] <- c("MDS Plot", "mdsplot.png")
 invisible(dev.off())
 
 pdf(mdsOutPdf)
-plotMDS(data, labels=labels, cex=0.5)
+plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main="MDS Plot")
 linkData[1, ] <- c("MDS Plot.pdf", "mdsplot.pdf")
 invisible(dev.off())
 

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -306,9 +306,13 @@ bcvOutPdf <- makeOut("bcvplot.pdf")
 bcvOutPng <- makeOut("bcvplot.png")
 qlOutPdf <- makeOut("qlplot.pdf")
 qlOutPng <- makeOut("qlplot.png")
-mdsOutPdf <- makeOut("mdsplot.pdf")
-mdsOutPng <- makeOut("mdsplot.png")
-mdOutPdf <- character()   # Initialise character vector
+mdsOutPdf <- character()   # Initialise character vector
+mdsOutPng <- character()
+for (i in 1:ncol(factors)) {
+    mdsOutPdf[i] <- makeOut(paste0("mdsplot_", names(factors)[i], ".pdf"))
+    mdsOutPng[i] <- makeOut(paste0("mdsplot_", names(factors)[i], ".png"))
+}
+mdOutPdf <- character()
 mdOutPng <- character()
 topOut <- character()
 for (i in 1:length(contrastData)) {
@@ -412,16 +416,40 @@ contrasts <- makeContrasts(contrasts=contrastData, levels=design)
 
 # Plot MDS
 labels <- names(counts)
+
+# MDS plot
 png(mdsOutPng, width=600, height=600)
-# Currently only using a single factor
-plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main="MDS Plot")
-imageData[1, ] <- c("MDS Plot", "mdsplot.png")
+plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main=paste("MDS Plot:", names(factors)[1]))
+imgName <- paste0("MDS Plot_", names(factors)[1], ".png")
+imgAddr <- paste0("mdsplot_", names(factors)[1], ".png")
+imageData[1, ] <- c(imgName, imgAddr)
 invisible(dev.off())
 
 pdf(mdsOutPdf)
-plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main="MDS Plot")
-linkData[1, ] <- c("MDS Plot.pdf", "mdsplot.pdf")
+plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main=paste("MDS Plot:", names(factors)[1]))
+linkName <- paste0("MDS Plot_", names(factors)[1], ".pdf")
+linkAddr <- paste0("mdsplot_", names(factors)[1], ".pdf")
+linkData[1, ] <- c(linkName, linkAddr)
 invisible(dev.off())
+
+# If additional factors create additional MDS plots coloured by factor
+if (ncol(factors) > 1) {
+    for (i in 2:ncol(factors)) {
+        png(mdsOutPng[i], width=600, height=600)
+        plotMDS(data, labels=labels, col=as.numeric(factors[, i]), cex=0.8, main=paste("MDS Plot:", names(factors)[i]))
+        imgName <- paste0("MDS Plot_", names(factors)[i], ".png")
+        imgAddr <- paste0("mdsplot_", names(factors)[i], ".png")
+        imageData <- rbind(imageData, c(imgName, imgAddr))
+        invisible(dev.off())
+
+        pdf(mdsOutPdf[i])
+        plotMDS(data, labels=labels, col=as.numeric(factors[, i]), cex=0.8, main=paste("MDS Plot:", names(factors)[i]))
+        linkName <- paste0("MDS Plot_", names(factors)[i], ".pdf")
+        linkAddr <- paste0("mdsplot_", names(factors)[i], ".pdf")
+        linkData <- rbind(linkData, c(linkName, linkAddr))
+        invisible(dev.off())
+    }
+}
 
 # BCV Plot
 png(bcvOutPng, width=600, height=600)

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -271,45 +271,7 @@ cp '$outReport.files_path'/*.tsv output_dir/
     </outputs>
 
     <tests>
-        <!-- Ensure report is output -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="WT-Mut" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <output_collection name="outTables" count="2">
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4582" />
-                   </assert_contents>
-               </element>
-                <element name="edgeR_WT-Mut" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*-0.4582" />
-                   </assert_contents>
-               </element>
-            </output_collection>
-            <output name="outReport" >
-                <assert_contents>
-                    <has_text text="edgeR Analysis Output" />
-                    <has_text text="quasi-likelihood" />
-                    <not_has_text text="likelihood ratio" />
-                    <not_has_text text="RData" />
-                </assert_contents>
-            </output>
-        </test>
-        <!-- Ensure annotation file input works -->
+         <!-- Ensure annotation file input works -->
         <test>
             <param name="format" value="matrix" />
             <param name="annoOpt" value="yes" />
@@ -332,119 +294,7 @@ cp '$outReport.files_path'/*.tsv output_dir/
                </element>
             </output_collection>
         </test>
-        <!-- Ensure RScript and RData file can be output -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="rscript" value="True"/>
-            <param name="rdaOption" value="true" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <output name="outReport" >
-                <assert_contents>
-                    <has_text text="RData" />
-                </assert_contents>
-            </output>
-            <output name="rscript" value="out_rscript.txt"/>
-        </test>
-        <!-- Ensure secondary factors work -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_factor">
-                <param name="factorName" value="Batch"/>
-                <param name="groupNames" value="b1,b2,b3,b1,b2,b3"/>
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <output_collection name="outTables" count="1" >
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4584" />
-                   </assert_contents>
-               </element>
-            </output_collection>
-        </test>
-        <!-- Ensure factors file input works -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="ffile" value="yes" />
-            <param name="finfo" value="factorinfo.txt" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <output_collection name="outTables" count="1">
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4584" />
-                   </assert_contents>
-               </element>
-            </output_collection>
-        </test>
-        <!-- Ensure normalised counts file output works-->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="normCounts" value="true" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <output_collection name="outTables" count="2">
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4582" />
-                   </assert_contents>
-               </element>
-                <element name="edgeR_normcounts" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*15.7535" />
-                   </assert_contents>
-               </element>
-            </output_collection>
-        </test>
-        <!-- Ensure likelihood ratio option works -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <param name="lrtOption" value="true" />
-            <output name="outReport" >
-                <assert_contents>
-                    <has_text text="likelihood ratio" />
-                    <not_has_text text="quasi-likelihood" />
-                </assert_contents>
-            </output>
-        </test>
+
         <!-- Ensure multiple counts files input works -->
         <test>
             <param name="format" value="files" />
@@ -504,9 +354,11 @@ cp '$outReport.files_path'/*.tsv output_dir/
                </element>
             </output_collection>
         </test>
-        <!-- Ensure filtering on CPM in Mnimum Samples works -->
+      <!-- Ensure RScript and RData file can be output -->
         <test>
             <param name="format" value="matrix" />
+            <param name="rscript" value="True"/>
+            <param name="rdaOption" value="true" />
             <param name="counts" value="matrix.txt" />
             <repeat name="rep_factor">
                 <param name="factorName" value="Genotype"/>
@@ -516,99 +368,12 @@ cp '$outReport.files_path'/*.tsv output_dir/
                 <param name="contrast" value="Mut-WT" />
             </repeat>
             <param name="normalisationOption" value="TMM" />
-            <param name="filt_select" value="yes" />
-            <param name="format_select" value="cpm" />
-            <!-- real cpmReq values would be a lot lower
-                 this is just for this tiny test dataset -->
-            <param name="cpmReq" value="1000" />
-            <param name="cpmSampleReq" value="3" />
             <output name="outReport" >
                 <assert_contents>
-                    <has_text text="CPM in at least" />
-                    <not_has_text text="after summing counts for all samples" />
-                    <not_has_text text="counts in at least" />
+                    <has_text text="RData" />
                 </assert_contents>
             </output>
-            <output_collection name="outTables" count="1" >
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4568" />
-                        <not_has_text text="-0.0682" />
-                   </assert_contents>
-               </element>
-            </output_collection>
-        </test>
-        <!-- Ensure filtering on Count in Minmum Samples works -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <param name="filt_select" value="yes" />
-            <param name="format_select" value="counts" />
-            <param name="cntReq" value="10" />
-            <param name="count_select" value="sample" />
-            <param name="cntSampleReq" value="3" />
-            <output name="outReport" >
-                <assert_contents>
-                    <has_text text="counts in at least" />
-                    <not_has_text text="after summing counts for all samples" />
-                    <not_has_text text="CPM in at least" />
-                </assert_contents>
-            </output>
-            <output_collection name="outTables" count="1" >
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4568" />
-                        <not_has_text text="-0.0682" />
-                   </assert_contents>
-               </element>
-
-            </output_collection>
-        </test>
-        <!-- Ensure filtering on Total Count works -->
-        <test>
-            <param name="format" value="matrix" />
-            <param name="counts" value="matrix.txt" />
-            <repeat name="rep_factor">
-                <param name="factorName" value="Genotype"/>
-                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
-            </repeat>
-            <repeat name="rep_contrast">
-                <param name="contrast" value="Mut-WT" />
-            </repeat>
-            <param name="normalisationOption" value="TMM" />
-            <param name="filt_select" value="yes" />
-            <param name="format_select" value="counts" />
-            <!-- real cntReq values would be a lot lower
-                 this is just for this tiny test dataset -->
-            <param name="cntReq" value="1000" />
-            <param name="count_select" value="total" />
-            <param name="totReq" value="true" />
-            <output name="outReport" >
-                <assert_contents>
-                    <has_text text="after summing counts for all samples" />
-                    <not_has_text text="counts in at least" />
-                    <not_has_text text="CPM in at least" />
-                </assert_contents>
-            </output>
-            <output_collection name="outTables" count="1" >
-                <element name="edgeR_Mut-WT" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
-                        <has_text_matching expression="11304.*0.4568" />
-                        <not_has_text text="-0.0682" />
-                   </assert_contents>
-               </element>
-            </output_collection>
+            <output name="rscript" value="out_rscript.txt"/>
         </test>
     </tests>
 
@@ -683,19 +448,19 @@ Example:
 **Gene Annotations:**
 Optional input for gene annotations, this can contain more
 information about the genes than just an ID number. The annotations will
-be available in the differential expression results table and the optional normalised counts table.
+be available in the differential expression results table and the optional normalised counts table. The file must contain a header row and have the gene IDs in the first column. The number of rows should match that of the counts files, add NA for any gene IDs with no annotation. The Galaxy tool **annotateMyIDs** can be used to obtain annotations for human, mouse, fly and zebrafish.
 
 Example:
 
     ==========  ==========  ===================================================
     **GeneID**  **Symbol**  **GeneName**
     ----------  ----------  ---------------------------------------------------
-    1287        Pzp         pregnancy zone protein
-    1298        Aanat       arylalkylamine N-acetyltransferase
-    1302        Aatk        apoptosis-associated tyrosine kinase
-    1303        Abca1       ATP-binding cassette, sub-family A (ABC1), member 1
-    1304        Abca4       ATP-binding cassette, sub-family A (ABC1), member 4
-    1305        Abca2       ATP-binding cassette, sub-family A (ABC1), member 2
+    11287        Pzp         pregnancy zone protein
+    11298        Aanat       arylalkylamine N-acetyltransferase
+    11302        Aatk        apoptosis-associated tyrosine kinase
+    11303        Abca1       ATP-binding cassette, sub-family A (ABC1), member 1
+    11304        Abca4       ATP-binding cassette, sub-family A (ABC1), member 4
+    11305        Abca2       ATP-binding cassette, sub-family A (ABC1), member 2
     ==========  ==========  ===================================================
 
 **Contrasts of Interest:**

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -120,12 +120,12 @@ cp '$outReport.files_path'/*.tsv output_dir/
                     </param>
                     <repeat name="rep_group" title="Group" min="2" default="2">
                         <param name="groupName" type="text" label="Name"
-                        help="Name of group that the counts files(s) belong to (e.g. WT or Mut). NOTE: Please only use letters, numbers or underscores (case sensitive).">
+                        help="Name of group that the counts files belong to (e.g. WT or Mut). NOTE: Please only use letters, numbers or underscores (case sensitive).">
                         <sanitizer>
                             <valid initial="string.letters,string.digits"><add value="_" /></valid>
                         </sanitizer>
                         </param>
-                        <param name="countsFile" type="data" format="tabular" multiple="true" label="Counts file(s)"/>
+                        <param name="countsFile" type="data" format="tabular" multiple="true" label="Counts files"/>
                     </repeat>
                 </repeat>
             </when>

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -1,4 +1,4 @@
-<tool id="edger" name="edgeR" version="3.20.7.1">
+<tool id="edger" name="edgeR" version="3.20.7.2">
     <description>
         Perform differential expression of count data
     </description>

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -271,7 +271,45 @@ cp '$outReport.files_path'/*.tsv output_dir/
     </outputs>
 
     <tests>
-         <!-- Ensure annotation file input works -->
+        <!-- Ensure report is output -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="WT-Mut" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <output_collection name="outTables" count="2">
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4582" />
+                   </assert_contents>
+               </element>
+                <element name="edgeR_WT-Mut" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*-0.4582" />
+                   </assert_contents>
+               </element>
+            </output_collection>
+            <output name="outReport" >
+                <assert_contents>
+                    <has_text text="edgeR Analysis Output" />
+                    <has_text text="quasi-likelihood" />
+                    <not_has_text text="likelihood ratio" />
+                    <not_has_text text="RData" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Ensure annotation file input works -->
         <test>
             <param name="format" value="matrix" />
             <param name="annoOpt" value="yes" />
@@ -294,7 +332,119 @@ cp '$outReport.files_path'/*.tsv output_dir/
                </element>
             </output_collection>
         </test>
-
+        <!-- Ensure RScript and RData file can be output -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="rscript" value="True"/>
+            <param name="rdaOption" value="true" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <output name="outReport" >
+                <assert_contents>
+                    <has_text text="RData" />
+                </assert_contents>
+            </output>
+            <output name="rscript" value="out_rscript.txt"/>
+        </test>
+        <!-- Ensure secondary factors work -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_factor">
+                <param name="factorName" value="Batch"/>
+                <param name="groupNames" value="b1,b2,b3,b1,b2,b3"/>
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <output_collection name="outTables" count="1" >
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4584" />
+                   </assert_contents>
+               </element>
+            </output_collection>
+        </test>
+        <!-- Ensure factors file input works -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="ffile" value="yes" />
+            <param name="finfo" value="factorinfo.txt" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <output_collection name="outTables" count="1">
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4584" />
+                   </assert_contents>
+               </element>
+            </output_collection>
+        </test>
+        <!-- Ensure normalised counts file output works-->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="normCounts" value="true" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <output_collection name="outTables" count="2">
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4582" />
+                   </assert_contents>
+               </element>
+                <element name="edgeR_normcounts" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
+                        <has_text_matching expression="11304.*15.7535" />
+                   </assert_contents>
+               </element>
+            </output_collection>
+        </test>
+        <!-- Ensure likelihood ratio option works -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <param name="lrtOption" value="true" />
+            <output name="outReport" >
+                <assert_contents>
+                    <has_text text="likelihood ratio" />
+                    <not_has_text text="quasi-likelihood" />
+                </assert_contents>
+            </output>
+        </test>
         <!-- Ensure multiple counts files input works -->
         <test>
             <param name="format" value="files" />
@@ -354,11 +504,9 @@ cp '$outReport.files_path'/*.tsv output_dir/
                </element>
             </output_collection>
         </test>
-      <!-- Ensure RScript and RData file can be output -->
+        <!-- Ensure filtering on CPM in Mnimum Samples works -->
         <test>
             <param name="format" value="matrix" />
-            <param name="rscript" value="True"/>
-            <param name="rdaOption" value="true" />
             <param name="counts" value="matrix.txt" />
             <repeat name="rep_factor">
                 <param name="factorName" value="Genotype"/>
@@ -368,12 +516,99 @@ cp '$outReport.files_path'/*.tsv output_dir/
                 <param name="contrast" value="Mut-WT" />
             </repeat>
             <param name="normalisationOption" value="TMM" />
+            <param name="filt_select" value="yes" />
+            <param name="format_select" value="cpm" />
+            <!-- real cpmReq values would be a lot lower
+                 this is just for this tiny test dataset -->
+            <param name="cpmReq" value="1000" />
+            <param name="cpmSampleReq" value="3" />
             <output name="outReport" >
                 <assert_contents>
-                    <has_text text="RData" />
+                    <has_text text="CPM in at least" />
+                    <not_has_text text="after summing counts for all samples" />
+                    <not_has_text text="counts in at least" />
                 </assert_contents>
             </output>
-            <output name="rscript" value="out_rscript.txt"/>
+            <output_collection name="outTables" count="1" >
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4568" />
+                        <not_has_text text="-0.0682" />
+                   </assert_contents>
+               </element>
+            </output_collection>
+        </test>
+        <!-- Ensure filtering on Count in Minmum Samples works -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <param name="filt_select" value="yes" />
+            <param name="format_select" value="counts" />
+            <param name="cntReq" value="10" />
+            <param name="count_select" value="sample" />
+            <param name="cntSampleReq" value="3" />
+            <output name="outReport" >
+                <assert_contents>
+                    <has_text text="counts in at least" />
+                    <not_has_text text="after summing counts for all samples" />
+                    <not_has_text text="CPM in at least" />
+                </assert_contents>
+            </output>
+            <output_collection name="outTables" count="1" >
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4568" />
+                        <not_has_text text="-0.0682" />
+                   </assert_contents>
+               </element>
+
+            </output_collection>
+        </test>
+        <!-- Ensure filtering on Total Count works -->
+        <test>
+            <param name="format" value="matrix" />
+            <param name="counts" value="matrix.txt" />
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
+            </repeat>
+            <repeat name="rep_contrast">
+                <param name="contrast" value="Mut-WT" />
+            </repeat>
+            <param name="normalisationOption" value="TMM" />
+            <param name="filt_select" value="yes" />
+            <param name="format_select" value="counts" />
+            <!-- real cntReq values would be a lot lower
+                 this is just for this tiny test dataset -->
+            <param name="cntReq" value="1000" />
+            <param name="count_select" value="total" />
+            <param name="totReq" value="true" />
+            <output name="outReport" >
+                <assert_contents>
+                    <has_text text="after summing counts for all samples" />
+                    <not_has_text text="counts in at least" />
+                    <not_has_text text="CPM in at least" />
+                </assert_contents>
+            </output>
+            <output_collection name="outTables" count="1" >
+                <element name="edgeR_Mut-WT" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*logCPM.*F.*PValue.*FDR" />
+                        <has_text_matching expression="11304.*0.4568" />
+                        <not_has_text text="-0.0682" />
+                   </assert_contents>
+               </element>
+            </output_collection>
         </test>
     </tests>
 

--- a/tools/edger/test-data/anno.txt
+++ b/tools/edger/test-data/anno.txt
@@ -1,7 +1,7 @@
 EntrezID	Symbol	GeneName	Chr	Length
-11287	Pzp	pregnancy zone protein	6	4681
-11298	Aanat	arylalkylamine N-acetyltransferase	11	1455
 11302	Aatk	apoptosis-associated tyrosine kinase	11	5743
+11287	Pzp	pregnancy zone protein	6	4681
 11303	Abca1	ATP-binding cassette, sub-family A (ABC1), member 1	4	10260
 11304	Abca4	ATP-binding cassette, sub-family A (ABC1), member 4	3	7248
 11305	Abca2	ATP-binding cassette, sub-family A (ABC1), member 2	2	8061
+11298	Aanat	arylalkylamine N-acetyltransferase	11	1455

--- a/tools/edger/test-data/out_rscript.txt
+++ b/tools/edger/test-data/out_rscript.txt
@@ -306,9 +306,13 @@ bcvOutPdf <- makeOut("bcvplot.pdf")
 bcvOutPng <- makeOut("bcvplot.png")
 qlOutPdf <- makeOut("qlplot.pdf")
 qlOutPng <- makeOut("qlplot.png")
-mdsOutPdf <- makeOut("mdsplot.pdf")
-mdsOutPng <- makeOut("mdsplot.png")
-mdOutPdf <- character()   # Initialise character vector
+mdsOutPdf <- character()   # Initialise character vector
+mdsOutPng <- character()
+for (i in 1:ncol(factors)) {
+    mdsOutPdf[i] <- makeOut(paste0("mdsplot_", names(factors)[i], ".pdf"))
+    mdsOutPng[i] <- makeOut(paste0("mdsplot_", names(factors)[i], ".png"))
+}
+mdOutPdf <- character()
 mdOutPng <- character()
 topOut <- character()
 for (i in 1:length(contrastData)) {
@@ -412,16 +416,40 @@ contrasts <- makeContrasts(contrasts=contrastData, levels=design)
 
 # Plot MDS
 labels <- names(counts)
+
+# MDS plot
 png(mdsOutPng, width=600, height=600)
-# Currently only using a single factor
-plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main="MDS Plot")
-imageData[1, ] <- c("MDS Plot", "mdsplot.png")
+plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main=paste("MDS Plot:", names(factors)[1]))
+imgName <- paste0("MDS Plot_", names(factors)[1], ".png")
+imgAddr <- paste0("mdsplot_", names(factors)[1], ".png")
+imageData[1, ] <- c(imgName, imgAddr)
 invisible(dev.off())
 
 pdf(mdsOutPdf)
-plotMDS(data, labels=labels, cex=0.5)
-linkData[1, ] <- c("MDS Plot.pdf", "mdsplot.pdf")
+plotMDS(data, labels=labels, col=as.numeric(factors[, 1]), cex=0.8, main=paste("MDS Plot:", names(factors)[1]))
+linkName <- paste0("MDS Plot_", names(factors)[1], ".pdf")
+linkAddr <- paste0("mdsplot_", names(factors)[1], ".pdf")
+linkData[1, ] <- c(linkName, linkAddr)
 invisible(dev.off())
+
+# If additional factors create additional MDS plots coloured by factor
+if (ncol(factors) > 1) {
+    for (i in 2:ncol(factors)) {
+        png(mdsOutPng[i], width=600, height=600)
+        plotMDS(data, labels=labels, col=as.numeric(factors[, i]), cex=0.8, main=paste("MDS Plot:", names(factors)[i]))
+        imgName <- paste0("MDS Plot_", names(factors)[i], ".png")
+        imgAddr <- paste0("mdsplot_", names(factors)[i], ".png")
+        imageData <- rbind(imageData, c(imgName, imgAddr))
+        invisible(dev.off())
+
+        pdf(mdsOutPdf[i])
+        plotMDS(data, labels=labels, col=as.numeric(factors[, i]), cex=0.8, main=paste("MDS Plot:", names(factors)[i]))
+        linkName <- paste0("MDS Plot_", names(factors)[i], ".pdf")
+        linkAddr <- paste0("mdsplot_", names(factors)[i], ".pdf")
+        linkData <- rbind(linkData, c(linkName, linkAddr))
+        invisible(dev.off())
+    }
+}
 
 # BCV Plot
 png(bcvOutPng, width=600, height=600)
@@ -471,7 +499,7 @@ if (wantLRT) {
 if (wantNorm) { 
         normalisedCounts <- cpm(data, normalized.lib.sizes=TRUE, log=TRUE) 
         normalisedCounts <- data.frame(data$genes, normalisedCounts)
-        write.table (normalisedCounts, file=normOut, row.names=FALSE, sep="\t")
+        write.table (normalisedCounts, file=normOut, row.names=FALSE, sep="\t", quote=FALSE)
         linkData <- rbind(linkData, c("edgeR_normcounts.tsv", "edgeR_normcounts.tsv"))
 }
 
@@ -494,7 +522,7 @@ for (i in 1:length(contrastData)) {
                                              
     # Write top expressions table
     top <- topTags(res, n=Inf, sort.by="PValue")
-    write.table(top, file=topOut[i], row.names=FALSE, sep="\t")
+    write.table(top, file=topOut[i], row.names=FALSE, sep="\t", quote=FALSE)
     
     linkName <- paste0("edgeR_", contrastData[i], ".tsv")
     linkAddr <- paste0("edgeR_", contrastData[i], ".tsv")
@@ -504,7 +532,7 @@ for (i in 1:length(contrastData)) {
     pdf(mdOutPdf[i])
     limma::plotMD(res, status=status,
                                 main=paste("MD Plot:", unmake.names(contrastData[i])), 
-                                col=alpha(c("firebrick", "blue"), 0.4), values=c("1", "-1"),
+                                hl.col=alpha(c("firebrick", "blue"), 0.4), values=c(1, -1),
                                 xlab="Average Expression", ylab="logFC")
     
     abline(h=0, col="grey", lty=2)
@@ -517,7 +545,7 @@ for (i in 1:length(contrastData)) {
     png(mdOutPng[i], height=600, width=600)
     limma::plotMD(res, status=status,
                                 main=paste("MD Plot:", unmake.names(contrastData[i])), 
-                                col=alpha(c("firebrick", "blue"), 0.4), values=c("1", "-1"),
+                                hl.col=alpha(c("firebrick", "blue"), 0.4), values=c(1, -1),
                                 xlab="Average Expression", ylab="logFC")
     
     abline(h=0, col="grey", lty=2)
@@ -622,7 +650,7 @@ cata("<ul>\n")
 
 if (filtCPM || filtSmpCount || filtTotCount) {
     if (filtCPM) {
-    tempStr <- paste("Genes without more than", opt$cmpReq,
+    tempStr <- paste("Genes without more than", opt$cpmReq,
                                      "CPM in at least", opt$sampleReq, "samples are insignificant",
                                      "and filtered out.")
     } else if (filtSmpCount) {

--- a/tools/edger/test-data/out_rscript.txt
+++ b/tools/edger/test-data/out_rscript.txt
@@ -338,7 +338,9 @@ flatCount <- numeric()
 data <- list()
 data$counts <- counts
 if (haveAnno) {
-    data$genes <- geneanno
+  # order annotation by genes in counts (assumes gene ids are in 1st column of geneanno)
+  annoord <- geneanno[match(row.names(counts), geneanno[,1]), ]
+  data$genes <- annoord
 } else {
     data$genes <- data.frame(GeneID=row.names(counts))
 }


### PR DESCRIPTION
- Add similar changes as recently made for it's twin tool limma-voom (https://github.com/galaxyproject/tools-iuc/pull/1830 and https://github.com/galaxyproject/tools-iuc/pull/1871)
    - Allow unordered annotations to be input
    - Remove quotes from output tables
    - Minor edits to text
    - Fix MD plot highlighted genes
    - Fix typo in report for CPM counts
- Add colours to samples in MDS plot pdf
- Output additional MDS plots if additional factors input (samples coloured by factors)