### PR TITLE
Repeat masker: fix crash when catalog in gzipped

### DIFF
--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -66,7 +66,11 @@
         sed -r 's/^ *// ; s/ *$//; s/\+ //; s/ +/\t/g' rm_input.fasta.polyout >'${output_polymorphic}' &&
       #end if
     #end if
-    mv rm_input.fasta.cat '${output_repeat_catalog}'
+    if [ -f 'rm_input.fasta.cat.gz' ]; then
+      zcat 'rm_input.fasta.cat.gz' > '${output_repeat_catalog}';
+    else
+      mv rm_input.fasta.cat '${output_repeat_catalog}';
+    fi
     ]]>
   </command>
 


### PR DESCRIPTION
It seems like sometimes repeatmasker decides to gzip its catalog output file... I experienced it with bigger input files, so it's hard to add a test case for it here.
Here's a fix for the failing mv command