### PR TITLE
Update CrossMap to 0.2.7. Fix crossmap_bam tests

### DIFF
--- a/tools/crossmap/crossmap_bam.xml
+++ b/tools/crossmap/crossmap_bam.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_bam" name="CrossMap BAM" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_bam" name="CrossMap BAM" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>
@@ -7,7 +7,6 @@
     <expand macro="stdio"/>
     <expand macro="version_command"/>
     <command><![CDATA[
-
 CrossMap.py bam
 '${chain_source.input_chain}'
 $optional_tags
@@ -17,9 +16,7 @@ $optional_tags
 -t $insert_size_fold
 
 '${input}'
-'${output}'
-
-&& mv '${output}.sorted.bam' '${output}'
+output
     ]]></command>
     <inputs>
         <param name="input" type="data" format="bam" label="BAM file"/>
@@ -34,7 +31,7 @@ $optional_tags
     </inputs>
 
     <outputs>
-        <data name="output" format="bam" label="${tool.name} on ${on_string}" />
+        <data name="output" format="bam" label="${tool.name} on ${on_string}" from_work_dir="output.sorted.bam" />
         <!-- CrossMap 0.2.5 does not produce output_unmapped -->
     </outputs>
 
@@ -115,7 +112,6 @@ SM
     multiple mapped
 SU
     uniquely mapped
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_bam.xml
+++ b/tools/crossmap/crossmap_bam.xml
@@ -45,7 +45,7 @@ $optional_tags
             <param name="input_chain" value="aToB.over.chain" ftype="csv"/>
             <param name="include_fails" value="False"/>
 
-            <output name="output" file="test_bam_01_output_a.bam" compare="diff" lines_diff="8"/>
+            <output name="output" file="test_bam_01_output_a.bam" ftype="bam" />
         </test>
         <test>
             <param name="index_source" value="cached"/>
@@ -53,7 +53,7 @@ $optional_tags
             <param name="input" value="test_bam_01_input_a.bam" ftype="bam" dbkey="hg18"/>
             <param name="include_fails" value="False"/>
 
-            <output name="output" file="test_bam_01_output_a.bam" compare="diff" lines_diff="8"/>
+            <output name="output" file="test_bam_01_output_a.bam" ftype="bam" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/crossmap/crossmap_bed.xml
+++ b/tools/crossmap/crossmap_bed.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_bed" name="CrossMap BED" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_bed" name="CrossMap BED" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>
@@ -24,8 +24,7 @@ CrossMap.py bed
 #if $merge_unmapped_entries:
     > '${output_combined}'
 #else:
-    '${output_valid}'
-    && mv '${output_valid}.unmap' '${output_failed}'
+    output
 #end if
 
     ]]></command>
@@ -41,10 +40,10 @@ CrossMap.py bed
     </inputs>
 
     <outputs>
-        <data name="output_valid" format="bed" label="${tool.name} (valid only) on ${on_string}">
+        <data name="output_valid" format="bed" label="${tool.name} (valid only) on ${on_string}" from_work_dir="output">
             <filter>merge_unmapped_entries is False</filter>
         </data>
-        <data name="output_failed" format="bed" label="${tool.name} (failed only) on ${on_string}">
+        <data name="output_failed" format="bed" label="${tool.name} (failed only) on ${on_string}" from_work_dir="output.unmap">
             <filter>merge_unmapped_entries is False</filter>
         </data>
 
@@ -135,7 +134,6 @@ Notes:
    skipped.
 7. If input region cannot be consecutively mapped target assembly, it will be split.
 8. \*.unmap file contains regions that cannot be unambiguously converted.
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_bigwig.xml
+++ b/tools/crossmap/crossmap_bigwig.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_bw" name="CrossMap BigWig" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_bw" name="CrossMap BigWig" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>
@@ -11,9 +11,7 @@
 CrossMap.py bigwig
 '${chain_source.input_chain}'
 '${input}'
-'${output}'
-
-&& mv '${output}.bw' '${output}'
+output
     ]]></command>
 
     <inputs>
@@ -23,7 +21,7 @@ CrossMap.py bigwig
     </inputs>
 
     <outputs>
-        <data name="output" format="bigwig" label="${tool.name} on ${on_string}" />
+        <data name="output" format="bigwig" label="${tool.name} on ${on_string}" from_work_dir="output.bw" />
     </outputs>
 
     <tests>
@@ -54,7 +52,6 @@ similar to wiggle format and can be converted into BigWig format using UCSC
 wigToBigWig tool. We export files in bedGraph because it is usually much
 smaller than file in wiggle format, and more importantly, CrossMap
 internally transforms wiggle into bedGraph to increase running speed.
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_gff.xml
+++ b/tools/crossmap/crossmap_gff.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_gff" name="CrossMap GFF" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_gff" name="CrossMap GFF" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>
@@ -16,7 +16,7 @@ CrossMap.py gff
     >
 #end if
 
-'${output}'
+output
     ]]></command>
 
     <inputs>
@@ -28,7 +28,7 @@ CrossMap.py gff
     </inputs>
 
     <outputs>
-        <data name="output" format="gff" label="${tool.name} on ${on_string}" />
+        <data name="output" format="gff" label="${tool.name} on ${on_string}" from_work_dir="output" />
     </outputs>
 
     <tests>
@@ -74,7 +74,6 @@ Notes:
   independently, and we do NOT check if features originally belonging to
   the same gene were converted into the same gene.
 - If user want to liftover gene annotation files, use BED12 format.
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_vcf.xml
+++ b/tools/crossmap/crossmap_vcf.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_vcf" name="CrossMap VCF" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_vcf" name="CrossMap VCF" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>
@@ -22,9 +22,7 @@ CrossMap.py vcf
 '${input_file}'
 '${seq_source.input_fasta}'
 
-'${output}'
-
-&& mv '${output}.unmap' '$output_unmapped'
+output
     ]]></command>
 
     <inputs>
@@ -59,8 +57,8 @@ CrossMap.py vcf
     </inputs>
 
     <outputs>
-        <data name="output" format="vcf" label="${tool.name} on ${on_string}" />
-        <data name="output_unmapped" format="vcf" label="${tool.name} (unmapped) on ${on_string}" />
+        <data name="output" format="vcf" label="${tool.name} on ${on_string}" from_work_dir="output" />
+        <data name="output_unmapped" format="vcf" label="${tool.name} (unmapped) on ${on_string}" from_work_dir="output.unmap" />
     </outputs>
 
     <tests>
@@ -107,7 +105,6 @@ Notes:
   you run CrossMap).
 - In the output VCF file, whether the chromosome IDs contain “chr” or not
   depends on the format of the input VCF file.
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_wig.xml
+++ b/tools/crossmap/crossmap_wig.xml
@@ -10,10 +10,7 @@
 CrossMap.py wig
 '${chain_source.input_chain}'
 '${input}'
-'${output}'
-
-&& mv '${output}.bw' '${output}'
-&& mv '${output}.sorted.bgr' '${output2}'
+output
     ]]></command>
 
     <inputs>
@@ -23,8 +20,8 @@ CrossMap.py wig
     </inputs>
 
     <outputs>
-        <data name="output" format="wig" label="${tool.name} on ${on_string}" />
-        <data name="output2" format="bedgraph" label="${tool.name} (bedgraph) on ${on_string}" />
+        <data name="output" format="bigwig" label="${tool.name} on ${on_string}" from_work_dir="output.bw" />
+        <data name="output2" format="bedgraph" label="${tool.name} (bedgraph) on ${on_string}" from_work_dir="output.sorted.bgr" />
     </outputs>
 
     <tests>
@@ -59,7 +56,6 @@ similar to wiggle format and can be converted into BigWig format using UCSC
 wigToBigWig tool. We export files in bedGraph because it is usually much
 smaller than file in wiggle format, and more importantly, CrossMap
 internally transforms wiggle into bedGraph to increase running speed.
-
     ]]></help>
 
     <citations>

--- a/tools/crossmap/crossmap_wig.xml
+++ b/tools/crossmap/crossmap_wig.xml
@@ -1,4 +1,4 @@
-<tool id="crossmap_wig" name="CrossMap Wig" version="@WRAPPER_VERSION@-0">
+<tool id="crossmap_wig" name="CrossMap Wig" version="@WRAPPER_VERSION@">
     <description>Convert genome coordinates or annotation files between genome assemblies</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/crossmap/macros.xml
+++ b/tools/crossmap/macros.xml
@@ -2,11 +2,11 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="0.2.5">crossmap</requirement>
+            <requirement type="package" version="0.2.7">crossmap</requirement>
             <yield/>
         </requirements>
     </xml>
-    <token name="@WRAPPER_VERSION@">0.2.5</token>
+    <token name="@WRAPPER_VERSION@">0.2.7</token>
     <xml name="stdio">
         <stdio>
             <regex match="Aborted (core dumped)" source="stdout" level="fatal"/>


### PR DESCRIPTION
No need to use `lines_diff` (there are no randomly changed lines in the SAM version of the BAMs).

But we need to specify `ftype="bam"` for the output data, otherwise Galaxy won't convert them to SAM when checking the outputs and fail with:

```
======================================================================
FAIL: CrossMap BAM ( crossmap_bam ) > Test-1
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/galaxy/test/functional/test_toolbox.py", line 316, in test_tool
    self.do_it(td)
  File "/opt/galaxy/test/functional/test_toolbox.py", line 82, in do_it
    raise e
JobOutputsError: History item  different than expected, difference (using diff):
( /usr/users/ga002/soranzon/software/nsoranzo_tools-iuc/tools/crossmap/test-data/test_bam_01_output_a.bam v. /tmp/tmppCnzEytest_bam_01_output_a.bam )
Binary data detected, not displaying diff

======================================================================
FAIL: CrossMap BAM ( crossmap_bam ) > Test-2
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/galaxy/test/functional/test_toolbox.py", line 316, in test_tool
    self.do_it(td)
  File "/opt/galaxy/test/functional/test_toolbox.py", line 82, in do_it
    raise e
JobOutputsError: History item  different than expected, difference (using diff):
( /usr/users/ga002/soranzon/software/nsoranzo_tools-iuc/tools/crossmap/test-data/test_bam_01_output_a.bam v. /tmp/tmp457bzptest_bam_01_output_a.bam )
Binary data detected, not displaying diff
```