### PR TITLE
Automatic annotation of tools with EDAM terms

### DIFF
--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -1,5 +1,12 @@
 <tool id="abyss-pe" name="ABySS" version="2.0.1.0">
     <description>de novo sequence assembler</description>
+    <edam_topics>
+        <edam_topic>topic_0091</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0524</edam_operation>
+        <edam_operation>operation_0525</edam_operation>
+    </edam_operations>
     <macros>
         <xml name="reads_conditional">
             <conditional name="reads">

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,5 +1,16 @@
 <tool id="bowtie2" name="Bowtie2" version="2.3.4.2" profile="18.01">
     <description>- map reads against reference genome</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0306</edam_operation>
+        <edam_operation>operation_3211</edam_operation>
+        <edam_operation>operation_3198</edam_operation>
+    </edam_operations>
     <macros>
         <import>bowtie2_macros.xml</import>
     </macros>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0"?>
 <tool id="bwa_mem" name="Map with BWA-MEM" version="@VERSION@.1">
     <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_2815</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3429</edam_operation>
+        <edam_operation>operation_3211</edam_operation>
+        <edam_operation>operation_0292</edam_operation>
+        <edam_operation>operation_3198</edam_operation>
+    </edam_operations>
     <macros>
         <import>read_group_macros.xml</import>
         <import>bwa_macros.xml</import>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0"?>
 <tool id="bwa" name="Map with BWA" version="@VERSION@.4">
     <description>- map short reads (&lt; 100 bp) against reference genome</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_2815</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3429</edam_operation>
+        <edam_operation>operation_3211</edam_operation>
+        <edam_operation>operation_0292</edam_operation>
+        <edam_operation>operation_3198</edam_operation>
+    </edam_operations>
     <macros>
         <import>read_group_macros.xml</import>
         <import>bwa_macros.xml</import>

--- a/tools/codeml/codeml.xml
+++ b/tools/codeml/codeml.xml
@@ -3,6 +3,17 @@
         Detects positive selection (paml package)
     </description>
 
+    <edam_topics>
+        <edam_topic>topic_3293</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+
+    <edam_operations>
+        <edam_operation>operation_0547</edam_operation>
+        <edam_operation>operation_0324</edam_operation>
+        <edam_operation>operation_3481</edam_operation>
+    </edam_operations>
+
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/colibread/lordec.xml
+++ b/tools/colibread/lordec.xml
@@ -1,6 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool profile="16.04" id="lordec" name="Lordec" version="0.6">
     <description>is a set a programs for correcting sequencing errors in PacBio reads</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0654</edam_topic>
+        <edam_topic>topic_3071</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3195</edam_operation>
+    </edam_operations>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/colibread/mapsembler2.xml
+++ b/tools/colibread/mapsembler2.xml
@@ -1,6 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool profile="16.04" id="mapsembler2" name="Mapsembler2" version="2.2.4">
     <description>is a targeted assembly software</description>
+    <edam_topics>
+        <edam_topic>topic_0196</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3183</edam_operation>
+    </edam_operations>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/colibread/takeabreak.xml
+++ b/tools/colibread/takeabreak.xml
@@ -1,6 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool profile="16.04" id="takeabreak" name="TakeABreak" version="1.1.2">
     <description>is a tool that can detect inversion breakpoints directly from raw NGS reads</description>
+    <edam_topics>
+        <edam_topic>topic_0199</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3197</edam_operation>
+    </edam_operations>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -1,5 +1,11 @@
 <tool id="deseq2" name="DESeq2" version="2.11.40.2">
     <description>Determines differentially expressed features from count tables</description>
+    <edam_topics>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3223</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.18.1">bioconductor-deseq2</requirement>
         <requirement type="package" version="1.6.0">bioconductor-tximport</requirement>

--- a/tools/egsea/egsea.xml
+++ b/tools/egsea/egsea.xml
@@ -1,5 +1,11 @@
 <tool id="egsea" name="EGSEA" version="1.6.0.1">
     <description> easy and efficient ensemble gene set testing</description>
+    <edam_topics>
+        <edam_topic>topic_2259</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3224</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.6.0">bioconductor-egsea</requirement>
         <requirement type="package" version="1.4.4">r-optparse</requirement>

--- a/tools/fasttree/fasttree.xml
+++ b/tools/fasttree/fasttree.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <tool id="fasttree" name="FASTTREE" version="@VERSION@">
     <description>adjust short reads</description>
+    <edam_topics>
+        <edam_topic>topic_3293</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0547</edam_operation>
+        <edam_operation>operation_0540</edam_operation>
+    </edam_operations>
     <macros>
         <token name="@VERSION@">2.1.10</token>
     </macros>

--- a/tools/feelnc/feelnc_wrapper.xml
+++ b/tools/feelnc/feelnc_wrapper.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tool id="feelnc" name="FEELnc" profile="17.01" version="0.1.1.1">
     <description>FlExible Extraction of LncRNA</description>
+    <edam_topics>
+        <edam_topic>topic_3170</edam_topic>
+        <edam_topic>topic_0659</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0226</edam_operation>
+        <edam_operation>operation_2990</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="0.1.1">feelnc</requirement>
     </requirements>

--- a/tools/flash/flash.xml
+++ b/tools/flash/flash.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <tool id="flash" name="FLASH" version="@VERSION@.3">
     <description>adjust length of short reads</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_0196</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0232</edam_operation>
+        <edam_operation>operation_0310</edam_operation>
+        <edam_operation>operation_3219</edam_operation>
+    </edam_operations>
     <macros>
         <token name="@VERSION@">1.2.11</token>
     </macros>

--- a/tools/fraggenescan/fraggenescan.xml
+++ b/tools/fraggenescan/fraggenescan.xml
@@ -1,5 +1,17 @@
 <tool id="fraggenescan" name="FragGeneScan" version="@WRAPPER_VERSION@.0">
     <description>for finding (fragmented) genes in short reads</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0654</edam_topic>
+        <edam_topic>topic_3053</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_2454</edam_operation>
+    </edam_operations>
     <macros>
         <token name="@WRAPPER_VERSION@">1.30</token>
     </macros>

--- a/tools/genehunter_modscore/genehunter_modscore.xml
+++ b/tools/genehunter_modscore/genehunter_modscore.xml
@@ -1,5 +1,15 @@
 <tool id="genehunter_modscore" name="Genehunter-Modscore" version="@VERSION@.0" >
     <description>Linkage and Haplotypes analysis</description>
+    <edam_topics>
+        <edam_topic>topic_0634</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+        <edam_topic>topic_2269</edam_topic>
+        <edam_topic>topic_3053</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0283</edam_operation>
+        <edam_operation>operation_2945</edam_operation>
+    </edam_operations>
     <macros>
         <token name="@VERSION@">3.0.0</token>
         <xml name="macro_npl_opts" >

--- a/tools/gff3_rebase/gff3_rebase.xml
+++ b/tools/gff3_rebase/gff3_rebase.xml
@@ -1,5 +1,17 @@
 <tool id="gff3.rebase" name="Rebase GFF3 features" version="1.2">
   <description>against parent features</description>
+  <edam_topics>
+    <edam_topic>topic_3307</edam_topic>
+    <edam_topic>topic_3071</edam_topic>
+    <edam_topic>topic_3372</edam_topic>
+    <edam_topic>topic_0091</edam_topic>
+  </edam_topics>
+  <edam_operations>
+    <edam_operation>operation_3763</edam_operation>
+    <edam_operation>operation_3431</edam_operation>
+    <edam_operation>operation_0224</edam_operation>
+    <edam_operation>operation_3436</edam_operation>
+  </edam_operations>
   <macros>
     <import>macros.xml</import>
   </macros>

--- a/tools/gffcompare/gffcompare.xml
+++ b/tools/gffcompare/gffcompare.xml
@@ -1,5 +1,26 @@
 <tool id="gffcompare" name="GffCompare" version="0.9.8">
     <description>compare assembled transcripts to a reference annotation</description>
+    <edam_topics>
+        <edam_topic>topic_3170</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_3320</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3258</edam_operation>
+        <edam_operation>operation_0315</edam_operation>
+        <edam_operation>operation_3565</edam_operation>
+        <edam_operation>operation_3800</edam_operation>
+        <edam_operation>operation_2451</edam_operation>
+        <edam_operation>operation_3563</edam_operation>
+        <edam_operation>operation_0372</edam_operation>
+        <edam_operation>operation_0492</edam_operation>
+        <edam_operation>operation_0438</edam_operation>
+        <edam_operation>operation_3436</edam_operation>
+        <edam_operation>operation_2495</edam_operation>
+        <edam_operation>operation_3435</edam_operation>
+        <edam_operation>operation_3198</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="0.9.8">gffcompare</requirement>
     </requirements>

--- a/tools/goseq/goseq.xml
+++ b/tools/goseq/goseq.xml
@@ -1,5 +1,11 @@
 <tool id="goseq" name="goseq" version="1.26.0">
     <description>tests for overrepresented gene categories</description>
+    <edam_topics>
+        <edam_topic>topic_3170</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3672</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.3.2">r-optparse</requirement>
         <requirement type="package" version="1.26.0">bioconductor-goseq</requirement>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,5 +1,11 @@
 <tool id="hisat2" name="HISAT2" version="2.1.0" profile="17.01">
     <description>A fast and sensitive alignment program</description>
+    <edam_topics>
+        <edam_topic>topic_3170</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0292</edam_operation>
+    </edam_operations>
     <macros>
         <import>hisat2_macros.xml</import>
     </macros>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -1,5 +1,13 @@
 <tool id="htseq_count" name="htseq-count" version="0.9.1" profile="16.04">
     <description> - Count aligned reads in a BAM file that overlap features in a GFF file</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0236</edam_operation>
+        <edam_operation>operation_2478</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="0.9.1">htseq</requirement>
         <requirement type="package" version="1.7">samtools</requirement>

--- a/tools/meme/fimo.xml
+++ b/tools/meme/fimo.xml
@@ -1,5 +1,17 @@
 <tool id="meme_fimo" name="FIMO" version="@WRAPPER_VERSION@.0">
     <description>- Scan a set of sequences for motifs</description>
+    <edam_topics>
+        <edam_topic>topic_2269</edam_topic>
+        <edam_topic>topic_0199</edam_topic>
+        <edam_topic>topic_3473</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_2238</edam_operation>
+        <edam_operation>operation_0415</edam_operation>
+        <edam_operation>operation_3092</edam_operation>
+        <edam_operation>operation_0238</edam_operation>
+    </edam_operations>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/metagenomeseq/metagenomeseq_normalization.xml
+++ b/tools/metagenomeseq/metagenomeseq_normalization.xml
@@ -1,5 +1,13 @@
 <tool id="metagenomeseq_normalizaton" name="metagenomeSeq Normalization" version="1.16.0-0.0.1">
     <description>Cumulative sum scaling</description>
+    <edam_topics>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_2238</edam_operation>
+        <edam_operation>operation_0564</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.16.0">bioconductor-metagenomeseq</requirement>
         <requirement type="package" version="1.2.0">bioconductor-biomformat</requirement>

--- a/tools/metaspades/metaspades.xml
+++ b/tools/metaspades/metaspades.xml
@@ -1,5 +1,21 @@
 <tool id="metaspades" name="metaSPAdes" version="3.9.0">
     <description>assembler for metagenomics datasets</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0196</edam_topic>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_3170</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0524</edam_operation>
+        <edam_operation>operation_3258</edam_operation>
+        <edam_operation>operation_0525</edam_operation>
+        <edam_operation>operation_0310</edam_operation>
+        <edam_operation>operation_3182</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="3.9.0">spades</requirement>
     </requirements>

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0"?>
 <tool id="minimap2" name="Map with minimap2" version="2.5" profile="17.01">
     <description>A fast pairwise aligner for genomic and spliced nucleotide sequences</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_2815</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3429</edam_operation>
+        <edam_operation>operation_3211</edam_operation>
+        <edam_operation>operation_0292</edam_operation>
+        <edam_operation>operation_3198</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="2.5">minimap2</requirement>
         <requirement type="package" version="1.6">samtools</requirement>

--- a/tools/mothur/taxonomy-to-krona.xml
+++ b/tools/mothur/taxonomy-to-krona.xml
@@ -1,5 +1,11 @@
 <tool id="mothur_taxonomy_to_krona" name="Taxonomy-to-Krona" version="1.0">
     <description>convert a mothur taxonomy file to Krona input format</description>
+    <edam_topics>
+        <edam_topic>topic_3174</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0337</edam_operation>
+    </edam_operations>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,5 +1,11 @@
 <tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.0">
     <description>aggregate results from bioinformatics analyses into a single report</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_2428</edam_operation>
+    </edam_operations>
     <macros>
         <token name="@WRAPPER_VERSION@">1.5</token>
         <token name="@ESCAPE_IDENTIFIER@">

--- a/tools/prinseq/prinseq.xml
+++ b/tools/prinseq/prinseq.xml
@@ -1,5 +1,15 @@
 <tool id="prinseq" name="PRINSEQ" version="0.20.4">
     <description>to process quality of sequences</description>
+    <edam_topics>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3187</edam_operation>
+        <edam_operation>operation_3219</edam_operation>
+        <edam_operation>operation_3192</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="0.20.4">prinseq</requirement>
     </requirements>

--- a/tools/prokka/prokka.xml
+++ b/tools/prokka/prokka.xml
@@ -1,5 +1,16 @@
 <tool id="prokka" name="Prokka" version="1.13">
     <description>Prokaryotic genome annotation</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_3299</edam_topic>
+        <edam_topic>topic_0637</edam_topic>
+        <edam_topic>topic_0091</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_2403</edam_operation>
+        <edam_operation>operation_0337</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.13">prokka</requirement>
     </requirements>

--- a/tools/raxml/raxml.xml
+++ b/tools/raxml/raxml.xml
@@ -1,5 +1,13 @@
 <tool id="raxml" name="Phyogenetic reconstruction with RaXML" version="8.2.4">
     <description>- Maximum Likelihood based inference of large phylogenetic trees</description>
+    <edam_topics>
+        <edam_topic>topic_3293</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0324</edam_operation>
+        <edam_operation>operation_2403</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="8.2.4">raxml</requirement>
     </requirements>

--- a/tools/rnaspades/rnaspades.xml
+++ b/tools/rnaspades/rnaspades.xml
@@ -1,5 +1,21 @@
 <tool id="rnaspades" name="rnaSPAdes" version="3.9.0.1">
     <description>assembler for RNA-Seq data</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0196</edam_topic>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_3170</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0524</edam_operation>
+        <edam_operation>operation_3258</edam_operation>
+        <edam_operation>operation_0525</edam_operation>
+        <edam_operation>operation_0310</edam_operation>
+        <edam_operation>operation_3182</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="3.9.0">spades</requirement>
     </requirements>

--- a/tools/samblaster/samblaster.xml
+++ b/tools/samblaster/samblaster.xml
@@ -1,5 +1,13 @@
 <tool id="samblaster" name="samblaster" version="0.1.24">
     <description>marks duplicates, outputs split reads, discordant read pairs and unmapped reads</description>
+    <edam_topics>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_0654</edam_topic>
+        <edam_topic>topic_0102</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3199</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="0.1.24">samblaster</requirement>
         <requirement type="package" version="0.6.5">sambamba</requirement>

--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -1,5 +1,21 @@
 <tool id="spades" name="SPAdes" version="3.11.1">
     <description>genome assembler for regular and single-cell projects</description>
+    <edam_topics>
+        <edam_topic>topic_0622</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+        <edam_topic>topic_0196</edam_topic>
+        <edam_topic>topic_3174</edam_topic>
+        <edam_topic>topic_3170</edam_topic>
+        <edam_topic>topic_3168</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0524</edam_operation>
+        <edam_operation>operation_3258</edam_operation>
+        <edam_operation>operation_0525</edam_operation>
+        <edam_operation>operation_0310</edam_operation>
+        <edam_operation>operation_3182</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="3.11.1">spades</requirement>
     </requirements>

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -1,5 +1,17 @@
 <tool id="taxonomy_krona_chart" name="Krona pie chart" version="2.6.1.1">
   <description>from taxonomic profile</description>
+  <edam_topics>
+    <edam_topic>topic_0622</edam_topic>
+    <edam_topic>topic_0080</edam_topic>
+    <edam_topic>topic_3174</edam_topic>
+    <edam_topic>topic_3299</edam_topic>
+    <edam_topic>topic_0637</edam_topic>
+    <edam_topic>topic_0091</edam_topic>
+  </edam_topics>
+  <edam_operations>
+    <edam_operation>operation_2403</edam_operation>
+    <edam_operation>operation_0337</edam_operation>
+  </edam_operations>
   <requirements>
     <requirement type="package" version="2.6.1">krona</requirement>
   </requirements>

--- a/tools/trinotate/trinotate.xml
+++ b/tools/trinotate/trinotate.xml
@@ -1,4 +1,12 @@
 <tool id="trinotate" name="Trinotate" version="3.0.1.0">
+    <edam_topics>
+        <edam_topic>topic_0203</edam_topic>
+        <edam_topic>topic_3512</edam_topic>
+        <edam_topic>topic_3308</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_3258</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="3.0.1">trinotate</requirement>
         <requirement type="package" version="1.18">gnu-wget</requirement>

--- a/tools/ucsc_blat/blat.xml
+++ b/tools/ucsc_blat/blat.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
 <tool id="ucsc_blat" name="UCSC BLAT Alignment Tool" version="35-0">
     <description>BLAST-like sequence alignment tool</description>
+    <edam_topics>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0292</edam_operation>
+    </edam_operations>
     <requirements>
       <requirement type="package" version="35">blat</requirement>
     </requirements>

--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -1,5 +1,14 @@
 <tool id="velvetoptimiser" name="VelvetOptimiser" version="2.2.5">
     <description>Automatically optimize Velvet assemblies</description>
+    <edam_topics>
+        <edam_topic>topic_0091</edam_topic>
+        <edam_topic>topic_0196</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0524</edam_operation>
+        <edam_operation>operation_0310</edam_operation>
+        <edam_operation>operation_0335</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="1.2.10">velvet</requirement>
         <requirement type="package" version="2.2.5">perl-velvetoptimiser</requirement>

--- a/tools/weblogo3/rgWebLogo3.xml
+++ b/tools/weblogo3/rgWebLogo3.xml
@@ -1,5 +1,14 @@
 <tool id="rgweblogo3" name="Sequence Logo" version="3.5.0">
     <description>generator for fasta (eg Clustal alignments)</description>
+    <edam_topics>
+        <edam_topic>topic_3511</edam_topic>
+        <edam_topic>topic_0080</edam_topic>
+    </edam_topics>
+    <edam_operations>
+        <edam_operation>operation_0566</edam_operation>
+        <edam_operation>operation_0564</edam_operation>
+        <edam_operation>operation_0239</edam_operation>
+    </edam_operations>
     <requirements>
         <requirement type="package" version="3.5.0">weblogo</requirement>
     </requirements>


### PR DESCRIPTION
This is the result of the hackathon session we have participated at Norwich during the ELIXIR Workshop for Galaxy training material and skills improvement.

Our goal was to enrich Galaxy tools' descriptions with EDAM terms (topics and operations) using bio.tool tools' annotations. The match between Galaxy tool and bio.tool tool was identified by DOI. As some of bio.tool tools' descriptions may contain PMID and PMCID instead, we've also used [PubMed ID converter API](https://www.ncbi.nlm.nih.gov/pmc/tools/id-converter-api/) to convert them to DOI.

The pipeline is implemented as a Jupyter notebook script and [available at Google Colab](https://drive.google.com/file/d/1KNw2FqPafhFoqQhLxxlGF7B5xEyVZ-yo/view?usp=sharing).

The correctness of the script was checked by picking a few tools arbitrarily and reproducing the pipeline manually for them. It might be a good idea to verify the correctness of annotations in a more reliable way.

This Pull Request includes direct tools' annotations. The autogenerated report for macros-based tools' annotations [is available here](https://gist.github.com/inkuzmin/48ed5fc481267e7528de76cab952d8b9).