### PR TITLE
Fix dependency error in deseq2

### DIFF
--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -4,6 +4,7 @@
         <requirement type="package" version="1.18.1">bioconductor-deseq2</requirement>
         <requirement type="package" version="1.6.0">bioconductor-tximport</requirement>
         <requirement type="package" version="1.30.0">bioconductor-genomicfeatures</requirement>
+        <requirement type="package" version="1.14.0">bioconductor-genomeinfodb</requirement>
         <requirement type="package" version="0.6.5">r-ggrepel</requirement>
         <requirement type="package" version="1.0.8">r-pheatmap</requirement>
     </requirements>


### PR DESCRIPTION
This error occurs when running deseq2
```
deseq2: Error: package or namespace load failed for 'GenomeInfoDb' in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
there is no package called 'GenomeInfoDbData'
Error: package 'GenomeInfoDb' could not be loaded
```
Version 2.11.40.2

Version 2.11.39 does not have the issue