### PR TITLE
FeatureCounts: small modifications (move up stranded param and add info on built-in annotation to Help)

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,4 +1,4 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.0.5" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.0.6" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
         <requirement type="package" version="1.6.0">subread</requirement>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -544,13 +544,27 @@ Annotations for gene regions should be provided in the GFF/GTF format:
  - http://genome.ucsc.edu/FAQ/FAQformat.html#format3
  - http://www.ensembl.org/info/website/upload/gff.html
 
-Alternatively, the featureCounts built-in annotations for genomes hg38, hg19, mm10 and mm9 can be used through selecting the built-in option above. These annotations were downloaded from NCBI RefSeq database and then adapted by merging overlapping exons from the same gene to form a set of disjoint exons for each gene. Genes with the same Entrez gene identifiers were also merged into one gene. See the Subread_ User's Guide for more information.
+Alternatively, the featureCounts built-in annotations for genomes hg38, hg19, mm10 and mm9 can be used through selecting the built-in option above. These annotation files are in simplified annotation format (SAF) as shown below. The GeneID column contains Entrez gene identifiers and each entry (row) is taken as a feature (e.g. an exon).
+
+Example - **Built-in annotation format**:
+
+  ======  ====  =======  =======  ======
+  GeneID  Chr   Start    End      Strand
+  ======  ====  =======  =======  ======
+  497097  chr1  3204563  3207049  -
+  497097  chr1  3411783  3411982  -
+  497097  chr1  3660633  3661579  -
+  ======  ====  =======  =======  ======
+
+These annotation files can be found in the `Subread package`_. You can see the version of Subread used by this wrapper in the tool form above under `Options > Requirements`. To create the files, the annotations were downloaded from NCBI RefSeq database and then adapted by merging overlapping exons from the same gene to form a set of disjoint exons for each gene. Genes with the same Entrez gene identifiers were also merged into one gene. See the `Subread User's Guide`_ for more information.
 
 Output format
 -------------
 FeatureCounts produces a table containing counted reads, per gene, per row. Optionally the last column can be set to be the effective gene-length. These tables are compatible with the DESeq2, edgeR and limma-voom Galaxy wrappers by IUC.
 
-.. _Subread: http://bioinf.wehi.edu.au/subread-package/SubreadUsersGuide.pdf
+.. _Subread: http://subread.sourceforge.net/
+.. _`Subread User's Guide`: http://bioinf.wehi.edu.au/subread-package/SubreadUsersGuide.pdf
+.. _`Subread package`: https://sourceforge.net/projects/subread/files/
     ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btt656</citation>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -28,11 +28,11 @@
             -o "output"
             -T \${GALAXY_SLOTS:-2}
 
+            -s  $strand_specificity
             -t '$extended_parameters.gff_feature_type'
             -g '$extended_parameters.gff_feature_attribute'
                 $extended_parameters.summarization_level
                 $extended_parameters.contribute_to_multiple_features
-            -s  $extended_parameters.strand_specificity
                 $extended_parameters.multimapping_enabled.multimapping_counts
 
                 #if str($extended_parameters.multimapping_enabled.multimapping_counts) == " -M":
@@ -117,6 +117,16 @@
                format="bam,sam"
                label="Alignment file"
                help="The input alignment file(s) where the gene expression has to be counted. The file can have a SAM or BAM format; but ALL files must be in the same format. Unless you are using a Gene annotation file from the History, these files must have the database/genome attribute already specified e.g. hg38, not the default: ?" >
+        </param>
+
+        <param name="strand_specificity"
+               type="select"
+               label="Specify strand information"
+               argument="-s"
+               help="Indicate if the data is stranded and if strand-specific read counting should be performed. Strand setting must be the same as the strand settings used to produce the mapped BAM input(s)">
+            <option value="0" selected="true">Unstranded</option>
+            <option value="1">Stranded (Forward)</option>
+            <option value="2">Stranded (Reverse)</option>
         </param>
 
         <conditional name="anno">
@@ -256,16 +266,6 @@
                 argument="-O"
                 label="Allow read to contribute to multiple features"
                 help="If specified, reads (or fragments if -p is specified) will be allowed to be assigned to more than one matched meta-feature (or matched feature if -f is specified)" />
-
-            <param name="strand_specificity"
-                   type="select"
-                   label="Strand specificity of the protocol"
-                   argument="-s"
-                   help="Indicate if strand-specific read counting should be performed.">
-                <option value="0" selected="true">Unstranded</option>
-                <option value="1">Stranded (forwards)</option>
-                <option value="2">Stranded (reverse)</option>
-            </param>
 
             <conditional name="multimapping_enabled">
                 <param name="multimapping_counts"


### PR DESCRIPTION
@jennaj I've added info on the built-in annotation now and moved up the stranded parameter out of Advanced options, as discussed in Gitter. What do you and/or anyone else think.
