### PR TITLE
FeatureCounts: Add how to get gene names for Entrez identifiers to Help section

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -556,7 +556,7 @@ Example - **Built-in annotation format**:
   497097  chr1  3660633  3661579  -
   ======  ====  =======  =======  ======
 
-These annotation files can be found in the `Subread package`_. You can see the version of Subread used by this wrapper in the tool form above under `Options > Requirements`. To create the files, the annotations were downloaded from NCBI RefSeq database and then adapted by merging overlapping exons from the same gene to form a set of disjoint exons for each gene. Genes with the same Entrez gene identifiers were also merged into one gene. See the `Subread User's Guide`_ for more information.
+These annotation files can be found in the `Subread package`_. You can see the version of Subread used by this wrapper in the tool form above under `Options > Requirements`. To create the files, the annotations were downloaded from NCBI RefSeq database and then adapted by merging overlapping exons from the same gene to form a set of disjoint exons for each gene. Genes with the same Entrez gene identifiers were also merged into one gene. See the `Subread User's Guide`_ for more information. Gene names can be obtained for these Entrez identifiers with the Galaxy **annotateMyIDs** tool.
 
 Output format
 -------------


### PR DESCRIPTION
I should have added this line in the last PR.