### PR TITLE
Explicitly cast BamTools Filter's rules param to a string

### DIFF
--- a/tool_collections/bamtools/bamtools_filter/bamtools-filter.xml
+++ b/tool_collections/bamtools/bamtools_filter/bamtools-filter.xml
@@ -27,7 +27,7 @@
         $(config[ 'filters' ].append( $filter ))
     #end for
     #if str( $rule_configuration.rules_selector ) == "true":
-        #set $config[ 'rule' ] = $rule_configuration.rules
+        #set $config[ 'rule' ] = str( $rule_configuration.rules )
     #end if
 #end if
 $json.dumps( $config, indent=4 )


### PR DESCRIPTION
Fixes the job setup error encountered when a rule is defined:

```pytb
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/runners/__init__.py", line 191, in prepare_job
    job_wrapper.prepare()
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 865, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/tools/evaluation.py", line 435, in build
    raise e
TypeError: <galaxy.tools.wrappers.InputValueWrapper object at 0x7f2929ada2d0> is not JSON serializable
```

I am not sure if this worked in some older version of Galaxy and failed due to tool framework changes, but this fixes it for 18.05, at least.

Originally reported in galaxyproject/usegalaxy-playbook#116.