### PR TITLE
Limma-voom: Make gene labels unique for Glimma plot to prevent errors with NAs

### DIFF
--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -808,9 +808,12 @@ for (i in 1:length(contrastData)) {
     linkData <- rbind(linkData, c(linkName, linkAddr))
     invisible(dev.off())
 
-    # Generate Glimma interactive MD plot and table, requires annotation file (assumes gene names in 2nd column)
+    # Generate Glimma interactive MD plot and table, requires annotation file (assumes gene labels/symbols in 2nd column)
     if (haveAnno) {
-        Glimma::glMDPlot(fit, coef=i, counts=y$counts, anno=y$genes, groups=factors[, 1],
+        # make gene labels unique to handle NAs
+        geneanno <- y$genes
+        geneanno[, 2] <- make.unique(geneanno[, 2])
+        Glimma::glMDPlot(fit, coef=i, counts=y$counts, anno=geneanno, groups=factors[, 1],
              status=status[, i], sample.cols=col.group,
              main=paste("MD Plot:", unmake.names(con)), side.main=colnames(y$genes)[2],
              folder=paste0("glimma_", unmake.names(con)), launch=FALSE)

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -1,4 +1,4 @@
-<tool id="limma_voom" name="limma" version="3.34.9.5">
+<tool id="limma_voom" name="limma" version="3.34.9.6">
     <description>
         Perform differential expression with limma-voom or limma-trend
     </description>
@@ -210,7 +210,7 @@ cp '$outReport.files_path'/*tsv output_dir/
 
         <!-- Contrasts -->
         <repeat name="rep_contrast" title="Contrast" min="1" default="1">
-            <param name="contrast" type="text" label="Contrast of Interest" help="Names of two groups to compare separated by a hyphen e.g. Mut-WT. If the order is Mut-WT the fold changes in the results will be up/down in Mut relative to WT. If you have more than one contrast enter each separately using the Insert Contrast button below. For differences between contrasts use e.g. (Mut1-WT)-(Mut2-WT). For more info, see Chapter 8 in the limma User's guide: https://www.bioconductor.org/packages/release/bioc/vignettes/limma/inst/doc/usersguide.pdf">
+            <param name="contrast" type="text" label="Contrast of Interest" help="Names of two groups to compare separated by a hyphen e.g. Mut-WT. If the order is Mut-WT the fold changes in the results will be up/down in Mut relative to WT. If you have more than one contrast enter each separately using the Insert Contrast button below. For differences between contrasts use e.g. (Mut1-Ctrl1)-(Mut2-Ctrl2). For more info, see Chapter 8 in the limma User's guide: https://www.bioconductor.org/packages/release/bioc/vignettes/limma/inst/doc/usersguide.pdf">
                 <validator type="empty_field" />
                 <validator type="regex" message="Please only use letters, numbers or underscores">^[\(\w\)-]+$</validator>
             </param>


### PR DESCRIPTION
as otherwise it will throw a wobbly. NAs are handled in the current Glimma version (1.18.1) but can't use that version yet as need to wait for Bioc 3.7 conda support. So in the interim have fixed it in the limma-voom wrapper here.