### PR TITLE
Add @TMPDIR_OPTION@ to set working directory

### DIFF
--- a/tools/picard/picard_AddCommentsToBam.xml
+++ b/tools/picard/picard_AddCommentsToBam.xml
@@ -2,7 +2,7 @@
   <description>add comments to BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -17,6 +17,7 @@
       #end for
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
       VALIDATION_STRINGENCY=${validation_stringency}
   ]]></command>
 

--- a/tools/picard/picard_AddOrReplaceReadGroups.xml
+++ b/tools/picard/picard_AddOrReplaceReadGroups.xml
@@ -3,10 +3,10 @@
   <macros>
     <import>picard_macros.xml</import>
     <import>read_group_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
-  <command detect_errors="exit_code">
+  <command detect_errors="exit_code"><![CDATA[
     @define_read_group_helpers@
     #set $rg_auto_name = $read_group_name_default($inputFile)
     @set_read_group_vars@
@@ -26,9 +26,10 @@
       VALIDATION_STRINGENCY="${validation_stringency}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
       OUTPUT="${outFile}"
 
-  </command>
+  ]]></command>
 
   <inputs>
     <param format="bam,sam" name="inputFile" type="data" label="Select SAM/BAM dataset or dataset collection" help="If empty, upload or import a SAM/BAM dataset" />

--- a/tools/picard/picard_BedToIntervalList.xml
+++ b/tools/picard/picard_BedToIntervalList.xml
@@ -2,7 +2,7 @@
   <description>convert coordinate data into picard interval list format</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -18,6 +18,7 @@
       picard CreateSequenceDictionary REFERENCE="${ref_fasta}" OUTPUT="${picard_dict}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
       &&
 
@@ -36,6 +37,7 @@
       SEQUENCE_DICTIONARY="${picard_dict}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
   ]]></command>
 

--- a/tools/picard/picard_CleanSam.xml
+++ b/tools/picard/picard_CleanSam.xml
@@ -2,7 +2,7 @@
   <description>perform SAM/BAM grooming</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -14,6 +14,7 @@
     OUTPUT="${outFile}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
     VALIDATION_STRINGENCY=${validation_stringency}
   ]]></command>
 

--- a/tools/picard/picard_CollectAlignmentSummaryMetrics.xml
+++ b/tools/picard/picard_CollectAlignmentSummaryMetrics.xml
@@ -2,7 +2,7 @@
   <description>writes a file containing summary alignment metrics</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -34,6 +34,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_CollectBaseDistributionByCycle.xml
+++ b/tools/picard/picard_CollectBaseDistributionByCycle.xml
@@ -2,7 +2,7 @@
   <description>charts the nucleotide distribution per cycle in a SAM or BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.1">r-base</requirement>
@@ -29,6 +29,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_CollectGcBiasMetrics.xml
+++ b/tools/picard/picard_CollectGcBiasMetrics.xml
@@ -2,7 +2,7 @@
   <description>charts the GC bias metrics</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.1">r-base</requirement>
@@ -31,6 +31,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_CollectInsertSizeMetrics.xml
+++ b/tools/picard/picard_CollectInsertSizeMetrics.xml
@@ -2,7 +2,7 @@
   <description>plots distribution of insert sizes</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.1">r-base</requirement>
@@ -35,6 +35,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_CollectRnaSeqMetrics.xml
+++ b/tools/picard/picard_CollectRnaSeqMetrics.xml
@@ -2,7 +2,7 @@
     <description> collect metrics about the alignment of RNA to various functional classes of loci in the genome</description>
     <macros>
         <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="3.4.1">r-base</requirement>
@@ -59,7 +59,7 @@
       OUTPUT="${outFile}"
       REFERENCE_SEQUENCE="${reference_fasta_filename}"
       ASSUME_SORTED="${assume_sorted}"
-
+      @TMPDIR_OPTION@
       VALIDATION_STRINGENCY=${validation_stringency}
 
    ]]></command>

--- a/tools/picard/picard_CollectWgsMetrics.xml
+++ b/tools/picard/picard_CollectWgsMetrics.xml
@@ -2,7 +2,7 @@
   <description>compute metrics for evaluating of whole genome sequencing experiments</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -26,6 +26,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_DownsampleSam.xml
+++ b/tools/picard/picard_DownsampleSam.xml
@@ -2,7 +2,7 @@
   <description>Downsample a file to retain a subset of the reads</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -16,6 +16,7 @@
       RANDOM_SEED=${seed}
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
       VALIDATION_STRINGENCY=${validation_stringency}
   ]]></command>
   <inputs>

--- a/tools/picard/picard_EstimateLibraryComplexity.xml
+++ b/tools/picard/picard_EstimateLibraryComplexity.xml
@@ -2,7 +2,7 @@
   <description>assess sequence library complexity from read sequences</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -25,6 +25,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_FastqToSam.xml
+++ b/tools/picard/picard_FastqToSam.xml
@@ -2,7 +2,7 @@
   <description>convert Fastq data into unaligned BAM</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -66,7 +66,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
-
+    @TMPDIR_OPTION@
   ]]></command>
   <inputs>
     <conditional name="input_type">

--- a/tools/picard/picard_FilterSamReads.xml
+++ b/tools/picard/picard_FilterSamReads.xml
@@ -2,7 +2,7 @@
   <description>include or exclude aligned and unaligned reads and read lists</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -18,6 +18,7 @@
     VALIDATION_STRINGENCY=LENIENT
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
     &&
 
@@ -35,6 +36,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_FixMateInformation.xml
+++ b/tools/picard/picard_FixMateInformation.xml
@@ -2,7 +2,7 @@
   <description>ensure that all mate-pair information is in sync between each read and it's mate pair</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -18,6 +18,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_MarkDuplicates.xml
+++ b/tools/picard/picard_MarkDuplicates.xml
@@ -2,7 +2,7 @@
   <description>examine aligned records in BAM datasets to locate duplicate molecules</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -38,6 +38,7 @@
     VALIDATION_STRINGENCY='${validation_stringency}'
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
+++ b/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
@@ -2,7 +2,7 @@
   <description>examine aligned records in BAM datasets to locate duplicate molecules</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -35,6 +35,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_MeanQualityByCycle.xml
+++ b/tools/picard/picard_MeanQualityByCycle.xml
@@ -2,7 +2,7 @@
   <description>chart distribution of base qualities</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.1">r-base</requirement>
@@ -29,6 +29,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_MergeBamAlignment.xml
+++ b/tools/picard/picard_MergeBamAlignment.xml
@@ -2,7 +2,7 @@
   <description>merge alignment data with additional info stored in an unmapped BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -17,6 +17,7 @@
       picard CreateSequenceDictionary REFERENCE="${ref_fasta}" OUTPUT="${picard_dict}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
       &&
 
@@ -85,6 +86,7 @@
       SORT_ORDER=coordinate
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
   ]]></command>
 

--- a/tools/picard/picard_MergeSamFiles.xml
+++ b/tools/picard/picard_MergeSamFiles.xml
@@ -2,7 +2,7 @@
   <description>merges multiple SAM/BAM datasets into one</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -27,6 +27,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_NormalizeFasta.xml
+++ b/tools/picard/picard_NormalizeFasta.xml
@@ -2,7 +2,7 @@
   <description>normalize fasta datasets</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -22,6 +22,7 @@
 
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_QualityScoreDistribution.xml
+++ b/tools/picard/picard_QualityScoreDistribution.xml
@@ -2,7 +2,7 @@
   <description>chart quality score distribution</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements">
     <requirement type="package" version="3.4.1">r-base</requirement>
@@ -30,6 +30,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_ReorderSam.xml
+++ b/tools/picard/picard_ReorderSam.xml
@@ -2,7 +2,7 @@
   <description>reorder reads to match ordering in reference sequences</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -18,6 +18,7 @@
       picard CreateSequenceDictionary REFERENCE="${ref_fasta}" OUTPUT="${picard_dict}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
       &&
 
@@ -38,6 +39,7 @@
       VALIDATION_STRINGENCY="${validation_stringency}"
       QUIET=true
       VERBOSITY=ERROR
+      @TMPDIR_OPTION@
 
   ]]></command>
 

--- a/tools/picard/picard_ReplaceSamHeader.xml
+++ b/tools/picard/picard_ReplaceSamHeader.xml
@@ -2,7 +2,7 @@
   <description>replace header in a SAM/BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -22,6 +22,7 @@
 
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_RevertOriginalBaseQualitiesAndAddMateCigar.xml
+++ b/tools/picard/picard_RevertOriginalBaseQualitiesAndAddMateCigar.xml
@@ -2,7 +2,7 @@
   <description>revert the original base qualities and add the mate cigar tag</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -20,6 +20,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_RevertSam.xml
+++ b/tools/picard/picard_RevertSam.xml
@@ -2,7 +2,7 @@
   <description>revert SAM/BAM datasets to a previous state</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -30,6 +30,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_SamToFastq.xml
+++ b/tools/picard/picard_SamToFastq.xml
@@ -2,7 +2,7 @@
   <description>extract reads and qualities from SAM/BAM dataset and convert to fastq</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -51,6 +51,7 @@
     VALIDATION_STRINGENCY="${validation_stringency}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
 
   ]]></command>
   <inputs>

--- a/tools/picard/picard_SortSam.xml
+++ b/tools/picard/picard_SortSam.xml
@@ -2,7 +2,7 @@
   <description>sort SAM/BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <command detect_errors="exit_code"><![CDATA[
@@ -21,6 +21,7 @@
     SORT_ORDER="${sort_order}"
     QUIET=true
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
     VALIDATION_STRINGENCY=${validation_stringency}
   ]]></command>
 

--- a/tools/picard/picard_ValidateSamFile.xml
+++ b/tools/picard/picard_ValidateSamFile.xml
@@ -2,7 +2,7 @@
   <description>assess validity of SAM/BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>
-    <token name="@WRAPPER_VERSION@">0</token>
+    <token name="@WRAPPER_VERSION@">1</token>
   </macros>
   <expand macro="requirements" />
   <stdio>
@@ -48,6 +48,7 @@
     MAX_OPEN_TEMP_FILES=`ulimit -Sn`
 
     VERBOSITY=ERROR
+    @TMPDIR_OPTION@
     QUIET=true
 
   ]]></command>

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TMPDIR_OPTION@">
-     `if [ -n "\$TMPDIR" ] ; then echo "TMP_DIR=\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then echo "TMP_DIR=\$TEMP" ; fi ; fi`</token>
+     `if [ -n "\$TMPDIR" ] ; then echo 'TMP_DIR=\$TMPDIR' ; else if [ -n "\$TEMP" ] ; then echo 'TMP_DIR=\$TEMP' ; fi ; fi`</token>
     <xml name="VS">
         <param name="validation_stringency" type="select" label="Select validation stringency" help=" Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.">
           <option value="LENIENT" selected="True">Lenient</option>

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TMPDIR_OPTION@">
-     `if [ -n "\$TMPDIR" ] ; then TMP_DIR="\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then TMP_DIR="\$TEMP" ; fi ; fi`</token>
+     `if [ -n "\$TMPDIR" ] ; then echo TMP_DIR="\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then echo TMP_DIR="\$TEMP" ; fi ; fi`</token>
     <xml name="VS">
         <param name="validation_stringency" type="select" label="Select validation stringency" help=" Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.">
           <option value="LENIENT" selected="True">Lenient</option>

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -1,5 +1,6 @@
 <macros>
-    <token name="@TMPDIR_OPTION@">`if [ -n "\$TEMP" ] ; then TMP_DIR=\$TEMP ; fi`</token>
+    <token name="@TMPDIR_OPTION@">
+     `if [ -n "\$TMPDIR" ] ; then TMP_DIR="\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then TMP_DIR="\$TEMP" ; fi ; fi`</token>
     <xml name="VS">
         <param name="validation_stringency" type="select" label="Select validation stringency" help=" Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.">
           <option value="LENIENT" selected="True">Lenient</option>

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -1,4 +1,5 @@
 <macros>
+    <token name="@TMPDIR_OPTION@">`if [ -n "\$TEMP" ] ; then TMP_DIR=\$TEMP ; fi`</token>
     <xml name="VS">
         <param name="validation_stringency" type="select" label="Select validation stringency" help=" Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.">
           <option value="LENIENT" selected="True">Lenient</option>

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TMPDIR_OPTION@">
-     `if [ -n "\$TMPDIR" ] ; then echo TMP_DIR="\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then echo TMP_DIR="\$TEMP" ; fi ; fi`</token>
+     `if [ -n "\$TMPDIR" ] ; then echo "TMP_DIR=\$TMPDIR" ; else if [ -n "\$TEMP" ] ; then echo "TMP_DIR=\$TEMP" ; fi ; fi`</token>
     <xml name="VS">
         <param name="validation_stringency" type="select" label="Select validation stringency" help=" Setting stringency to SILENT can improve performance when processing a BAM file in which variable-length data (read, qualities, tags) do not otherwise need to be decoded.">
           <option value="LENIENT" selected="True">Lenient</option>


### PR DESCRIPTION
I recently ran into a problem with `picard` running out of disk space on our cluster as it was writing to `/tmp` on worker nodes. This behaviour is controlled by the TMP_DIR command line parameter to the picard tools. This PR adds this parameter to each wrapper and propagates the setting from the `$TEMP` environment variable

The Galaxy admin can set `$TEMP` using a `<env>` clause in `job_conf.xml`. For jobs running with the local job runner `$TEMP` is [already set](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/runners/local.py#L50) by default.

An alternative way to set the temporary working directory for picard would be to set `-Djava.io.tmpdir=` to a sensible value as recommended on [Biostars](https://www.biostars.org/p/42613/). The effect seems to be the same as setting `TMP_DIR` thus setting `TMP_DIR` was chosen as the more straightforward of the two options.