### PR TITLE
Small Change to intersectBed.xml

### DIFF
--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_intersectbed" name="Intersect intervals" version="@WRAPPER_VERSION@.1">
+<tool id="bedtools_intersectbed" name="Intersect intervals" version="@WRAPPER_VERSION@.2">
     <description>find overlapping intervals in various ways</description>
     <macros>
         <import>macros.xml</import>
@@ -9,8 +9,9 @@
 <![CDATA[
         #set modes = ' '.join( str($overlap_mode).split(',') )
 
-        #if $modes=="None":
-            #set modes = ""
+        #if $modes == "None":
+            #set modes = ''
+        #end if
 
         bedtools intersect
             #if $inputA.is_of_type('bam'):

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -9,6 +9,9 @@
 <![CDATA[
         #set modes = ' '.join( str($overlap_mode).split(',') )
 
+        #if $modes=="None":
+            #set modes = ""
+
         bedtools intersect
             #if $inputA.is_of_type('bam'):
                 -abam '${inputA}'


### PR DESCRIPTION
Small change due to a fatal error when no overlap mode is selected. Leading to:

***** ERROR: Unrecognized parameter: None *****

However the intersect tool of bed allows for a default behavior which is not supported if the user is forced to pick an overlap mode.