### PR TITLE
bedtools intersect: add -sorted, -bed, -e options

### DIFF
--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -33,16 +33,17 @@
                   -f '${fraction_cond.fractionA}'
                 #end if
                 #if str($fraction_cond.fractionB) != "None" and str($fraction_cond.fractionB):
-                  -f '${fraction_cond.fractionB}'
+                  -F '${fraction_cond.fractionB}'
                 #end if
             #else if $fraction_cond.fraction_select == "joint":
-                $fraction_cond.reciprocal fraction_cond.fraction
+                $fraction_cond.reciprocal -f $fraction_cond.fraction
             #end if
             $invert
             $once
             $header
             $modes
             $sorted
+            $bed
             $count
             > '${output}'
 ]]>

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_intersectbed" name="Intersect intervals" version="@WRAPPER_VERSION@.2">
+<tool id="bedtools_intersectbed" name="Intersect intervals" version="@WRAPPER_VERSION@+galaxy3">
     <description>find overlapping intervals in various ways</description>
     <macros>
         <import>macros.xml</import>
@@ -28,14 +28,21 @@
             #end if
             $split
             $strand
-            #if str($fraction) != "None" and str($fraction):
-              -f '${fraction}'
+            #if $fraction_cond.fraction_select == "separate":
+                #if str($fraction_cond.fractionA) != "None" and str($fraction_cond.fractionA):
+                  -f '${fraction_cond.fractionA}'
+                #end if
+                #if str($fraction_cond.fractionB) != "None" and str($fraction_cond.fractionB):
+                  -f '${fraction_cond.fractionB}'
+                #end if
+            #else if $fraction_cond.fraction_select == "joint":
+                $fraction_cond.reciprocal fraction_cond.fraction
             #end if
-            $reciprocal
             $invert
             $once
             $header
             $modes
+            $sorted
             $count
             > '${output}'
 ]]>
@@ -66,12 +73,29 @@
         </param>
 
         <expand macro="split" />
-        <!-- -f -->
-        <param name="fraction" type="text"
-            label="Minimum overlap required as a fraction of the BAM alignment"
-            help="Alignments are only retained if the overlap with the an interval in the BED file comprises at least this fraction of the BAM alignment's length.  For example, to require that the overlap affects 50% of the BAM alignment, use 0.50. (-f)"/>
-        <!-- -r -->
-        <expand macro="reciprocal" />
+        <conditional name="fraction_cond">
+            <param name='fraction_select' type='select' label='Required overlap'>
+                <option value='none' selected='true'>None</option>
+                <option value='separate'>Specify separately for A and B</option>
+                <option value='joint'>Specify jointly for A and B</option>
+            </param>
+            <when value="none"/>
+            <when value='separate'>
+                <!-- -f -->
+                <param name="fractionA" argument="-f" value="1e-9" type="float"
+                    label="Minimum overlap required as a fraction of A" help="Default 1e-9 corresponds to 1bp."/>
+                <!-- -F -->
+                <param name="fractionB" argument="-F" value="1e-9" type="float"
+                    label="Minimum overlap required as a fraction of B" help="Default 1e-9 corresponds to 1bp."/>
+            </when>
+            <when value='joint'>
+                <!-- -r / -e -->
+                <param name="fraction" argument="-r/-e" value="1e-9" type="float"
+                    label="Minimum overlap required" help="Default 1e-9 corresponds to 1bp."/>
+                <param name="reciprocal" type="boolean" checked="true" truevalue="-r" falsevalue="-e"
+                    label="Require that the fraction of overlap be reciprocal for A AND B. Otherwise the overlap needs to cover the specified fraction of A OR B."/>
+            </when>
+        </conditional>
         <!-- -v -->
         <param name="invert" type="boolean" checked="false" truevalue="-v" falsevalue=""
             label="Report only those alignments that **do not** overlap with file(s) B"
@@ -84,10 +108,20 @@
         <param name="count" type="boolean" checked="false" truevalue="-c" falsevalue=""
             label="For each entry in A, report the number of overlaps with B."
             help="Reports 0 for A entries that have no overlap with B. (-c)" />
+        <!-- -bed -->
+        <param argument="-bed" type="boolean" checked="false" truevalue="-bed" falsevalue=""
+            label="When using BAM input (-abam), write output as BED instead of BAM." />
+        <!-- -sorted -g  -->
+        <param argument="-sorted" type="boolean" checked="false" truevalue="-sorted" falsevalue=""
+            label="For coordinate sorted input file the more efficient sweeping algorithm is enabled." />
         <expand macro="print_header" />
     </inputs>
     <outputs>
-        <data format_source="inputA" name="output" metadata_source="inputA"/>
+        <data format_source="inputA" name="output" metadata_source="inputA">
+            <change_format>
+                <when input="bed" value="-bed" format="bed" />
+            </change_format>
+        </data>
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
- `-sorted`: allow to use the faster algorithm for sorted input
- `-bed`: output bed for bam input
- `-e` A OR B for reciprocal overlap fractions
