### PR TITLE
DEXSeq: Add python 2.7 requirement to dexseq_count

### DIFF
--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -1,10 +1,11 @@
-<tool id="dexseq_count" name="DEXSeq-Count" version="@VERSION@.0">
+<tool id="dexseq_count" name="DEXSeq-Count" version="@VERSION@.1">
     <description>Prepare and count exon abundancies from RNA-seq data</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="0.9.1">htseq</requirement>
+        <requirement type="package" version="2.7">python</requirement>
     </expand>
     <stdio>
         <!-- Anything other than zero is an error -->


### PR DESCRIPTION
This PR adds python 2.7 as a requirement to DEXSeq-Count as otherwise the Count reads mode can fail with an error like:
`
Fatal error: Exit code 1 ()
Traceback (most recent call last):
  File "/usr/local/tools/_conda/envs/mulled-v1-683dc60555985982bcd77839627baa1ef503a6a15fb8cf27f5b492bbedd69ac4/bin/dexseq_count.py", line 98, in <module>
    features[f.iv] += f
  File "python3/src/HTSeq/_HTSeq.pyx", line 451, in HTSeq._HTSeq.ChromVector.__iadd__
  File "python3/src/HTSeq/_HTSeq.pyx", line 466, in HTSeq._HTSeq.ChromVector.apply
  File "python3/src/HTSeq/_HTSeq.pyx", line 449, in HTSeq._HTSeq.ChromVector.__iadd__.addval
TypeError: unhashable type: 'GenomicFeature'
`