### PR TITLE
Changes to coords2clnt.xml

### DIFF
--- a/tools/bctools/coords2clnt.xml
+++ b/tools/bctools/coords2clnt.xml
@@ -6,11 +6,16 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
         coords2clnt.py
+        $threeprime 
         '$alignment_coordinates'
         > '$crosslinking_coordinates'
     ]]></command>
     <inputs>
         <param name="alignment_coordinates" type="data" format="bed" label="Alignments in BED format"/>
+        <param name="threeprime" argument="--threeprime" label="Set position one nt downstream of 3'-end as crosslinked nucleotide." type="boolean"
+               truevalue="--threeprime" falsevalue="" checked="False"
+               help="Set position one nt downstream of 3'-end as crosslinked nucleotide. By default the crosslink site will be assumed to be one nt upstream of
+the 5'-end of the read."/>
     </inputs>
     <outputs>
         <data name="crosslinking_coordinates" format="bed"/>


### PR DESCRIPTION
Adding a new option to the tool, allowing the user to detect crosslinking nucleotides at the 3' end.