### PR TITLE
hisat2 serialize samtools

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,11 +1,11 @@
-<tool id="hisat2" name="HISAT2" version="2.1.0" profile="17.01">
+<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy1" profile="17.01">
     <description>A fast and sensitive alignment program</description>
     <macros>
         <import>hisat2_macros.xml</import>
     </macros>
     <requirements>
         <requirement type="package" version="2.1.0">hisat2</requirement>
-        <requirement type="package" version="1.4">samtools</requirement>
+        <requirement type="package" version="1.8">samtools</requirement>
     </requirements>
     <stdio>
         <regex level="fatal" match="hisat2-align exited with value 1" source="both" />
@@ -292,9 +292,11 @@ hisat2
     --summary-file summary.txt
 #end if
 
+-S tempsamfile &&
+
 ## Convert SAM output to sorted BAM
 
-| samtools sort - -@ \${GALAXY_SLOTS:-1} -l 6 -o '${output_alignments}'
+samtools sort tempsamfile -@ \${GALAXY_SLOTS:-1} -l 6 -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -14,9 +14,6 @@
     </stdio>
     <version_command>hisat2 --version</version_command>
     <command><![CDATA[
-## Use pipefail if available to quit with first non-zero exit code
-set -o | grep -q pipefail && set -o pipefail;
-
 ## Prepare HISAT2 index
 
 #if $reference_genome.source == "history":
@@ -292,11 +289,17 @@ hisat2
     --summary-file summary.txt
 #end if
 
--S tempsamfile &&
-
 ## Convert SAM output to sorted BAM
+## using the two pipe stages has the following effect
+## - hisat2 and sort run in parallel, during this time sort produces
+##   presorted temporary files but does not produce output (hence 
+##   view does not run)
+## - once hisat is finished sort will start to merge the temporary 
+##   files (which should be fast also on a single thread) gives the 
+##   sorted output to view which only compresses the files (now 
+##   using full parallelism again)
 
-samtools sort tempsamfile -@ \${GALAXY_SLOTS:-1} -l 6 -o '${output_alignments}'
+| samtools sort -l 0 -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
 
 ## Rename any output fastq files
 


### PR DESCRIPTION
Currently hisat2 and samtools sort run in parallel each with the full number of threads (ie in theory up to 2x GALAXY_SLOTS). 

The suggested solution tries to reduce the over-usage, ie. it would use at most one CPU more than GALAXY_SLOTS. 

see also https://github.com/samtools/samtools/issues/891

I you think this is not a good idea we could serialize hisat2 and samtools sort using a temporary file. 

(plus samtools is updated to 1.8)
