### PR TITLE
Enable meme_chip to run Centrimo

### DIFF
--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -16,29 +16,27 @@ meme-chip '$input'
 $sequence_alphabet
 -o '$output.files_path'
 #if str($options_type_cond.options_type)=='advanced':
-    ## FIXME: CentriMo cannot be run,  See the comments in the input section.
-    ## #set run_centrimo = $options_type_cond.run_centrimo_cond.run_centrimo
-    ## #if str($run_centrimo) == "yes":
-    ##     -db $options_type_cond.run_centrimo_cond.meme_motif_databases.fields.path
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_local:
-    ##         -centrimo-local
-    ##     #end if
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_score:
-    ##         -centrimo-score $options_type_cond.run_centrimo_cond.centrimo_score
-    ##     #end if
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_maxreg:
-    ##         -centrimo-maxreg $options_type_cond.run_centrimo_cond.centrimo_maxreg
-    ##     #end if
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_ethresh:
-    ##         -centrimo-ethresh $options_type_cond.run_centrimo_cond.centrimo_ethresh
-    ##     #end if
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_noseq:
-    ##         -centrimo-noseq
-    ##     #end if
-    ##     #if $options_type_cond.run_centrimo_cond.centrimo_flip:
-    ##         -centrimo-flip
-    ##     #end if
-    ## #end if
+    #if str($options_type_cond.run_centrimo_cond.run_centrimo) == "yes":
+        -db $options_type_cond.run_centrimo_cond.meme_motif_databases.fields.path
+        #if $options_type_cond.run_centrimo_cond.centrimo_local:
+            -centrimo-local
+        #end if
+        #if $options_type_cond.run_centrimo_cond.centrimo_score:
+            -centrimo-score $options_type_cond.run_centrimo_cond.centrimo_score
+        #end if
+        #if $options_type_cond.run_centrimo_cond.centrimo_maxreg:
+            -centrimo-maxreg $options_type_cond.run_centrimo_cond.centrimo_maxreg
+        #end if
+        #if $options_type_cond.run_centrimo_cond.centrimo_ethresh:
+            -centrimo-ethresh $options_type_cond.run_centrimo_cond.centrimo_ethresh
+        #end if
+        #if $options_type_cond.run_centrimo_cond.centrimo_noseq:
+            -centrimo-noseq
+        #end if
+        #if $options_type_cond.run_centrimo_cond.centrimo_flip:
+            -centrimo-flip
+        #end if
+    #end if
     $options_type_cond.search_given_strand
     -order $options_type_cond.background_model_order
     #if str($options_type_cond.subsampling_cond.subsampling) == "no":
@@ -98,23 +96,16 @@ $sequence_alphabet
             </param>
             <when value="basic"/>
             <when value="advanced">
-                <!--
-                FIXME: CentriMo cannot be run since the tool form cannot populate the mem_motif_database select list below.
                 <conditional name="run_centrimo_cond">
                     <param name="run_centrimo" type="select" label="Run TOMTOM and CentriMo?">
                         <option value="yes" selected="true">Yes</option>
                         <option value="no">No</option>
                     </param>
                     <when value="yes">
-
-                        We have 2 dynamic select lists here.  The first select list (meme_motif_database_dir) is populated from the meme_motif_databases
-                        data table.  The second select list (meme_motif_database) is dynamically re-rendered whenever the selection in the meme_motif_database_dir
-                        select list is changed.  This composition used to work (see Examples->Dynamic Options section of
-                        https://docs.galaxyproject.org/en/latest/dev/schema.html) but no longer does.  We'll have to figure out what is broken in
-                        the dynamic options code in ~/parameters/basic.py in order to uncomment this block.
-
                         <param name="meme_motif_database_dir" type="select" label="Select the motifs (DNA)" refresh_on_change="True">
                             <options from_data_table="meme_motif_databases">
+                                <column name="name" index="1"/>
+                                <column name="value" index="2"/>
                                 <filter type="sort_by" column="1"/>
                                 <validator type="no_options" message="No MEME motif databases are available for the selected input"/>
                             </options>
@@ -129,7 +120,6 @@ $sequence_alphabet
                     </when>
                     <when value="no"/>
                 </conditional>
-                -->
                 <param name="background_model_order" type="select" label="Select the order of the Markov background model">
                     <option value="0">0-order model of sequences</option>
                     <option value="1" selected="True">1st order model of sequences</option>

--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -98,8 +98,8 @@ $sequence_alphabet
             <when value="advanced">
                 <conditional name="run_centrimo_cond">
                     <param name="run_centrimo" type="select" label="Run TOMTOM and CentriMo?">
-                        <option value="yes" selected="true">Yes</option>
-                        <option value="no">No</option>
+                        <option value="no" selected="true">No</option>
+                        <option value="yes">Yes</option>
                     </param>
                     <when value="yes">
                         <param name="meme_motif_database_dir" type="select" label="Select the motifs (DNA)" refresh_on_change="True">

--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -106,6 +106,7 @@ $sequence_alphabet
                             <options from_data_table="meme_motif_databases">
                                 <column name="name" index="1"/>
                                 <column name="value" index="2"/>
+                                <column name="path" index="2"/>
                                 <filter type="sort_by" column="1"/>
                                 <validator type="no_options" message="No MEME motif databases are available for the selected input"/>
                             </options>

--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -1,4 +1,4 @@
-<tool id="meme_chip" name="MEME-ChIP" version="4.11.3">
+<tool id="meme_chip" name="MEME-ChIP" profile="18.09" version="4.11.3">
     <description>- motif discovery, enrichment analysis and clustering on large nucleotide datasets</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -1,4 +1,4 @@
-<tool id="meme_chip" name="MEME-ChIP" version="4.11.2">
+<tool id="meme_chip" name="MEME-ChIP" version="4.11.3">
     <description>- motif discovery, enrichment analysis and clustering on large nucleotide datasets</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Since https://github.com/galaxyproject/galaxy/pull/6374 was merged, tools will once again render multiple dependent dynamic select lists, where selecting an option in the first will render the options in the second.

With this fix, we can now include the option to run Centrimo here in the meme_chip tool, which requires installation of the ```meme motif databases downloader``` data manager tool.  This https://github.com/galaxyproject/tools-iuc/pull/1772 will have to be merged and made available in the MTS to enable this.