### PR TITLE
Update deseq2.R

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -203,7 +203,7 @@ dir <- ""
 if (!useTXI & hasHeader) {
     countfiles <- lapply(as.character(sampleTable$filename), function(x){read.delim(x, row.names=1)})
     tbl <- do.call("cbind", countfiles)
-    rownames(sampleTable) <- colnames(tbl) # take sample ids from header
+    colnames(tbl) <- rownames(sampleTable) # take sample ids from header
 
     # check for htseq report lines (from DESeqDataSetFromHTSeqCount function)
     oldSpecialNames <- c("no_feature", "ambiguous", "too_low_aQual",

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -196,7 +196,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="normCounts" value="True"/>
             <output name="counts_out">
                 <assert_contents>
-                    <has_text_matching expression="untreat1\tuntreat2\tuntreat3\tuntreat4\ttreat1\ttreat2\ttreat3" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
                     <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
                 </assert_contents>
             </output>


### PR DESCRIPTION
Colnames from the "sampleTable" should be assigned to the "tbl".

FOR CONTRIBUTOR:
* [x ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
