### PR TITLE
Heatmap.2: don't reorder input if not clustering

### DIFF
--- a/tools/ggplot2/heatmap2.xml
+++ b/tools/ggplot2/heatmap2.xml
@@ -1,4 +1,4 @@
-<tool id="ggplot2_heatmap2" name="heatmap2" version="@VERSION@+galaxy0">
+<tool id="ggplot2_heatmap2" name="heatmap2" version="@VERSION@+galaxy1">
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -74,7 +74,7 @@ colorscale
         main = '$title', key.xlab='$key', keysize=1, cexCol=0.8, cexRow = 0.8, srtCol=45)
 #else
     heatmap.2(linput,
-        dendrogram="none", scale = '$scale', labRow = rlabs, labCol = clabs,
+        dendrogram="none", Colv=FALSE, Rowv=FALSE, scale = '$scale', labRow = rlabs, labCol = clabs,
         col=colfunc(50), trace="none", density.info = "none", margins=c(8,8), 
         main='$title', key.xlab='$key', keysize=1, cexCol=0.8, cexRow = 0.8, srtCol=45)
 #end if


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

This is a request from a user. If you select not to cluster the input still gets reordered. This fixes that and maintains the input order.