### PR TITLE
migmap does create blast databases relative to the conda directory

### DIFF
--- a/tools/migmap/migmap.xml
+++ b/tools/migmap/migmap.xml
@@ -1,4 +1,4 @@
-<tool id="migmap" name="MiGMAP" version="1.0.2.1">
+<tool id="migmap" name="MiGMAP" version="1.0.2.2">
     <description>mapper for full-length T- and B-cell repertoire sequencing
     </description>
     <requirements>
@@ -6,6 +6,9 @@
     </requirements>
     <command detect_errors='exit_code'><![CDATA[
 export IGBLAST_PATH=\$(dirname \$(which igblastn)) &&
+mkdir temp_db &&
+cp -r "\${IGBLAST_PATH}/../share/igblast/" ./temp_db &&
+
 #if $input.is_of_type('fasta') :
     ln -s '$input' in.fa &&
 #else
@@ -22,7 +25,7 @@ migmap
         -q $qual_threshold
     #end if
     -p "\${GALAXY_SLOTS:-4}"
-    --data-dir "\${IGBLAST_PATH}/../share/igblast"
+    --data-dir ./temp_db/igblast/
     -S $species 
     -R $receptor_list
     --report '$report'

--- a/tools/migmap/migmap.xml
+++ b/tools/migmap/migmap.xml
@@ -7,7 +7,7 @@
     <command detect_errors='exit_code'><![CDATA[
 export IGBLAST_PATH=\$(dirname \$(which igblastn)) &&
 mkdir temp_db &&
-cp -r "\${IGBLAST_PATH}/../share/igblast/" ./temp_db &&
+ln -s "\${IGBLAST_PATH}/../share/igblast/" ./temp_db/ &&
 
 #if $input.is_of_type('fasta') :
     ln -s '$input' in.fa &&

--- a/tools/migmap/migmap.xml
+++ b/tools/migmap/migmap.xml
@@ -28,7 +28,6 @@ migmap
     --data-dir ./temp_db/igblast/
     -S $species 
     -R $receptor_list
-    --report '$report'
     #if $input.is_of_type('fasta'): 
         in.fa
     #else
@@ -74,7 +73,6 @@ migmap
     </inputs>
     <outputs>
         <data name="output" format="tabular"/>
-        <data name="report" format="txt"/>
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [x] .shed.yml file ok
    - [x] Toolshed user `iuc` has access to associated toolshed repo(s)
* [x] Indentation is correct (4 spaces)
* [x] Tool version/build ok
* [x] `<command/>`
  - [x] Text parameters, input and output files `'single quoted'`
  - [x] Use of `<![CDATA[ ... ]]>` tags
  - [x] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [x] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [x] Tests
  - [x] Parameters are reasonably covered
  - [x] Test files are appropriate
* [x] Help
  - [x] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [x] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
