### PR TITLE
Mothur: add tool citations

### DIFF
--- a/tools/mothur/align.seqs.xml
+++ b/tools/mothur/align.seqs.xml
@@ -248,5 +248,9 @@ on the secondary structure.
 .. _align.seqs: https://www.mothur.org/wiki/Align.seqs
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+         <citation type="doi">10.1093/nar/gkl244</citation>
+         <citation type="doi">10.1371/journal.pone.0008230</citation>
+         <citation type="doi">10.1371/journal.pcbi.1000844</citation>
+    </expand>
 </tool>

--- a/tools/mothur/amova.xml
+++ b/tools/mothur/amova.xml
@@ -107,5 +107,7 @@ The Make_Design tool can construct a design file from a Mothur dataset that cont
 .. _amova: https://www.mothur.org/wiki/Amova
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1111/j.1442-9993.2001.01070.pp.x</citation>
+    </expand>
 </tool>

--- a/tools/mothur/anosim.xml
+++ b/tools/mothur/anosim.xml
@@ -73,5 +73,7 @@ The Make_Design tool can construct a design file from a Mothur dataset that cont
 .. _anosim: https://www.mothur.org/wiki/Anosim
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1111/j.1442-9993.1993.tb00438.x</citation>
+    </expand>
 </tool>

--- a/tools/mothur/chimera.bellerophon.xml
+++ b/tools/mothur/chimera.bellerophon.xml
@@ -88,5 +88,7 @@ Tips for using Bellerophon:
 .. _chimera.bellerophon: https://www.mothur.org/wiki/Chimera.bellerophon
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+         <citation type="doi">10.1093/bioinformatics/bth226</citation>
+    </expand>
 </tool>

--- a/tools/mothur/chimera.ccode.xml
+++ b/tools/mothur/chimera.ccode.xml
@@ -127,5 +127,7 @@ The program can analyze sequences for any required word length. Generally, value
 .. _chimera.ccode: https://www.mothur.org/wiki/Chimera.ccode
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+           <citation type="doi">10.1093/bioinformatics/bti008</citation>
+    </expand>
 </tool>

--- a/tools/mothur/chimera.perseus.xml
+++ b/tools/mothur/chimera.perseus.xml
@@ -71,5 +71,7 @@ The chimera.perseus_ command reads a fasta and name file, and outputs potentiall
 .. _chimera.perseus: https://www.mothur.org/wiki/Chimera.perseus
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1186/1471-2105-12-38</citation>
+    </expand>
 </tool>

--- a/tools/mothur/chimera.pintail.xml
+++ b/tools/mothur/chimera.pintail.xml
@@ -154,5 +154,6 @@ The sequence to be checked (the query) is first globally aligned with a phylogen
     ]]></help>
     <expand macro="citations">
         <citation type="doi">10.1128/AEM.71.12.7724-7736.2005</citation>
+        <citation type="doi">10.1128/AEM.00556-06</citation>
     </expand>
 </tool>

--- a/tools/mothur/chimera.slayer.xml
+++ b/tools/mothur/chimera.slayer.xml
@@ -168,5 +168,7 @@ It is not recommended to blindly discard all sequences flagged as chimeras. Some
 .. _chimera.slayer: https://www.mothur.org/wiki/Chimera.slayer
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1101/gr.112730.110 </citation>
+    </expand>
 </tool>

--- a/tools/mothur/chimera.uchime.xml
+++ b/tools/mothur/chimera.uchime.xml
@@ -197,5 +197,7 @@ The chimera.uchime_ command reads a fasta file and reference file and outputs po
 Version 1.23.0: Upgrades tool dependency to mothur 1.33 and adds support for count (mothur 1.28) and dereplicate (mothur 1.29) options.
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1093/bioinformatics/btr381</citation>
+    </expand>
 </tool>

--- a/tools/mothur/classify.otu.xml
+++ b/tools/mothur/classify.otu.xml
@@ -205,5 +205,7 @@ The basis parameter allows you indicate what you want the summary file to repres
 v1.21.0: Updated to use Mothur 1.33. Added count parameter (1.28.0) and persample parameter (1.29.0)
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.02810-10</citation>
+    </expand>
 </tool>

--- a/tools/mothur/classify.seqs.xml
+++ b/tools/mothur/classify.seqs.xml
@@ -227,5 +227,9 @@ The classify.seqs_ command assigns sequences to chosen taxonomy outline.
 v1.22.0: Updated for Mothur 1.33. Added count parameter (1.28), added relabund parameter (1.33), bayesian term changed to wang.
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.00062-07</citation>
+        <citation type="doi">10.1093/nar/25.17.3389</citation>
+        <citation type="doi"> 10.1128/AEM.03006-05</citation>
+    </expand>
 </tool>

--- a/tools/mothur/clearcut.xml
+++ b/tools/mothur/clearcut.xml
@@ -130,5 +130,7 @@ Clearcut is capable of taking either a distance matrix or a multiple sequence al
 v.1.20.0: Trivial upgrade to Mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1093/bioinformatics/btl478</citation>
+    </expand>
 </tool>

--- a/tools/mothur/cluster.classic.xml
+++ b/tools/mothur/cluster.classic.xml
@@ -91,5 +91,8 @@ The cluster.classic_ command assign sequences to OTUs (Operational Taxonomy Unit
 .. _cluster.classic: https://www.mothur.org/wiki/Cluster.classic
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.02810-10</citation>
+        <citation type="doi">10.1128/AEM.71.3.1501-1506.2005</citation>
+    </expand>
 </tool>

--- a/tools/mothur/cluster.split.xml
+++ b/tools/mothur/cluster.split.xml
@@ -361,5 +361,7 @@ The cluster.split_ command assign sequences to OTUs (Operational Taxonomy Unit).
 v1.28.0: Upgraded to Mothur 1.33, introduced cluster boolean.
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.02810-10</citation>
+    </expand>
 </tool>

--- a/tools/mothur/cluster.xml
+++ b/tools/mothur/cluster.xml
@@ -192,5 +192,8 @@ The cluster_ command assign sequences to OTUs (Operational Taxonomy Unit).  The 
 .. _cluster: https://www.mothur.org/wiki/Cluster
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.02810-10</citation>
+        <citation type="doi">10.1128/AEM.71.3.1501-1506.2005</citation>
+    </expand>
 </tool>

--- a/tools/mothur/collect.shared.xml
+++ b/tools/mothur/collect.shared.xml
@@ -99,5 +99,7 @@ The collect.shared_ command generates collector's curves for calculators_, which
 .. _collect.shared: https://www.mothur.org/wiki/Collect.shared
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.00474-06</citation>
+    </expand>
 </tool>

--- a/tools/mothur/collect.single.xml
+++ b/tools/mothur/collect.single.xml
@@ -110,5 +110,7 @@ The collect.single_ command generates collector's curves using calculators_, tha
 .. _collect.single: https://www.mothur.org/wiki/Collect.single
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.00474-06</citation>
+    </expand>
 </tool>

--- a/tools/mothur/cooccurrence.xml
+++ b/tools/mothur/cooccurrence.xml
@@ -166,5 +166,7 @@ Please see [5] for more details on metric/null model selection.
 v1.26.0: Updated to Mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1890/0012-9658(2000)081[2606:NMAOSC]2.0.CO;2</citation>
+    </expand>
 </tool>

--- a/tools/mothur/corr.axes.xml
+++ b/tools/mothur/corr.axes.xml
@@ -117,5 +117,24 @@ The corr.axes_ command calculates the correlation of data to axes.
 v.1.21.0: Updated to mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex">
+@book{mccune2002analysis,
+  title={Analysis of ecological communities},
+  author={McCune, Bruce and Grace, James B and Urban, Dean L},
+  volume={28},
+  year={2002},
+  publisher={MjM software design Gleneden Beach, OR}
+}
+        </citation>
+        <citation type="bibtex">
+@misc{legendre1998numerical,
+  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
+  author={Legendre, Pierre and Legendre, Louis},
+  year={1998},
+  publisher={Elsevier Science Amsterdam, The Netherlands}
+}
+        </citation>
+
+    </expand>
 </tool>

--- a/tools/mothur/corr.axes.xml
+++ b/tools/mothur/corr.axes.xml
@@ -118,23 +118,6 @@ v.1.21.0: Updated to mothur 1.33
 
     ]]></help>
     <expand macro="citations">
-        <citation type="bibtex">
-@book{mccune2002analysis,
-  title={Analysis of ecological communities},
-  author={McCune, Bruce and Grace, James B and Urban, Dean L},
-  volume={28},
-  year={2002},
-  publisher={MjM software design Gleneden Beach, OR}
-}
-        </citation>
-        <citation type="bibtex">
-@misc{legendre1998numerical,
-  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
-  author={Legendre, Pierre and Legendre, Louis},
-  year={1998},
-  publisher={Elsevier Science Amsterdam, The Netherlands}
-}
-        </citation>
-
+        <expand macro="citations-ecology"/>
     </expand>
 </tool>

--- a/tools/mothur/dist.seqs.xml
+++ b/tools/mothur/dist.seqs.xml
@@ -90,5 +90,7 @@ The dist.seqs_ command will calculate uncorrected pairwise distances between ali
 v.1.20.0: Updated to Mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1371/journal.pcbi.1000844</citation>
+    </expand>
 </tool>

--- a/tools/mothur/filter.shared.xml
+++ b/tools/mothur/filter.shared.xml
@@ -114,7 +114,5 @@ The filter.shared_ is used to remove OTUs based on various critieria.
 .. _filter.shared: https://www.mothur.org/wiki/Filter.shared
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/get.communitytype.xml
+++ b/tools/mothur/get.communitytype.xml
@@ -156,5 +156,7 @@ echo 'get.communitytype(
 
 .. _get.communitytype: https://www.mothur.org/wiki/Get.communitytype
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1371/journal.pone.0030126</citation>
+    </expand>
 </tool>

--- a/tools/mothur/get.mimarkspackage.xml
+++ b/tools/mothur/get.mimarkspackage.xml
@@ -90,7 +90,5 @@ The get.mimarkspackage_ command creates a mimarks package form with your groups.
 .. _get.mimarkspackage: https://www.mothur.org/wiki/Get.mimarkspackage
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/homova.xml
+++ b/tools/mothur/homova.xml
@@ -94,5 +94,7 @@ The Make_Design tool can construct a design file from a Mothur dataset that cont
 v.1.20.0: Updated to Mothur 1.33, added sets parameter
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1046/j.1420-9101.1996.9020153.x</citation>
+    </expand>
 </tool>

--- a/tools/mothur/indicator.xml
+++ b/tools/mothur/indicator.xml
@@ -159,21 +159,6 @@ v.1.22.0: Updated to Mothur 1.33
     ]]></help>
     <expand macro="citations">
         <citation type="doi">10.1890/0012-9615(1997)067[0345:SAAIST]2.0.CO;2</citation>
-        <citation type="bibtex">
-@book{mccune2002analysis,
-  title={Analysis of ecological communities},
-  author={McCune, Bruce and Grace, James B and Urban, Dean L},
-  volume={28},
-  year={2002},
-  publisher={MjM software design Gleneden Beach, OR}
-}
-        </citation>
-        <citation type="bibtex">
-@misc{legendre1998numerical,
-  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
-  author={Legendre, Pierre and Legendre, Louis},
-  year={1998},
-  publisher={Elsevier}
-        </citation>
+        <expand macro="citations-ecology"/>
     </expand>
 </tool>

--- a/tools/mothur/indicator.xml
+++ b/tools/mothur/indicator.xml
@@ -157,5 +157,23 @@ The indicator_ command reads a shared_ or relabund_ file and a tree file, and ou
 v.1.22.0: Updated to Mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1890/0012-9615(1997)067[0345:SAAIST]2.0.CO;2</citation>
+        <citation type="bibtex">
+@book{mccune2002analysis,
+  title={Analysis of ecological communities},
+  author={McCune, Bruce and Grace, James B and Urban, Dean L},
+  volume={28},
+  year={2002},
+  publisher={MjM software design Gleneden Beach, OR}
+}
+        </citation>
+        <citation type="bibtex">
+@misc{legendre1998numerical,
+  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
+  author={Legendre, Pierre and Legendre, Louis},
+  year={1998},
+  publisher={Elsevier}
+        </citation>
+    </expand>
 </tool>

--- a/tools/mothur/lefse.xml
+++ b/tools/mothur/lefse.xml
@@ -113,5 +113,7 @@ echo 'lefse(
 
 .. _lefse: https://www.mothur.org/wiki/Lefse
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1186/gb-2011-12-6-r60</citation>
+    </expand>
 </tool>

--- a/tools/mothur/libshuff.xml
+++ b/tools/mothur/libshuff.xml
@@ -116,5 +116,8 @@ The libshuff_ method is a generic test that describes whether two or more commun
 .. _libshuff: https://www.mothur.org/wiki/Libshuff
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.67.9.4374-4376.2001</citation>
+        <citation type="doi">10.1128/AEM.70.9.5485-5492.2004</citation>
+    </expand>
 </tool>

--- a/tools/mothur/macros.xml
+++ b/tools/mothur/macros.xml
@@ -243,4 +243,23 @@ in the Department of Microbiology and Immunology at The University of Michigan. 
             <yield/>
         </citations>
     </xml>
+    <xml name="citations-ecology">
+        <citation type="bibtex">
+            @book{mccune2002analysis,
+              title={Analysis of ecological communities},
+              author={McCune, Bruce and Grace, James B and Urban, Dean L},
+              volume={28},
+              year={2002},
+              publisher={MjM software design Gleneden Beach, OR}
+            }
+        </citation>
+        <citation type="bibtex">
+            @misc{legendre1998numerical,
+              title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
+              author={Legendre, Pierre and Legendre, Louis},
+              year={1998},
+              publisher={Elsevier Science Amsterdam, The Netherlands}
+            }
+        </citation>
+    </xml>
 </macros>

--- a/tools/mothur/make.lefse.xml
+++ b/tools/mothur/make.lefse.xml
@@ -81,7 +81,5 @@ The make.lefse_ allows you to create a lefse formatted input file from mothur's 
 .. _make.lefse: https://www.mothur.org/wiki/Make.lefse
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/make.lookup.xml
+++ b/tools/mothur/make.lookup.xml
@@ -100,7 +100,7 @@ The make.lookup_ allows you to create custom lookup files for use with shhh.flow
 .. _make.lookup: https://www.mothur.org/wiki/Make.lookup
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations">
+        <citation type="doi">10.1038/nmeth.1361</citation>
+    </expand>
 </tool>

--- a/tools/mothur/make.sra.xml
+++ b/tools/mothur/make.sra.xml
@@ -208,7 +208,5 @@ The make.sra_ creates the necessary files for a NCBI submission.
 .. _make.sra: https://www.mothur.org/wiki/Make.sra
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/mantel.xml
+++ b/tools/mothur/mantel.xml
@@ -64,22 +64,6 @@ The mantel_ command calculates the Mantel correlation coefficient between two ma
 
     ]]></help>
     <expand macro="citations">
-        <citation type="bibtex">
-@book{mccune2002analysis,
-  title={Analysis of ecological communities},
-  author={McCune, Bruce and Grace, James B and Urban, Dean L},
-  volume={28},
-  year={2002},
-  publisher={MjM software design Gleneden Beach, OR}
-}
-        </citation>
-        <citation type="bibtex">
-@misc{legendre1998numerical,
-  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
-  author={Legendre, Pierre and Legendre, Louis},
-  year={1998},
-  publisher={Elsevier Science Amsterdam, The Netherlands}
-}
-        </citation>
+        <expand macro="citations-ecology"/>
     </expand>
 </tool>

--- a/tools/mothur/mantel.xml
+++ b/tools/mothur/mantel.xml
@@ -63,5 +63,23 @@ The mantel_ command calculates the Mantel correlation coefficient between two ma
 .. _mantel: https://www.mothur.org/wiki/Mantel
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex">
+@book{mccune2002analysis,
+  title={Analysis of ecological communities},
+  author={McCune, Bruce and Grace, James B and Urban, Dean L},
+  volume={28},
+  year={2002},
+  publisher={MjM software design Gleneden Beach, OR}
+}
+        </citation>
+        <citation type="bibtex">
+@misc{legendre1998numerical,
+  title={Numerical Ecology, Volume 24, (Developments in Environmental Modelling)},
+  author={Legendre, Pierre and Legendre, Louis},
+  year={1998},
+  publisher={Elsevier Science Amsterdam, The Netherlands}
+}
+        </citation>
+    </expand>
 </tool>

--- a/tools/mothur/metastats.xml
+++ b/tools/mothur/metastats.xml
@@ -113,5 +113,7 @@ The metastats_ command generate principle components plot data.
 v.1.21.0: Updated to mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1371/journal.pcbi.1000352</citation>
+    </expand>
 </tool>

--- a/tools/mothur/mimarks.attributes.xml
+++ b/tools/mothur/mimarks.attributes.xml
@@ -52,7 +52,5 @@ The mimarks.attributes_ command reads `BioSample Attributes`_ xml and generates 
 .. _get.mimarkspackage: https://www.mothur.org/wiki/Get.mimarkspackage
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/nmds.xml
+++ b/tools/mothur/nmds.xml
@@ -81,5 +81,14 @@ The nmds_ command generates non-metric multidimensional scaling data from a phyl
 v1.20.0: Updated to mothur 1.33
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex">
+@book{cox2000multidimensional,
+  title={Multidimensional scaling},
+  author={Cox, Trevor F and Cox, Michael AA},
+  year={2000},
+  publisher={Chapman and hall/CRC}
+}
+        </citation>
+    </expand>
 </tool>

--- a/tools/mothur/pairwise.seqs.xml
+++ b/tools/mothur/pairwise.seqs.xml
@@ -126,5 +126,8 @@ The pairwise.seqs_ command will calculate uncorrected pairwise distances between
 .. _pairwise.seqs: https://www.mothur.org/wiki/Pairwise.seqs
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1016/0022-2836(70)90057-4</citation>
+        <citation type="doi">10.1016/0022-2836(82)90398-9</citation>
+    </expand>
 </tool>

--- a/tools/mothur/parsimony.xml
+++ b/tools/mothur/parsimony.xml
@@ -89,5 +89,32 @@ probability that the communities have the same structure by chance. The value do
 v.1.20.0: Added count parameter
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex">
+@article{slatkin1989cladistic,
+  title={A cladistic measure of gene flow inferred from the phylogenies of alleles.},
+  author={Slatkin, Montgomery and Maddison, Wayne P},
+  journal={Genetics},
+  volume={123},
+  number={3},
+  pages={603--613},
+  year={1989},
+  publisher={Genetics Soc America}
+}
+        </citation>
+        <citation type="bibtex">
+@article{slatkin1990detecting,
+  title={Detecting isolation by distance using phylogenies of genes.},
+  author={Slatkin, Montgomery and Maddison, Wayne P},
+  journal={Genetics},
+  volume={126},
+  number={1},
+  pages={249--260},
+  year={1990},
+  publisher={Genetics Soc America}
+}
+        </citation>
+        <citation type="doi">10.1128/AEM.68.8.3673-3682.2002</citation>
+        <citation type="doi">10.1128/AEM.72.4.2379-2384.2006</citation>
+    </expand>
 </tool>

--- a/tools/mothur/pca.xml
+++ b/tools/mothur/pca.xml
@@ -80,5 +80,7 @@ The pca_ command generate principle components plot data for a shared_ or relabu
 .. _pca: https://www.mothur.org/wiki/Pca
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <expand macro="citations-ecology"/>
+    </expand>
 </tool>

--- a/tools/mothur/pcoa.xml
+++ b/tools/mothur/pcoa.xml
@@ -51,5 +51,7 @@ The pcoa_ command performs principal coordinate analysis on a phylip-formatted_d
 .. _pcoa: https://www.mothur.org/wiki/Pcoa
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <expand macro="citations-ecology"/>
+    </expand>
 </tool>

--- a/tools/mothur/phylo.diversity.xml
+++ b/tools/mothur/phylo.diversity.xml
@@ -131,5 +131,7 @@ The phylo.diversity_ command calculates alpha diversity as the total of the uniq
 v.1.21.0: Updated to Mothur 1.33, added count parameter
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1098/rstb.1994.0085</citation>
+    </expand>
 </tool>

--- a/tools/mothur/pre.cluster.xml
+++ b/tools/mothur/pre.cluster.xml
@@ -141,5 +141,7 @@ calculation much faster.
 v1.24.0: Updated to mothur 1.33, added count and topdown parameter
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1098/rstb.1994.0085</citation>
+    </expand>
 </tool>

--- a/tools/mothur/primer.design.xml
+++ b/tools/mothur/primer.design.xml
@@ -95,7 +95,5 @@ The primer.design_ allows you to identify sequence fragments that are specific t
 .. _primer.design: https://www.mothur.org/wiki/Primer.design
 
     ]]></help>
-    <citations>
-        <citation type="doi">10.1128/AEM.01541-09</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/mothur/rarefaction.shared.xml
+++ b/tools/mothur/rarefaction.shared.xml
@@ -238,5 +238,14 @@ The rarefaction.shared_ command generates inter-sample rarefaction curves using 
 .. _rarefaction.shared: https://www.mothur.org/wiki/Rarefaction.shared
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex"><![CDATA[
+@book{magurran2013measuring,
+  title={Measuring biological diversity},
+  author={Magurran, Anne E},
+  year={2013},
+  publisher={John Wiley \& Sons}
+}
+        ]]></citation>
+    </expand>
 </tool>

--- a/tools/mothur/rarefaction.single.xml
+++ b/tools/mothur/rarefaction.single.xml
@@ -104,5 +104,14 @@ The rarefaction.single_ command generates intra-sample rarefaction curves using 
 .. _rarefaction.single: https://www.mothur.org/wiki/Rarefaction.single
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="bibtex"><![CDATA[
+@book{magurran2013measuring,
+  title={Measuring biological diversity},
+  author={Magurran, Anne E},
+  year={2013},
+  publisher={John Wiley \& Sons}
+}
+        ]]></citation>
+    </expand>
 </tool>

--- a/tools/mothur/sens.spec.xml
+++ b/tools/mothur/sens.spec.xml
@@ -121,5 +121,7 @@ The sens.spec_ command takes a list_ and either a column_  or phylip_ distance m
 .. _sens.spec: https://www.mothur.org/wiki/Sens.spec
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.02810-10</citation>
+    </expand>
 </tool>

--- a/tools/mothur/seq.error.xml
+++ b/tools/mothur/seq.error.xml
@@ -169,5 +169,7 @@ This is demonstrated in https://www.mothur.org/wiki/Schloss_SOP#Error_analysis
 .. _seq.error: https://www.mothur.org/wiki/Seq.error
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1371/journal.pone.0027310</citation>
+    </expand>
 </tool>

--- a/tools/mothur/shhh.flows.xml
+++ b/tools/mothur/shhh.flows.xml
@@ -87,5 +87,9 @@ The shhh.flows_ command is Pat Schloss's translation of Chris Quince's PyroNoise
 .. _shhh.flows: https://www.mothur.org/wiki/Shhh.flows
 
     ]]></help>
-    <expand macro="citations"/>
+     <expand macro="citations">
+        <citation type="doi">10.1371/journal.pone.0027310</citation>
+        <citation type="doi">10.1186/1471-2105-12-38</citation>
+        <citation type="doi">10.1038/nmeth.1361</citation>
+    </expand>
 </tool>

--- a/tools/mothur/shhh.seqs.xml
+++ b/tools/mothur/shhh.seqs.xml
@@ -62,5 +62,8 @@ The shhh.seqs_ command is a mothur-based rewrite of Chris Quince's sequence deno
 .. _shhh.seqs: https://www.mothur.org/wiki/Shhh.seqs
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1371/journal.pone.0027310</citation>
+        <citation type="doi">10.1186/1471-2105-12-38</citation>
+    </expand>
 </tool>

--- a/tools/mothur/unifrac.unweighted.xml
+++ b/tools/mothur/unifrac.unweighted.xml
@@ -193,5 +193,7 @@ The unifrac.unweighted_ command the unweighted UniFrac algorithm. The unifrac.we
 .. _unifrac.unweighted: https://www.mothur.org/wiki/Unifrac.unweighted
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.71.12.8228-8235.2005</citation>
+    </expand>
 </tool>

--- a/tools/mothur/unifrac.weighted.xml
+++ b/tools/mothur/unifrac.weighted.xml
@@ -210,5 +210,7 @@ The unifrac.weighted_ command implements the weighted UniFrac algorithm. The uni
 .. _unifrac.weighted: https://www.mothur.org/wiki/Unifrac.weighted
 
     ]]></help>
-    <expand macro="citations"/>
+    <expand macro="citations">
+        <citation type="doi">10.1128/AEM.71.12.8228-8235.2005</citation>
+    </expand>
 </tool>


### PR DESCRIPTION
This adds the citations listed under mothur's `mothur.component(citations)` command for each mothur component (thanks for the tip @bernt-matthias)

----

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
