### PR TITLE
Limma-voom: add option to output filtered count matrix

### DIFF
--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -166,6 +166,7 @@ spec <- matrix(c(
     "totReq", "y", 0, "logical",
     "cntReq", "z", 1, "integer",
     "sampleReq", "s", 1, "integer",
+    "filtCounts", "F", 0, "logical",
     "normCounts", "x", 0, "logical",
     "rdaOpt", "r", 0, "logical",
     "lfcReq", "l", 1, "double",
@@ -216,6 +217,12 @@ if (is.null(opt$annoPath)) {
     haveAnno <- FALSE
 } else {
     haveAnno <- TRUE
+}
+
+if (is.null(opt$filtCounts)) {
+    wantFilt <- FALSE
+} else {
+    wantFilt <- TRUE
 }
 
 if (is.null(opt$normCounts)) {
@@ -364,7 +371,7 @@ for (i in 1:length(contrastData)) {
     topOut[i] <- makeOut(paste0(deMethod, "_", con, ".tsv"))
     glimmaOut[i] <- makeOut(paste0("glimma_", con, "/MD-Plot.html"))
 }
-
+filtOut <- makeOut(paste0(deMethod, "_filtcounts.tsv"))
 normOut <- makeOut(paste0(deMethod, "_normcounts.tsv"))
 rdaOut <- makeOut(paste0(deMethod, "_analysis.RData"))
 sessionOut <- makeOut("session_info.txt")
@@ -439,6 +446,13 @@ if (filtCPM || filtSmpCount || filtTotCount) {
 
     data$counts <- data$counts[keep, ]
     data$genes <- data$genes[keep, , drop=FALSE]
+
+    if (wantFilt) {
+        print("Outputting filtered counts")
+        filt_counts <- data.frame(data$genes, data$counts)
+        write.table(filt_counts, file=filtOut, row.names=FALSE, sep="\t", quote=FALSE)
+        linkData <- rbind(linkData, data.frame(Label=paste0(deMethod, "_", "filtcounts.tsv"), Link=paste0(deMethod, "_", "filtcounts.tsv"), stringsAsFactors=FALSE))
+    }
 
     # Plot Density
     if ("d" %in% plots) {

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -1,4 +1,4 @@
-<tool id="limma_voom" name="limma" version="3.34.9.7">
+<tool id="limma_voom" name="limma" version="3.34.9.8">
     <description>
         Perform differential expression with limma-voom or limma-trend
     </description>
@@ -75,6 +75,10 @@ Rscript '$__tool_directory__/limma_voom.R'
 
 #if $out.plots:
     -P $out.plots
+#end if
+
+#if $out.filtCounts:
+    -F
 #end if
 
 #if $out.normCounts:
@@ -271,6 +275,10 @@ cp '$outReport.files_path'/*tsv output_dir/
                 <option value="m">MD Plots for individual samples</option>
                 <option value="h">Heatmaps (top DE genes) </option>
                 <option value="s">Stripcharts (top DE genes)</option>
+            </param>
+            <param name="filtCounts" type="boolean" truevalue="1" falsevalue="0" checked="false"
+                label="Output Filtered Counts Table?"
+                help="Output a file containing the raw filtered counts if Filter Low Counts is selected. Default: No">
             </param>
             <param name="normCounts" type="boolean" truevalue="1" falsevalue="0" checked="false"
                 label="Output Normalised Counts Table?"

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -473,9 +473,10 @@ cp '$outReport.files_path'/*tsv output_dir/
                 </element>
             </output_collection>
         </test>
-        <!-- Ensure normalised counts file output works-->
+        <!-- Ensure filtered and normalised count outputs works-->
         <test>
             <param name="format" value="matrix" />
+            <param name="filtCounts" value="true" />
             <param name="normCounts" value="true" />
             <param name="counts" value="matrix.txt" />
             <repeat name="rep_factor">
@@ -485,19 +486,31 @@ cp '$outReport.files_path'/*tsv output_dir/
             <repeat name="rep_contrast">
                 <param name="contrast" value="Mut-WT" />
             </repeat>
+            <param name="filt_select" value="yes" />
+            <param name="format_select" value="counts"/>
+            <param name="cntReq" value="10"/>
+            <param name="count_select" value="sample"/>
+            <param name="cntSampleReq" value="3"/>
             <param name="normalisationOption" value="TMM" />
             <param name="topgenes" value="6" />
-            <output_collection name="outTables" count="2">
+            <output_collection name="outTables" count="3">
                 <element name="limma-voom_Mut-WT" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="GeneID.*logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
-                        <has_text_matching expression="11304.*0.4573" />
+                        <has_text_matching expression="11304.*0.45.*15.52.*4.94.*7.74.*0.0001.*5.27" />
                     </assert_contents>
                 </element>
                 <element name="limma-voom_normcounts" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*15.7545" />
+                        <has_text_matching expression="11304.*15.7.*15.8.*15.6.*15.3.*15.2.*15.2" />
+                    </assert_contents>
+                </element>
+                <element name="limma-voom_filtcounts" ftype="tabular" >
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
+                        <has_text_matching expression="11304.*361.*397.*346.*356.*312.*337" />
+                        <not_has_text text="11302"/>
                     </assert_contents>
                 </element>
             </output_collection>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [x] .shed.yml file ok
    - [x] Toolshed user `iuc` has access to associated toolshed repo(s)
* [x] Indentation is correct (4 spaces)
* [x] Tool version/build ok
* [x] `<command/>`
  - [x] Text parameters, input and output files `'single quoted'`
  - [x] Use of `<![CDATA[ ... ]]>` tags
  - [x] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [x] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [x] Tests
  - [x] Parameters are reasonably covered
  - [x] Test files are appropriate
* [x] Help
  - [x] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [x] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
