### PR TITLE
Cutadapt: fix for paired collection for multiqc

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -1,4 +1,4 @@
-<tool id="cutadapt" name="Cutadapt" version="1.16.1" profile="17.09">
+<tool id="cutadapt" name="Cutadapt" version="1.16.2" profile="17.09">
     <description>Remove adapter sequences from Fastq/Fasta</description>
     <macros>
         <import>macros.xml</import>
@@ -27,7 +27,8 @@
 #set paired = True
 #set input_1 = $library.input_1.forward
 #set input_2 = $library.input_1.reverse
-#set read1 = re.sub('[^\w\-\s]', '_', str($library.input_1.name))
+#set read1 = re.sub('[^\w\-\s]', '_', str($library.input_1.name)) + "_1"
+#set read2 = re.sub('[^\w\-\s]', '_', str($library.input_1.name)) + "_2"
 #else
 #set input_1 = $library.input_1
 #set read1 = re.sub('[^\w\-\s]', '_', str($library.input_1.element_identifier))


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

If a paired collection is input to cutadapt the cutadapt report doesn't work well with multiqc, as multiqc uses the R2 name and currently in the cutadapt wrapper `input_r` is being used for all samples e.g see below (so multiqc can't differentiate different samples):

```
This is cutadapt 1.16 with Python 3.6.4
Command line parameters: -j 1 --format=fastq --output=out1.gz --paired-output=out2.gz --error-rate=0.1 --times=1 --overlap=3 --minimum-length=20 --pair-filter=any --quality-cutoff=20 ERR188044.fq.gz input_r.fq.gz 
```

This PR is a fix for this, it adds a _1 and _2 to the paired collection fastq names.