### PR TITLE
MultiQC: Add element_identifier to RSeQC Infer Experiment

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,4 +1,4 @@
-<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.0">
+<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@.1">
     <description>aggregate results from bioinformatics analyses into a single report</description>
     <macros>
         <token name="@WRAPPER_VERSION@">1.5</token>
@@ -306,8 +306,9 @@ mkdir multiqc_WDir &&
                 #end for
             #elif str($repeat2.type.type) == "infer_experiment"
                 #set $pattern = "Fraction of reads explained by"
-                #for $k, $file in enumerate($repeat2.type.input)
-                    #set file_path = os.path.join($repeat_dir, 'file_' + str($k) + '_infer_experiment.txt') 
+                #for $file in $repeat2.type.input
+                    @ESCAPE_IDENTIFIER@
+                    #set file_path = os.path.join($repeat_dir, str($identifier))
                     grep -q "$pattern" $file || die "'$pattern' not found in the file" &&
                     ln -s '$file' '$file_path' &&
                 #end for


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

This adds the element_identifier to RSeQC Infer Experiment results (at the moment you get "file_0_infer_experiment", "file_1_infer_experiment" used as the names in the MultiQC report)