### PR TITLE
gtfToBed12: Add label to outputs to distinguish BED12 from table

### DIFF
--- a/tools/gtfToBed12/gtfToBed12.xml
+++ b/tools/gtfToBed12/gtfToBed12.xml
@@ -1,4 +1,4 @@
-<tool id="gtftobed12" name="Convert GTF to BED12" version="357.1">
+<tool id="gtftobed12" name="Convert GTF to BED12" version="357">
     <requirements>
         <requirement type="package" version="357">ucsc-gtftogenepred</requirement>
         <requirement type="package" version="357">ucsc-genepredtobed</requirement>

--- a/tools/gtfToBed12/gtfToBed12.xml
+++ b/tools/gtfToBed12/gtfToBed12.xml
@@ -1,4 +1,4 @@
-<tool id="gtftobed12" name="Convert GTF to BED12" version="357">
+<tool id="gtftobed12" name="Convert GTF to BED12" version="357.1">
     <requirements>
         <requirement type="package" version="357">ucsc-gtftogenepred</requirement>
         <requirement type="package" version="357">ucsc-genepredtobed</requirement>
@@ -62,8 +62,8 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="bed_file" format="bed12" metadata_source="gtf_file" />
-        <data name="transcript_info_file" format="tabular" metadata_source="gtf_file">
+        <data name="bed_file" format="bed12" metadata_source="gtf_file" label="${tool.name} on ${on_string}: BED12"/>
+        <data name="transcript_info_file" format="tabular" metadata_source="gtf_file" label="${tool.name} on ${on_string}: Table">
             <filter>advanced_options['infoOut']</filter>
         </data>
     </outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

This PR adds `label=` with BED12 or Table to the two outputs as they currently both get the same name.