### PR TITLE
fastp: update to version 0.19.3

### DIFF
--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -6,7 +6,7 @@
     <requirements>
         <requirement type="package" version="@WRAPPER_VERSION@">fastp</requirement>
     </requirements>
-    <version_command>fastp --version | tail -n 1</version_command>
+    <version_command>fastp -v</version_command>
     <command detect_errors="exit_code"><![CDATA[
 ## Link input files
 

--- a/tools/fastp/macros.xml
+++ b/tools/fastp/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@WRAPPER_VERSION@">0.18.0</token>
+    <token name="@WRAPPER_VERSION@">0.19.3</token>
 
     <xml name="adapter_sequence1">
         <param name="adapter_sequence1" argument="--adapter_sequence" type="text" optional="true" label="Adapter sequence for input 1"


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
