### PR TITLE
Cutadapt: Fix read 1 output for workflows, format needs to be fastqsanger not fasta

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -1,4 +1,4 @@
-<tool id="cutadapt" name="Cutadapt" version="1.16.2" profile="17.09">
+<tool id="cutadapt" name="Cutadapt" version="1.16.3" profile="17.09">
     <description>Remove adapter sequences from Fastq/Fasta</description>
     <macros>
         <import>macros.xml</import>
@@ -223,7 +223,7 @@ $read_mod_options.trim_n
     </inputs>
 
     <outputs>
-        <data name="out1" format="fasta" metadata_source="input_1" from_work_dir="out1*" label="${tool.name} on ${on_string}: Read 1 Output">
+        <data name="out1" format="fastqsanger" metadata_source="input_1" from_work_dir="out1*" label="${tool.name} on ${on_string}: Read 1 Output">
             <expand macro="inherit_format_1" />
         </data>
         <data name="out2" format="fastqsanger" metadata_source="input_2" from_work_dir="out2*" label="${tool.name} on ${on_string}: Read 2 Output" >


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

This is fix for https://github.com/galaxyproject/tools-iuc/issues/2020