### PR TITLE
Parameterize repeated fastp parameters and add paired collection

### DIFF
--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -196,39 +196,17 @@ mv first${ext} '${out1}'
                 <option value="paired">Paired</option>
             </param>
             <when value="single">
-                <expand macro="in1" />
-                <section name="adapter_trimming_options" title="Adapter Trimming Options" expanded="False">
-                    <param name="disable_adapter_trimming" argument="-A" type="boolean" truevalue="-A" falsevalue="" checked="false" label="Disable adapter trimming" help="Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled."/>
-                    <expand macro="adapter_sequence1" />
-                </section>
-                <section name="global_trimming_options" title="Global Trimming Options" expanded="False">
-                    <param name="trim_front1" argument="-f" type="integer" optional="true" label="Trim front for input 1" help="Trimming how many bases in front for read1, default is 0."/>
-                    <param name="trim_tail1" argument="-t" type="integer" optional="true" label="Trim tail for input 1" help="Trimming how many bases in tail for read1, default is 0."/>
-                </section>
+                <expand macro="in" />
+                <expand macro="adapter_trimming_options" />
+                <expand macro="global_trimming_options" />
             </when>
             <when value="paired">
-                <expand macro="in1" />
-                <param name="in2" argument="-I" type="data" format="fastq,fastq.gz" optional="true" label="Input 2" help="Input FASTQ file #2."/>
-                <section name="adapter_trimming_options" title="Adapter trimming options" expanded="False">
-                    <param name="disable_adapter_trimming" argument="-A" type="boolean" truevalue="-A" falsevalue="" checked="false" label="Disable adapter trimming" help="Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled."/>
-                    <expand macro="adapter_sequence1" />
-                    <param name="adapter_sequence2" argument="--adapter_sequence_r2" type="text" optional="true" label="Adapter sequence for input 2" help="The adapter for read2 (PE data only). This is used if R1/R2 are found not overlapped. If not specified, it will be the same as adapter sequence value for input 1.">
-                        <sanitizer>
-                            <valid>
-                                <add value="A"/>
-                                <add value="T"/>
-                                <add value="C"/>
-                                <add value="G"/>
-                            </valid>
-                        </sanitizer>
-                    </param>
-                </section>
-                <section name="global_trimming_options" title="Global trimming options" expanded="False">
-                    <param name="trim_front1" argument="-f" type="integer" optional="true" label="Trim front for input 1" help="Trimming how many bases in front for read1, default is 0."/>
-                    <param name="trim_tail1" argument="-t" type="integer" optional="true" label="Trim tail for input 1" help="Trimming how many bases in tail for read1, default is 0."/>
-                    <param name="trim_front2" argument="-F" type="integer" optional="true" label="Trim front for input 2" help="Trimming how many bases in front for read2. If it's not specified, it will follow read1's settings."/>
-                    <param name="trim_tail2" argument="-T" type="integer" optional="true" label="Trim tail for input 2" help="Trimming how many bases in tail for read2. If it's not specified, it will follow read1's settings."/>
-                </section>
+                <expand macro="in" read_number="1" argument="-i"/>
+                <expand macro="in" read_number="2" argument="-I"/>
+                <expand macro="adapter_trimming_options">
+                    <expand macro="adapter_sequence" read_number="2"/>
+                </expand>
+                <expand macro="global_trimming_options_paired" />
             </when>
         </conditional>
 

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -20,7 +20,7 @@
     #end if
     #set $in1 = $single_paired.paired_input.forward
     #set $in2 = $single_paired.paired_input.reverse
-    #set $in1_name = re.sub('[^\w\-\s]', '_', str("%s_%s" % ($single_paired.paired_input.name, "R1"))) + $ext
+    #set $in1_name = re.sub('[^\w\-\s]', '_', str($single_paired.paired_input.name)) + $ext
     #set $in2_name = re.sub('[^\w\-\s]', '_', str("%s_%s" % ($single_paired.paired_input.name, "R2"))) + $ext
     #set out1 = $output_paired_coll.forward
     #set out2 = $output_paired_coll.reverse
@@ -35,7 +35,7 @@
     ln -s '$in1' '$in1_name' &&
 
     #if str($single_paired.single_paired_selector) == 'paired':
-        #set $in2_name = re.sub('[^\w\-\s]', '_', str($in2.element_identifier)) + $ext
+        #set $in2_name = re.sub('[^\w\-\s]', '_', str("%s_R2" % $in2.element_identifier)) + $ext
         ln -s '$in2' '$in2_name' &&
     #end if
 #end if

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -1,4 +1,4 @@
-<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@.1">
+<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@.2">
     <description>- fast all-in-one preprocessing for FASTQ files</description>
     <macros>
         <import>macros.xml</import>
@@ -12,18 +12,32 @@
 
 ## Link input files
 
-#if $in1.is_of_type('fastq.gz')
-    #set ext = '.fastq.gz'
+#set ext = '.fastq'
+
+#if $single_paired.single_paired_selector == 'paired_collection':
+    #if $single_paired.paired_input.forward.is_of_type('fastq.gz'):
+        #set ext = '.fastq.gz'
+    #end if
+    #set $in1 = $single_paired.paired_input.forward
+    #set $in2 = $single_paired.paired_input.reverse
+    #set $in1_name = re.sub('[^\w\-\s]', '_', str("%s_%s" % ($single_paired.paired_input.name, "R1"))) + $ext
+    #set $in2_name = re.sub('[^\w\-\s]', '_', str("%s_%s" % ($single_paired.paired_input.name, "R2"))) + $ext
+    #set out1 = $output_paired_coll.forward
+    #set out2 = $output_paired_coll.reverse
+    ln -s '$in1' '$in1_name' &&
+    ln -s '$in2' '$in2_name' &&
 #else
-    #set ext = '.fastq'
-#end if
+    #if $in1.is_of_type('fastq.gz')
+        #set ext = '.fastq.gz'
+    #end if
 
-#set $in1_name = re.sub('[^\w\-\s]', '_', str($in1.element_identifier)) + $ext
-ln -s '$in1' $in1_name &&
+    #set $in1_name = re.sub('[^\w\-\s]', '_', str($in1.element_identifier)) + $ext
+    ln -s '$in1' '$in1_name' &&
 
-#if str($single_paired.single_paired_selector) == 'paired':
-    #set $in2_name = re.sub('[^\w\-\s]', '_', str($in2.element_identifier)) + $ext
-    ln -s '$in2' $in2_name &&
+    #if str($single_paired.single_paired_selector) == 'paired':
+        #set $in2_name = re.sub('[^\w\-\s]', '_', str($in2.element_identifier)) + $ext
+        ln -s '$in2' '$in2_name' &&
+    #end if
 #end if
 
 
@@ -38,11 +52,11 @@ fastp
     --phred64
 #end if
 
--i $in1_name
+-i '$in1_name'
 -o first${ext}
 
-#if str($single_paired.single_paired_selector) == 'paired':
-    -I $in2_name
+#if str($single_paired.single_paired_selector).startswith('paired'):
+    -I '$in2_name'
     -O second${ext}
 #end if
 
@@ -55,7 +69,7 @@ $single_paired.adapter_trimming_options.disable_adapter_trimming
     --adapter_sequence '$single_paired.adapter_trimming_options.adapter_sequence1'
 #end if
 
-#if str($single_paired.single_paired_selector) == 'paired':
+#if str($single_paired.single_paired_selector).startswith('paired'):
     #if str($single_paired.adapter_trimming_options.adapter_sequence2):
         --adapter_sequence_r2 '$single_paired.adapter_trimming_options.adapter_sequence2'
     #end if
@@ -72,7 +86,7 @@ $single_paired.adapter_trimming_options.disable_adapter_trimming
     -t $single_paired.global_trimming_options.trim_tail1
 #end if
 
-#if str($single_paired.single_paired_selector) == 'paired':
+#if str($single_paired.single_paired_selector).startswith('paired'):
     #if str($single_paired.global_trimming_options.trim_front2):
         -F $single_paired.global_trimming_options.trim_front2
     #end if
@@ -183,7 +197,7 @@ $read_mod_options.base_correction_options.correction
 &&
 
 mv first${ext} '${out1}'
-#if str($single_paired.single_paired_selector) == 'paired':
+#if str($single_paired.single_paired_selector).startswith('paired'):
     &&
     mv second${ext} '${out2}'
 #end if
@@ -194,6 +208,7 @@ mv first${ext} '${out1}'
             <param name="single_paired_selector" type="select" label="Single-end or paired reads">
                 <option value="single" selected="true">Single-end</option>
                 <option value="paired">Paired</option>
+                <option value="paired_collection">Paired Collection</option>
             </param>
             <when value="single">
                 <expand macro="in" />
@@ -203,6 +218,13 @@ mv first${ext} '${out1}'
             <when value="paired">
                 <expand macro="in" read_number="1" argument="-i"/>
                 <expand macro="in" read_number="2" argument="-I"/>
+                <expand macro="adapter_trimming_options">
+                    <expand macro="adapter_sequence" read_number="2"/>
+                </expand>
+                <expand macro="global_trimming_options_paired" />
+            </when>
+        <when value="paired_collection">
+                <param name="paired_input" type="data_collection" collection_type="paired" format="fastq,fastq.gz" label="Select paired collection(s)"/>
                 <expand macro="adapter_trimming_options">
                     <expand macro="adapter_sequence" read_number="2"/>
                 </expand>
@@ -290,10 +312,15 @@ mv first${ext} '${out1}'
     </inputs>
 
     <outputs>
-        <data name="out1" format_source="in1" label="${tool.name} on ${on_string}: Read 1 Output"/>
+        <data name="out1" format_source="in1" label="${tool.name} on ${on_string}: Read 1 Output">
+            <filter>single_paired['single_paired_selector'] in ["single", "paired"]</filter>
+        </data>
         <data name="out2" format_source="in2" label="${tool.name} on ${on_string}: Read 2 Output">
             <filter>single_paired['single_paired_selector'] == "paired"</filter>
         </data>
+        <collection name="output_paired_coll" type="paired" structured_like="paired_input" inherit_format="true" label="Paired-end output of ${tool.name} on ${on_string}">
+            <filter>single_paired['single_paired_selector'] == "paired_collection"</filter>
+        </collection>
         <data name="report_html" format="html" from_work_dir="fastp.html" label="${tool.name} on ${on_string}: HTML Report">
             <filter>output_options['report_html'] is True</filter>
         </data>
@@ -313,6 +340,25 @@ mv first${ext} '${out1}'
                     <has_text text="fastp report"/>
                 </assert_contents>
             </output>
+        </test>
+        <!-- Ensure paired collection works -->
+        <test expect_num_outputs="3">
+            <param name="single_paired_selector" value="paired_collection"/>
+            <param name="paired_input">
+                <collection type="paired">
+                    <element name="forward" value="bwa-mem-fastq1.fq" ftype="fastqsanger" />
+                    <element name="reverse" value="bwa-mem-fastq2.fq" ftype="fastqsanger" />
+                </collection>
+            </param>
+            <output name="report_html">
+                <assert_contents>
+                    <has_text text="fastp report"/>
+                </assert_contents>
+            </output>
+            <output_collection name="output_paired_coll" type="paired">
+                <element name="forward" value="out_bwa1.fq" ftype="fastqsanger"/>
+                <element name="reverse" value="out_bwa2.fq" ftype="fastqsanger"/>
+            </output_collection>
         </test>
         <!-- Ensure custom adapter works -->
         <test expect_num_outputs="2">

--- a/tools/fastp/macros.xml
+++ b/tools/fastp/macros.xml
@@ -1,9 +1,35 @@
 <macros>
     <token name="@WRAPPER_VERSION@">0.19.3</token>
 
-    <xml name="adapter_sequence1">
-        <param name="adapter_sequence1" argument="--adapter_sequence" type="text" optional="true" label="Adapter sequence for input 1"
-            help="The adapter for read1. For SE data, if not specified, the adapter will be auto-detected. For PE data, this is used if R1/R2 are found not overlapped.">
+    <xml name="adapter_trimming_options">
+        <section name="adapter_trimming_options" title="Adapter Trimming Options" expanded="False">
+            <param name="disable_adapter_trimming" argument="-A" type="boolean" truevalue="-A" falsevalue="" checked="false" label="Disable adapter trimming" help="Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled."/>
+            <expand macro="adapter_sequence" read_number="1" />
+            <yield />
+        </section>
+        <section name="global_trimming_options" title="Global Trimming Options" expanded="False">
+            <param name="trim_front1" argument="-f" type="integer" optional="true" label="Trim front for input 1" help="Trimming how many bases in front for read1, default is 0."/>
+            <param name="trim_tail1" argument="-t" type="integer" optional="true" label="Trim tail for input 1" help="Trimming how many bases in tail for read1, default is 0."/>
+        </section>
+    </xml>
+
+    <xml name="global_trimming_options">
+        <section name="global_trimming_options" title="Global trimming options" expanded="False">
+            <param name="trim_front1" argument="-f" type="integer" optional="true" label="Trim front for input 1" help="Trimming how many bases in front for read1, default is 0."/>
+            <param name="trim_tail1" argument="-t" type="integer" optional="true" label="Trim tail for input 1" help="Trimming how many bases in tail for read1, default is 0."/>
+            <yield/>
+        </section>
+    </xml>
+
+    <xml name="global_trimming_options_paired">
+        <expand macro="global_trimming_options">
+            <param name="trim_front2" argument="-F" type="integer" optional="true" label="Trim front for input 2" help="Trimming how many bases in front for read2. If it's not specified, it will follow read1's settings."/>
+            <param name="trim_tail2" argument="-T" type="integer" optional="true" label="Trim tail for input 2" help="Trimming how many bases in tail for read2. If it's not specified, it will follow read1's settings."/>
+        </expand>
+    </xml>
+
+    <xml name="adapter_sequence" token_read_number="1">
+        <param name="adapter_sequence@READ_NUMBER@" argument="--adapter_sequence@READ_NUMBER@" type="text" optional="true" label="Adapter sequence for input @READ_NUMBER@" help="The adapter for read@READ_NUMBER@. For SE data, if not specified, the adapter will be auto-detected. For PE data, this is used if R1/R2 are found not overlapped.">
             <sanitizer>
                 <valid>
                     <add value="A"/>
@@ -14,9 +40,11 @@
             </sanitizer>
         </param>
     </xml>
-    <xml name="in1">
-        <param name="in1" argument="-i" type="data" format="fastq,fastq.gz" label="Input 1" help="Input FASTQ file #1"/>
+
+    <xml name="in" token_read_number="1" token_argument="-i">
+        <param name="in@READ_NUMBER@" argument="@ARGUMENT@" type="data" format="fastq,fastq.gz" label="Input @READ_NUMBER@" help="Input FASTQ file #@READ_NUMBER@"/>
     </xml>
+
     <xml name="poly_g_min_len">
         <param name="poly_g_min_len" argument="--poly_g_min_len" type="integer" optional="true" label="PolyG minimum length"
             help="The minimum length to detect polyG in the read tail. 10 by default."/>


### PR DESCRIPTION
No other changes so far.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
