### PR TITLE
Bam to fastq fixes 

### DIFF
--- a/tool_collections/samtools/macros.xml
+++ b/tool_collections/samtools/macros.xml
@@ -30,12 +30,12 @@
         <option value="8">The mate is unmapped</option>
         <option value="16">Read strand</option>
         <option value="32">Mate strand</option>
-        <option value="48">Read is the first in a pair</option>
-        <option value="64">Read is the second in a pair</option>
+        <option value="64">Read is the first in a pair</option>
+        <option value="128">Read is the second in a pair</option>
         <option value="256">The alignment or this read is not primary</option>
         <option value="512">The read fails platform/vendor quality checks</option>
-        <option value="768">The read is a PCR or optical duplicate</option>
-        <option value="1024">Supplementary alignment</option>
+        <option value="1024">The read is a PCR or optical duplicate</option>
+        <option value="2048">Supplementary alignment</option>
     </xml>
     <xml name="citations">
         <citations>

--- a/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
+++ b/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
@@ -33,7 +33,7 @@
     ]]>
     </command>
     <inputs>
-        <param name="input" type="data" format="bam,sam" label="BAM or SAM file to convert" />
+        <param name="input" type="data" format="bam,unsorted.bam,qname_sorted.bam,qname_input_sorted.bam,sam" label="BAM or SAM file to convert" />
         <param argument="--reference" type="data" format="fasta" optional="True" label="Reference FASTA" />
         <param name="copy_flags" argument="-t" type="boolean" truevalue="-t" falsevalue="" label="Copy RG/BC/QT flags to output header" />
         <param name="omit_read_number" argument="-n" type="boolean" truevalue="-n" falsevalue="" label="Do not append /1 and /2 to read names" />

--- a/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
+++ b/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="samtools_fastx" name="Samtools extract" version="@TOOL_VERSION@">
+<tool id="samtools_fastx" name="Samtools extract" version="@TOOL_VERSION@.1">
     <description>FASTA or FASTQ from a SAM file</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -23,7 +23,11 @@
         </param>
     </inputs>
     <outputs>
-        <data name="output1" format="bam" />
+        <data name="output1" format="bam">
+            <change_format>
+                <when input="sort_mode" value="-n" format="qname_sorted.bam" />
+            </change_format>
+        </data>
     </outputs>
     <tests>
         <test>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -37,7 +37,7 @@
         <test>
             <param name="input1" value="1.bam" ftype="bam" />
             <param name="sort_mode" value="-n"/>
-            <output name="output1" file="1_sort_read_names.bam" ftype="bam" sort="True"/>
+            <output name="output1" file="1_sort_read_names.bam" ftype="qname_sorted.bam" sort="True"/>
         </test>
     </tests>
     <help>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_sort" name="Sort" version="2.0.1">
+<tool id="samtools_sort" name="Sort" version="2.0.1.1">
     <description>order of storing aligned sequences</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
before these patches these tools could not work  to convert an aligned bam back to fastq files  to be used as input for aligners.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
