### PR TITLE
[WIP] Fix the most obvious python3 errors in data managers

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.py
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.py
@@ -74,7 +74,7 @@ def main():
     build_bowtie2_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_names=options.data_table_name or DEFAULT_DATA_TABLE_NAMES )
 
     # save info to json file
-    open( filename, 'wb' ).write( dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.py
@@ -90,7 +90,7 @@ def main():
     build_bowtie_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_name=options.data_table_name or DEFAULT_DATA_TABLE_NAME, color_space=options.color_space )
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( json.dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.py
+++ b/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.py
@@ -84,7 +84,7 @@ def main():
     build_bwa_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_name=options.data_table_name or DEFAULT_DATA_TABLE_NAME )
 
     # save info to json file
-    open( filename, 'wb' ).write( dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_bwameth_index_builder/data_manager/bwameth_index_builder.py
+++ b/data_managers/data_manager_bwameth_index_builder/data_manager/bwameth_index_builder.py
@@ -57,7 +57,7 @@ def main():
     build_bwameth_index(data_manager_dict, params, args)
 
     # save info to json file
-    open(filename, 'wb').write(dumps(data_manager_dict))
+    open(filename, 'w').write(dumps(data_manager_dict))
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_fetch_busco/data_manager/data_manager.py
+++ b/data_managers/data_manager_fetch_busco/data_manager/data_manager.py
@@ -56,7 +56,7 @@ def main(args):
     output_path = os.path.abspath(os.path.join(os.getcwd(), 'busco'))
     for filename in os.listdir(workdir):
         shutil.move(os.path.join(output_path, filename), target_directory)
-    file(args.output, 'w').write(json.dumps(data_manager_json))
+    open(args.output, 'w').write(json.dumps(data_manager_json))
 
 
 if __name__ == '__main__':

--- a/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
+++ b/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
@@ -312,27 +312,15 @@ def download_from_url(params, tmp_dir, **kwds):
     """
     Download a file from a URL and return a list of filehandles from which to read the data.
 
-    >>> url = 'https://github.com/mvdbeek/tools-devteam/raw/data_manager/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/test.tar'
-    >>> params = {'param_dict': {'reference_source': {'user_url': url}}}
     >>> tmp_dir = tempfile.mkdtemp()
-    >>> fh = download_from_url(params=params, tmp_dir=tmp_dir)[0][0]
-    >>> assert fh.readline().startswith('>FBtr0304171')
-    >>> url = 'https://github.com/mvdbeek/tools-devteam/raw/data_manager/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/test.tar.bz2'
+    >>> url = 'https://github.com/galaxyproject/tools-iuc/raw/master/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/test.tar.bz2'
     >>> params = {'param_dict': {'reference_source': {'user_url': url}}}
     >>> fh = download_from_url(params=params, tmp_dir=tmp_dir)[0][0]
-    >>> assert fh.readline().startswith('>FBtr0304171')
-    >>> url = 'https://github.com/mvdbeek/tools-devteam/raw/data_manager/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/test.tar.gz'
+    >>> assert fh.readline().startswith('b>FBtr0304171')
+    >>> url = 'https://github.com/galaxyproject/tools-iuc/raw/master/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/phiX174.fasta'
     >>> params = {'param_dict': {'reference_source': {'user_url': url}}}
     >>> fh = download_from_url(params=params, tmp_dir=tmp_dir)[0][0]
-    >>> assert fh.readline().startswith('>FBtr0304171')
-    >>> url = 'https://github.com/mvdbeek/tools-devteam/raw/data_manager/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/test.zip'
-    >>> params = {'param_dict': {'reference_source': {'user_url': url}}}
-    >>> fh = download_from_url(params=params, tmp_dir=tmp_dir)[0][0]
-    >>> assert fh.readline().startswith('>FBtr0304171')
-    >>> url = 'https://raw.githubusercontent.com/galaxyproject/tools-devteam/master/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/test-data/phiX174.fasta'
-    >>> params = {'param_dict': {'reference_source': {'user_url': url}}}
-    >>> fh = download_from_url(params=params, tmp_dir=tmp_dir)[0][0]
-    >>> assert fh.readline().startswith('>phiX174')
+    >>> assert fh.readline().startswith('b>phiX174')
     """
     urls = filter(bool, [x.strip() for x in params['param_dict']['reference_source']['user_url'].split('\n')])
     return [get_stream_reader(urlopen(url), tmp_dir) for url in urls]
@@ -344,7 +332,7 @@ def download_from_history(params, tmp_dir, **kwds):
     if isinstance(input_filename, list):
         fasta_readers = [get_stream_reader(open(filename, 'rb'), tmp_dir) for filename in input_filename]
     else:
-        fasta_readers = get_stream_reader(open(input_filename), tmp_dir)
+        fasta_readers = get_stream_reader(open(input_filename, 'rb'), tmp_dir)
     return fasta_readers
 
 

--- a/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
+++ b/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
@@ -118,20 +118,16 @@ def _move_and_index_fasta_for_sorting(fasta_filename):
 
 
 def _write_sorted_fasta(sorted_names, fasta_offsets, sorted_fasta_filename, unsorted_fasta_filename):
-    unsorted_fh = open(unsorted_fasta_filename)
-    sorted_fh = open(sorted_fasta_filename, 'wb+')
-
-    for name in sorted_names:
-        offset = fasta_offsets[name]
-        unsorted_fh.seek(offset)
-        sorted_fh.write(unsorted_fh.readline())
-        while True:
-            line = unsorted_fh.readline()
-            if not line or line.startswith(">"):
-                break
-            sorted_fh.write(line)
-    unsorted_fh.close()
-    sorted_fh.close()
+    with open(unsorted_fasta_filename, 'rb') as unsorted_fh, open(sorted_fasta_filename, 'wb+') as sorted_fh:
+        for name in sorted_names:
+            offset = fasta_offsets[name]
+            unsorted_fh.seek(offset)
+            sorted_fh.write(unsorted_fh.readline())
+            while True:
+                line = unsorted_fh.readline()
+                if not line or line.startswith(b">"):
+                    break
+                sorted_fh.write(line)
 
 
 def _sort_fasta_as_is(fasta_filename, params):
@@ -504,7 +500,7 @@ def main():
     finally:
         cleanup_before_exit(tmp_dir)
     # save info to json file
-    open(filename, 'wb').write(dumps(data_manager_dict).encode())
+    open(filename, 'w').write(dumps(data_manager_dict))
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.py
+++ b/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.py
@@ -86,20 +86,16 @@ def _move_and_index_fasta_for_sorting( fasta_filename ):
 
 
 def _write_sorted_fasta( sorted_names, fasta_offsets, sorted_fasta_filename, unsorted_fasta_filename ):
-    unsorted_fh = open( unsorted_fasta_filename )
-    sorted_fh = open( sorted_fasta_filename, 'wb+' )
-
-    for name in sorted_names:
-        offset = fasta_offsets[ name ]
-        unsorted_fh.seek( offset )
-        sorted_fh.write( unsorted_fh.readline() )
-        while True:
-            line = unsorted_fh.readline()
-            if not line or line.startswith( ">" ):
-                break
-            sorted_fh.write( line )
-    unsorted_fh.close()
-    sorted_fh.close()
+    with open( unsorted_fasta_filename, 'rb' ) as unsorted_fh, open( sorted_fasta_filename, 'wb+' ) as sorted_fh:
+        for name in sorted_names:
+            offset = fasta_offsets[ name ]
+            unsorted_fh.seek( offset )
+            sorted_fh.write( unsorted_fh.readline() )
+            while True:
+                line = unsorted_fh.readline()
+                if not line or line.startswith( b">" ):
+                    break
+                sorted_fh.write( line )
 
 
 def _int_to_roman( integer ):

--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -82,8 +82,8 @@ def main():
         }
     }
 
-    # ... and save it to the json results file
-    with open( sys.argv[1], 'wb' ) as out:
+    # save info to json file
+    with open( sys.argv[1], 'w' ) as out:
         out.write( json.dumps( data_manager_dict ) )
 
 

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.py
@@ -172,5 +172,5 @@ if __name__ == "__main__":
     # Write output JSON
     print("Outputting JSON")
     print(str(json.dumps(data_tables)))
-    open(jsonfile, 'wb').write(json.dumps(data_tables))
+    open(jsonfile, 'w').write(json.dumps(data_tables))
     print("Done.")

--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.py
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.py
@@ -163,7 +163,7 @@ def main():
     data_table_entries = get_data_table_entries( params['param_dict'], options.galaxy_data_manager_data_path )
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( { "data_tables": data_table_entries} ) )
+    open( filename, 'w' ).write( json.dumps( { "data_tables": data_table_entries} ) )
 
     get_file_content( params['param_dict'], target_directory )
 

--- a/data_managers/data_manager_metaphlan2_database_downloader/data_manager/data_manager_metaphlan2_download.py
+++ b/data_managers/data_manager_metaphlan2_database_downloader/data_manager/data_manager_metaphlan2_download.py
@@ -145,6 +145,6 @@ if __name__ == "__main__":
     # Write output JSON
     print("Outputting JSON")
     print(str(json.dumps(data_tables)))
-    with open(jsonfile, 'wb') as out:
+    with open(jsonfile, 'w') as out:
         out.write(json.dumps(data_tables))
     print("Done.")

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Data manager for reference data for the 'mothur_toolsuite' Galaxy tools
+import functools
 import json
 import optparse
 import os
@@ -228,12 +229,12 @@ def download_file(url, target=None, wd=None):
     Returns the name that the file is saved with.
 
     """
-    print "Downloading %s" % url
+    print("Downloading %s" % url)
     if not target:
         target = os.path.basename(url)
     if wd:
         target = os.path.join(wd, target)
-    print "Saving to %s" % target
+    print("Saving to %s" % target)
     open(target, 'wb').write(urllib2.urlopen(url).read())
     return target
 
@@ -254,13 +255,13 @@ def unpack_zip_archive(filen, wd=None):
 
     """
     if not zipfile.is_zipfile(filen):
-        print "%s: not ZIP formatted file"
+        print("%s: not ZIP formatted file")
         return [filen]
     file_list = []
     z = zipfile.ZipFile(filen)
     for name in z.namelist():
-        if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-            print "Ignoring %s" % name
+        if functools.reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
+            print("Ignoring %s" % name)
             continue
         if wd:
             target = os.path.join(wd, name)
@@ -268,21 +269,21 @@ def unpack_zip_archive(filen, wd=None):
             target = name
         if name.endswith('/'):
             # Make directory
-            print "Creating dir %s" % target
+            print("Creating dir %s" % target)
             try:
                 os.makedirs(target)
             except OSError:
                 pass
         else:
             # Extract file
-            print "Extracting %s" % name
+            print("Extracting %s" % name)
             try:
                 os.makedirs(os.path.dirname(target))
             except OSError:
                 pass
             open(target, 'wb').write(z.read(name))
             file_list.append(target)
-    print "Removing %s" % filen
+    print("Removing %s" % filen)
     os.remove(filen)
     return file_list
 
@@ -305,23 +306,23 @@ def unpack_tar_archive(filen, wd=None):
     """
     file_list = []
     if not tarfile.is_tarfile(filen):
-        print "%s: not TAR file"
+        print("%s: not TAR file")
         return [filen]
     t = tarfile.open(filen)
     for name in t.getnames():
         # Check for unwanted files
-        if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-            print "Ignoring %s" % name
+        if functools.reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
+            print("Ignoring %s" % name)
             continue
         # Extract file
-        print "Extracting %s" % name
+        print("Extracting %s" % name)
         t.extract(name, wd)
         if wd:
             target = os.path.join(wd, name)
         else:
             target = name
         file_list.append(target)
-    print "Removing %s" % filen
+    print("Removing %s" % filen)
     os.remove(filen)
     return file_list
 
@@ -339,9 +340,9 @@ def unpack_archive(filen, wd=None):
     current working directory.
 
     """
-    print "Unpack %s" % filen
+    print("Unpack %s" % filen)
     ext = os.path.splitext(filen)[1]
-    print "Extension: %s" % ext
+    print("Extension: %s" % ext)
     if ext == ".zip":
         return unpack_zip_archive(filen, wd=wd)
     elif ext == ".tgz":
@@ -382,7 +383,7 @@ def identify_type(filen):
     try:
         return MOTHUR_FILE_TYPES[ext]
     except KeyError:
-        print "WARNING: unknown file type for " + filen + ", skipping"
+        print("WARNING: unknown file type for " + filen + ", skipping")
         return None
 
 
@@ -415,26 +416,26 @@ def fetch_from_mothur_website(data_tables, target_dir, datasets):
     """
     # Make working dir
     wd = tempfile.mkdtemp(suffix=".mothur", dir=os.getcwd())
-    print "Working dir %s" % wd
+    print("Working dir %s" % wd)
     # Iterate over all requested reference data URLs
     for dataset in datasets:
-        print "Handling dataset '%s'" % dataset
+        print("Handling dataset '%s'" % dataset)
         for name in MOTHUR_REFERENCE_DATA[dataset]:
             for f in fetch_files(MOTHUR_REFERENCE_DATA[dataset][name], wd=wd):
                 type_ = identify_type(f)
                 entry_name = "%s (%s)" % (os.path.splitext(os.path.basename(f))[0], name)
-                print "%s\t\'%s'\t.../%s" % (type_, entry_name, os.path.basename(f))
+                print( "%s\t\'%s'\t.../%s" % (type_, entry_name, os.path.basename(f)))
                 if type_ is not None:
                     # Move to target dir
                     ref_data_file = os.path.basename(f)
                     f1 = os.path.join(target_dir, ref_data_file)
-                    print "Moving %s to %s" % (f, f1)
+                    print("Moving %s to %s" % (f, f1))
                     os.rename(f, f1)
                     # Add entry to data table
                     table_name = "mothur_%s" % type_
                     add_data_table_entry(data_tables, table_name, dict(name=entry_name, value=ref_data_file))
     # Remove working dir
-    print "Removing %s" % wd
+    print("Removing %s" % wd)
     shutil.rmtree(wd)
 
 
@@ -450,7 +451,7 @@ def files_from_filesystem_paths(paths):
     files = []
     for path in paths:
         path = os.path.abspath(path)
-        print "Examining '%s'..." % path
+        print("Examining '%s'..." % path)
         if os.path.isfile(path):
             # Store full path for file
             files.append(path)
@@ -459,7 +460,7 @@ def files_from_filesystem_paths(paths):
             for f in os.listdir(path):
                 files.extend(files_from_filesystem_paths((os.path.join(path, f), )))
         else:
-            print "Not a file or directory, ignored"
+            print("Not a file or directory, ignored")
     return files
 
 
@@ -489,14 +490,14 @@ def import_from_server(data_tables, target_dir, paths, description, link_to_data
     for f in files:
         type_ = identify_type(f)
         if type_ is None:
-            print "%s: unrecognised type, skipped" % f
+            print("%s: unrecognised type, skipped" % f)
             continue
         ref_data_file = os.path.basename(f)
         target_file = os.path.join(target_dir, ref_data_file)
         entry_name = "%s" % os.path.splitext(ref_data_file)[0]
         if description:
             entry_name += " (%s)" % description
-        print "%s\t\'%s'\t.../%s" % (type_, entry_name, ref_data_file)
+        print("%s\t\'%s'\t.../%s" % (type_, entry_name, ref_data_file))
         # Link to or copy the data
         if link_to_data:
             os.symlink(f, target_file)
@@ -508,7 +509,7 @@ def import_from_server(data_tables, target_dir, paths, description, link_to_data
 
 
 if __name__ == "__main__":
-    print "Starting..."
+    print("Starting...")
 
     # Read command line
     parser = optparse.OptionParser()
@@ -518,8 +519,8 @@ if __name__ == "__main__":
     parser.add_option('--description', action='store', dest='description', default='')
     parser.add_option('--link', action='store_true', dest='link_to_data')
     options, args = parser.parse_args()
-    print "options: %s" % options
-    print "args   : %s" % args
+    print("options: %s" % options)
+    print("args   : %s" % args)
 
     # Check for JSON file
     if len(args) != 1:
@@ -532,7 +533,7 @@ if __name__ == "__main__":
     params, target_dir = read_input_json(jsonfile)
 
     # Make the target directory
-    print "Making %s" % target_dir
+    print("Making %s" % target_dir)
     os.mkdir(target_dir)
 
     # Set up data tables dictionary
@@ -554,7 +555,7 @@ if __name__ == "__main__":
         paths = options.paths.replace('__cn__', '\n').replace('__cr__', '\r').split()
         import_from_server(data_tables, target_dir, paths, description, link_to_data=options.link_to_data)
     # Write output JSON
-    print "Outputting JSON"
-    print str(json.dumps(data_tables))
-    open(jsonfile, 'wb').write(json.dumps(data_tables))
-    print "Done."
+    print("Outputting JSON")
+    print(str(json.dumps(data_tables)))
+    open(jsonfile, 'w').write(json.dumps(data_tables))
+    print("Done.")

--- a/data_managers/data_manager_picard_index_builder/data_manager/picard_index_builder.py
+++ b/data_managers/data_manager_picard_index_builder/data_manager/picard_index_builder.py
@@ -74,7 +74,7 @@ def main():
     build_picard_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_name=options.data_table_name or DEFAULT_DATA_TABLE_NAME )
 
     # save info to json file
-    open( filename, 'wb' ).write( dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_plant_tribes_scaffolds_downloader/data_manager/data_manager_plant_tribes_scaffolds_download.py
+++ b/data_managers/data_manager_plant_tribes_scaffolds_downloader/data_manager/data_manager_plant_tribes_scaffolds_download.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
 # Data manager for downloading Plant Tribes scaffolds data.
+from __future__ import print_function
+
 import argparse
 import json
 import os
@@ -62,7 +64,7 @@ def url_download(url, work_directory):
             else:
                 break
     except Exception as e:
-        print >>sys.stderr, str(e)
+        print(str(e), file=sys.stderr)
     finally:
         if src:
             src.close()
@@ -131,6 +133,5 @@ else:
 # Get the scaffolds data.
 data_manager_dict = download(target_directory, args.web_url, args.config_web_url, description)
 # Write the JSON output dataset.
-fh = open(args.out_file, 'wb')
-fh.write(json.dumps(data_manager_dict))
-fh.close()
+with open(args.out_file, 'w') as fh:
+    fh.write(json.dumps(data_manager_dict))

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
@@ -404,7 +404,7 @@ def main():
     data_manager_dict = fulfill_data_table_entries( data_table_entries, data_manager_dict, target_directory )
 
     # save info to json file
-    open( filename, 'wb' ).write( dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.py
+++ b/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.py
@@ -85,7 +85,7 @@ def main():
     build_sam_index( data_manager_dict, options.fasta_filename, target_directory, options.fasta_dbkey, sequence_id, sequence_name, data_table_name=options.data_table_name or DEFAULT_DATA_TABLE_NAME )
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( json.dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.py
@@ -50,7 +50,7 @@ def main():
     data_manager_dict = fetch_databases( data_manager_dict, target_directory)
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( json.dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
@@ -138,7 +138,7 @@ def main():
         download_database( data_manager_dict, target_directory, genome_version, organism )
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( json.dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.py
+++ b/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.py
@@ -195,7 +195,7 @@ def main():
     data_manager_dict['data_tables'][data_table].append(data_table_entry)
 
     # save info to json file
-    open(filename, 'wb').write(json.dumps(data_manager_dict))
+    open(filename, 'w').write(json.dumps(data_manager_dict))
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.py
+++ b/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.py
@@ -23,7 +23,7 @@ def main():
         withGTF = "1"
 
     data_manager_dict = {'data_tables': {options.data_table: [dict({"value": options.value, "dbkey": options.dbkey, "name": options.name, "path": options.subdir, "with-gtf": withGTF} )]}}
-    open( options.config_file, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open( options.config_file, 'w' ).write( json.dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_twobit_builder/data_manager/twobit_builder.py
+++ b/data_managers/data_manager_twobit_builder/data_manager/twobit_builder.py
@@ -92,7 +92,7 @@ def main():
     build_twobit( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name )
 
     # save info to json file
-    open( filename, 'wb' ).write( dumps( data_manager_dict ) )
+    open( filename, 'w' ).write( dumps( data_manager_dict ) )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These should be fairly uncontroversial (but I haven't tested them all ...).
 - don't open file in binary mode when writing dumps of dictionaries, which are unicode on py3
  - replace print statement with print function
  - replace reduce with functools.reduce (which just points at the reduce builtin on py2)

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
