### PR TITLE
UMI-tools: Allow tabular barcode file input to umi-tools extract

### DIFF
--- a/tools/umi_tools/umi-tools_extract.xml
+++ b/tools/umi_tools/umi-tools_extract.xml
@@ -90,7 +90,7 @@
             </param>
             <when value="no" />
             <when value="yes" >
-                <param name="filter_barcode_file" type="data" format="tsv" label="Barcode File" />
+                <param name="filter_barcode_file" type="data" format="tabular,tsv" label="Barcode File" />
                 <param name="filter_correct" argument="--error-correct-cell" type="boolean" truevalue="--error-correct-cell" falsevalue="" checked="false" label="Apply correction to cell barcodes?" help="This only applies if your barcode file has two columns output from the umi_tools whitelist command." />
             </when>
         </conditional>


### PR DESCRIPTION
The umi-tools whitelist tool outputs a tabular barcode file but at the moment the umi-tools extract tool only accepts a tsv barcode file as input. This PR enables the whitelist tabular output to be input to umi-tools extract.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
