### PR TITLE
scPipe: Add species parameter

### DIFF
--- a/tools/scpipe/scpipe.R
+++ b/tools/scpipe/scpipe.R
@@ -20,6 +20,7 @@ suppressPackageStartupMessages({
 option_list <- list(
     make_option(c("-fasta","--fasta"), type="character", help="Genome fasta file"),
     make_option(c("-exons","--exons"), type="character", help="Exon annotation gff3 file"),
+    make_option(c("-organism","--organism"), type="character", help="Organism e.g. hsapiens_gene_ensembl"),
     make_option(c("-barcodes","--barcodes"), type="character", help="Cell barcodes csv file"),
     make_option(c("-read1","--read1"), type="character", help="Read 1 fastq.gz"),
     make_option(c("-read2","--read2"), type="character", help="Read 2 fastq.gz"),
@@ -139,7 +140,9 @@ create_report(sample_name=args$samplename,
    barcode_anno=barcode_anno,
    max_mis=args$max_mis,
    UMI_cor=args$UMI_cor,
-   gene_fl=args$gene_fl)
+   gene_fl=args$gene_fl,
+   organism=args$organism,
+   gene_id_type="ensembl_gene_id")
 }
 
 if (!is.null(args$rdata) ) {

--- a/tools/scpipe/scpipe.xml
+++ b/tools/scpipe/scpipe.xml
@@ -1,4 +1,4 @@
-<tool id="scpipe" name="scPipe" version="1.0.0">
+<tool id="scpipe" name="scPipe" version="1.0.0+galaxy1">
     <description>- preprocessing pipeline for single cell RNA-seq</description>
     <requirements>
         <requirement type="package" version="1.0.0">bioconductor-scpipe</requirement>
@@ -71,6 +71,7 @@ Rscript '$__tool_directory__/scpipe.R'
 
 --fasta '$fasta_name'
 --exons '$anno_name'
+--organism '$organism'
 --samplename '$in1_name'
 --read1 '$in1_name'
 --read2 '$in2_name'
@@ -128,8 +129,11 @@ sed -e "s/,/\${TAB}/g" gene_count.csv > gene_count.tsv
                 <param name="ref_fa_hist" type="data" format="fasta" label="Select a history FASTA" />
             </when>
         </conditional>
-        <param name="exons" type="data" format="gff3" label="Exon annotation GFF3 file" help="Current supported sources: ENSEMBL, GENCODE and RefSeq"/>
-
+        <param name="exons" type="data" format="gff3" label="Exon annotation GFF3 file" help="Current supported source is ENSEMBL"/>
+        <param name="organism" type="text" label="Species gene id" help="This must be in biomaRt ENSEMBL listDatsets() format e.g. hsapiens_gene_ensembl. See the biomaRt user guide here: https://www.bioconductor.org/packages/release/bioc/vignettes/biomaRt/inst/doc/biomaRt.html">
+            <validator type="empty_field" />
+            <validator type="regex" message="Only letters and underscores are allowed">^[\(\w\)]+$</validator>
+        </param>
         <conditional name="paired_format">
             <param name="paired_format_selector" type="select" label="Paired reads or Paired collection">
                 <option value="paired">Paired</option>
@@ -188,6 +192,7 @@ sed -e "s/,/\${TAB}/g" gene_count.csv > gene_count.tsv
             <param name="fasta_source" value="history"/>
             <param name="ref_fa_hist" ftype="fasta" value="mm10_MT19.fa.gz"/>
             <param name="exons" ftype="gff3" value="mm10_MT19.gff3.gz"/>
+            <param name="organism" value="mmusculus_gene_ensembl"/>
             <param name="paired_format_selector" value="paired" />
             <param name="in1" ftype="fastqsanger.gz" value="CB51_MT19_R1.gz"/>
             <param name="in2" ftype="fastqsanger.gz" value="CB51_MT19_R2.gz"/>
@@ -210,6 +215,7 @@ sed -e "s/,/\${TAB}/g" gene_count.csv > gene_count.tsv
         <test>
             <param name="fasta_source" value="cached"/>
             <param name="exons" ftype="gff3" value="mm10_MT19.gff3.gz"/>
+            <param name="organism" value="mmusculus_gene_ensembl"/>
             <param name="paired_format_selector" value="paired" />
             <param name="in1" ftype="fastqsanger.gz" dbkey="mm10" value="CB51_MT19_R1.gz"/>
             <param name="in2" ftype="fastqsanger.gz" dbkey="mm10" value="CB51_MT19_R2.gz"/>
@@ -237,7 +243,7 @@ Examples of the report output can be found here_.
 **Inputs**
 
     * Reference genome in FASTA format
-    * Exon annotation in GFF3 format
+    * Exon annotation in ENSEMBL GFF3 format
     * Paired-end FASTQ.GZ reads
     * Cell barcodes TAB-separated file (Optional)
 


### PR DESCRIPTION
I've changed this to require specifying an Ensembl species id, as that's needed to
identify ribosomal and mitochondrial genes for the QC metrics. Also then the gene names get used instead of the (harder to interpret) gene ids in the plot of highest expressed genes and heatmap of highly variable genes in the report.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
