### PR TITLE
Fastx_toolkit: Fix gzip outputs

### DIFF
--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_nucleotides_changer" version="1.0.1" name="RNA/DNA" >
+<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="RNA/DNA" >
     <description>converter</description>
     <macros>
         <import>macros.xml</import>
@@ -9,6 +9,10 @@
 -$mode
 -v
 -o '$output'
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
     <inputs>
         <expand macro="fasta_input" />

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -9,10 +9,7 @@
 -$mode
 -v
 -o '$output'
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
     <inputs>
         <expand macro="fasta_input" />

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
@@ -11,10 +11,7 @@
 -v
 -o '$output'
 @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_filter" version="1.0.1" name="Filter by quality">
+<tool id="cshl_fastq_quality_filter" version="1.0.2" name="Filter by quality">
     <description></description>
     <macros>
         <import>macros.xml</import>
@@ -11,6 +11,10 @@
 -v
 -o '$output'
 @FQQUAL@
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -10,10 +10,7 @@ $SKIPN
 $RENAMESEQ
 -o '$output'
 -v @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
     <inputs>
         <expand macro="fastq_input" />

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_to_fasta" name="FASTQ to FASTA" version="1.0.1">
+<tool id="cshl_fastq_to_fasta" name="FASTQ to FASTA" version="1.0.2">
     <description>converter from FASTX-toolkit</description>
     <macros>
         <import>macros.xml</import>
@@ -10,6 +10,10 @@ $SKIPN
 $RENAMESEQ
 -o '$output'
 -v @FQQUAL@
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
     <inputs>
         <expand macro="fastq_input" />

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
@@ -9,6 +9,10 @@
 -v
 -o '$output'
 @FQQUAL@
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
@@ -9,10 +9,7 @@
 -v
 -o '$output'
 @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_clipper" name="Clip" version="1.0.2">
+<tool id="cshl_fastx_clipper" name="Clip" version="1.0.3">
     <description>adapter sequences</description>
     <macros>
         <import>macros.xml</import>
@@ -14,6 +14,9 @@
 $KEEP_N
 $DISCARD_OPTIONS
 @FQQUAL@
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -14,9 +14,7 @@
 $KEEP_N
 $DISCARD_OPTIONS
 @FQQUAL@
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
@@ -10,10 +10,7 @@
 -o '$output'
 -v
 @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
@@ -10,6 +10,10 @@
 -o '$output'
 -v
 @FQQUAL@
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
 
     <inputs>

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
@@ -8,10 +8,7 @@
 @CATS@ fastx_reverse_complement -v
 -o '$output'
 @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
+@GZIP@
     ]]></command>
     <inputs>
         <expand macro="fastx_input" />

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_reverse_complement" version="1.0.1" name="Reverse-Complement">
+<tool id="cshl_fastx_reverse_complement" version="1.0.2" name="Reverse-Complement">
     <description></description>
     <macros>
         <import>macros.xml</import>
@@ -8,6 +8,10 @@
 @CATS@ fastx_reverse_complement -v
 -o '$output'
 @FQQUAL@
+
+#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+    -z
+#end if
     ]]></command>
     <inputs>
         <expand macro="fastx_input" />

--- a/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
+++ b/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
@@ -10,11 +10,7 @@
 -l $last
 -o '$output'
 @FQQUAL@
-
-#if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
-    -z
-#end if
-
+@GZIP@
     ]]></command>
     <inputs>
         <expand macro="fastx_input" />

--- a/tool_collections/fastx_toolkit/macros.xml
+++ b/tool_collections/fastx_toolkit/macros.xml
@@ -18,6 +18,13 @@
             #end if
         ]]>
     </token>
+    <token name="@GZIP@">
+        <![CDATA[
+            #if $input.is_of_type('fasta.gz', 'fastqsanger.gz', 'fastqsolexa.gz', 'fastqillumina.gz'):
+                -z
+            #end if
+        ]]>
+    </token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@VERSION@">fastx_toolkit</requirement>


### PR DESCRIPTION
From working on https://github.com/galaxyproject/tools-iuc/pull/2042 I found that there are other fastx tools that would likely have a similar issue to the one reported by @hepcat72 here: https://github.com/galaxyproject/tools-iuc/issues/2036 (e.g. outputting fastq but giving it the datatype fastq.gz). So in this PR I've added the -z flag to the tools listed below, the tools that have the -z option listed on the [fastx website](http://hannonlab.cshl.edu/fastx_toolkit/commandline.html).

-  fastq_to_fasta
-  fastx_clipper 
-  fastx_renamer 
-  fastx_artifacts_filter
-  fastq_quality_filter
-  fastx_reverse_complement
-  fasta_nucleotide_changer

Should I increase the wrapper versions here or not?

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
