### PR TITLE
fastp: Fix for polyX when disabling polyG

### DIFF
--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -154,7 +154,7 @@ $filter_options.low_complexity_filter.enable_low_complexity_filter
 
 #if $read_mod_options.polyx_tail_trimming.polyx_trimming_select == '-x':
     $read_mod_options.polyx_tail_trimming.polyx_trimming_select
-    #if str($read_mod_options.polyg_tail_trimming.poly_g_min_len):
+    #if str($read_mod_options.polyx_tail_trimming.poly_x_min_len):
         --poly_x_min_len $read_mod_options.polyx_tail_trimming.poly_x_min_len
     #end if
 #end if
@@ -260,7 +260,7 @@ mv first${ext} '${out1}'
         <!-- Read Modification Options -->
          <section name="read_mod_options" title="Read Modification Options">
             <conditional name="polyg_tail_trimming">
-                <param name="trimming_select" type="select" label="PolyG tail trimming" help="Useful for NextSeq/NovaSeq data">
+                <param name="trimming_select" type="select" label="PolyG tail trimming" help="This feature is enabled for NextSeq/NovaSeq data by default. NextSeq/NovaSeq data is detected by the machine ID in the FASTQ records.">
                     <option value="" selected="true">Automatic trimming for Illumina NextSeq/NovaSeq data</option>
                     <option value="-g">Force polyG tail trimming</option>
                     <option value="-G">Disable polyG tail trimming</option>
@@ -442,6 +442,15 @@ mv first${ext} '${out1}'
             <param name="single_paired_selector" value="single"/>
             <param name="trimming_select" value="-g"/>
             <param name="poly_g_min_len" value="10"/>
+            <output name="out1" ftype="fastq.gz" decompress="True" file="out1.fq.gz"/>
+        </test>
+        <!-- Ensure polyX trimming works -->
+        <test expect_num_outputs="2">
+            <param name="in1" ftype="fastq.gz" value="R1.fq.gz"/>
+            <param name="single_paired_selector" value="single"/>
+            <param name="trimming_select" value="-G"/>
+            <param name="polyx_trimming_select" value="-x"/>
+            <param name="poly_x_min_len" value="10"/>
             <output name="out1" ftype="fastq.gz" decompress="True" file="out1.fq.gz"/>
         </test>
     </tests>

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -1,4 +1,4 @@
-<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@.2">
+<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@.3">
     <description>- fast all-in-one preprocessing for FASTQ files</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Get error if selecting polyX and disabling polyG due to small copy/paste bug. Fixed in this PR and test added.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
