### PR TITLE
hisat2: Drop --secondary and --max-seeds, which don't seem to exist anymore

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,4 +1,4 @@
-<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy2" profile="17.01">
+<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy3" profile="17.01">
     <description>A fast and sensitive alignment program</description>
     <macros>
         <import>hisat2_macros.xml</import>
@@ -291,8 +291,6 @@ hisat2
 
 #if str($adv.reporting_options.reporting_options_selector) == "advanced":
     -k ${adv.reporting_options.max_primary}
-    --max-seeds ${adv.reporting_options.max_seeds}
-    $adv.reporting_options.secondary
 #end if
 
 
@@ -534,8 +532,6 @@ hisat2
                 <when value="defaults" />
                 <when value="advanced">
                     <param name="max_primary" argument="-k" type="integer" min="0" optional="true" label="Primary alignments" help="Search for at most K distinct, primary alignments for each read. Primary alignments mean alignments whose alignment score is equal or higher than any other alignments. The search terminates when it can't find more distinct valid alignments, or when it finds K, whichever happens first. The alignment score for a paired-end alignment equals the sum of the alignment scores of the individual mates. Each reported read or pair alignment beyond the first has the SAM 'secondary' bit (which equals 256) set in its FLAGS field. For reads that have more than K distinct, valid alignments, HISAT2 does not guarantee that the K alignments reported are the best possible in terms of alignment score. HISAT2 is not designed with large values for -k in mind, so when aligning reads to long repetitive genomes, a large K can be very, very slow. Default: 5 (HFM) or 10 (HGFM)" />
-                    <param name="max_seeds" argument="--max-seeds" type="integer" min="0" optional="true" label="Maximum number of seeds that will be extended" help="HISAT2, like other aligners, uses seed-and-extend approaches. HISAT2 tries to extend seeds to full-length alignments. HISAT2 extends up to these many seeds and skips the rest of the seeds. Large values for --max-seeds may improve alignment sensitivity, but HISAT2 is not designed with large values for --max-seeds in mind, and when aligning reads to long repetitive genomes, a large --max-seeds can be very, very slow. Default: 5 (HFM) or 10 (HGFM)" />
-                    <param name="secondary" argument="--secondary" type="boolean" truevalue="--secondary" falsevalue="" label="Report secondary alignments" />
                 </when>
             </conditional>
 
@@ -1082,12 +1078,6 @@ Note that if your reads are from a stranded library, you need to choose the appr
             It searches for at most `<int>` distinct, primary alignments for each read. Primary alignments mean alignments whose alignment score is equal or higher than any other alignments. The search terminates when it can't find more distinct valid alignments, or when it finds `<int>`, whichever happens first. The alignment score for a paired-end alignment equals the sum of the alignment scores of the individual mates. Each reported read or pair alignment beyond the first has the SAM 'secondary' bit (which equals 256) set in its FLAGS field. For reads that have more than `<int>` distinct, valid alignments, hisat2 does not guarantee that the `<int>` alignments reported are the best possible in terms of alignment score. Default: 5 (HFM) or 10 (HGFM)
 
             Note: HISAT2 is not designed with large values for `-k` in mind, and when aligning reads to long, repetitive genomes large `-k` can be very, very slow.
-
-    -max-seeds
-            HISAT2, like other aligners, uses seed-and-extend approaches. HISAT2 tries to extend seeds to full-length alignments. In HISAT2, `--max-seeds` is used to control the maximum number of seeds that will be extended. HISAT2 extends up to these many seeds and skips the rest of the seeds. Large values for `--max-seeds` may improve alignment sensitivity, but HISAT2 is not designed with large values for `--max-seeds` in mind, and when aligning reads to long, repetitive genomes large `--max-seeds` can be very, very slow. The default value is the maximum of 5 and the value that comes with `-k`.
-
-    --secondary
-            Report secondary alignments.
 
 -----
 


### PR DESCRIPTION
I was trying to run hisat2 with the --seconday flag, but it would just hand forver.
Upon closer inspection I saw there is no `--secondary` flag anymore, and neither is `--max-seeds`


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
