### PR TITLE
Jbrowse: small change to match/match_part tracks

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -572,7 +572,9 @@ class JbrowseConnector(object):
 
         if 'match' in gffOpts:
             config['glyph'] = 'JBrowse/View/FeatureGlyph/Segments'
-            cmd += ['--type', gffOpts['match']]
+            if bool(gffOpts['match']):
+                # Can be empty for CanvasFeatures = will take all by default
+                cmd += ['--type', gffOpts['match']]
 
         cmd += ['--clientConfig', json.dumps(clientConfig),
                 ]

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -451,8 +451,8 @@ $trackxml &&
                                name="name"
                                type="text"
                                value="match"
-                               help="Match_parts have several options for the parent feature type, such as cDNA_match, match, translated_nucleotide_match, etc. Please select the appropriate one here"
-                               optional="False"/>
+                               help="Match_parts have several options for the parent feature type, such as cDNA_match, match, translated_nucleotide_match, etc. Please select the appropriate one here. You can leave empty to try autodetection (only works with CanvasFeatures track type)."
+                               optional="True"/>
                     </when>
                     <when value="false" />
                 </conditional>

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -13,7 +13,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy0</token>
+  <token name="@WRAPPER_VERSION@">galaxy1</token>
   <xml name="stdio">
     <stdio>
       <exit_code range="1:"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

Working on https://github.com/galaxyproject/training-material/pull/950, I have some gff which contains match/match_part features, but with varying parent type name (match, expressed_sequence_match, protein_match) in the same file. Currently I can't display all the features with their subfeatures as I'm forced to specify a single parent type.
In fact CanvasFeatures tracks don't really need to specify it, by default it will auto detect everything. So here's a patch to allow leaving the option empty and let it be autodetected.
For HTMLFeautres track type, it will just display features but not subfeatures which is not dramatic I think (same as if I entered the wrong name in the field).

What do you think @erasche?