### PR TITLE
Quote database name in kraken

### DIFF
--- a/tool_collections/kraken/kraken/kraken.xml
+++ b/tool_collections/kraken/kraken/kraken.xml
@@ -37,7 +37,7 @@
                 #else:
                     --fasta-input
                 #end if
-                "${single_paired.input_pair.forward}" "${single_paired.input_pair.reverse}"
+                '${single_paired.input_pair.forward}' '${single_paired.input_pair.reverse}'
                 ${single_paired.check_names}
             #else:
                 #if $single_paired.input_sequences.is_of_type('fastq')
@@ -49,13 +49,13 @@
             #end if
 
             #if $split_reads:
-                --classified-out "${classified_out}" --unclassified-out "${unclassified_out}"
+                --classified-out '${classified_out}' --unclassified-out '${unclassified_out}'
             #end if
 
             ## The --output option was changed to redirect as it does not work properly is some situations. For example, on test database the tool classifies 4 reads but does not write them into a file if --output is specified. It does however print correct output into STDOUT. This behavior can be re-created with test database provided in test-data/test_db/ folder. This is the reason for incrementing version number from 1.1.2 to 1.1.3
 
-            > "${output}"
-            ##kraken-translate --db ${kraken_database.fields.name} "${output}" > "${translated}"
+            > '${output}'
+            ##kraken-translate --db '${kraken_database.fields.name}' '${output}' > '${translated}'
     ]]></command>
     <inputs>
         <conditional name="single_paired">

--- a/tool_collections/kraken/kraken_report/kraken-mpa-report.xml
+++ b/tool_collections/kraken/kraken_report/kraken-mpa-report.xml
@@ -26,7 +26,7 @@
     kraken-mpa-report
         @INPUT_DATABASE@
         #for $name in $names:
-            "${name}"
+            '${name}'
         #end for
 
         ${show_zeros}

--- a/tool_collections/kraken/macros.xml
+++ b/tool_collections/kraken/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@WRAPPER_VERSION@">1.2.3</token>
+    <token name="@WRAPPER_VERSION@">1.2.4</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="0.10.6_eaf8fb68">kraken</requirement>
@@ -23,6 +23,6 @@
             <citation type="doi">10.1186/gb-2014-15-3-r46</citation>
         </citations>
     </xml>
-    <token name="@INPUT_DATABASE@">--db ${kraken_database.fields.name}</token>
-    <token name="@SET_DATABASE_PATH@">export KRAKEN_DB_PATH="${kraken_database.fields.path}"</token>
+    <token name="@INPUT_DATABASE@">--db '${kraken_database.fields.name}'</token>
+    <token name="@SET_DATABASE_PATH@">export KRAKEN_DB_PATH='${kraken_database.fields.path}'</token>
 </macros>

--- a/tool_collections/kraken/test_database.loc
+++ b/tool_collections/kraken/test_database.loc
@@ -1,1 +1,1 @@
-test_db	test_db	${__HERE__}
+test_db	Test database	${__HERE__}


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [X] - This PR does something else (explain below)

Ensures the database name is quoted (and puts a space in the test case), and also switches filename quoting to use single quotes rather than double quotes.

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
