### PR TITLE
Standardise kraken_databases.loc fields

### DIFF
--- a/tool_collections/kraken/kraken/kraken.xml
+++ b/tool_collections/kraken/kraken/kraken.xml
@@ -116,8 +116,16 @@
             <param name="split_reads" value="false"/>
             <param name="quick" value="no"/>
             <param name="only-classified-output" value="false"/>
-            <param name="kraken_database" value="test_db"/>
-
+            <param name="kraken_database" value="old_style_test_entry"/>
+            <output name="output" file="kraken_test1_output.tab" ftype="tabular"/>
+        </test>
+        <test>
+            <param name="single_paired_selector" value="no"/>
+            <param name="input_sequences" value="kraken_test1.fa" ftype="fasta"/>
+            <param name="split_reads" value="false"/>
+            <param name="quick" value="no"/>
+            <param name="only-classified-output" value="false"/>
+            <param name="kraken_database" value="new_style_test_entry"/>
             <output name="output" file="kraken_test1_output.tab" ftype="tabular"/>
         </test>
     </tests>

--- a/tool_collections/kraken/kraken_databases.loc.sample
+++ b/tool_collections/kraken/kraken_databases.loc.sample
@@ -1,0 +1,18 @@
+# Expect three columns, tab separated, as follows:
+# - value (Galaxy records this in the Galaxy DB)
+# - name (Galaxy shows this in the UI)
+# - path (folder name containing the Kraken DB)
+#
+# e.g.
+# plants2018<tab>Plant genomes (2018)<tab>/path/to/krakenDB/plants_2018
+#
+# For backward compatibility the Kraken wrapper also accepts:
+# - value (Galaxy records this in the Galaxy DB)
+# - name (Final part of folder name, Galaxy shows this in the UI)
+# - path (Parent folder name, where $path/$name contains the Kraken DB)
+#
+# e.g.
+# plants2018<tab>plants_2018<tab>/path/to/krakenDB
+#
+# Please avoid this legacy usage, as not all tools using
+# the kraken_databases.loc file will understand it.

--- a/tool_collections/kraken/macros.xml
+++ b/tool_collections/kraken/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@WRAPPER_VERSION@">1.2.4</token>
+    <token name="@WRAPPER_VERSION@">1.3.0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="0.10.6_eaf8fb68">kraken</requirement>
@@ -23,6 +23,10 @@
             <citation type="doi">10.1186/gb-2014-15-3-r46</citation>
         </citations>
     </xml>
-    <token name="@INPUT_DATABASE@">--db '${kraken_database.fields.name}'</token>
-    <token name="@SET_DATABASE_PATH@">export KRAKEN_DB_PATH='${kraken_database.fields.path}'</token>
+    <!-- See the kraken_databases.loc.sample documentation,
+	 this if statement is for backward compatibility as early
+	 versions of the wrapper assumed the UI facing field name
+	 was also part of the directory path -->
+    <token name="@SET_DATABASE_PATH@">if [ -d '${kraken_database.fields.path}/${kraken_database.fields.name}' ]; then export KRAKEN_DEFAULT_DB='${kraken_database.fields.path}/${kraken_database.fields.name}'; else export KRAKEN_DEFAULT_DB='${kraken_database.fields.path}'; fi</token>
+    <token name="@INPUT_DATABASE@">--db "\$KRAKEN_DEFAULT_DB"</token>
 </macros>

--- a/tool_collections/kraken/test_database.loc
+++ b/tool_collections/kraken/test_database.loc
@@ -1,1 +1,20 @@
-test_db	test_db	${__HERE__}
+# Tab separated with three columns:
+# - value (Galaxy records this in the Galaxy DB)
+# - name (Galaxy shows this in the UI)
+# - path (folder name containing the Kraken DB)
+#
+# Modern usage assumes $path is the folder containing
+# the Kraken database of interest:
+#
+new_style_test_entry	"Test Database"	${__HERE__}/test_db
+
+# The kraken wrapper still supports an alternative
+# legacy usage where $path/$name is the folder
+# containing the Kraken database of interest, meaning
+# $name must be both a folder name and human readable
+# description of the DB to show in the Galaxy UI:
+old_style_test_entry	test_db	${__HERE__}
+
+# NOTE: This legacy style should be avoided as other
+# tools also using the kraken_database.loc file may
+# not understand it!


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [X] - This PR does something else (explain below)

This would close #2079 by bringing the use of ``kraken_databases.loc`` in line with typical usage.

(*update:* This branch originally included work since merged as the earlier narrower pull request #2077).

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
