### PR TITLE
Fix typo in Gene Body Coverage tool name?

### DIFF
--- a/tools/rseqc/geneBody_coverage.xml
+++ b/tools/rseqc/geneBody_coverage.xml
@@ -1,4 +1,4 @@
-<tool id="rseqc_geneBody_coverage" name="Gene Body Converage (BAM)" version="@WRAPPER_VERSION@.2">
+<tool id="rseqc_geneBody_coverage" name="Gene Body Coverage (BAM)" version="@WRAPPER_VERSION@.2">
   <description>
     Read coverage over gene body.
   </description>


### PR DESCRIPTION
Can tool names be changed? Can this tool name be changed to `Gene Body Coverage (BAM)` instead of the current name that has a typo (`Gene Body Converage (BAM)`) ? As `Gene Body Converage (BAM)` is what is used as the collection name in the history, see below.

Same typo is in the related `Gene Body Converage (Bigwig)` tool.

<img width="348" alt="screen shot 2018-09-18 at 12 50 28 pm" src="https://user-images.githubusercontent.com/5591821/45661760-44204000-bb42-11e8-80db-21229f51a779.png">


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
