### PR TITLE
Filtlong: Change fastq output to fastqsanger

### DIFF
--- a/tools/filtlong/filtlong.xml
+++ b/tools/filtlong/filtlong.xml
@@ -43,7 +43,7 @@ filtlong
     '$input_file' > output.fastq
     ]]></command>
     <inputs>
-        <param name="input_file" type="data" format="fastq" label="Input FASTQ" help="FASTQ of input reads"/>
+        <param name="input_file" type="data" format="fastqsanger" label="Input FASTQ" help="FASTQ of input reads"/>
         <section name="output_thresholds" title="Output thresholds">
             <param argument="--target_bases" type="integer" min="0" optional="True" label="Total bases" help="Keep only the best reads up to this many total bases"/>
             <param argument="--keep_percent" type="float" min="0" max="100" optional="True" label="Keep percentage" help="Keep only this percentage of the best reads (measured by bases)"/>
@@ -53,8 +53,8 @@ filtlong
         </section>
         <section name="external_references" title="External references">
             <param argument="--assembly" type="data" format="fasta" optional="True" label="Reference assembly" help="Reference assembly in FASTA format"/>
-            <param argument="--illumina_1" type="data" format="fastq,fastq.gz" optional="True" label="Reference Illumina read" help="Reference Illumina reads in FASTQ format"/>
-            <param argument="--illumina_2" type="data" format="fastq,fastq.gz" optional="True" label="Reference Illumina read" help="Reference Illumina reads in FASTQ format"/>
+            <param argument="--illumina_1" type="data" format="fastqsanger,fastqsanger.gz" optional="True" label="Reference Illumina read" help="Reference Illumina reads in FASTQ format"/>
+            <param argument="--illumina_2" type="data" format="fastqsanger,fastqsanger.gz" optional="True" label="Reference Illumina read" help="Reference Illumina reads in FASTQ format"/>
         </section>
         <section name="score_weights" title="Score weights">
             <param argument="--length_weight" type="float" min="0" value="1" optional="True" label="Weight length score" help="Weight given to the length score (default: 1)"/>
@@ -74,16 +74,16 @@ filtlong
     </outputs>
     <tests>
         <test>
-            <param name="input_file" ftype="fastq" value="test.fastq"/>
+            <param name="input_file" ftype="fastqsanger" value="test.fastq"/>
             <param name="min_length" value="1000"/>
             <param name="keep_percent" value="50"/>
             <param name="target_bases" value="500000000"/>
             <output name="outfile" ftype="fastqsanger" file="output.fastq"/>
         </test>
         <test>
-            <param name="input_file" ftype="fastq" value="test_reference.fasta"/>
-            <param name="illumina_1" ftype="fastq.gz" value="test_reference_1.fastq.gz"/>
-            <param name="illumina_2" ftype="fastq.gz" value="test_reference_2.fastq.gz"/>
+            <param name="input_file" ftype="fastqsanger" value="test_reference.fasta"/>
+            <param name="illumina_1" ftype="fastqsanger.gz" value="test_reference_1.fastq.gz"/>
+            <param name="illumina_2" ftype="fastqsanger.gz" value="test_reference_2.fastq.gz"/>
             <param name="min_length" value="1000"/>
             <param name="keep_percent" value="90"/>
             <param name="target_bases" value="500000000"/>

--- a/tools/filtlong/filtlong.xml
+++ b/tools/filtlong/filtlong.xml
@@ -70,7 +70,7 @@ filtlong
         </section>
     </inputs>
     <outputs>
-        <data name="outfile" format="fastq" from_work_dir="output.fastq" label="${tool.name} on ${on_string}: Filtered FASTQ"/>
+        <data name="outfile" format="fastqsanger" from_work_dir="output.fastq" label="${tool.name} on ${on_string}: Filtered FASTQ"/>
     </outputs>
     <tests>
         <test>
@@ -78,7 +78,7 @@ filtlong
             <param name="min_length" value="1000"/>
             <param name="keep_percent" value="50"/>
             <param name="target_bases" value="500000000"/>
-            <output name="outfile" ftype="fastq" file="output.fastq"/>
+            <output name="outfile" ftype="fastqsanger" file="output.fastq"/>
         </test>
         <test>
             <param name="input_file" ftype="fastq" value="test_reference.fasta"/>
@@ -89,7 +89,7 @@ filtlong
             <param name="target_bases" value="500000000"/>
             <param name="trim" value="True"/>
             <param name="split" value="500"/>
-            <output name="outfile" ftype="fastq" file="output_reference.fastq"/>
+            <output name="outfile" ftype="fastqsanger" file="output_reference.fastq"/>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
