### PR TITLE
Porechop: Change fastq output to fastqsanger 

### DIFF
--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -67,9 +67,9 @@ porechop
     <outputs>
         <data name="outfile" format="fasta" from_work_dir="out.*" label="${tool.name} on ${on_string}: Trimmed">
             <change_format>
-                <when input="format" value="fastq" format="fastq"/>
+                <when input="format" value="fastqsanger" format="fastq"/>
                 <when input="format" value="fasta.gz" format="fasta.gz"/>
-                <when input="format" value="fastq.gz" format="fastq.gz"/>
+                <when input="format" value="fastqsanger.gz" format="fastq.gz"/>
             </change_format>
         </data>
     </outputs>
@@ -82,7 +82,7 @@ porechop
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>
             <param name="format" value="fastq"/>
-            <output name="outfile" ftype="fastq" file="out.fastq"/>
+            <output name="outfile" ftype="fastqsanger" file="out.fastq"/>
         </test>
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>
@@ -92,7 +92,7 @@ porechop
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>
             <param name="format" value="fastq.gz"/>
-            <output name="outfile" ftype="fastq.gz" file="out.fastq.gz" compare="sim_size"/>
+            <output name="outfile" ftype="fastqsanger.gz" file="out.fastq.gz" compare="sim_size"/>
         </test>
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>

--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -29,12 +29,12 @@ porechop
 
     ]]></command>
     <inputs>
-        <param name="input_file" type="data" format="fasta,fastq" label="Input FASTA/FASTQ" help="FASTA/FASTQ of input reads" />
+        <param name="input_file" type="data" format="fasta,fastqsanger" label="Input FASTA/FASTQ" help="FASTA/FASTQ of input reads" />
         <param name="format" type="select" label="Output format for the reads" help="Output format for the reads">
-            <option selected="True" value="fasta">FASTA</option>
-            <option value="fastq">FASTQ</option>
-            <option value="fasta.gz">FASTA.gz</option>
-            <option value="fastq.gz">FASTQ.gz</option>
+            <option selected="True" value="fasta">fasta</option>
+            <option value="fastq">fastq</option>
+            <option value="fasta.gz">fasta.gz</option>
+            <option value="fastq.gz">fastq.gz</option>
         </param>
         <section name="barcode_binning_settings" title="Barcode binning settings">
             <param argument="--barcode_threshold" type="float" min="0" max="100" value="75.0" optional="True" label="Percent identity for binning" help="A read must have at least this percent identity to a barcode to be binned (default: 75.0)"/>
@@ -67,9 +67,9 @@ porechop
     <outputs>
         <data name="outfile" format="fasta" from_work_dir="out.*" label="${tool.name} on ${on_string}: Trimmed">
             <change_format>
-                <when input="format" value="fastqsanger" format="fastq"/>
+                <when input="format" value="fastq" format="fastqsanger"/>
                 <when input="format" value="fasta.gz" format="fasta.gz"/>
-                <when input="format" value="fastqsanger.gz" format="fastq.gz"/>
+                <when input="format" value="fastq.gz" format="fastqsanger.gz"/>
             </change_format>
         </data>
     </outputs>

--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -30,7 +30,7 @@ porechop
     ]]></command>
     <inputs>
         <param name="input_file" type="data" format="fasta,fastq" label="Input FASTA/FASTQ" help="FASTA/FASTQ of input reads" />
-        <param name="format" type="select" label="Output format for the reads" help="Output format for the reads - if auto, the format will be chosen based on the output filename or the input read format">
+        <param name="format" type="select" label="Output format for the reads" help="Output format for the reads">
             <option selected="True" value="fasta">FASTA</option>
             <option value="fastq">FASTQ</option>
             <option value="fasta.gz">FASTA.gz</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
