### PR TITLE
Bandage: Add option for txt input

### DIFF
--- a/tools/bandage/bandage_image.xml
+++ b/tools/bandage/bandage_image.xml
@@ -19,7 +19,7 @@ Bandage
     #end if
     ]]></command>
     <inputs>
-        <param name="input_file" type="data" format="tabular" label="Graphical Fragment Assembly" />
+        <param name="input_file" type="data" format="tabular,txt" label="Graphical Fragment Assembly" />
         <param argument="--height" type="integer" min="1" value="1000" optional="True" label="Image height" help="If only height or width is set, the other will be determined automatically. If both are set, the image will be exactly that size. Default: 1000."/>
         <param argument="--width" type="integer" min="1" optional="True" label="Image width" help="If only height or width is set, the other will be determined automatically. If both are set, the image will be exactly that size. Default: not set."/>
         <param name="output_format" type="select" label="Produce jpg, png or svg file?">

--- a/tools/bandage/bandage_info.xml
+++ b/tools/bandage/bandage_info.xml
@@ -14,7 +14,7 @@ Bandage
     > out.txt
     ]]></command>
     <inputs>
-        <param name="input_file" type="data" format="tabular" label="Graphical Fragment Assembly" />
+        <param name="input_file" type="data" format="tabular, txt" label="Graphical Fragment Assembly" />
         <param argument="--tsv" type="boolean" checked="false" truevalue="--tsv" falsevalue="" label="Output the information in a single tab-delimited line starting with the graph file"/>
     </inputs>
     <outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
