### PR TITLE
unicycler: change output GFA to tabular

### DIFF
--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -177,7 +177,7 @@ $pilon.no_pilon
         </section>
     </inputs>
     <outputs>
-        <data name="assembly_graph" format="txt" from_work_dir="assembly.gfa" label="${tool.name} on ${on_string}: Final Assembly Graph" />
+        <data name="assembly_graph" format="tabular" from_work_dir="assembly.gfa" label="${tool.name} on ${on_string}: Final Assembly Graph" />
         <data name="assembly" format="fasta" from_work_dir="assembly.fasta" label="${tool.name} on ${on_string}: Final Assembly"/>
     </outputs>
     <tests>
@@ -213,7 +213,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="txt">
+            <output name="assembly_graph" ftype="tabular">
                 <assert_contents>
                     <has_text text="TACGGGGAAGGACGTC"/>
                 </assert_contents>
@@ -268,7 +268,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="txt">
+            <output name="assembly_graph" ftype="tabular">
                 <assert_contents>
                     <has_text text="TACGGGGAAGGACGTC" />
                 </assert_contents>
@@ -315,7 +315,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="txt">
+            <output name="assembly_graph" ftype="tabular">
                 <assert_contents>
                     <has_text text="TACGGGGAAGGACGTC" />
                 </assert_contents>
@@ -335,7 +335,7 @@ $pilon.no_pilon
                 <param name="kmers" value="21,23"/>
             </section>
             <param name="long" value="only_long.fasta" ftype="fasta" />
-            <output name="assembly_graph" ftype="txt">
+            <output name="assembly_graph" ftype="tabular">
                 <assert_contents>
                     <has_text text="S" />
                 </assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
