### PR TITLE
Fix to GTF2Bed12 

### DIFF
--- a/tools/gtfToBed12/gtfToBed12.xml
+++ b/tools/gtfToBed12/gtfToBed12.xml
@@ -68,30 +68,30 @@
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1" >
             <param name="gtf_file" value="gtf2bed_test.gtf"/>
             <output name="bed_file" file="gtf2bed_test.bed" ftype="bed12"/>
         </test>
-        <test>
+        <test expect_num_outputs="1" >
             <param name="gtf_file" value="gtf2bed_test_missing_exon.gtf"/>
             <param name="advanced_options_selector" value="advanced" />
             <param name="ignoreGroupsWithoutExons" value="true" />
             <output name="bed_file" file="gtf2bed_test_missing_exon.bed" ftype="bed12"/>
         </test>
-        <test>
+        <test expect_num_outputs="1" >
             <param name="gtf_file" value="gtf2bed_test.gtf"/>
             <param name="advanced_options_selector" value="advanced" />
             <param name="includeVersion" value="true" />
             <output name="bed_file" file="gtf2bed_test_include_version.bed" ftype="bed12"/>
         </test>
-        <test>
+        <test expect_num_outputs="2" >
             <param name="gtf_file" value="gtf2bed_test.gtf"/>
             <param name="advanced_options_selector" value="advanced" />
             <param name="infoOut" value="true" />
             <output name="bed_file" file="gtf2bed_test.bed" ftype="bed12"/>
             <output name="transcript_info_file" file="gtf2bed_test_transcript_info.txt" ftype="tabular"/>
         </test>
-        <test>
+        <test expect_num_outputs="1" >
             <param name="gtf_file" value="gtf2bed_test.gtf"/>
             <param name="advanced_options_selector" value="advanced" />
             <repeat name="sourcePrefixes">
@@ -99,7 +99,7 @@
             </repeat>
             <output name="bed_file" file="gtf2bed_test_havana.bed" ftype="bed12"/>
         </test>
-        <test>
+        <test expect_num_outputs="1" >
             <param name="gtf_file" value="gtf2bed_test.gtf"/>
             <param name="advanced_options_selector" value="advanced" />
             <repeat name="sourcePrefixes">

--- a/tools/gtfToBed12/gtfToBed12.xml
+++ b/tools/gtfToBed12/gtfToBed12.xml
@@ -64,7 +64,7 @@
     <outputs>
         <data name="bed_file" format="bed12" metadata_source="gtf_file" label="${tool.name} on ${on_string}: BED12"/>
         <data name="transcript_info_file" format="tabular" metadata_source="gtf_file" label="${tool.name} on ${on_string}: Table">
-            <filter>advanced_options['infoOut']</filter>
+            <filter>(advanced_options['advanced_options_selector'] == 'advanced') and (advanced_options['infoOut'])</filter>
         </data>
     </outputs>
     <tests>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

******

Small bug:

 * The tool has two outputs:
   * Bed12
   * Tabular (info)

The tabular file is set to only output when `infoFile` flag is set, which is unchecked by default.
However,  feed it any GTF and it will still output the tabular file (albeit completely blank). This fixes that.

 * Added extra filter to fix a blank tabular from being generated on defaults
