### PR TITLE
featureCounts: Try to clarify the different outputs in the labels

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,4 +1,4 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.2" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.3" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
         <requirement type="package" version="1.6.2">subread</requirement>
@@ -414,7 +414,7 @@
     <outputs>
         <data format="tabular"
               name="output_medium"
-              label="${tool.name} on ${on_string}">
+              label="${tool.name} on ${on_string}: Counts (with length)">
             <filter>format == "tabdel_medium"</filter>
             <actions>
                 <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier},Length" />
@@ -429,7 +429,7 @@
 
         <data format="tabular"
               name="output_short"
-              label="${tool.name} on ${on_string}">
+              label="${tool.name} on ${on_string}: Counts">
             <filter>format == "tabdel_short"</filter>
             <actions>
                 <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier}" />
@@ -438,7 +438,7 @@
 
         <data format="tabular"
               name="output_full"
-              label="${tool.name} on ${on_string}: count table">
+              label="${tool.name} on ${on_string}: Counts (with location)">
             <filter>format == "tabdel_full"</filter>
             <actions>
                 <action name="column_names" type="metadata" default="Geneid,Chr,Start,End,Strand,Length,${alignment.element_identifier}" />
@@ -447,7 +447,7 @@
 
         <data format="tabular"
               name="output_summary"
-              label="${tool.name} on ${on_string}: summary">
+              label="${tool.name} on ${on_string}: Summary">
             <actions>
                 <action name="column_names" type="metadata" default="Status,${alignment.element_identifier}" />
             </actions>
@@ -455,7 +455,7 @@
 
         <data format="tabular"
               name="output_feature_lengths"
-              label="${tool.name} on ${on_string}: feature lengths">
+              label="${tool.name} on ${on_string}: Feature lengths">
             <filter>include_feature_length_file</filter>
             <actions>
                 <action name="column_names" type="metadata" default="Feature,Length" />
@@ -463,7 +463,7 @@
         </data>
 
         <data name="output_jcounts" format="tabular"
-              label="${tool.name} on ${on_string}: junction counts">
+              label="${tool.name} on ${on_string}: Junction counts">
             <filter>extended_parameters['exon_exon_junction_read_counting_enabled']['count_exon_exon_junction_reads']</filter>
             <actions>
                 <action name="column_names" type="metadata"


### PR DESCRIPTION
For the To do `Add "counts" in FeatureCounts file name (in the tool)` here: https://github.com/galaxyproject/training-material/issues/1006#issuecomment-424038382

Not sure if this is the best naming to use, if there are better ideas let me know!

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
