### PR TITLE
Fix output names for RSeQC gene body coverage when processing collection

### DIFF
--- a/tools/rseqc/geneBody_coverage.xml
+++ b/tools/rseqc/geneBody_coverage.xml
@@ -1,4 +1,4 @@
-<tool id="rseqc_geneBody_coverage" name="Gene Body Coverage (BAM)" version="@WRAPPER_VERSION@.2">
+<tool id="rseqc_geneBody_coverage" name="Gene Body Coverage (BAM)" version="@WRAPPER_VERSION@.3">
   <description>
     Read coverage over gene body.
   </description>
@@ -29,9 +29,9 @@
         #end for
         geneBody_coverage.py -i 'input_list.txt' -r '${refgene}' --minimum_length ${minimum_length} -o output
     #else
-        #set $safename = re.sub('[^\w\-_]', '_', $input.element_identifier)
-        ln -sf '${input}' '${safename}.bam' &&
-        ln -sf '${input.metadata.bam_index}' '${safename}.bam.bai' &&
+        #set $safename = re.sub('[^\w\-_]', '_', $batch_mode.input.element_identifier)
+        ln -sf '${batch_mode.input}' '${safename}.bam' &&
+        ln -sf '${batch_mode.input.metadata.bam_index}' '${safename}.bam.bai' &&
         geneBody_coverage.py -i '${safename}.bam' -r '${refgene}' --minimum_length ${minimum_length} -o output
     #end if
     ]]>


### PR DESCRIPTION
Addresses the issue discussed in 
https://github.com/galaxyproject/galaxy/issues/6182

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
