### PR TITLE
Fixed some linting errors.

### DIFF
--- a/tools/rseqc/inner_distance.xml
+++ b/tools/rseqc/inner_distance.xml
@@ -88,7 +88,7 @@ Output
 
 1. output.inner_distance.txt:
     - first column is read ID
-    -second column is inner distance. Could be negative value if PE reads were overlapped or mapping error (e.g. Read1_start &lt; Read2_start, while Read1_end >> Read2_end due to spliced mapping of read1)
+    - second column is inner distance. Could be negative value if PE reads were overlapped or mapping error (e.g. Read1_start &lt; Read2_start, while Read1_end >> Read2_end due to spliced mapping of read1)
     - third column indicates how paired reads were mapped: PE_within_same_exon, PE_within_diff_exon,PE_reads_overlap
 2. output..inner_distance_freq.txt:
     - inner distance starts

--- a/tools/rseqc/tin.xml
+++ b/tools/rseqc/tin.xml
@@ -89,7 +89,7 @@ reproducible RNA sequencing. However, it has several weaknesses:
 
 * RIN has very limited sensitivity to measure substantially degraded RNA
   samples such as preserved clinical tissues. (ref:
-  http://www.illumina.com/documents/products/technotes/technote-truseq-rna-access.pdf).
+  https://www.illumina.com/content/dam/illumina-marketing/documents/products/technotes/technote-truseq-rna-access.pdf).
 
 To overcome these limitations, we developed TIN, an algorithm that is able
 to measure RNA integrity at transcript level. TIN calculates a score (0 <=


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
