### PR TITLE
Limma-voom: Output normalised and filtered counts outside collection

### DIFF
--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -371,8 +371,8 @@ for (i in 1:length(contrastData)) {
     topOut[i] <- makeOut(paste0(deMethod, "_", con, ".tsv"))
     glimmaOut[i] <- makeOut(paste0("glimma_", con, "/MD-Plot.html"))
 }
-filtOut <- makeOut(paste0(deMethod, "_filtcounts.tsv"))
-normOut <- makeOut(paste0(deMethod, "_normcounts.tsv"))
+filtOut <- makeOut(paste0(deMethod, "_", "filtcounts"))
+normOut <- makeOut(paste0(deMethod, "_", "normcounts"))
 rdaOut <- makeOut(paste0(deMethod, "_analysis.RData"))
 sessionOut <- makeOut("session_info.txt")
 
@@ -451,7 +451,7 @@ if (filtCPM || filtSmpCount || filtTotCount) {
         print("Outputting filtered counts")
         filt_counts <- data.frame(data$genes, data$counts)
         write.table(filt_counts, file=filtOut, row.names=FALSE, sep="\t", quote=FALSE)
-        linkData <- rbind(linkData, data.frame(Label=paste0(deMethod, "_", "filtcounts.tsv"), Link=paste0(deMethod, "_", "filtcounts.tsv"), stringsAsFactors=FALSE))
+        linkData <- rbind(linkData, data.frame(Label=paste0(deMethod, "_", "filtcounts.tsv"), Link=paste0(deMethod, "_", "filtcounts"), stringsAsFactors=FALSE))
     }
 
     # Plot Density
@@ -723,7 +723,7 @@ if (wantTrend) {
     # Save normalised counts (log2cpm)
     if (wantNorm) {
         write.table(logCPM, file=normOut, row.names=TRUE, sep="\t", quote=FALSE)
-        linkData <- rbind(linkData, c((paste0(deMethod, "_", "normcounts.tsv")), (paste0(deMethod, "_", "normcounts.tsv"))))
+        linkData <- rbind(linkData, c((paste0(deMethod, "_", "normcounts.tsv")), (paste0(deMethod, "_", "normcounts"))))
     }
 } else {
     # limma-voom approach
@@ -774,7 +774,7 @@ if (wantTrend) {
     if (wantNorm) {
         norm_counts <- data.frame(vData$genes, vData$E)
         write.table(norm_counts, file=normOut, row.names=FALSE, sep="\t", quote=FALSE)
-        linkData <- rbind(linkData, c((paste0(deMethod, "_", "normcounts.tsv")), (paste0(deMethod, "_", "normcounts.tsv"))))
+        linkData <- rbind(linkData, c((paste0(deMethod, "_", "normcounts.tsv")), (paste0(deMethod, "_", "normcounts"))))
     }
 
     # Fit linear model and estimate dispersion with eBayes
@@ -1052,7 +1052,9 @@ for (i in 1:nrow(linkData)) {
 
 cata("<h4>Tables:</h4>\n")
 for (i in 1:nrow(linkData)) {
-    if (grepl(".tsv", linkData$Link[i])) {
+    if (grepl("counts$", linkData$Link[i])) {
+        HtmlLink(linkData$Link[i], linkData$Label[i])
+    } else if (grepl(".tsv", linkData$Link[i])) {
         HtmlLink(linkData$Link[i], linkData$Label[i])
     }
 }

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -1,4 +1,4 @@
-<tool id="limma_voom" name="limma" version="3.34.9.8">
+<tool id="limma_voom" name="limma" version="3.34.9.9">
     <description>
         Perform differential expression with limma-voom or limma-trend
     </description>
@@ -123,7 +123,12 @@ mkdir ./output_dir
 #if $anno.annoOpt=='yes':
     cp -r ./glimma* '$outReport.files_path' &&
 #end if
+
 cp '$outReport.files_path'/*tsv output_dir/
+
+#if $out.filtCounts or $out.normCounts:
+    && cp '$outReport.files_path'/*counts output_dir/
+#end if
 
 #if $out.rscript:
     && cp '$__tool_directory__/limma_voom.R' '$rscript'
@@ -328,9 +333,15 @@ cp '$outReport.files_path'/*tsv output_dir/
 
     <outputs>
         <data name="outReport" format="html" label="${tool.name} on ${on_string}: Report" />
-        <collection name="outTables" type="list" label="${tool.name} on ${on_string}: Tables">
+        <collection name="outTables" type="list" label="${tool.name} on ${on_string}: DE tables">
             <discover_datasets pattern="(?P&lt;name&gt;.+)\.tsv$" format="tabular" directory="output_dir" visible="false" />
         </collection>
+        <data name="outFilt" format="tabular" from_work_dir="output_dir/*_filtcounts" label="${tool.name} on ${on_string}: Filtered counts">
+            <filter>out['filtCounts']</filter>
+        </data>
+        <data name="outNorm" format="tabular" from_work_dir="output_dir/*_normcounts" label="${tool.name} on ${on_string}: Normalised counts">
+            <filter>out['normCounts']</filter>
+        </data>
         <data name="rscript" format="txt" label="${tool.name} on ${on_string}: Rscript">
             <filter>out['rscript']</filter>
         </data>
@@ -493,27 +504,27 @@ cp '$outReport.files_path'/*tsv output_dir/
             <param name="cntSampleReq" value="3"/>
             <param name="normalisationOption" value="TMM" />
             <param name="topgenes" value="6" />
-            <output_collection name="outTables" count="3">
+            <output_collection name="outTables" count="1">
                 <element name="limma-voom_Mut-WT" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="GeneID.*logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
                         <has_text_matching expression="11304.*0.45.*15.52.*4.94.*7.74.*0.0001.*5.27" />
                     </assert_contents>
                 </element>
-                <element name="limma-voom_normcounts" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*15.7.*15.8.*15.6.*15.3.*15.2.*15.2" />
-                    </assert_contents>
-                </element>
-                <element name="limma-voom_filtcounts" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*361.*397.*346.*356.*312.*337" />
-                        <not_has_text text="11302"/>
-                    </assert_contents>
-                </element>
             </output_collection>
+            <output name="outNorm" ftype="tabular" >
+                <assert_contents>
+                    <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
+                    <has_text_matching expression="11304.*15.7.*15.8.*15.6.*15.3.*15.2.*15.2" />
+                </assert_contents>
+            </output>
+            <output name="outFilt" ftype="tabular" >
+                <assert_contents>
+                    <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
+                    <has_text_matching expression="11304.*361.*397.*346.*356.*312.*337" />
+                    <not_has_text text="11302"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- Ensure multiple counts files input works -->
         <test>
@@ -554,7 +565,7 @@ cp '$outReport.files_path'/*tsv output_dir/
             </repeat>
             <param name="topgenes" value="6" />
             <param name="normCounts" value="true" />
-            <output_collection name="outTables" count="3">
+            <output_collection name="outTables" count="2">
                 <element name="limma-voom_Mut-WT" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
@@ -567,13 +578,13 @@ cp '$outReport.files_path'/*tsv output_dir/
                         <has_text_matching expression="11304.*Abca4.*-0.4590" />
                     </assert_contents>
                 </element>
-                <element name="limma-voom_normcounts" ftype="tabular" >
-                    <assert_contents>
-                        <has_text_matching expression="EntrezID.*Symbol.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*Abca4.*15.7545" />
-                    </assert_contents>
-                </element>
             </output_collection>
+            <output name="outNorm" ftype="tabular" >
+                <assert_contents>
+                    <has_text_matching expression="EntrezID.*Symbol.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
+                    <has_text_matching expression="11304.*Abca4.*15.7545" />
+                </assert_contents>
+            </output>
         </test>
         <!-- Ensure limma-trend option works -->
         <test>


### PR DESCRIPTION
output separately instead of within collection

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
