### PR TITLE
Update libgd in circos since it  doesn't pass planemo test (Error:  missing GD)

### DIFF
--- a/tools/circos/macros.xml
+++ b/tools/circos/macros.xml
@@ -3,7 +3,6 @@
   <token name="@WRAPPER_VERSION@">0.9-RC2</token>
   <xml name="requirements">
       <requirements>
-        <requirement type="package" version="2.2.5">libgd</requirement>
         <requirement type="package" version="0.69.5">circos</requirement>
         <requirement type="package" version="2.7">python</requirement>
         <requirement type="package" version="0.6.4">bcbiogff</requirement>

--- a/tools/circos/macros.xml
+++ b/tools/circos/macros.xml
@@ -3,7 +3,7 @@
   <token name="@WRAPPER_VERSION@">0.9-RC2</token>
   <xml name="requirements">
       <requirements>
-        <requirement type="package" version="2.2.3">libgd</requirement>
+        <requirement type="package" version="2.2.5">libgd</requirement>
         <requirement type="package" version="0.69.5">circos</requirement>
         <requirement type="package" version="2.7">python</requirement>
         <requirement type="package" version="0.6.4">bcbiogff</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
