### PR TITLE
Avoid blacklist/whitelist in user-facing stacks genotypes text

### DIFF
--- a/tools/stacks/stacks_genotypes.xml
+++ b/tools/stacks/stacks_genotypes.xml
@@ -1,4 +1,4 @@
-<tool id="stacks_genotypes" name="Stacks: genotypes" version="@WRAPPER_VERSION@.0">
+<tool id="stacks_genotypes" name="Stacks: genotypes" version="@WRAPPER_VERSION@.1">
     <description>analyse haplotypes or genotypes in a genetic cross ('genotypes' program)</description>
     <macros>
         <import>macros.xml</import>
@@ -117,8 +117,8 @@
             <param name="mindepth" type="integer" value="" optional="true" argument="-m" label="Minimum stack depth required before exporting a locus in a particular individual" />
             <param name="lnl" type="float" value="" optional="true" argument="--lnl_lim" label="Filter loci with log likelihood values below this threshold" />
 
-            <param name="whitelist" argument="-W" format="txt,tabular" type="data" optional="true" label="Specify a file containing Whitelisted markers to include in the export" />
-            <param name="blacklist" argument="-B" format="txt,tabular" type="data" optional="true" label="Specify a file containing Blacklisted markers to be excluded from the export" />
+            <param name="whitelist" argument="-W" format="txt,tabular" type="data" optional="true" label="Specify a file containing markers to include in the export" />
+            <param name="blacklist" argument="-B" format="txt,tabular" type="data" optional="true" label="Specify a file containing markers to exclude from the export" />
 
             <param name="manual_cor" argument="--cor_path" type="data" format="tabular,txt" optional="true" label="Path to file containing manual genotype corrections from a Stacks SQL database to incorporate into output." />
 

--- a/tools/stacks/stacks_genotypes.xml
+++ b/tools/stacks/stacks_genotypes.xml
@@ -1,4 +1,4 @@
-<tool id="stacks_genotypes" name="Stacks: genotypes" version="@WRAPPER_VERSION@.1">
+<tool id="stacks_genotypes" name="Stacks: genotypes" version="@WRAPPER_VERSION@.0">
     <description>analyse haplotypes or genotypes in a genetic cross ('genotypes' program)</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
The terms 'whitelist' and 'blacklist' for inclusion or exclusion have undesirable associations, making it better to use more neutral language.

See also "Be careful in the words that we choose" in the main Galaxy Project Code of Conduct,
https://github.com/galaxyproject/galaxy/blob/dev/CODE_OF_CONDUCT.md and #2123 

Here we can't change the parameter names without breaking backward compatibility, so this is a cosmetic change only. The command line arguments -B and -W remain, but this reflects the underlying tool itself.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
