### PR TITLE
Switch error checking to aggressive

### DIFF
--- a/tools/spotyping/spotyping.xml
+++ b/tools/spotyping/spotyping.xml
@@ -1,4 +1,4 @@
-<tool id="spotyping" name="SpoTyping" version="@TOOL_VERSION@+galaxy1" profile="17.01">
+<tool id="spotyping" name="SpoTyping" version="@TOOL_VERSION@+galaxy2" profile="17.01">
   <description>fast and accurate in silico Mycobacterium spoligotyping from sequence reads</description>
 
   <macros>
@@ -9,7 +9,7 @@
     <requirement type="package" version="@TOOL_VERSION@">spotyping</requirement>
   </requirements>
 
-  <command detect_errors="exit_code"><![CDATA[
+  <command detect_errors="aggressive"><![CDATA[
     #set $input_file='input.' + $input.extension
     ln -s '${input}' $input_file &&
     SpoTyping.py
@@ -59,6 +59,13 @@
           <has_text text="1111111111111111101111111111111100001111111" />
         </assert_contents>
       </output>
+    </test>
+    <test expect_failure="true">
+      <param name="input" value="input.fastq.gz" ftype="fastq.gz" />
+      <param name="seq" value="--seq" />
+      <assert_stderr>
+        <has_text text="BLAST options error" />
+      </assert_stderr>
     </test>
     <test expect_num_outputs="2">
       <param name="input" value="input.fastq.gz" ftype="fastq.gz" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
