### PR TITLE
Avoid Python2-specific imports in picard tool wrappers

### DIFF
--- a/tools/picard/picard_EstimateLibraryComplexity.xml
+++ b/tools/picard/picard_EstimateLibraryComplexity.xml
@@ -18,7 +18,7 @@
     MAX_DIFF_RATE="${max_diff_rate}"
     MIN_MEAN_QUALITY="${min_mean_quality}"
     MAX_GROUP_RATIO="${max_group_ratio}"
-    READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
+    READ_NAME_REGEX='${ str( $read_name_regex ) }'
     OPTICAL_DUPLICATE_PIXEL_DISTANCE="${optical_duplicate_pixel_distance}"
 
     VALIDATION_STRINGENCY="${validation_stringency}"

--- a/tools/picard/picard_EstimateLibraryComplexity.xml
+++ b/tools/picard/picard_EstimateLibraryComplexity.xml
@@ -18,8 +18,7 @@
     MAX_DIFF_RATE="${max_diff_rate}"
     MIN_MEAN_QUALITY="${min_mean_quality}"
     MAX_GROUP_RATIO="${max_group_ratio}"
-    #import pipes
-    READ_NAME_REGEX=${ pipes.quote( str( $read_name_regex ) ) or "''" }
+    READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
     OPTICAL_DUPLICATE_PIXEL_DISTANCE="${optical_duplicate_pixel_distance}"
 
     VALIDATION_STRINGENCY="${validation_stringency}"
@@ -36,10 +35,7 @@
     <param name="max_group_ratio" type="integer" value="500" label="Do not process self-similar groups that are this many times over the mean expected group size" help="MAX_GROUP_RATIO; I.e. if the input contains 10m read pairs and MIN_IDENTICAL_BASES is set to 5, then the mean expected group size would be approximately 10 reads; default-500"/>
 
     <param name="read_name_regex" type="text" value="[a-zA-Z0-9]+:[0-9]:([0-9]+):([0-9]+):([0-9]+).*." label="Regular expression that can be used to parse read names in the incoming SAM/BAM dataset" help="READ_NAME_REGEX; Read names are parsed to extract three variables: tile/region, x coordinate and y coordinate. These values are used to estimate the rate of optical duplication in order to give a more accurate estimated library size. See help below for more info; default=[a-zA-Z0-9]+:[0-9]:([0-9]+):([0-9]+):([0-9]+).*.">
-      <sanitizer>
-        <valid initial="string.printable">
-        </valid>
-      </sanitizer>
+      <expand macro="sanitize_query" />
     </param>
     <param name="optical_duplicate_pixel_distance" type="integer" value="100" min="0" max="500" label="The maximum offset between two duplicte clusters in order to consider them optical duplicates" help="OPTICAL_DUPLICATE_PIXEL_DISTANCE; default=100"/>
 

--- a/tools/picard/picard_MarkDuplicates.xml
+++ b/tools/picard/picard_MarkDuplicates.xml
@@ -25,7 +25,7 @@
     DUPLICATE_SCORING_STRATEGY='${duplicate_scoring_strategy}'
 
     #if $read_name_regex:
-      READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
+      READ_NAME_REGEX='${ str( $read_name_regex ) }'
     #end if
     OPTICAL_DUPLICATE_PIXEL_DISTANCE='${optical_duplicate_pixel_distance}'
 

--- a/tools/picard/picard_MarkDuplicates.xml
+++ b/tools/picard/picard_MarkDuplicates.xml
@@ -24,9 +24,8 @@
 
     DUPLICATE_SCORING_STRATEGY='${duplicate_scoring_strategy}'
 
-    #import pipes
     #if $read_name_regex:
-      READ_NAME_REGEX=${ pipes.quote( str( $read_name_regex ) ) }
+      READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
     #end if
     OPTICAL_DUPLICATE_PIXEL_DISTANCE='${optical_duplicate_pixel_distance}'
 
@@ -55,11 +54,7 @@
     </param>
 
     <param name="read_name_regex" type="text" value="" label="Regular expression that can be used in unusual situations to parse non-standard read names in the incoming SAM/BAM dataset" help="READ_NAME_REGEX; Read names are parsed to extract three variables: tile/region, x coordinate and y coordinate. These values are used to estimate the rate of optical duplication in order to give a more accurate estimated library size. See help below for more info; default='' (uses : separation)">
-
-      <sanitizer>
-        <valid initial="string.printable">
-        </valid>
-      </sanitizer>
+      <expand macro="sanitize_query" />
     </param>
     <param name="optical_duplicate_pixel_distance" type="integer" value="100" min="0" max="500" label="The maximum offset between two duplicte clusters in order to consider them optical duplicates" help="OPTICAL_DUPLICATE_PIXEL_DISTANCE; default=100"/>
 

--- a/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
+++ b/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
@@ -26,7 +26,7 @@
 
     DUPLICATE_SCORING_STRATEGY="${duplicate_scoring_strategy}"
 
-    READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
+    READ_NAME_REGEX='${ str( $read_name_regex ) }'
     OPTICAL_DUPLICATE_PIXEL_DISTANCE="${optical_duplicate_pixel_distance}"
 
 

--- a/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
+++ b/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
@@ -26,8 +26,7 @@
 
     DUPLICATE_SCORING_STRATEGY="${duplicate_scoring_strategy}"
 
-    #import pipes
-    READ_NAME_REGEX=${ pipes.quote( str( $read_name_regex ) ) or "''" }
+    READ_NAME_REGEX='${ str( $read_name_regex ) or "''" }'
     OPTICAL_DUPLICATE_PIXEL_DISTANCE="${optical_duplicate_pixel_distance}"
 
 
@@ -54,10 +53,7 @@
 
 
     <param name="read_name_regex" type="text" value="[a-zA-Z0-9]+:[0-9]:([0-9]+):([0-9]+):([0-9]+).*." label="Regular expression that can be used to parse read names in the incoming SAM/BAM dataset" help="READ_NAME_REGEX; Read names are parsed to extract three variables: tile/region, x coordinate and y coordinate. These values are used to estimate the rate of optical duplication in order to give a more accurate estimated library size. See help below for more info; default=[a-zA-Z0-9]+:[0-9]:([0-9]+):([0-9]+):([0-9]+).*.">
-      <sanitizer>
-        <valid initial="string.printable">
-        </valid>
-      </sanitizer>
+      <expand macro="sanitize_query" />
     </param>
     <param name="optical_duplicate_pixel_distance" type="integer" value="100" min="0" max="500" label="The maximum offset between two duplicte clusters in order to consider them optical duplicates" help="OPTICAL_DUPLICATE_PIXEL_DISTANCE; default=100"/>
 

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -9,6 +9,17 @@
         </param>
     </xml>
 
+    <xml name="sanitize_query">
+        <sanitizer invalid_char="">
+            <valid initial="string.printable">
+                <remove value="&apos;" />
+            </valid>
+            <mapping initial="none">
+                <add source="&apos;" target="&apos;&quot;&apos;&quot;&apos;" />
+            </mapping>
+       </sanitizer>
+    </xml>
+
     <token name="@TOOL_VERSION@">2.18.2</token>
 
     <xml name="requirements">

--- a/tools/picard/picard_macros.xml
+++ b/tools/picard/picard_macros.xml
@@ -10,7 +10,7 @@
     </xml>
 
     <xml name="sanitize_query">
-        <sanitizer invalid_char="">
+        <sanitizer>
             <valid initial="string.printable">
                 <remove value="&apos;" />
             </valid>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
