### PR TITLE
samtools: added missing .shed yml for depth

### DIFF
--- a/tool_collections/samtools/samtools_depth/.shed.yml
+++ b/tool_collections/samtools/samtools_depth/.shed.yml
@@ -1,10 +1,10 @@
 categories:
 - SAM
-description: computes the depth at each position or region
+description: Computes the depth at each position or region
 long_description: |
   Computes the depth at each position or region of a sequence for a given alignment file
 name: samtools_depth
 owner: iuc
-homepage_url: http://www.htslib.org/
+homepage_url: https://www.htslib.org/
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tool_collections/samtools/samtools_depth
 type: unrestricted

--- a/tool_collections/samtools/samtools_depth/.shed.yml
+++ b/tool_collections/samtools/samtools_depth/.shed.yml
@@ -1,0 +1,10 @@
+categories:
+- SAM
+description: computes the depth at each position or region
+long_description: |
+  Computes the depth at each position or region of a sequence for a given alignment file
+name: samtools_depth
+owner: iuc
+homepage_url: http://www.htslib.org/
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tool_collections/samtools/samtools_depth
+type: unrestricted

--- a/tool_collections/samtools/samtools_depth/samtools_depth.xml
+++ b/tool_collections/samtools/samtools_depth/samtools_depth.xml
@@ -8,7 +8,7 @@
     <expand macro="version_command"/>
     <command><![CDATA[
         ## create symlinks to bams and index files (0,..., n-1 + 0.[bai|crai],...,n-1.[bai|crai] )
-        @PREPIDX_MULTIPLE@
+        @PREPARE_IDX_MULTIPLE@
 
         samtools depth
         $all
@@ -90,7 +90,8 @@
         <test>
             <param name="input_bams" value="eboVir3.bam,eboVir3.2.bam" ftype="bam" />
             <param name="minlength" value="10" />
-            <!-- TODO odd thing: I did not expect values > 4 in the output, but there are ... ?-->
+	    <!-- odd thing: I did not expect values > 4 in the output, but there are ... ?
+		 see https://github.com/samtools/samtools/issues/889-->
             <param name="maxdepth" value="4" />
             <param name="basequality" value="11"  />
             <param name="mapquality" value="12" />

--- a/tool_collections/samtools/samtools_depth/samtools_depth.xml
+++ b/tool_collections/samtools/samtools_depth/samtools_depth.xml
@@ -7,32 +7,32 @@
     <expand macro="stdio"/>
     <expand macro="version_command"/>
     <command><![CDATA[
-        ## create symlinks to bams and index files (0,..., n-1 + 0.[bai|crai],...,n-1.[bai|crai] )
-        @PREPARE_IDX_MULTIPLE@
+## create symlinks to bams and index files (0,..., n-1 + 0.[bai|crai],...,n-1.[bai|crai] )
+@PREPARE_IDX_MULTIPLE@
 
-        samtools depth
-        $all
-        #if $cond_region.select_region == 'bed':
-            -b '$cond_region.input_bed'
-        #else if $cond_region.select_region == 'text':
-            -r $cond_region.region
-        #end if
-        #if str($minlength) != '':
-            -l $minlength
-        #end if
-        #if str($maxdepth) != '':
-            -m $maxdepth
-        #end if
-        #if str($basequality) != '':
-            -q $basequality
-        #end if
-        #if str($mapquality) != '':
-            -Q $mapquality
-        #end if
-        #for $i in range(len( $input_bams )):
-            ${i}
-        #end for
-        > '${output}'
+samtools depth
+$all
+#if $cond_region.select_region == 'bed':
+    -b '$cond_region.input_bed'
+#else if $cond_region.select_region == 'text':
+    -r $cond_region.region
+#end if
+#if str($minlength) != '':
+    -l $minlength
+#end if
+#if str($maxdepth) != '':
+    -m $maxdepth
+#end if
+#if str($basequality) != '':
+    -q $basequality
+#end if
+#if str($mapquality) != '':
+    -Q $mapquality
+#end if
+#for $i in range(len( $input_bams )):
+    ${i}
+#end for
+> '${output}'
     ]]></command>
     <inputs>
         <param name="input_bams" type="data" format="bam" multiple="true" label="BAM file(s)" />
@@ -90,8 +90,8 @@
         <test>
             <param name="input_bams" value="eboVir3.bam,eboVir3.2.bam" ftype="bam" />
             <param name="minlength" value="10" />
-	    <!-- odd thing: I did not expect values > 4 in the output, but there are ... ?
-		 see https://github.com/samtools/samtools/issues/889-->
+            <!-- Odd thing: I did not expect values > 4 in the output, but there are ... ?
+             see https://github.com/samtools/samtools/issues/889 -->
             <param name="maxdepth" value="4" />
             <param name="basequality" value="11"  />
             <param name="mapquality" value="12" />


### PR DESCRIPTION
Adds missing shed yml file for samtools depth (also fixes a wrong macro name). 

Two questions: 

- the other samtools yml files have mixed devteam / iuc owners. I guess this is intended? 
- samtools certainly could need a suite definition. It would be great if this could be included .. maybe in this PR? I would need some information how this can be done. As far as I see its now done in the shed.yml files, but the documentation is still sparse.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
