### PR TITLE
Removal `optional="true"` from boolean params

### DIFF
--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -167,7 +167,7 @@
             <when value="No" />
         </conditional>
 
-        <param name="format" type="select" label="Format of Input Files" help="For Paired-end BAM (BAMPE) the 'Build model step' will be ignored and the real fragments will be used for each template defined by leftmost and rightmost mapping positions (--format). Default: Single-end BAM">
+        <param argument="--format" type="select" label="Format of Input Files" help="For Paired-end BAM (BAMPE) the 'Build model step' will be ignored and the real fragments will be used for each template defined by leftmost and rightmost mapping positions. Default: Single-end BAM">
             <option value="BAM" selected="True">Single-end BAM</option>
             <option value="BAMPE">Paired-end BAM</option>
             <option value="BED">Single-end BED</option>
@@ -183,13 +183,13 @@
             <when value="create_model">
                 <param name="mfold_lower" type="integer" value="5" label="Set lower mfold bound" help="Select the lower region within MFOLD range of high confidence enrichment ratio against background to build model. Fold-enrichment in regions must be higher than lower limit (--mfold). Default: 5" />
                 <param name="mfold_upper" type="integer" value="50" label="Set upper mfold bound" help="Select the upper region within MFOLD range of high confidence enrichment ratio against background to build model. Fold-enrichment in regions must be lower than the upper limit (--mfold). Default: 50"/>
-                <param name="band_width" type="integer" value="300"
+                <param name="band_width" argument="--bw" type="integer" value="300"
                 label="Band width for picking regions to compute fragment size"
-                help=" You can set this parameter as the medium fragment size expected from sonication or size selection (--bw). Default: 300" />
+                help=" You can set this parameter as the medium fragment size expected from sonication or size selection. Default: 300" />
             </when>
             <when value="nomodel">
-                <param name="extsize" type="integer" value="200" label="Set extension size" help="The arbitrary extension size in bp. When nomodel is true, MACS will use this value as fragment size to extend each read towards 3-prime; end, then pile them up. It is exactly twice the number of obsolete SHIFTSIZE. In previous language, each read is moved 5-prime-to-3-prime direction to middle of fragment by 0.5 d, then extended to both direction with 0.5 d. This is equivalent to say each read is extended towards 5-prime-to-3-prime into a d size fragment. --extsize (this option) and --shift (the option below) can be combined when necessary. See --shift option below. Default: 200 (--extsize)."/>
-                <param name="shift" type="integer" value="0" label="Set shift size" help="(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion while setting it other than default value. When NOMODEL is set, MACS will use this value to move cutting ends (5-prime) towards 5-prime-to-3-prime  direction then apply EXTSIZE to extend them to fragments. When this value is negative, ends will be moved toward 3-prime-to-5-prime  direction. Recommended to keep it as default 0 for ChIP-Seq datasets, or -1 * 0.5 of --extsize (option above) together with --extsize option for detecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you can't set values other than 0 if format is paired-end data (BAMPE). Default: 0 (--shift)."/>
+                <param argument="--extsize" type="integer" value="200" label="Set extension size" help="The arbitrary extension size in bp. When nomodel is true, MACS will use this value as fragment size to extend each read towards 3-prime; end, then pile them up. It is exactly twice the number of obsolete SHIFTSIZE. In previous language, each read is moved 5-prime-to-3-prime direction to middle of fragment by 0.5 d, then extended to both direction with 0.5 d. This is equivalent to say each read is extended towards 5-prime-to-3-prime into a d size fragment. --extsize (this option) and --shift (the option below) can be combined when necessary. See --shift option below. Default: 200."/>
+                <param argument="--shift" type="integer" value="0" label="Set shift size" help="(NOT the legacy --shiftsize option!) The arbitrary shift in bp. Use discretion while setting it other than default value. When NOMODEL is set, MACS will use this value to move cutting ends (5-prime) towards 5-prime-to-3-prime  direction then apply EXTSIZE to extend them to fragments. When this value is negative, ends will be moved toward 3-prime-to-5-prime  direction. Recommended to keep it as default 0 for ChIP-Seq datasets, or -1 * 0.5 of --extsize (option above) together with --extsize option for detecting enriched cutting loci such as certain DNAseI-Seq datasets. Note, you can't set values other than 0 if format is paired-end data (BAMPE). Default: 0"/>
             </when>
         </conditional>
 
@@ -199,10 +199,10 @@
                 <option value="pvalue">p-value</option>
             </param>
             <when value="pvalue">
-                <param name="pvalue" type="float" value="" label="p-value cutoff for peak detection" help="default: not set (--pvalue)"/>
+                <param argument="--pvalue" type="float" value="" label="p-value cutoff for peak detection" help="Default: not set"/>
             </when>
             <when value="qvalue">
-                <param name="qvalue" type="float" value="0.05" label="Minimum FDR (q-value) cutoff for peak detection" help="The q-value (minimum FDR) cutoff to call significant regions. Default is 0.05. For broad marks, you can try 0.05 as cutoff. Q-values are calculated from p-values using Benjamini-Hochberg procedure. (--qvalue)"/>
+                <param argument="--qvalue" type="float" value="0.05" label="Minimum FDR (q-value) cutoff for peak detection" help="The q-value (minimum FDR) cutoff to call significant regions. Default is 0.05. For broad marks, you can try 0.05 as cutoff. Q-values are calculated from p-values using Benjamini-Hochberg procedure"/>
             </when>
         </conditional>
 
@@ -215,24 +215,24 @@
         </param>
 
         <section name="advanced_options" title="Advanced Options">
-                <param name="to_large" type="boolean" truevalue="--to-large" falsevalue="" checked="False" optional="True"
+                <param name="to_large" argument="--to-large" type="boolean" truevalue="--to-large" falsevalue="" checked="false"
                     label="When set, scale the small sample up to the bigger sample"
-                    help="By default, the bigger dataset will be scaled down towards the smaller dataset, which will lead to smaller p/qvalues and more specific results. Keep in mind that scaling down will bring down background noise more. (--to-large). Default: No"/>
-                <param name="nolambda" type="boolean" truevalue="--nolambda" falsevalue="" checked="False" optional="True"
-                    label="Use fixed background lambda as local lambda for every peak region" help="up to 9X more time consuming (--nolambda). Default: No"/>
-                <param name="spmr" type="boolean" truevalue="--SPMR" falsevalue="" checked="False" optional="True"
+                    help="By default, the bigger dataset will be scaled down towards the smaller dataset, which will lead to smaller p/qvalues and more specific results. Keep in mind that scaling down will bring down background noise more. Default: No"/>
+                <param argument="--nolambda" type="boolean" truevalue="--nolambda" falsevalue="" checked="false"
+                    label="Use fixed background lambda as local lambda for every peak region" help="up to 9X more time consuming. Default: No"/>
+                <param name="spmr" argument="--SPMR" type="boolean" truevalue="--SPMR" falsevalue="" checked="false"
                     label="Save signal per million reads for fragment pileup profiles"
-                    help="Requires 'Scores in bedGraph files (--bdg)' output to be selected. (--SPMR). Default: No"/>
-                <param name="ratio" type="float" optional="True"
+                    help="Requires 'Scores in bedGraph files (--bdg)' output to be selected. Default: No"/>
+                <param argument="--ratio" type="float" optional="true"
                     label="When set, use a custom scaling ratio of ChIP/control (e.g. calculated using NCIS) for linear scaling"
-                    help="(--ratio) Default: ignore"/>
+                    help="Default: ignore"/>
                 <param name="slocal" type="integer" optional="True" label="The small nearby region in basepairs to calculate dynamic lambda"
                     help="This is used to capture the bias near the peak summit region. Invalid if there is no control data. If you set this to 0, MACS will skip slocal lambda calculation. *Note* that MACS will always perform a d-size local lambda calculation. The final local bias should be the maximum of the lambda value from d, slocal, and llocal size windows. (--slocal). Default: 1000"/>
-                <param name="llocal" type="integer" optional="True" label="The large nearby region in basepairs to calculate dynamic lambda"
-                    help="This is used to capture the surround bias. If you set this to 0, MACS will skip llocal lambda calculation. *Note* that MACS will always perform a d-size local lambda calculation. The final local bias should be the maximum of the lambda value from d, slocal, and llocal size windows. (--llocal) Default: 10000"/>
+                <param argument="--llocal" type="integer" optional="True" label="The large nearby region in basepairs to calculate dynamic lambda"
+                    help="This is used to capture the surround bias. If you set this to 0, MACS will skip llocal lambda calculation. *Note* that MACS will always perform a d-size local lambda calculation. The final local bias should be the maximum of the lambda value from d, slocal, and llocal size windows. Default: 10000"/>
                 <conditional name="broad_options">
-                    <param name="broad_options_selector" type="select"
-                        label="Composite broad regions" help="by putting nearby highly enriched regions into a broad region with loose cutoff (--broad)">
+                    <param name="broad_options_selector" argument="--broad" type="select"
+                        label="Composite broad regions" help="by putting nearby highly enriched regions into a broad region with loose cutoff">
                         <option value="nobroad" selected="true">No broad regions</option>
                         <option value="broad">broad regions</option>
                     </param>
@@ -241,9 +241,8 @@
                             help="value is either p-value or q-value as specified above (--broad-cutoff)"/>
                     </when>
                     <when value="nobroad">
-                        <param name="call_summits" type="boolean" truevalue="--call-summits" falsevalue="" checked="False"
-                            label="Use a more sophisticated signal processing approach to find subpeak summits in each enriched peak region"
-                            help="(--call-summits)"/>
+                        <param name="call_summits" argument="--call-summits" type="boolean" truevalue="--call-summits" falsevalue="" checked="false"
+                            label="Use a more sophisticated signal processing approach to find subpeak summits in each enriched peak region"/>
                     </when>
                 </conditional>
                 <expand macro="keep_duplicates" />
@@ -350,7 +349,6 @@
         </test>
     </tests>
     <help><![CDATA[
-
 .. class:: infomark
 
 **What it does**
@@ -401,13 +399,13 @@ The default output is the narrowPeak BED file (BED6+4 format). This contains the
 
     Example:
 
-    ======= ========= ======= ============ ==== === ======= ======== ======= =======
-    1          2        3          4        5    6     7       8         9   **10**
-    ======= ========= ======= ============ ==== === ======= ======== ======= =======
+    ======= ========= ======= ============= ==== === ======= ======== ======= =======
+    1          2        3          4         5    6     7       8         9   **10**
+    ======= ========= ======= ============= ==== === ======= ======== ======= =======
     chr1    840081    840400  treat1_peak_1  69   .  4.89872 10.50944 6.91052 158
     chr1    919419    919785  treat1_peak_2  87   .  5.85158 12.44148 8.70936 130
     chr1    937220    937483  treat1_peak_3  66   .  4.87632 10.06728 6.61759 154
-    ======= ========= ======= ============ ==== === ======= ======== ======= =======
+    ======= ========= ======= ============= ==== === ======= ======== ======= =======
 
     Columns contain the following data:
 
@@ -459,13 +457,13 @@ A BED file which contains the peak summits locations for every peaks. The 5th co
 
     Example:
 
-    ======= ========= ======= ============ =======
-    1          2        3          4        **5**
-    ======= ========= ======= ============ =======
+    ======= ========= ======= ============= =======
+    1          2        3          4         **5**
+    ======= ========= ======= ============= =======
     chr1    840239    840240  treat1_peak_1 6.91052
     chr1    919549    919550  treat1_peak_2 8.70936
     chr1    937374    937375  treat1_peak_3 6.61759
-    ======= ========= ======= ============ =======
+    ======= ========= ======= ============= =======
 
     Columns contain the following data:
 
@@ -518,14 +516,13 @@ If the broad option (--broad) is selected unded Advanced Options above, MACS2 wi
 
     Example:
 
-    ======= ========= ======= ============ ==== === ======= ======= =======
-    1        2         3       4            5    6   7       8       9
-    ======= ========= ======= ============ ==== === ======= ======= =======
-    chr1    840081    840400  treat1_peak_1  52   .  4.08790 8.57605 5.21506
-    chr1    919419    919785  treat1_peak_2  56   .  4.37270 8.90436 5.60462
-    chr1    937220    937483  treat1_peak_3  48   .  4.02343 8.06676 4.86861
-    ======= ========= ======= ============ ==== === ======= ======= =======
-
+    ======= ====== ====== ============= ==== === ======= ======= =======
+    1        2      3      4             5    6   7       8       9
+    ======= ====== ====== ============= ==== === ======= ======= =======
+    chr1    840081 840400 treat1_peak_1   52   . 4.08790 8.57605 5.21506
+    chr1    919419 919785 treat1_peak_2   56   . 4.37270 8.90436 5.60462
+    chr1    937220 937483 treat1_peak_3   48   . 4.02343 8.06676 4.86861
+    ======= ====== ====== ============= ==== === ======= ======= =======
 
 Columns contain the following data:
 
@@ -546,13 +543,13 @@ If the broad option (--broad) is selected unded Advanced Options above, MACS2 wi
 
     Example:
 
-    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
-    1       2         3       4            5    6    7       8       9   10  11  12  13      14     15
-    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
-    chr1    840081    840400  treat1_peak_1  52   .  840081  840400   0   1  319  0  4.08790 8.57605 5.21506
-    chr1    919419    919785  treat1_peak_2  56   .  919419  919785   0   1  366  0  4.37270 8.90436 5.60462
-    chr1    937220    937483  treat1_peak_3  48   .  937220  937483   0   1  263  0  4.02343 8.06676 4.86861
-    ======= ========= ======= ============ ==== === ======= ======= === === === === ======= ======= =======
+    ======= ========= ======= ============= === === ======= ======= === === === === ======= ======= =======
+    1       2         3       4              5   6     7       8     9   10  11  12  13      14     15
+    ======= ========= ======= ============= === === ======= ======= === === === === ======= ======= =======
+    chr1    840081    840400  treat1_peak_1  52   .  840081  840400   0   1 319   0 4.08790 8.57605 5.21506
+    chr1    919419    919785  treat1_peak_2  56   .  919419  919785   0   1 366   0 4.37270 8.90436 5.60462
+    chr1    937220    937483  treat1_peak_3  48   .  937220  937483   0   1 263   0 4.02343 8.06676 4.86861
+    ======= ========= ======= ============= === === ======= ======= === === === === ======= ======= =======
 
 Columns contain the following data:
 


### PR DESCRIPTION
Also:
- use the `argument` attribute
- fix tables in tool help

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
