### PR TITLE
velvet_optimiser: update to 2.2.6

### DIFF
--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -1,9 +1,8 @@
-<tool id="velvetoptimiser" name="VelvetOptimiser" version="2.2.5">
+<tool id="velvetoptimiser" name="VelvetOptimiser" version="2.2.6">
     <description>Automatically optimize Velvet assemblies</description>
     <requirements>
-        <requirement type="package" version="5.22.0">perl</requirement>
         <requirement type="package" version="1.2.10">velvet</requirement>
-        <requirement type="package" version="2.2.5">perl-velvetoptimiser</requirement>
+        <requirement type="package" version="2.2.6">perl-velvetoptimiser</requirement>
     </requirements>
     <version_command>VelvetOptimiser.pl --version</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

A tiny PR to update velvetoptimiser to v2.2.6