### PR TITLE
Exonerate: fix output format

### DIFF
--- a/tools/exonerate/exonerate.xml
+++ b/tools/exonerate/exonerate.xml
@@ -98,7 +98,7 @@
                 <param name="input_fasta" value="genome.fa"/>
             </conditional>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="out_target.gff" lines_diff="2"/>
+            <output name="output_gff" file="out_target.gff" lines_diff="8"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -107,7 +107,7 @@
                 <param name="input_fasta" value="merlin"/>
             </conditional>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="out_target.gff" lines_diff="2"/>
+            <output name="output_gff" file="out_target.gff" lines_diff="8"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -116,7 +116,7 @@
                 <param name="input_fasta" value="genome.fa"/>
             </conditional>
             <param name="outformat" value="querygff"/>
-            <output name="output_gff" file="out_query.gff" lines_diff="2"/>
+            <output name="output_gff" file="out_query.gff" lines_diff="8"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -135,7 +135,7 @@
             </conditional>
             <param name="model" value="est2genome"/>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="est2genome.gff" lines_diff="2"/>
+            <output name="output_gff" file="est2genome.gff" lines_diff="4"/>
         </test>
         <test>
             <param name="query" value="proteome.fa"/>
@@ -155,7 +155,7 @@
             </conditional>
             <param name="model" value="coding2coding"/>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="coding2coding.gff" lines_diff="2"/>
+            <output name="output_gff" file="coding2coding.gff" lines_diff="4"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/exonerate/exonerate.xml
+++ b/tools/exonerate/exonerate.xml
@@ -83,10 +83,10 @@
         <param name='bestn' type='integer' min="0" max="10000" value="0" label="Report best N results per query (0 to report all)"/>
     </inputs>
     <outputs>
-        <data name="output_gff" format="txt" label="${tool.name} on $on_string">
+        <data name="output_gff" format="gff" label="${tool.name} on $on_string">
             <filter>outformat != 'alignment'</filter>
         </data>
-        <data name="output_ali" format="gff" label="${tool.name} on $on_string">
+        <data name="output_ali" format="txt" label="${tool.name} on $on_string">
             <filter>outformat == 'alignment'</filter>
         </data>
     </outputs>

--- a/tools/exonerate/exonerate.xml
+++ b/tools/exonerate/exonerate.xml
@@ -98,7 +98,7 @@
                 <param name="input_fasta" value="genome.fa"/>
             </conditional>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="out_target.gff"/>
+            <output name="output_gff" file="out_target.gff" lines_diff="2"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -107,7 +107,7 @@
                 <param name="input_fasta" value="merlin"/>
             </conditional>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="out_target.gff"/>
+            <output name="output_gff" file="out_target.gff" lines_diff="2"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -116,7 +116,7 @@
                 <param name="input_fasta" value="genome.fa"/>
             </conditional>
             <param name="outformat" value="querygff"/>
-            <output name="output_gff" file="out_query.gff"/>
+            <output name="output_gff" file="out_query.gff" lines_diff="2"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -135,7 +135,7 @@
             </conditional>
             <param name="model" value="est2genome"/>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="est2genome.gff"/>
+            <output name="output_gff" file="est2genome.gff" lines_diff="2"/>
         </test>
         <test>
             <param name="query" value="proteome.fa"/>
@@ -145,7 +145,7 @@
             </conditional>
             <param name="model" value="protein2genome"/>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="protein2genome.gff"/>
+            <output name="output_gff" file="protein2genome.gff" lines_diff="2"/>
         </test>
         <test>
             <param name="query" value="genome.fa"/>
@@ -155,7 +155,7 @@
             </conditional>
             <param name="model" value="coding2coding"/>
             <param name="outformat" value="targetgff"/>
-            <output name="output_gff" file="coding2coding.gff"/>
+            <output name="output_gff" file="coding2coding.gff" lines_diff="2"/>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

A little fix for the output format of exonerate