### PR TITLE
Trinity: fix option name

### DIFF
--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -7,7 +7,7 @@
         </requirements>
     </xml>
 
-    <token name="@WRAPPER_VERSION@">2.8.3</token>
+    <token name="@WRAPPER_VERSION@">2.8.4</token>
 
     <token name="@COMMAND_PAIRED_STRAND_JACCARD@">
         #if $pool.inputs.strand.is_strand_specific:

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -190,7 +190,7 @@
                 </conditional>
             </when>
         </conditional>
-        <param name="norm" type="boolean" argument="--normalize_reads" truevalue="--normalize_reads" falsevalue="" checked="true" label="Run in silico normalization of reads" help="Defaults to max. read coverage of 50."/>
+        <param name="norm" type="boolean" argument="--no_normalize_reads" truevalue="" falsevalue="--no_normalize_reads" checked="true" label="Run in silico normalization of reads" help="Defaults to max. read coverage of 50."/>
         <section name="additional_params" title="Additional Options" expanded="False">
             <param name="min_contig_length" argument="--min_contig_length" type="integer" optional="true" value="200" min="1" label="Minimum Contig Length" help="All contigs shorter than this will be discarded"/>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

A little patch to fix #2143 (thanks for reporting @alpapan!)