### PR TITLE
Maker: update 2.31.10 + add support for mpi

### DIFF
--- a/tools/maker/macros.xml
+++ b/tools/maker/macros.xml
@@ -6,7 +6,7 @@
             <yield />
         </requirements>
     </xml>
-    <token name="@VERSION@">2.31.9</token>
+    <token name="@VERSION@">2.31.10</token>
 
     <xml name="citations">
         <citations>

--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -35,7 +35,7 @@
             export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
-        mpiexec -n \${GALAXY_SLOTS:-4} maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl
+        mpiexec -n \${GALAXY_SLOTS:-4} maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl < /dev/null
 
         &&
 

--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="maker" name="Maker" profile="16.04" version="@VERSION@.1">
+<tool id="maker" name="Maker" profile="16.04" version="@VERSION@">
     <description>genome annotation pipeline</description>
     <macros>
         <import>macros.xml</import>
@@ -18,7 +18,7 @@
 
         &&
 
-        sed "s/cpus=/cpus=\${GALAXY_SLOTS:-4}/g" '$ctl' > maker_opts.ctl
+        cp '$ctl' maker_opts.ctl
 
         &&
 
@@ -35,7 +35,8 @@
             export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
-        maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl
+        ## THREADS_DAEMON_MODEL=1 is a magic way to avoid segfault with openmpi, something to do with threads and system() calls in perl code
+        export THREADS_DAEMON_MODEL=1 && mpirun -n 1 maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl
 
         &&
 
@@ -192,7 +193,7 @@ other_gff= # extra features to pass-through to final MAKER generated GFF3 file
 
 #-----External Application Behavior Options
 alt_peptide=${advanced.alt_peptide} # amino acid used to replace non-standard amino acids in BLAST databases
-cpus= # max number of cpus to use in BLAST and RepeatMasker (not for MPI, leave 1 when using MPI)
+cpus=1 # max number of cpus to use in BLAST and RepeatMasker (not for MPI, leave 1 when using MPI)
 
 #-----MAKER Behavior Options
 max_dna_len=${advanced.max_dna_len} # length for dividing up contigs into chunks (increases/decreases memory usage)

--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -35,8 +35,7 @@
             export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
-        ## THREADS_DAEMON_MODEL=1 is a magic way to avoid segfault with openmpi, something to do with threads and system() calls in perl code
-        export THREADS_DAEMON_MODEL=1 && mpirun -n 1 maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl
+        mpiexec -n \${GALAXY_SLOTS:-4} maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl
 
         &&
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

A minor update for maker, and also added support for MPI (finally found a way to avoid systematic segfault).
I'm a little nervous with the MPI stuff, but tests are ok (= in a non-cluster environment) and it seems to work fine on our cluster with a properly configure job destination.