### PR TITLE
Porechop: fastqsanger.gz is not available in Galaxy

### DIFF
--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -109,7 +109,7 @@ porechop
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>
             <param name="format" value="fastq.gz"/>
-            <output name="outfile" ftype="fastqsanger.gz" file="out.fastq.gz" compare="sim_size"/>
+            <output name="outfile" ftype="fastq.gz" file="out.fastq.gz" compare="sim_size"/>
         </test>
         <test>
             <param name="input_file" ftype="fasta" value="test_format.fasta"/>

--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -86,7 +86,7 @@ porechop
             <change_format>
                 <when input="format" value="fastq" format="fastqsanger"/>
                 <when input="format" value="fasta.gz" format="fasta.gz"/>
-                <when input="format" value="fastq.gz" format="fastqsanger.gz"/>
+                <when input="format" value="fastq.gz" format="fastq.gz"/>
             </change_format>
         </data>
     </outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
