### PR TITLE
Update metaspades.xml

### DIFF
--- a/tools/metaspades/metaspades.xml
+++ b/tools/metaspades/metaspades.xml
@@ -1,4 +1,4 @@
-<tool id="metaspades" name="metaSPAdes" version="3.9.0">
+<tool id="metaspades" name="metaSPAdes" version="3.9.1">
     <description>assembler for metagenomics datasets</description>
     <requirements>
         <requirement type="package" version="3.9.0">spades</requirement>
@@ -72,6 +72,7 @@
     <outputs>
         <data name="out_contigs" format="fasta" from_work_dir="contigs.fasta" label="SPAdes contigs (fasta)" />
         <data name="out_scaffolds" format="fasta" from_work_dir="scaffolds.fasta" label="SPAdes scaffolds (fasta)" />
+        <data name="out_fastg" format="text" from_work_dir="assembly_graph.fastg" label="SPAdes assembly graph (fastg)" />
         <data name="out_log" format="txt" from_work_dir="spades.log" label="SPAdes log" />
     </outputs>
     <tests>

--- a/tools/metaspades/metaspades.xml
+++ b/tools/metaspades/metaspades.xml
@@ -1,4 +1,4 @@
-<tool id="metaspades" name="metaSPAdes" version="3.9.1">
+<tool id="metaspades" name="metaSPAdes" version="3.9.0">
     <description>assembler for metagenomics datasets</description>
     <requirements>
         <requirement type="package" version="3.9.0">spades</requirement>


### PR DESCRIPTION
PR to output Assembly-graph FASTG file in the Galaxy history. Currently, there is no "fastg" format defined on Galaxy (If I am wrong, please let me know), so, I have used regular "text" format to output the fastg file.

Thanks,
Praveen


FOR CONTRIBUTOR:
* [x ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
