### PR TITLE
WIP to allow tools used in soil mothur tutorial to run on pulsar

### DIFF
--- a/tools/mothur/classify.seqs.xml
+++ b/tools/mothur/classify.seqs.xml
@@ -55,6 +55,9 @@ echo 'classify.seqs(
 | sed 's/ //g'  ## mothur trips over whitespace
 | ./mothur
 | tee mothur.out.log
+&& cp fasta*.taxonomy out.fasta.taxonomy
+&& cp fasta*.tax.summary out.fasta.tax.summary
+&& cp tax.taxonomy*.tree.sum out.tax.taxonomy.tree.sum
     ]]></command>
     <inputs>
         <param argument="fasta" type="data" format="fasta" label="fasta - Candiate Sequences"/>
@@ -131,9 +134,9 @@ echo 'classify.seqs(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="taxonomy_out" format="mothur.seq.taxonomy" from_work_dir="fasta*.taxonomy" label="${tool.name} on ${on_string}: taxonomy"/>
-        <data name="tax_summary" format="mothur.tax.summary" from_work_dir="fasta*.tax.summary" label="${tool.name} on ${on_string}: tax.summary"/>
-        <data name="tree_sum" format="tabular" from_work_dir="tax.taxonomy*.tree.sum" label="${tool.name} on ${on_string}: tree.sum"/>
+        <data name="taxonomy_out" format="mothur.seq.taxonomy" from_work_dir="out.fasta.taxonomy" label="${tool.name} on ${on_string}: taxonomy"/>
+        <data name="tax_summary" format="mothur.tax.summary" from_work_dir="out.fasta.tax.summary" label="${tool.name} on ${on_string}: tax.summary"/>
+        <data name="tree_sum" format="tabular" from_work_dir="out.tax.taxonomy.tree.sum" label="${tool.name} on ${on_string}: tree.sum"/>
     </outputs>
     <tests>
         <test><!-- test with wang method -->

--- a/tools/mothur/cluster.split.xml
+++ b/tools/mothur/cluster.split.xml
@@ -90,21 +90,22 @@ echo 'cluster.split(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
-#import glob
-&& cp splitby.*.list out.splitby.list
-#if glob.glob("splitby.*.rabund"):
-	&& cp splitby.*.rabund out.splitby.rabund
+
+#if $cluster:
+    && cp splitby.*.list '$otulist'
 #end if
-#if glob.glob("splitby.*.sabund"):
-	&& cp splitby.*.sabund out.splitby.sabund
+#if $rabund:
+    && cp splitby.*.rabund '$rabund'
+#end if
+#if $sabund:
+    && cp splitby.*.sabund '$sabund'
 #end if
 #if not $cluster:
-	&& cp splitby.*.file out.splitby.file
+    && cp splitby.*.file '$splitfile'
 #end if
-#if glob.glob("splitby.*.sensspec"):
-	&& cp splitby.*.sensspec out.splitby.sensspec
+#if $sensspec:
+    && cp splitby.*.sensspec '$sensspec'
 #end if
-
     ]]></command>
     <inputs>
         <conditional name="splitby">
@@ -196,15 +197,19 @@ echo 'cluster.split(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="rabund" format="mothur.rabund" from_work_dir="out.splitby.rabund" label="${tool.name} on ${on_string}: rabund (Rank Abundance)">
-             <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
-             <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
+        <data name="rabund" format="mothur.rabund" label="${tool.name} on ${on_string}: rabund (Rank Abundance)">
+            <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
+            <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
+            <filter>cluster</filter>
         </data>
-        <data name="sabund" format="mothur.sabund" from_work_dir="out.splitby.sabund" label="${tool.name} on ${on_string}: sabund (Species Abundance)">
-             <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
-             <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
+        <data name="sabund" format="mothur.sabund" label="${tool.name} on ${on_string}: sabund (Species Abundance)">
+            <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
+            <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
+            <filter>cluster</filter>
         </data>
-        <data name="otulist" format="mothur.list" from_work_dir="out.splitby.list" label="${tool.name} on ${on_string}: list (OTU List)"/>
+        <data name="otulist" format="mothur.list" label="${tool.name} on ${on_string}: list (OTU List)">
+            <filter>cluster</filter>
+        </data>
         <collection name="splitdist" type="list" label="${tool.name} on ${on_string}: split dist">
             <filter>not cluster</filter>
             <discover_datasets pattern=".*?\.column\.dist\.(?P&lt;designation&gt;.*)\.temp" format="mothur.dist"/>
@@ -213,10 +218,10 @@ echo 'cluster.split(
             <filter>not cluster</filter>
             <discover_datasets pattern=".*?\.names\.(?P&lt;designation&gt;.*)\.temp" format="mothur.names"/>
         </collection>
-        <data name="splitfile" format="txt" from_work_dir="out.splitby.file" label="${tool.name} on ${on_string}: split.file">
+        <data name="splitfile" format="txt" label="${tool.name} on ${on_string}: split.file">
             <filter>not cluster</filter>
         </data>
-        <data name="sensspec" format="txt" from_work_dir="out.splitby.sensspec" label="${tool.name} on ${on_string}: sensspec">
+        <data name="sensspec" format="txt" label="${tool.name} on ${on_string}: sensspec">
             <filter>runsensspec and splitby['condmethod']['method'] == "opti"</filter>
         </data>
     </outputs>

--- a/tools/mothur/cluster.split.xml
+++ b/tools/mothur/cluster.split.xml
@@ -90,6 +90,21 @@ echo 'cluster.split(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+#import glob
+&& cp splitby.*.list out.splitby.list
+#if glob.glob("splitby.*.rabund"):
+	&& cp splitby.*.rabund out.splitby.rabund
+#end if
+#if glob.glob("splitby.*.sabund"):
+	&& cp splitby.*.sabund out.splitby.sabund
+#end if
+#if not $cluster:
+	&& cp splitby.*.file out.splitby.file
+#end if
+#if glob.glob("splitby.*.sensspec"):
+	&& cp splitby.*.sensspec out.splitby.sensspec
+#end if
+
     ]]></command>
     <inputs>
         <conditional name="splitby">
@@ -181,15 +196,15 @@ echo 'cluster.split(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="rabund" format="mothur.rabund" from_work_dir="splitby.*.rabund" label="${tool.name} on ${on_string}: rabund (Rank Abundance)">
+        <data name="rabund" format="mothur.rabund" from_work_dir="out.splitby.rabund" label="${tool.name} on ${on_string}: rabund (Rank Abundance)">
              <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
              <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
         </data>
-        <data name="sabund" format="mothur.sabund" from_work_dir="splitby.*.sabund" label="${tool.name} on ${on_string}: sabund (Species Abundance)">
+        <data name="sabund" format="mothur.sabund" from_work_dir="out.splitby.sabund" label="${tool.name} on ${on_string}: sabund (Species Abundance)">
              <filter>splitby['nameOrCount'].ext != "mothur.count_table"</filter>
              <filter>splitby['matrix']['nameOrCount'].ext != "mothur.count_table"</filter>
         </data>
-        <data name="otulist" format="mothur.list" from_work_dir="splitby.*.list" label="${tool.name} on ${on_string}: list (OTU List)"/>
+        <data name="otulist" format="mothur.list" from_work_dir="out.splitby.list" label="${tool.name} on ${on_string}: list (OTU List)"/>
         <collection name="splitdist" type="list" label="${tool.name} on ${on_string}: split dist">
             <filter>not cluster</filter>
             <discover_datasets pattern=".*?\.column\.dist\.(?P&lt;designation&gt;.*)\.temp" format="mothur.dist"/>
@@ -198,10 +213,10 @@ echo 'cluster.split(
             <filter>not cluster</filter>
             <discover_datasets pattern=".*?\.names\.(?P&lt;designation&gt;.*)\.temp" format="mothur.names"/>
         </collection>
-        <data name="splitfile" format="txt" from_work_dir="splitby.*.file" label="${tool.name} on ${on_string}: split.file">
+        <data name="splitfile" format="txt" from_work_dir="out.splitby.file" label="${tool.name} on ${on_string}: split.file">
             <filter>not cluster</filter>
         </data>
-        <data name="sensspec" format="txt" from_work_dir="splitby.*.sensspec" label="${tool.name} on ${on_string}: sensspec">
+        <data name="sensspec" format="txt" from_work_dir="out.splitby.sensspec" label="${tool.name} on ${on_string}: sensspec">
             <filter>runsensspec and splitby['condmethod']['method'] == "opti"</filter>
         </data>
     </outputs>

--- a/tools/mothur/count.seqs.xml
+++ b/tools/mothur/count.seqs.xml
@@ -27,6 +27,7 @@ echo 'count.seqs(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+&& cp name*.count_table out.count_table
     ]]></command>
     <inputs>
         <param name="name" type="data" format="mothur.names" label="name - Sequences Name reference"/>
@@ -50,7 +51,7 @@ echo 'count.seqs(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="seq_count" format="mothur.count_table" from_work_dir="name*.count_table" label="${tool.name} on ${on_string}: count_table"/>
+        <data name="seq_count" format="mothur.count_table" from_work_dir="out.count_table" label="${tool.name} on ${on_string}: count_table"/>
     </outputs>
     <tests>
         <test><!-- test default params -->

--- a/tools/mothur/filter.seqs.xml
+++ b/tools/mothur/filter.seqs.xml
@@ -40,6 +40,11 @@ mv fasta.filter.fasta '${identifier}.filter.fasta'
     #set $identifier=re.sub('[^\w\-\s]', '_', str($i.fasta.element_identifier))
     && mv fasta${inputs.index($i)}.filter.fasta '${identifier}.filter.fasta'
 #end for
+#if not $inputs:
+	&& cp *.filter.fasta out.filter.fasta
+#end if
+&& cp fasta*.filter fasta.out.filter
+
     ]]></command>
     <inputs>
         <param name="fasta" type="data" format="mothur.align" label="fasta - Alignment Fasta"/>
@@ -63,12 +68,12 @@ mv fasta.filter.fasta '${identifier}.filter.fasta'
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="out_filter" format="mothur.filter" from_work_dir="fasta*.filter" label="${tool.name} on ${on_string}: filter"/>
+        <data name="out_filter" format="mothur.filter" from_work_dir="fasta.out.filter" label="${tool.name} on ${on_string}: filter"/>
         <collection name="filteredfastas" type="list" label="${tool.name} on ${on_string}: filtered fastas">
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.filter\.fasta" format="fasta"/>
             <filter>inputs</filter> <!-- only output collection if multiple outputs-->
         </collection>
-        <data name="filteredfasta" format="fasta" from_work_dir="*.filter.fasta" label="${tool.name} on ${on_string}: filtered fasta">
+        <data name="filteredfasta" format="fasta" from_work_dir="out.filter.fasta" label="${tool.name} on ${on_string}: filtered fasta">
             <filter>not inputs</filter>
         </data>
     </outputs>

--- a/tools/mothur/make.group.xml
+++ b/tools/mothur/make.group.xml
@@ -38,6 +38,8 @@ echo 'make.group(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+&&
+cp *groups out.group
     ]]></command>
     <inputs>
         <conditional name="method">
@@ -60,7 +62,7 @@ echo 'make.group(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="output" format="mothur.groups" from_work_dir="*groups" label="${tool.name} on ${on_string}: group"/>
+        <data name="output" format="mothur.groups" from_work_dir="out.group" label="${tool.name} on ${on_string}: group"/>
     </outputs>
     <tests>
         <test> <!-- test manual groups creation -->

--- a/tools/mothur/make.shared.xml
+++ b/tools/mothur/make.shared.xml
@@ -38,11 +38,16 @@ echo 'make.shared(
 | tee mothur.out.log &&
 
 ## move output files to correct destination
-mv mothur.*.logfile "$logfile" &&
+mv mothur.*.logfile "$logfile"
+
+&& cp intype_otu*.shared out.intype_otu.shared
+#if $intype['group'].ext == "mothur.groups":
+	&& intype_otu*.groups out.intype_otu.groups
+#end if
 #if $intype.infile == 'otulist' and $intype.groups:
-    mv intype_otu*.groups "$groupout"
+    && mv intype_otu*.groups "$groupout"
 #else
-    mv intype_otu*.shared "$shared"
+    && mv intype_otu*.shared "$shared"
 #end if
     ]]></command>
     <inputs>
@@ -71,8 +76,8 @@ mv mothur.*.logfile "$logfile" &&
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="shared" format="mothur.shared" from_work_dir="intype_otu*.shared" label="${tool.name} on ${on_string}: shared"/>
-        <data name="groupout" format="mothur.groups" from_work_dir="intype_otu*.groups" label="${tool.name} on ${on_string}: groups">
+        <data name="shared" format="mothur.shared" from_work_dir="out.intype_otu.shared" label="${tool.name} on ${on_string}: shared"/>
+        <data name="groupout" format="mothur.groups" from_work_dir="out.intype_otu.groups" label="${tool.name} on ${on_string}: groups">
             <filter>intype['group'].ext == "mothur.groups"</filter>
         </data>
         <collection name="labelshares" type="list" label="${tool.name} on ${on_string}: share files per label">

--- a/tools/mothur/pre.cluster.xml
+++ b/tools/mothur/pre.cluster.xml
@@ -39,6 +39,15 @@ echo 'pre.cluster(
 cat fasta* &&
 
 if [ -f fasta.precluster.map ]; then mv fasta.precluster.map fasta.precluster.fasta.map; fi
+
+&& cp fasta*.precluster.dat out.fasta.precluster.dat
+
+#if $name.ext != "mothur.count_table":
+	&& cp fasta*.precluster.names out.fasta.precluster.names
+#end if
+#if $name.ext == "mothur.count_table":
+	&& cp fasta*.precluster.count_table out.fasta.precluster.count_table
+#end if
     ]]></command>
     <inputs>
         <param argument="fasta" type="data" format="fasta" label="fasta - Sequence Fasta"/>
@@ -55,11 +64,11 @@ if [ -f fasta.precluster.map ]; then mv fasta.precluster.map fasta.precluster.fa
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="fasta_out" format_source="fasta" from_work_dir="fasta*.precluster.dat" label="${tool.name} on ${on_string}: precluster.fasta"/>
-        <data name="names_out" format="mothur.names" from_work_dir="fasta*.precluster.names" label="${tool.name} on ${on_string}: precluster.names">
+        <data name="fasta_out" format_source="fasta" from_work_dir="out.fasta.precluster.dat" label="${tool.name} on ${on_string}: precluster.fasta"/>
+        <data name="names_out" format="mothur.names" from_work_dir="out.fasta.precluster.names" label="${tool.name} on ${on_string}: precluster.names">
             <filter>name.ext != "mothur.count_table"</filter>
         </data>
-        <data name="count_out" format="mothur.count_table" from_work_dir="fasta*.precluster.count_table" label="${tool.name} on ${on_string}: precluster.count_table">
+        <data name="count_out" format="mothur.count_table" from_work_dir="out.fasta.precluster.count_table" label="${tool.name} on ${on_string}: precluster.count_table">
             <filter>name.ext == "mothur.count_table"</filter>
         </data>
         <collection name="map_out" type="list" label="${tool.name} on ${on_string}: precluster.map">

--- a/tools/mothur/screen.seqs.xml
+++ b/tools/mothur/screen.seqs.xml
@@ -86,6 +86,24 @@ echo 'screen.seqs(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+&& cp fasta*.good.dat out.good.dat
+&& cp fasta*.bad.accnos out.bad.accnos
+
+#if $qfile:
+	&& cp qfile*.good.dat out.qfile.good.dat
+#end if
+
+#if $names:
+	&& cp names*.good.dat out.names.good.dat
+#end if
+
+#if $groups:
+	&& cp groups*.good.dat out.groups.good.dat
+#end if
+
+#if $count:
+	&& cp count*.good.dat out.count.good.dat
+#end if
     ]]></command>
     <inputs>
         <param argument="fasta" type="data" format="fasta,mothur.align" label="fasta - Fasta to screen"/>
@@ -145,24 +163,24 @@ echo 'screen.seqs(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="fasta_out" format_source="fasta" from_work_dir="fasta*.good.dat" label="${tool.name} on ${on_string}: good.${fasta.datatype.file_ext}"/>
-        <data name="bad_accnos" format="mothur.accnos" from_work_dir="fasta*.bad.accnos" label="${tool.name} on ${on_string}: bad.accnos"/>
-        <data name="qfile_out" format_source="qfile" from_work_dir="qfile*.good.dat" label="${tool.name} on ${on_string}: qfile">
+        <data name="fasta_out" format_source="fasta" from_work_dir="out.good.dat" label="${tool.name} on ${on_string}: good.${fasta.datatype.file_ext}"/>
+        <data name="bad_accnos" format="mothur.accnos" from_work_dir="out.bad.accnos" label="${tool.name} on ${on_string}: bad.accnos"/>
+        <data name="qfile_out" format_source="qfile" from_work_dir="out.qfile.good.dat" label="${tool.name} on ${on_string}: qfile">
             <filter>qfile</filter>
         </data>
-        <data name="names_out" format="mothur.names" from_work_dir="names*.good.dat" label="${tool.name} on ${on_string}: names">
+        <data name="names_out" format="mothur.names" from_work_dir="out.names.good.dat" label="${tool.name} on ${on_string}: names">
             <filter>names</filter>
         </data>
-        <data name="groups_out" format="mothur.groups" from_work_dir="groups*.good.dat" label="${tool.name} on ${on_string}: groups">
+        <data name="groups_out" format="mothur.groups" from_work_dir="out.groups.good.dat" label="${tool.name} on ${on_string}: groups">
             <filter>groups</filter>
         </data>
         <data name="alignreport_out" format="mothur.align.report" from_work_dir="alignreport.good.align.report" label="${tool.name} on ${on_string}: align.report">
-            <filter>alignrep.alignreport</filter>
+            <filter> alignrep['usealign'] == "yes" </filter>
         </data>
         <data name="contigsreport_out" format="tabular" from_work_dir="contigsreport.good.contigs.report" label="${tool.name} on ${on_string}: contigs.report">
-            <filter>contigsrep.contigsreport</filter>
+            <filter> contigsrep['usecontigs'] == "yes" </filter>
         </data>
-        <data name="count_out" format="mothur.count_table" from_work_dir="count*.good.dat" label="${tool.name} on ${on_string}: count">
+        <data name="count_out" format="mothur.count_table" from_work_dir="out.count.good.dat" label="${tool.name} on ${on_string}: count">
             <filter>count</filter>
         </data>
     </outputs>

--- a/tools/mothur/summary.seqs.xml
+++ b/tools/mothur/summary.seqs.xml
@@ -27,6 +27,7 @@ echo 'summary.seqs(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+&& cp fasta*.summary out.summary
     ]]></command>
     <inputs>
         <param name="fasta" type="data" format="fasta,mothur.align" label="fasta - Dataset"/>
@@ -36,7 +37,7 @@ echo 'summary.seqs(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="out_summary" format="mothur.summary" from_work_dir="fasta*.summary" label="${tool.name} on ${on_string}: summary"/>
+        <data name="out_summary" format="mothur.summary" from_work_dir="out.summary" label="${tool.name} on ${on_string}: summary"/>
     </outputs>
     <tests>
         <test>

--- a/tools/mothur/unique.seqs.xml
+++ b/tools/mothur/unique.seqs.xml
@@ -25,6 +25,12 @@ echo 'unique.seqs(
 | sed 's/ //g'  ## mothur trips over whitespace
 | mothur
 | tee mothur.out.log
+&& cp fasta*.unique.* out.unique
+#if $format == "name":
+	&& cp fasta*.names out.names
+#elif $format == "count":
+	&& cp fasta*.count_table out.count_table
+#end if
     ]]></command>
     <inputs>
         <param name="fasta" type="data" format="fasta" label="fasta - Sequences to filter"/>
@@ -37,11 +43,11 @@ echo 'unique.seqs(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <data name="out_fasta" format_source="fasta" from_work_dir="fasta*.unique.*" label="${tool.name} on ${on_string}: fasta"/>
-        <data name="out_names" format="mothur.names" from_work_dir="fasta*.names" label="${tool.name} on ${on_string}: names">
+        <data name="out_fasta" format_source="fasta" from_work_dir="out.unique" label="${tool.name} on ${on_string}: fasta"/>
+        <data name="out_names" format="mothur.names" from_work_dir="out.names" label="${tool.name} on ${on_string}: names">
             <filter> format == "name" </filter>
         </data>
-        <data name="out_count" format="mothur.count_table" from_work_dir="fasta*.count_table" label="${tool.name} on ${on_string}: count_table">
+        <data name="out_count" format="mothur.count_table" from_work_dir="out.count_table" label="${tool.name} on ${on_string}: count_table">
             <filter> format == "count" </filter>
         </data>
     </outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This is mainly a WIP to get some of the mothur tools to work under pulsar. Pulsar can't collect outputs with wildcards in the filenames. I've only changed the tools used in the mothur soil sample GTN tutorial.

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
