### PR TITLE
cutadapt: removed duplicate dollar

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -133,7 +133,7 @@ $read_mod_options.trim_n
     --suffix="$read_mod_options.suffix"
 #end if
 #if str($read_mod_options.length) != '0':
-    --length=$$read_mod_options.length
+    --length=$read_mod_options.length
 #end if
 #if $read_mod_options.length_tag != '':
     --length-tag="$read_mod_options.length_tag"


### PR DESCRIPTION
minor bugfix

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
