### PR TITLE
jbrowse: track type Bigwig defaults to autoscale "local"

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -526,8 +526,8 @@ $trackxml &&
 
                 <conditional name="scaling" label="Scaling">
                     <param type="select" label="Track Scaling" name="scale_select">
-                        <option value="auto_local">Autoscale (local)</option>
-                        <option value="auto_global" selected="true">Autoscale (global)</option>
+                        <option value="auto_local" selected="true">Autoscale (local)</option>
+                        <option value="auto_global">Autoscale (global)</option>
                         <option value="fixed">Specify Min/Max</option>
                     </param>
                     <when value="auto_local"></when>

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -13,7 +13,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy1</token>
+  <token name="@WRAPPER_VERSION@">galaxy2</token>
   <xml name="stdio">
     <stdio>
       <exit_code range="1:"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

Fix https://github.com/galaxyproject/tools-iuc/issues/2174