### PR TITLE
Upgraded shovill to version 1.0.4, including multiple assembler support

### DIFF
--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -1,7 +1,7 @@
-<tool id="shovill" name="Shovill" version="0.9.0">
+<tool id="shovill" name="Shovill" version="1.0.4">
     <description>Faster SPAdes assembly of Illumina reads</description>
     <requirements>
-        <requirement type="package" version="0.9.0">shovill</requirement>
+        <requirement type="package" version="1.0.4">shovill</requirement>
     </requirements>
     <version_command>shovill --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
@@ -31,7 +31,7 @@
             $adv.nocorr
             --minlen $adv.minlen
             --mincov $adv.mincov
-            --asm $adv.asm
+            --assembler $assembler
 
     ]]></command>
     <inputs>
@@ -50,6 +50,12 @@
         </conditional>
         <param name="trim" argument="--trim" type="boolean" truevalue="--trim" falsevalue="" label="Trim reads" help="Use Trimmomatic to remove common adaptors first (default: OFF)" />
         <param name="log" type="boolean" label="Output log file?" checked="true" help="Return the Shovill log file as part of the output. Default is on" />
+        <param name="assembler" arguement="--assembler" type="select" label="Assembler to use" help="Which assembler would you like shovill to use, default is Spades">
+            <option value="skesa">skesa</option>
+            <option value="megahit">megahit</option>
+            <option value="velvet">velvet</option>
+            <option value="spades" selected="true">Spades</option>
+        </param>
         <section name="adv" title="Advanced options" expanded="False">
             <param name="namefmt" argument="--namefmt" type="text" value="contig%05d" label="Contig name format" help="Format of contig FASTA IDs in 'printf' style (default: 'contig%05d')" >
                 <sanitizer>
@@ -68,16 +74,11 @@
             <param name="nocorr" argument="--nocorr" type="boolean" truevalue="--nocorr" falsevalue="" checked="True" label="Disable post-assembly correction" help="Disable post assembly correction with pilon (default: ON)" />
             <param name="minlen" argument="--minlen" type="integer" value="0" label="Minimum contig length" help="Minimum length of contig to be output. 0 is AUTO (default: 0)" />
             <param name="mincov" argument="--mincov" type="integer" value="2" label="Minimum contig coverage" help="Minimum coverage to call part of a contig. 0 is AUTO (default: 2)" />
-            <param name="asm" argument="--asm" type="select" label="Spades result to correct" help="Which SPAdes output to correct for: before_rr, contigs or scaffolds. (default: 'contigs')">
-                <option value="before_rr">before_rr</option>
-                <option value="contigs" selected="true">contigs</option>
-                <option value="scaffolds">scaffolds</option>
-            </param>
         </section>
     </inputs>
 
     <outputs>
-        <data name="shovill_std_log" format="txt" label="${tool.name} on ${on_string} Log file" from_work_dir="out/00-shovill.log" >
+        <data name="shovill_std_log" format="txt" label="${tool.name} on ${on_string} Log file" from_work_dir="out/shovill.log" >
             <filter>log</filter>
         </data>
         <data format="fasta" name="contigs" label="${tool.name} on ${on_string}: Contigs" from_work_dir="out/contigs.fa"/>
@@ -85,7 +86,7 @@
     </outputs>
 
     <tests>
-        <test> <!-- Test 0: Basic test -->
+        <test> <!-- Test 1: Basic test -->
             <param name="lib_type" value="paired" />
             <param name="R1" value="mutant_R1.fastq" ftype="fastqsanger" />
             <param name="R2" value="mutant_R2.fastq" ftype="fastqsanger" />
@@ -96,17 +97,14 @@
             </output>
             <output name="shovill_std_log" ftype="txt" >
                 <assert_contents>
-                    <has_text text="Running: seqtk"/>
-                    <has_text text="Running: kmc"/>
-                    <has_text text="Running: lighter"/>
-                    <has_text text="User supplied --nocorr"/>
-                    <has_text text="Running: flash"/>
-                    <has_text text="Running: spades"/>
-                    <has_text text="Done."/>
+                    <has_text text="[mash]"/>
+                    <has_text text="[lighter] Processed 24960 reads"/>
+                    <has_text text="[FLASH] FLASH v1.2.11 complete!"/>
+                    <has_text text="[spades] ======= SPAdes pipeline finished."/>
                 </assert_contents>
             </output>
         </test>
-        <test> <!-- Test 1: Auto everything + trim + different name format test -->
+        <test> <!-- Test 2: Auto everything + trim + different name format test -->
             <param name="lib_type" value="paired" />
             <param name="R1" value="mutant_R1.fastq" ftype="fastqsanger" />
             <param name="R2" value="mutant_R2.fastq" ftype="fastqsanger" />
@@ -125,16 +123,71 @@
             </output>
             <output name="shovill_std_log" ftype="txt" >
                 <assert_contents>
-                    <has_text text="Running: seqtk"/>
-                    <has_text text="Running: kmc"/>
-                    <has_text_matching expression="Running:\s+\S+\s+trimmomatic"/>
-                    <has_text text="Running: lighter"/>
-                    <has_text text="Running: flash"/>
-                    <has_text text="Running: spades"/>
-                    <has_text text="Running: bwa index"/>
-                    <has_text text="Running: (bwa mem"/>
-                    <has_text text="Running: _JAVA"/>
-                    <has_text text="Done."/>
+                    <has_text text="[mash] Writing to"/>
+                    <has_text text="[trimmomatic] TrimmomaticPE: Completed successfully"/>
+                    <has_text text="[lighter] Processed 24960 reads:"/>
+                    <has_text text="[FLASH] FLASH v1.2.11 complete!"/>
+                    <has_text text="[spades] ======= SPAdes pipeline finished."/>
+                    <has_text text="[bwa+samtools-sort] [samclip] Done."/>
+                    <has_text text="[pilon] Mean total coverage:"/>
+                    <has_text text="[shovill] Done."/>
+                </assert_contents>
+            </output>
+        </test>
+        <test> <!-- Test 3: Alternate assembler #1: Megahit -->
+            <param name="lib_type" value="paired" />
+            <param name="R1" value="mutant_R1.fastq" ftype="fastqsanger" />
+            <param name="R2" value="mutant_R2.fastq" ftype="fastqsanger" />
+            <param name="assembler" value="megahit" />
+            <output name="contigs" ftype="fasta">
+                <assert_contents>
+                    <has_text text="&gt;contig00001"/>
+                </assert_contents>
+            </output>
+            <output name="shovill_std_log" ftype="txt" >
+                <assert_contents>
+                    <has_text text="[mash]"/>
+                    <has_text text="[lighter] Processed 24960 reads"/>
+                    <has_text text="[FLASH] FLASH v1.2.11 complete!"/>
+                    <has_text text="[megahit] --- [STAT]"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test> <!-- Test 4: Alternate assembler #2: Skesa -->
+            <param name="lib_type" value="paired" />
+            <param name="R1" value="mutant_R1.fastq" ftype="fastqsanger" />
+            <param name="R2" value="mutant_R2.fastq" ftype="fastqsanger" />
+            <param name="assembler" value="skesa" />
+            <output name="contigs" ftype="fasta">
+                <assert_contents>
+                    <has_text text="&gt;contig00001"/>
+                </assert_contents>
+            </output>
+            <output name="shovill_std_log" ftype="txt" >
+                <assert_contents>
+                    <has_text text="[mash]"/>
+                    <has_text text="[lighter] Processed 24960 reads"/>
+                    <has_text text="[FLASH] FLASH v1.2.11 complete!"/>
+                    <has_text text="[skesa] DONE"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test> <!-- Test 5: Alternate assembler #3: Velvet -->
+            <param name="lib_type" value="paired" />
+            <param name="R1" value="mutant_R1.fastq" ftype="fastqsanger" />
+            <param name="R2" value="mutant_R2.fastq" ftype="fastqsanger" />
+            <param name="assembler" value="velvet" />
+            <output name="contigs" ftype="fasta">
+                <assert_contents>
+                    <has_text text="&gt;contig00001"/>
+                </assert_contents>
+            </output>
+            <output name="shovill_std_log" ftype="txt" >
+                <assert_contents>
+                    <has_text text="[mash]"/>
+                    <has_text text="[lighter] Processed 24960 reads"/>
+                    <has_text text="[FLASH] FLASH v1.2.11 complete!"/>
+                    <has_text text="[velvetg] Final graph has"/>
                 </assert_contents>
             </output>
         </test>
@@ -147,6 +200,7 @@ Details and options:
     - Takes paired end Illumina fastq reads
     - Trim reads:   Use Trimmomatic to remove common adaptors first (default: OFF)
     - Output log file:  If set to "Yes", tool will return Shovill's log file as part of the output
+    - Assembler:    Which assembler should shovill use from: Skesa, Megahit, Velvet or Spades. Spades is the default.
 
 Advanced options:
     - Name format:          Format of output contig FASTA IDs in 'printf' style (default: 'contig%05d')

--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -50,7 +50,7 @@
         </conditional>
         <param name="trim" argument="--trim" type="boolean" truevalue="--trim" falsevalue="" label="Trim reads" help="Use Trimmomatic to remove common adaptors first (default: OFF)" />
         <param name="log" type="boolean" label="Output log file?" checked="true" help="Return the Shovill log file as part of the output. Default is on" />
-        <param name="assembler" arguement="--assembler" type="select" label="Assembler to use" help="Which assembler would you like shovill to use, default is Spades">
+        <param name="assembler" argument="--assembler" type="select" label="Assembler to use" help="Which assembler would you like shovill to use, default is Spades">
             <option value="skesa">skesa</option>
             <option value="megahit">megahit</option>
             <option value="velvet">velvet</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This new version of Shovill adds support for multiple assemblers including: Spades, Velvet, Skesa and Megahit.

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
