### PR TITLE
 DESeq2: estimatesizefactors, vst normalization and rlog normalization

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -58,7 +58,7 @@ spec <- matrix(c(
   "tximport", "i", 0, "logical",
   "txtype", "y", 1, "character",
   "tx2gene", "x", 1, "character", # a space-sep tx-to-gene map or GTF file (auto detect .gtf/.GTF)
-  "esf", "e", 0, "character",
+  "esf", "e", 1, "character",
   "fit_type", "t", 1, "integer",
   "many_contrasts", "m", 0, "logical",
   "outlier_replace_off" , "a", 0, "logical",

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -291,19 +291,14 @@ if (!is.null(opt$countsfile)) {
 }
 
 if (!is.null(opt$rlogfile)) {
-    print("rlogTransformation")
-    labs <- paste0(seq_len(ncol(dds)), ": ", do.call(paste, as.list(colData(dds)[factors])))
     rLogNormalized <-rlogTransformation(dds)
     rLogNormalizedMat <- assay(rLogNormalized)
-    colnames(rLogNormalizedMat) <- labs
     write.table(rLogNormalizedMat, file=opt$rlogfile, sep="\t", col.names=NA, quote=FALSE)
 }
 
 if (!is.null(opt$vstfile)) {
-    labs <- paste0(seq_len(ncol(dds)), ": ", do.call(paste, as.list(colData(dds)[factors])))
     vstNormalized<-varianceStabilizingTransformation(dds)
     vstNormalizedMat <- assay(vstNormalized)
-    colnames(vstNormalizedMat)<-labs
     write.table(vstNormalizedMat, file=opt$vstfile, sep="\t", col.names=NA, quote=FALSE)
 }
 

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -215,7 +215,7 @@ Rscript '${__tool_directory__}/deseq2.R'
     </outputs>
     <tests>
         <!--Ensure counts files with header works -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="4">
             <repeat name="rep_factorName">
                 <param name="factorName" value="Treatment"/>
                 <repeat name="rep_factorLevel">
@@ -246,7 +246,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <output name="vst_out">
                 <assert_contents>
                     <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*" />
                 </assert_contents>
             </output>
             <output name="deseq_out" >
@@ -278,7 +278,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             </output>
         </test>
         <!--Ensure counts files without header works -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="4">
             <repeat name="rep_factorName">
                 <param name="factorName" value="Treatment"/>
                 <repeat name="rep_factorLevel">
@@ -310,7 +310,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <output name="vst_out">
                 <assert_contents>
                     <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*" />
                 </assert_contents>
             </output>
             <output name="deseq_out" >

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -43,6 +43,12 @@ Rscript '${__tool_directory__}/deseq2.R'
     #if $normCounts:
         -n '$counts_out'
     #end if
+    #if $normRLog:
+        -r '$rlog_out'
+    #end if
+    #if $normVST:
+        -v '$vst_out'
+    #end if
     #set $filename_to_element_identifiers = {}
     #set $temp_factor_names = list()
     #for $factor in $rep_factorName:
@@ -63,6 +69,9 @@ Rscript '${__tool_directory__}/deseq2.R'
 
     -f '#echo json.dumps(temp_factor_names)#'
     -l '#echo json.dumps(filename_to_element_identifiers)#'
+    #if $esf:
+        -e $esf
+    #end if
     -t $fit_type
     #if $batch_factors
         --batch_factors '$batch_factors'
@@ -142,9 +151,26 @@ Rscript '${__tool_directory__}/deseq2.R'
             help="output an additional PDF files" />
         <param name="normCounts" type="boolean" truevalue="1" falsevalue="0" checked="false"
             label="Output normalized counts table" />
+        <param name="normRLog" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            label="Output rLog normalized table" />
+        <param name="normVST" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            label="Output VST normalized table" />
         <param name="many_contrasts" type="boolean" truevalue="1" falsevalue="0" checked="false"
             label="Output all levels vs all levels of primary factor (use when you have >2 levels for primary factor)"
             help=" DESeq2 performs independent ﬁltering by default using the mean of normalized counts as a ﬁlter statistic" />
+        <param name="esf" type="select" label="Method for estimateSizeFactors" 
+            help="Method for estimation: either 'ratio', 'poscounts', or 'iterate'. 'ratio' uses the standard median ratio method introduced in DESeq. 
+                The size factor is the median ratio of the sample over a 'pseudosample': for each gene, the geometric mean of all samples. 
+                'poscounts' and 'iterate' offer alternative estimators, which can be used even when all genes contain a sample with a zero (a problem 
+                for the default method, as the geometric mean becomes zero, and the ratio undefined). The 'poscounts' estimator deals with a gene with 
+                some zeros, by calculating a modified geometric mean by taking the n-th root of the product of the non-zero counts. This evolved out of 
+                use cases with Paul McMurdie's phyloseq package for metagenomic samples. The 'iterate' estimator iterates between estimating the dispersion 
+                with a design of ~1, and finding a size factor vector by numerically optimizing the likelihood of the ~1 model.">
+            <option value="" selected="true">No Selection (use default)</option>
+            <option value="ratio">ratio</option>
+            <option value="poscounts">poscounts</option>
+            <option value="iterate">iterate</option>
+        </param>
         <param name="fit_type" type="select" label="Fit type">
             <option value="1" selected="true">parametric</option>
             <option value="2">local</option>
@@ -179,6 +205,12 @@ Rscript '${__tool_directory__}/deseq2.R'
         </data>
         <data format="tabular" name="counts_out" label="Normalized counts file on ${on_string}">
             <filter>normCounts == True</filter>
+        </data>
+        <data format="tabular" name="rlog_out" label="rLog-Normalized file on ${on_string}">
+            <filter>normRLog == True</filter>
+        </data>
+        <data format="tabular" name="vst_out" label="VST-Normalized file on ${on_string}">
+            <filter>normVST == True</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -237,12 +237,6 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
                 </assert_contents>
             </output>
-            <output name="counts_out">
-                <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
-                </assert_contents>
-            </output>
             <output name="rlog_out">
                 <assert_contents>
                     <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -158,7 +158,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         <param name="many_contrasts" type="boolean" truevalue="1" falsevalue="0" checked="false"
             label="Output all levels vs all levels of primary factor (use when you have >2 levels for primary factor)"
             help=" DESeq2 performs independent ﬁltering by default using the mean of normalized counts as a ﬁlter statistic" />
-        <param name="esf" type="select" label="Method for estimateSizeFactors" 
+        <param name="esf" type="select" label="(optional) Method for estimateSizeFactors" 
             help="Method for estimation: either 'ratio', 'poscounts', or 'iterate'. 'ratio' uses the standard median ratio method introduced in DESeq. 
                 The size factor is the median ratio of the sample over a 'pseudosample': for each gene, the geometric mean of all samples. 
                 'poscounts' and 'iterate' offer alternative estimators, which can be used even when all genes contain a sample with a zero (a problem 

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -303,13 +303,13 @@ Rscript '${__tool_directory__}/deseq2.R'
             </output>
             <output name="rlog_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
                     <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
                 </assert_contents>
             </output>
             <output name="vst_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
                     <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*" />
                 </assert_contents>
             </output>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -73,7 +73,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         -e $esf
     #end if
     -t $fit_type
-    #if $batch_factors
+    #if $batch_factors:
         --batch_factors '$batch_factors'
     #end if
     #if $outlier_replace_off:
@@ -158,7 +158,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         <param name="many_contrasts" type="boolean" truevalue="1" falsevalue="0" checked="false"
             label="Output all levels vs all levels of primary factor (use when you have >2 levels for primary factor)"
             help=" DESeq2 performs independent ﬁltering by default using the mean of normalized counts as a ﬁlter statistic" />
-        <param name="esf" type="select" label="(optional) Method for estimateSizeFactors" 
+        <param name="esf" type="select" label="(Optional) Method for estimateSizeFactors" 
             help="Method for estimation: either 'ratio', 'poscounts', or 'iterate'. 'ratio' uses the standard median ratio method introduced in DESeq. 
                 The size factor is the median ratio of the sample over a 'pseudosample': for each gene, the geometric mean of all samples. 
                 'poscounts' and 'iterate' offer alternative estimators, which can be used even when all genes contain a sample with a zero (a problem 

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -206,10 +206,10 @@ Rscript '${__tool_directory__}/deseq2.R'
         <data format="tabular" name="counts_out" label="Normalized counts file on ${on_string}">
             <filter>normCounts == True</filter>
         </data>
-        <data format="tabular" name="rlog_out" label="rLog-Normalized file on ${on_string}">
+        <data format="tabular" name="rlog_out" label="rLog-Normalized counts file on ${on_string}">
             <filter>normRLog == True</filter>
         </data>
-        <data format="tabular" name="vst_out" label="VST-Normalized file on ${on_string}">
+        <data format="tabular" name="vst_out" label="VST-Normalized counts file on ${on_string}">
             <filter>normVST == True</filter>
         </data>
     </outputs>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -1,4 +1,4 @@
-<tool id="deseq2" name="DESeq2" version="2.11.40.2">
+<tool id="deseq2" name="DESeq2" version="2.11.40.3">
     <description>Determines differentially expressed features from count tables</description>
     <requirements>
         <requirement type="package" version="1.18.1">bioconductor-deseq2</requirement>
@@ -229,7 +229,27 @@ Rscript '${__tool_directory__}/deseq2.R'
             </repeat>
             <param name="pdf" value="False"/>
             <param name="normCounts" value="True"/>
+            <param name="normRLog" value="True"/>
+            <param name="normVST" value="True"/>
             <output name="counts_out">
+                <assert_contents>
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                </assert_contents>
+            </output>
+            <output name="counts_out">
+                <assert_contents>
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                </assert_contents>
+            </output>
+            <output name="rlog_out">
+                <assert_contents>
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                </assert_contents>
+            </output>
+            <output name="vst_out">
                 <assert_contents>
                     <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
                     <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
@@ -279,9 +299,23 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="header" value="False"/>
             <param name="pdf" value="False"/>
             <param name="normCounts" value="True"/>
+            <param name="normRLog" value="True"/>
+            <param name="normVST" value="True"/>
             <output name="counts_out">
                 <assert_contents>
                     <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                </assert_contents>
+            </output>
+            <output name="rlog_out">
+                <assert_contents>
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                </assert_contents>
+            </output>
+            <output name="vst_out">
+                <assert_contents>
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
                     <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
                 </assert_contents>
             </output>


### PR DESCRIPTION
This pull request add additional features for deseq2 wrapper such as choosing method for estimatesizefactors, generate vst normalization file and rlog normalization file. Changing method for estimateSizeFactor will be helpful when the user gets error message like `Error in estimateSizeFactorsForMatrix(counts(object), locfunc = locfunc,  : every gene contains at least one zero, cannot compute log geometric means`. 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
