### PR TITLE
hisat2: fix failing when -k is unspecified

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -290,7 +290,9 @@ hisat2
 ## Reporting options
 
 #if str($adv.reporting_options.reporting_options_selector) == "advanced":
-    -k ${adv.reporting_options.max_primary}
+    #if str($adv.reporting_options.max_primary) != '':
+        -k ${adv.reporting_options.max_primary}
+    #end if
 #end if
 
 
@@ -613,6 +615,7 @@ hisat2
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
+            <param name="adv|reporting_options|reporting_options_selector" value="advanced"/>
             <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
         </test>
         <!-- Ensure advanced scoring options work -->


### PR DESCRIPTION
If a user choses the advanced reporting options (eg just to check which options are available) and does not specify a value for `-k` then hisat crashed. 

The crashing behaviour was quite odd 

hisat reports: `(ERR): hisat2-align exited with value 1`

but the hisat2 perl wrapper and samtools were still running with 0 CPU load. 


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
