### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@ tools/jq/*                       @erasche
 tools/hmmer3/*                   @erasche
 tools/progressivemauve/*         @erasche
 tools/ncbi_entrez_eutils/*       @erasche
+tools/mothur/*                   @shiltemann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# See documentation here:
+# https://blog.github.com/2017-07-06-introducing-code-owners/
+
+tools/art/*                      @erasche
+tools/circos/*                   @erasche @shiltemann
+tools/jbrowse/*                  @erasche @abretaud
+tools/blastxml_to_gapped_gff3/*  @erasche
+tools/gff3_rebase/*              @erasche
+tools/jq/*                       @erasche
+tools/hmmer3/*                   @erasche
+tools/progressivemauve/*         @erasche
+tools/ncbi_entrez_eutils/*       @erasche


### PR DESCRIPTION
I've added a CODEOWNERS file pinging myself (and @shiltemann / @abretaud for a couple of things)

This will automatically request our reviews when someone makes changes to the specified folders. I want this because a new contributor's PR (#2175) went unnoticed for 10 days because I missed it. With a review request, it is a lot harder for me to miss.

In IUC there is a strong sense of code ownership, I think I would like to know if people make modifications to tools I've developed and to have discussions with them regarding their modifications.

This is completely opt-in, if you don't want reviews requested, you don't have to use this feature at all, this is just for me for now.
