### PR TITLE
[WIP] RaceID with LOOM support

### DIFF
--- a/tools/raceid/scripts/loomconverter.R
+++ b/tools/raceid/scripts/loomconverter.R
@@ -1,0 +1,68 @@
+library(devtools)
+
+## Install these
+## devtools::install_github(repo = "hhoeflin/hdf5r")
+## devtools::install_github(repo = "mojaveazure/loomR", ref = "develop")
+
+library(loomR)
+library(RaceID)
+
+## Pull an R object
+
+## This R object is NOT an SC object but an object that CONTAINS sc
+## Realistically, when moving out of the filter stage, the R object should just be an SC object.
+##rdat <- readRDS('out_traject_default.ltree.rdat')
+
+## This is an SCSeq object (specific to RaceID3)
+sc <- readRDS('matrix.filter.rdat')
+
+lc <- loomR::create("test3.loom", data=sc@expdata)
+#lc <- loomR::connect("test.loom", mode='r+')
+
+## Create a layer that matches the dimensions of the raw_matrix
+makeLayer <- function(mat.raw, mat.layer){
+    ##
+    ## Make a blank matrix of raw size with same names ##
+    ##
+    mat.new <- matrix(-Inf, nrow=nrow(mat.raw), ncol=ncol(mat.raw))
+    rownames(mat.new) <- rownames(mat.raw)
+    colnames(mat.new) <- colnames(mat.raw)
+    ##
+    ## Check that layer hasn't any new genes or cells
+    ##
+    if (sum(rownames(mat.layer) %in% rownames(mat.new)) != nrow(mat.layer)){
+        message("Layer has new features not present in raw_matrix")
+    }
+    if (sum(colnames(mat.layer) %in% colnames(mat.new)) != ncol(mat.layer)){
+        message("Layer has new cells not present in raw_matrix")
+    }
+    ##
+    ## Replace all cell/feature combo sets (slow)
+    ##
+    for (r in rownames(mat.layer)){
+        for (c in colnames(mat.layer)){
+            mat.new[r,c] <- mat.layer[r,c]
+        }
+    }
+    return(mat.new)
+}
+
+## Add Filter
+lc$add.layer(list(filter = makeLayer(sc@expdata, getfdata(sc))))
+## Add Normal
+lc$add.layer(list(normal = makeLayer(sc@expdata, sc@ndata)))
+
+
+## generateLoom <- function(sc){
+##     loomfile <- loomR::create
+##     (
+##         filename = filename,
+##         data = from@raw.data[, cell.order],
+##         cell.attrs = from@meta.data[cell.order, ],
+##         layers = list('norm_data' = t(x = from@data[, cell.order])),
+##         chunk.dims = chunk.dims,
+##         chunk.size = chunk.size,
+##         overwrite = overwrite,
+##         display.progress = display.progress
+##     )
+## }


### PR DESCRIPTION
This is an initial stab at integrating LOOM support into RaceID.

A general purpose LoomR wrapper for converting R-objects would be ideal, since it could be prepended and appended to existing Cheetah code in a given wrapper. However, every R-object requires the library that generated it to be loaded, and each R S4 object stores their data differently.

At the moment I will write an individual script for RaceID, and see if I can derive out some general-purpose functions that could be used to make a more broad conversion script.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
