### PR TITLE
Spades: fix error with fastsanger input datatype

### DIFF
--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -1,4 +1,4 @@
-<tool id="spades" name="SPAdes" version="@TOOL_VERSION@">
+<tool id="spades" name="SPAdes" version="@TOOL_VERSION@+galaxy1">
     <description>genome assembler for regular and single-cell projects</description>
     <macros>
         <import>macros.xml</import>
@@ -20,7 +20,7 @@
     <command>
     <![CDATA[
     ## A real command looks like: spades.py -k 21,33,55,77,99,127 --careful -1 Y.fastq.gz -2 X.fastq.gz -t 24 -o output
-    
+
     if [[ -n \$GALAXY_MEMORY_MB ]]; then
         GALAXY_MEMORY_GB=\$(( GALAXY_MEMORY_MB / 1024 ));
     fi &&
@@ -49,17 +49,17 @@
         --$prefix$i-$library.orientation
         #for $file in $library.files
             #if $file.file_type.type == "separate"
-                --$prefix$i-1 $file.file_type.fwd_reads.extension:$file.file_type.fwd_reads
-                --$prefix$i-2 $file.file_type.fwd_reads.extension:$file.file_type.rev_reads
+                --$prefix$i-1 $file.file_type.fwd_reads.extension.replace('fastqsanger', 'fastq'):$file.file_type.fwd_reads
+                --$prefix$i-2 $file.file_type.fwd_reads.extension.replace('fastqsanger', 'fastq'):$file.file_type.rev_reads
             #elif $file.file_type.type == "interleaved"
-                --$prefix$i-12 $file.file_type.interleaved_reads.extension:$file.file_type.interleaved_reads
+                --$prefix$i-12 $file.file_type.interleaved_reads.extension.replace('fastqsanger', 'fastq'):$file.file_type.interleaved_reads
             #elif $file.file_type.type == "merged"
-                --$prefix$i-m $file.file_type.merged_reads.extension:$file.file_type.merged_reads
+                --$prefix$i-m $file.file_type.merged_reads.extension.replace('fastqsanger', 'fastq'):$file.file_type.merged_reads
             #elif $file.file_type.type == "unpaired"
-                --$prefix$i-s $file.file_type.unpaired_reads.extension:$file.file_type.unpaired_reads
+                --$prefix$i-s $file.file_type.unpaired_reads.extension.replace('fastqsanger', 'fastq'):$file.file_type.unpaired_reads
             #elif $file.file_type.type == "paired-collection"
-                --$prefix$i-1 $file.file_type.fastq_collection.forward.extension:$file.file_type.fastq_collection.forward
-                --$prefix$i-2 $file.file_type.fastq_collection.reverse.extension:$file.file_type.fastq_collection.reverse
+                --$prefix$i-1 $file.file_type.fastq_collection.forward.extension.replace('fastqsanger', 'fastq'):$file.file_type.fastq_collection.forward
+                --$prefix$i-2 $file.file_type.fastq_collection.reverse.extension.replace('fastqsanger', 'fastq'):$file.file_type.fastq_collection.reverse
             #end if
         #end for
     #end for
@@ -75,24 +75,24 @@
     #end for
     #for $read in $sanger_reads:
         #if $read:
-            --sanger $read.extension:$read
+            --sanger $read.extension.replace('fastqsanger', 'fastq'):$read
         #end if
     #end for
     #for $contig in $trusted_contigs:
         #if $contig:
-            --trusted-contigs $contig.extension:$contig
+            --trusted-contigs $contig.extension.replace('fastqsanger', 'fastq'):$contig
         #end if
     #end for
     #for $contig in $untrusted_contigs:
         #if $contig:
-            --untrusted-contigs $contig.extension:$contig
+            --untrusted-contigs $contig.extension.replace('fastqsanger', 'fastq'):$contig
         #end if
     #end for
     && python '$write_tsv_script' < contigs.fasta > '$out_contig_stats'
     && python '$write_tsv_script' < scaffolds.fasta > '$out_scaffold_stats'
     ]]>
     </command>
-    
+
     <configfiles>
         <configfile name="write_tsv_script"><![CDATA[#!/usr/bin/env python
 import sys,re
@@ -106,7 +106,7 @@ for i,line in enumerate(sys.stdin):
 ]]>
          </configfile>
     </configfiles>
-    
+
     <inputs>
         <param argument="--sc" falsevalue="" help="This option is required for MDA (single-cell) data." label="Single-cell?" name="sc" truevalue="--sc" type="boolean">
             <option value="false">No</option>
@@ -219,7 +219,7 @@ for i,line in enumerate(sys.stdin):
                 </assert_contents>
             </output>
         </test>
-        <test> <!-- Test 1 - basic test with k=33 fasta input -->
+        <test> <!-- Test 2 - basic test with k=33 fasta input -->
             <param name="sc" value="false" />
             <param name="onlyassembler" value="true"/>
             <param name="careful" value="false" />
@@ -234,7 +234,7 @@ for i,line in enumerate(sys.stdin):
                 </assert_contents>
             </output>
         </test>
-        <test> <!-- Test 1 - basic test with k=33 and gzipped input -->
+        <test> <!-- Test 3 - basic test with k=33 and gzipped input -->
             <param name="sc" value="false" />
             <param name="careful" value="false" />
             <param name="kmers" value="33" />
@@ -248,7 +248,7 @@ for i,line in enumerate(sys.stdin):
                 </assert_contents>
             </output>
         </test>
-        <test> <!-- Test 2 - auto k -->
+        <test> <!-- Test 4 - auto k -->
             <param name="sc" value="false" />
             <param name="careful" value="false" />
             <param name="auto_kmer_choice" value="true" />
@@ -257,7 +257,7 @@ for i,line in enumerate(sys.stdin):
             <param ftype="fastq" name="rev_reads" value="ecoli_1K_2.fq" />
             <output compare="re_match" file="auto_kmer_output.fa" ftype="fasta" lines_diff="1" name="out_contigs" />
         </test>
-        <test> <!-- Test 3 - k=77 -->
+        <test> <!-- Test 5 - k=77 -->
             <param name="sc" value="false" />
             <param name="careful" value="false" />
             <param name="kmers" value="77" />
@@ -266,7 +266,7 @@ for i,line in enumerate(sys.stdin):
             <param ftype="fastq" name="rev_reads" value="ecoli_1K_2.fq" />
             <output compare="re_match" file="kmer_77_output.fa" ftype="fasta" lines_diff="1" name="out_contigs" />
         </test>
-        <test> <!-- Test 4 - test for extra graph outputs -->
+        <test> <!-- Test 6 - test for extra graph outputs -->
             <param name="sc" value="false" />
             <param name="careful" value="false" />
             <param name="kmers" value="33" />
@@ -289,6 +289,20 @@ for i,line in enumerate(sys.stdin):
             <output name="scaffold_graph">
                 <assert_contents>
                     <has_text text="NODE_"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test> <!-- Test 7 - basic test with k=33 and fastsanger input -->
+            <param name="sc" value="false" />
+            <param name="careful" value="false" />
+            <param name="kmers" value="33" />
+            <param name="lib_type" value="paired_end" />
+            <param ftype="fastqsanger" name="fwd_reads" value="ecoli_1K_1.fq" />
+            <param ftype="fastqsanger" name="rev_reads" value="ecoli_1K_2.fq" />
+            <output compare="re_match" file="kmer_33_output.fa" ftype="fasta" lines_diff="1" name="out_contigs" />
+            <output name="out_contig_stats">
+                <assert_contents>
+                    <has_text_matching expression="NODE_1\t1000"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -306,6 +306,20 @@ for i,line in enumerate(sys.stdin):
                 </assert_contents>
             </output>
         </test>
+        <test> <!-- Test 8 - basic test with k=33 and fastsanger.gz input -->
+            <param name="sc" value="false" />
+            <param name="careful" value="false" />
+            <param name="kmers" value="33" />
+            <param name="lib_type" value="paired_end" />
+            <param ftype="fastqsanger.gz" name="fwd_reads" value="ecoli_1K_1.fq.gz" />
+            <param ftype="fastqsanger.gz" name="rev_reads" value="ecoli_1K_2.fq.gz" />
+            <output compare="re_match" file="kmer_33_output.fa" ftype="fasta" lines_diff="1" name="out_contigs" />
+            <output name="out_contig_stats">
+                <assert_contents>
+                    <has_text_matching expression="NODE_1\t1000"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help>
 <![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

Hi,
A fix for a little bug found by one of our user: when using fastqsanger input files for spades, you had an error like this:
`== Error ==  file not found: /galaxy/database/jobs_directory/000/125/125750/working/fastqsanger://galaxy/database/files/002/114/dataset_2114659.dat (interlaced reads, library number: 1, library type: paired-end)`