### PR TITLE
add validator to motif-id param

### DIFF
--- a/tools/meme/fimo.xml
+++ b/tools/meme/fimo.xml
@@ -112,7 +112,9 @@ fimo
                     <when value="no"/>
                     <when value="yes">
                         <repeat name="motifs" title="Supply input motif ID">
-                            <param name="motif" type="text" value="" label="Motif ID" />
+                            <param name="motif" type="text" value="" label="Specify motif by id">
+                                <validator type="empty_field" />
+                            </param>
                         </repeat>
                     </when>
                 </conditional>

--- a/tools/meme/fimo.xml
+++ b/tools/meme/fimo.xml
@@ -23,7 +23,7 @@ fimo
 
         #if str( $options_type.motifs_cond.motif_selector) == 'yes':
             #for $motif in $options_type.motifs_cond.motifs:
-                --motif $motif.motif
+                --motif '$motif.motif'
             #end for
         #end if
 
@@ -114,6 +114,7 @@ fimo
                         <repeat name="motifs" title="Supply input motif ID">
                             <param name="motif" type="text" value="" label="Specify motif by id">
                                 <validator type="empty_field" />
+                                <validator type="regex" message="Value may include alphanumeric characters.">[A-Za-z]+</validator>
                             </param>
                         </repeat>
                     </when>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
