### PR TITLE
Busco bugfix (AUGUSTUS_CONFIG_PATH issue)

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -9,16 +9,16 @@
 
         &&
 
+        if [ -z "\$AUGUSTUS_CONFIG_PATH" ] ; then BUSCO_PATH=\$(dirname \$(which run_BUSCO.py)) ; export AUGUSTUS_CONFIG_PATH=\$(realpath \${BUSCO_PATH}/../config) ; fi &&
+        cp -r "\$AUGUSTUS_CONFIG_PATH/" augustus_dir/ &&
+        export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
+
         #if $adv.aug_prediction.augustus_mode == 'history':
             ## Using an augustus model from history, we need to unzip it and let augustus find it
-
-            cp -r "\$AUGUSTUS_CONFIG_PATH/" augustus_dir/ &&
 
             mkdir -p 'augustus_dir/species/' &&
 
             tar -C 'augustus_dir/species/' -xzvf '${adv.aug_prediction.augustus_model}' > /dev/null &&
-
-            export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
         run_BUSCO.py


### PR DESCRIPTION
* Set AUGUSTUS_CONFIG_PATH for all use cases
* Copy Augustus config for all use cases (this needs to be writeable)

NOTE: Correct operation relies on BLAST+ < 2.4, this is supported from bioconda recipe for v. 3.0.2 built 9

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
