### PR TITLE
Updates to VCFFilter documentation and filter field

### DIFF
--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -1,4 +1,4 @@
-<tool id="vcffilter2" name="VCFfilter:" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="vcffilter2" name="VCFfilter:" version="@WRAPPER_VERSION@+galaxy2">
     <description>filter VCF data in a variety of attributes</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -80,11 +80,18 @@ You can specify the following options within the **Specify filtering expression*
     -o, --or              use logical OR instead of AND to combine filters
     -r, --region          specify a region on which to target the filtering (must be used in conjunction with -f or -g)
 
-Filters are specified in the form {ID} {operator} {value}::
+To specify filters, click on the 'Insert Add filters' button, choose a filter type
+(e.g., 'Info filter' or 'Genotype filter'), and specify filter value according to the
+following pattern::
 
- -f "DP > 10"          # for info fields
- -g "GT = 1|1"         # for genotype fields
- -f "CpG"              # for 'flag' fields
+- For 'Info filter (-f)':: {ID} {operator} {value}
+    For instance::  DP > 10
+
+- For 'Genotype fields (-g)':: {ID} {operator} {value}
+    For instance::  GT = 1|1
+
+- For 'Flag' fields (when 'Info filter (-f)' is selected for filter type field):: {value}
+    For instance::  CpG
 
 Any number of filters may be specified.  They are combined via logical AND unless the --or option is specified. For convenience, you can specify "QUAL" to refer to the quality of the site, even though it does not appear in the INFO fields.
 

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -12,7 +12,6 @@ ln -s '$input1' input1.vcf &&
 bgzip input1.vcf &&
 tabix -p vcf input1.vcf.gz &&
 vcffilter
-$filter_type '$filter_value'
 #for $filter_el in $filter_repeat:
     $filter_el.filter_type '$filter_el.filter_value'
 #end for
@@ -31,27 +30,7 @@ input1.vcf.gz
     ]]></command>
     <inputs>
         <param name="input1" type="data" format="vcf" label="VCF dataset to filter"/>
-
-        <!-- First filter is required. -->
-        <param name="filter_type" type="select" label="Select the filter type">
-            <option value="-f">Info filter (-f)</option>
-            <option value="-g">Genotype filter (-g)</option>
-        </param>
-        <param name="filter_value" type="text" value="DP &gt; 10" label="Specify filterting value" help="See explanation of filtering options below">
-            <sanitizer>
-                <valid initial="string.printable">
-                    <remove value="&apos;"/>
-                    <remove value="&quot;"/>
-                </valid>
-                <mapping initial="none">
-                    <add source="&apos;" target=""/>
-                    <add source="&quot;" target=""/>
-                </mapping>
-            </sanitizer>
-        </param>
-
-        <!-- Additional filters are allowed. -->
-        <repeat name="filter_repeat" title="more filters">
+        <repeat name="filter_repeat" title="more filters" min="1">
             <param name="filter_type" type="select" label="Select the filter type">
                 <option value="-f">Info filter (-f)</option>
                 <option value="-g">Genotype filter (-g)</option>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -49,7 +49,7 @@ input1.vcf.gz
         </param>
 
         <!-- Additional filters are allowed. -->
-        <repeat name="filter_repeat" title="Add more filters">
+        <repeat name="filter_repeat" title="more filters">
             <param name="filter_type" type="select" label="Select the filter type">
                 <option value="-f">Info filter (-f)</option>
                 <option value="-g">Genotype filter (-g)</option>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -41,9 +41,11 @@ input1.vcf.gz
             <sanitizer>
                 <valid initial="string.printable">
                     <remove value="&apos;"/>
+                    <remove value="&quot;"/>
                 </valid>
                 <mapping initial="none">
-                    <add source="&apos;" target="__sq__"/>
+                    <add source="&apos;" target=""/>
+                    <add source="&quot;" target=""/>
                 </mapping>
             </sanitizer>
         </param>
@@ -58,9 +60,11 @@ input1.vcf.gz
                 <sanitizer>
                     <valid initial="string.printable">
                         <remove value="&apos;"/>
+                        <remove value="&quot;"/>
                     </valid>
                     <mapping initial="none">
-                        <add source="&apos;" target="__sq__"/>
+                        <add source="&apos;" target=""/>
+                        <add source="&quot;" target=""/>
                     </mapping>
                 </sanitizer>
             </param>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -12,6 +12,7 @@ ln -s '$input1' input1.vcf &&
 bgzip input1.vcf &&
 tabix -p vcf input1.vcf.gz &&
 vcffilter
+$filter_type '$filter_value'
 #for $filter_el in $filter_repeat:
     $filter_el.filter_type '$filter_el.filter_value'
 #end for
@@ -30,7 +31,25 @@ input1.vcf.gz
     ]]></command>
     <inputs>
         <param name="input1" type="data" format="vcf" label="VCF dataset to filter"/>
-        <repeat name="filter_repeat" title="Add filters">
+
+        <!-- First filter is required. -->
+        <param name="filter_type" type="select" label="Select the filter type">
+            <option value="-f">Info filter (-f)</option>
+            <option value="-g">Genotype filter (-g)</option>
+        </param>
+        <param name="filter_value" type="text" value="DP &gt; 10" label="Specify filterting value" help="See explanation of filtering options below">
+            <sanitizer>
+                <valid initial="string.printable">
+                    <remove value="&apos;"/>
+                </valid>
+                <mapping initial="none">
+                    <add source="&apos;" target="__sq__"/>
+                </mapping>
+            </sanitizer>
+        </param>
+
+        <!-- Additional filters are allowed. -->
+        <repeat name="filter_repeat" title="Add more filters">
             <param name="filter_type" type="select" label="Select the filter type">
                 <option value="-f">Info filter (-f)</option>
                 <option value="-g">Genotype filter (-g)</option>


### PR DESCRIPTION
This PR makes the following updates to the VCFFilter:
1. Update the documentation of VCFFilter for more intuitive description of how to specify filters;
2. Ignore `"` (double-quotation) and `'` (single-quotation) for the filter field (if given, the wrapper removes the quotations);
3. Require at least one filter. 