### PR TITLE
Test for RepeatMasker in PATH

### DIFF
--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -204,8 +204,8 @@
       <param name="poly" value="-poly" />
       <param name="repeat_lib" value="repeats.fasta" ftype="fasta" />
       <output name="output_masked_genome" file="small.fasta.masked" />
-      <output name="output_table" file="small.fasta.stats" lines_diff="4" />
-      <output name="output_repeat_catalog" file="small.fasta.cat" />
+      <output name="output_table" file="small.fasta.stats" lines_diff="6" />
+      <output name="output_repeat_catalog" file="small.fasta.cat" lines_diff="2" />
       <output name="output_log" file="small.fasta.log" />
       <output name="output_alignment" file="small.fasta.align" />
       <output name="output_polymorphic" file="small.fasta.poly" />
@@ -219,7 +219,7 @@
       <param name="species_list" value="anopheles" />
       <output name="output_masked_genome" file="small.fasta.masked" />
       <output name="output_table" file="small_repbase.fasta.stats" lines_diff="2" />
-      <output name="output_repeat_catalog" file="small.fasta.cat" />
+      <output name="output_repeat_catalog" file="small.fasta.cat" lines_diff="2" />
       <output name="output_log" file="small_repbase.fasta.log" />
     </test>
   </tests>

--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -1,4 +1,4 @@
-<tool id="repeatmasker_wrapper" name="RepeatMasker" version="4.0.7+galaxy1" profile="17.01">
+<tool id="repeatmasker_wrapper" name="RepeatMasker" version="4.0.7+galaxy2" profile="17.01">
   <description>RepeatMasker</description>
 
   <requirements>
@@ -6,7 +6,9 @@
   </requirements>
 
   <command detect_errors="exit_code"><![CDATA[
-    RM_LIB_PATH=\$(dirname \$(which RepeatMasker))/../share/RepeatMasker/Libraries &&
+    RM_PATH=\$(which RepeatMasker) && 
+    if [ -z "\$RM_PATH" ] ; then echo "Failed to find RepeatMasker in PATH (\$PATH)" >&2 ; exit 1 ; fi &&
+    RM_LIB_PATH=\$(dirname \$RM_PATH)/../share/RepeatMasker/Libraries &&
     mkdir lib &&
     export REPEATMASKER_LIB_DIR=\$(pwd)/lib &&
       for file in \$(ls \$RM_LIB_PATH) ; do  ln -s \$RM_LIB_PATH/\$file lib/\$file ; done &&

--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -191,8 +191,8 @@
       <param name="source_type" value="library" />
       <param name="repeat_lib" value="repeats.fasta" ftype="fasta" />
       <output name="output_masked_genome" file="small.fasta.masked" />
-      <output name="output_table" file="small.fasta.stats" lines_diff="2" />
-      <output name="output_repeat_catalog" file="small.fasta.cat" />
+      <output name="output_table" file="small.fasta.stats" lines_diff="4" />
+      <output name="output_repeat_catalog" file="small.fasta.cat" lines_diff="2" />
       <output name="output_log" file="small.fasta.log" />
     </test>
     <test expect_num_outputs="7">


### PR DESCRIPTION
Current recipe produces a not-helpful error message if RepeatMasker is not in the PATH. This adds a check and more useful error message.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
