### PR TITLE
Simplify and document the logic of the gemini data manager

### DIFF
--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -9,37 +9,49 @@ import sys
 import yaml
 
 
+def write_gemini_config(config, config_file):
+    with open(config_file, 'w') as fo:
+        yaml.dump(config, fo, allow_unicode=False, default_flow_style=False)
+
+
 def main():
     today = datetime.date.today()
     params = json.loads( open( sys.argv[1] ).read() )
     target_directory = params[ 'output_data' ][0]['extra_files_path']
     os.mkdir( target_directory )
-    # The target_directory needs to be specified twice for the following
-    # invocation of gemini.
-    # In essence, the GEMINI_CONFIG environment variable makes gemini store
-    # its yaml configuration file in that directory, while the
-    # --annotation-dir argument makes it write the same path into the yaml
-    # file, which is then used for determining where the actual annotation
-    # files should be stored.
+
+    # Generate a minimal configuration file for GEMINI update
+    # to instruct the tool to download the annotation data into a
+    # subfolder of the target directory.
+    config_file = os.path.join(target_directory, 'gemini-config.yaml')
+    anno_dir = os.path.join(target_directory, 'gemini/data')
+    gemini_bootstrap_config = {'annotation_dir': anno_dir}
+    write_gemini_config(gemini_bootstrap_config, config_file)
+
+    # Now gemini update can be called to download the data.
+    # The GEMINI_CONFIG environment variable lets the tool discover
+    # the configuration file we prepared for it.
+    # Note that the tool will rewrite the file turning it into a
+    # complete gemini configuration file.
     gemini_env = os.environ.copy()
     gemini_env['GEMINI_CONFIG'] = target_directory
-    cmd = "gemini --annotation-dir %s update --dataonly %s %s" % (
-        target_directory,
+    cmd = "gemini update --dataonly %s %s" % (
         params['param_dict']['gerp_bp'],
         params['param_dict']['cadd']
     )
     subprocess.check_call( cmd, shell=True, env=gemini_env )
 
-    # modify the newly created gemini config file to contain a relative
-    # annotation dir path, which will be interpreted as relative to
-    # the job working directory at runtime by any gemini tool
-    config_file = os.path.join(target_directory, 'gemini-config.yaml')
+    # GEMINI tool wrappers that need access to the annotation files
+    # are supposed to symlink them into a gemini/data subfolder of
+    # the job working directory. To have GEMINI discover them there,
+    # we need to set this location as the 'annotation_dir' in the
+    # configuration file.
     with open(config_file) as fi:
         config = yaml.load(fi)
-    config['annotation_dir'] = 'gemini/data'
-    with open(config_file, 'w') as fo:
-        yaml.dump(config, fo, allow_unicode=False, default_flow_style=False)
+    config.update({'annotation_dir': 'gemini/data'})
+    write_gemini_config(config, config_file)
 
+    # Finally, we prepare the metadata for the new data table record ...
     data_manager_dict = {
         'data_tables': {
             'gemini_versioned_databases': [
@@ -55,7 +67,7 @@ def main():
         }
     }
 
-    # save info to json file
+    # ... and save it to the json results file
     with open( sys.argv[1], 'wb' ) as out:
         out.write( json.dumps( data_manager_dict ) )
 

--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -48,7 +48,7 @@ def main():
     # configuration file.
     with open(config_file) as fi:
         config = yaml.load(fi)
-    config.update({'annotation_dir': 'gemini/data'})
+    config['annotation_dir'] = 'gemini/data'
     write_gemini_config(config, config_file)
 
     # Finally, we prepare the metadata for the new data table record ...


### PR DESCRIPTION
By generating a minimal configuration file before gemini first
tries to access it, we avoid potential issues with existing config
files in other places and do not have to rely on the gemini
--annotation-dir option to specify the annotation file download
location.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
