### PR TITLE
Volcano plot: Fix for labelling genes

### DIFF
--- a/tools/volcanoplot/volcanoplot.R
+++ b/tools/volcanoplot/volcanoplot.R
@@ -48,20 +48,26 @@ results <- mutate(results, sig=ifelse((fdr<opt$signif_thresh & logFC>opt$lfc_thr
 results <- results[order(results$Pvalue),]
 if (!is.null(opt$label_file)) {
     labelfile <- read.delim(opt$label_file)
+    # label genes specified in file
     tolabel <- filter(results, labels %in% labelfile[, 1])
-} else if (!is.null(opt$top_num)) {
-    tolabel <- filter(results, fdr<opt$signif_thresh) %>% top_n(opt$top_num)
-} else {
+} else if (is.null(opt$top_num)) {
+    # label all significant genes
     tolabel <- filter(results, fdr<opt$signif_thresh)
+} else if (opt$top_num > 0) {
+    # label only top significant genes
+    tolabel <- filter(results, fdr<opt$signif_thresh) %>% 
+    top_n(n=opt$top_num, Pvalue)
+} else if (opt$top_num == 0) {
+    # no labels
+    tolabel <- NULL
 }
 
 pdf("out.pdf")
 p <- ggplot(results, aes(logFC, -log10(Pvalue))) +
     geom_point(aes(col=sig)) +
-    geom_label_repel(data=tolabel, aes(label=labels, fill=factor(sig)), colour="white", segment.colour="black", show.legend=FALSE) +
     scale_color_manual(values=colours) +
     scale_fill_manual(values=colours) +
-    theme(panel.grid.major = element_blank(), 
+    theme(panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),
         panel.background = element_blank(),
         axis.line = element_line(colour = "black"),
@@ -79,6 +85,9 @@ if (!is.null(opt$legend)) {
     p <- p + labs(colour=opt$legend)
 } else {
     p <- p + labs(colour="")
+}
+if (!is.null(tolabel)) {
+    p <- p + geom_label_repel(data=tolabel, aes(label=labels, fill=factor(sig)), colour="white", segment.colour="black", show.legend=FALSE)
 }
 
 print(p)

--- a/tools/volcanoplot/volcanoplot.xml
+++ b/tools/volcanoplot/volcanoplot.xml
@@ -25,6 +25,7 @@ Rscript '${__tool_directory__}/volcanoplot.R'
     #else if $labels.label_select == 'signif':
         #if $labels.top_num:
             -t $labels.top_num
+        #end if
     #else
         -t 0
     #end if

--- a/tools/volcanoplot/volcanoplot.xml
+++ b/tools/volcanoplot/volcanoplot.xml
@@ -123,7 +123,7 @@ A tabular file with a header row containing the columns below (additional column
     * Log fold change
     * Labels (e.g. Gene symbols or IDs)
 
-All significant points, those meeting the specified FDR and Log Fold Change thresholds, will be coloured, red for upregulated, blue for downregulated. Users can choose to apply labels to the points (such as gene symbols) from the Labels column. To label all significant points, select "Signficant" for the **Points to label** option, or to only label the top most significant specify a number under "Only label top most significant". Users can label any points of interest through selecting **Points to label** "Input from file" and providing a tabular labels file. The labels file must contain a header row and have the labels in the first column. These labels must match the labels in the main input file.
+All significant points, those meeting the specified FDR and Log Fold Change thresholds, will be coloured, red for upregulated, blue for downregulated. Users can choose to apply labels to the points (such as gene symbols) from the Labels column. To label all significant points, select "Significant" for the **Points to label** option, or to only label the top most significant specify a number under "Only label top most significant". Users can label any points of interest through selecting **Points to label** "Input from file" and providing a tabular labels file. The labels file must contain a header row and have the labels in the first column. These labels must match the labels in the main input file.
 
 **Outputs**
 

--- a/tools/volcanoplot/volcanoplot.xml
+++ b/tools/volcanoplot/volcanoplot.xml
@@ -1,4 +1,4 @@
-<tool id="volcanoplot" name="Volcano Plot" version="0.0.1">
+<tool id="volcanoplot" name="Volcano Plot" version="0.0.2">
     <description>create a volcano plot</description>
     <requirements>
         <requirement type="package" version="3.0.0">r-ggplot2</requirement>
@@ -22,8 +22,11 @@ Rscript '${__tool_directory__}/volcanoplot.R'
     -x $lfc_thresh
     #if $labels.label_select == 'file':
         -f '$labels.label_file'
-    #else if $labels.top_num:
-        -t $labels.top_num
+    #else if $labels.label_select == 'signif':
+        #if $labels.top_num:
+            -t $labels.top_num
+    #else
+        -t 0
     #end if
     #if $plot_options.title:
         -T '$plot_options.title'
@@ -49,12 +52,13 @@ Rscript '${__tool_directory__}/volcanoplot.R'
         <param name="signif_thresh" type="float" max="1" value="0.05" label="Significance threshold" help="Default: 0.05"/>
         <param name="lfc_thresh" type="float" value="0" label="LogFC threshold to colour" help="Default: 0"/>
         <conditional name="labels">
-            <param name="label_select" type="select" label="Points to label" help="Select to label top significant points or input labels from file. All points meeting the significance threshold are labelled by default.">
-                <option value="signif" selected="True">Significant</option>
+            <param name="label_select" type="select" label="Points to label" help="Select to label significant points or input labels from file. Default: None">
+                <option value="none" selected="True">None</option>
+                <option value="signif">Significant</option>
                 <option value="file">Input from file</option>
             </param>
             <when value="signif">
-                <param name="top_num" type="integer" optional="True" label="Only label top most significant" help="Specify the top number of points to label by P value significance"/>
+                <param name="top_num" type="integer" optional="True" label="Only label top most significant" help="Specify the top number of points to label by P value significance. If no number is specified, all points that pass the FDR and Log Fold Change thresholds will be labelled."/>
             </when>
             <when value="file">
                 <param name="label_file" type="data" format="tabular" label="File of labels"/>
@@ -119,7 +123,7 @@ A tabular file with a header row containing the columns below (additional column
     * Log fold change
     * Labels (e.g. Gene symbols or IDs)
 
-All points meeting the specified significance threshold will be labelled by default with the values in the Labels columns. Users can select to only label the top significant points under **Plot Options** or only to label certain points through providing a tabular labels file. The labels file must contin a header row and have the labels in the first column. These labels must match the labels in the main input file. If no labels are desired specify 0 for "Only label top most signifcant". If a log fold change (lfc) threshold is specified, points that meet the significance threshold and lfc threshold will be coloured red if upregulated and blue if downregulated.
+All significant points, those meeting the specified FDR and Log Fold Change thresholds, will be coloured, red for upregulated, blue for downregulated. Users can choose to apply labels to the points (such as gene symbols) from the Labels column. To label all significant points, select "Signficant" for the **Points to label** option, or to only label the top most significant specify a number under "Only label top most significant". Users can label any points of interest through selecting **Points to label** "Input from file" and providing a tabular labels file. The labels file must contain a header row and have the labels in the first column. These labels must match the labels in the main input file.
 
 **Outputs**
 


### PR DESCRIPTION
Fix for labelling genes, as currently all significant genes get labelled unless a file of genes is supplied, the options for selected labelling are being ignored.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
