### PR TITLE
Add paste to requirements and bump subread version

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,8 +1,9 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.3" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.3+galaxy1" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
-        <requirement type="package" version="1.6.2">subread</requirement>
-        <requirement type="package" version="1.7">samtools</requirement>
+        <requirement type="package" version="1.6.3">subread</requirement>
+        <requirement type="package" version="1.9">samtools</requirement>
+        <requirement type="package" version="3.0.5">paste</requirement>
     </requirements>
 
     <version_command>featureCounts -v 2&gt;&amp;1 | grep .</version_command>
@@ -553,7 +554,7 @@
             <section name="extended_parameters" >
                 <param name="R" value="true" />
             </section>
-            <output name="output_bam" value="subset.sorted.featurecounts.bam" />
+            <output name="output_bam" value="subset.sorted.featurecounts.bam" compare="sim_size"/>
         </test>
     </tests>
 


### PR DESCRIPTION
subread 1.6.3 is a bugfix release (http://subread.sourceforge.net/), no new options were added.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
