### PR TITLE
samtools_stats: add perl for plot-bamstats

### DIFF
--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -1,10 +1,11 @@
-<tool id="samtools_stats" name="Samtools stats" version="2.0.2">
+<tool id="samtools_stats" name="Samtools stats" version="2.0.2+galaxy1">
     <description>generate statistics for BAM dataset</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="5.0.4">gnuplot</requirement>
+        <requirement type="package" version="5.26">perl</requirement>
     </expand>
     <expand macro="stdio"/>
     <expand macro="version_command"/>

--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -4,7 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.0.4">gnuplot</requirement>
+        <requirement type="package" version="5.2.3">gnuplot</requirement>
         <requirement type="package" version="5.26">perl</requirement>
     </expand>
     <expand macro="stdio"/>


### PR DESCRIPTION
Noticed this when running containerized tool tests.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
