### PR TITLE
Update abricate.xml

### DIFF
--- a/tools/abricate/abricate.xml
+++ b/tools/abricate/abricate.xml
@@ -15,7 +15,18 @@
             --minid=$adv.min_dna_id
         #end if
         --db=$adv.db
-        > '$report'
+        > out
+        
+        &&
+
+        #if $adv.fix_file_name
+            ##import re
+            ##set escaped_element_identifier = re.sub('[^\w\-\.]', '_', str($file_input.element_identifier))
+            awk -F"\t" '{if (FNR > 1) $1="$file_input.element_identifier"; print $0}' out > '$report'
+        #else:
+            cat out > '$report'
+        #end if
+
     ]]></command>
 
     <inputs>
@@ -32,6 +43,7 @@
             </param>
             <param name="no_header" argument="--noheader" type="boolean" truevalue="--noheader" falsevalue="" label="Suppress header" help="Suppress output file's column headings" />
             <param name="min_dna_id" argument="--minid" type="float" value="75" min="0" max="100" optional="true" label="Minimum DNA identity" />
+            <param name="fix_file_name" type="boolean" truevalue="yes" falsevalue="no"  checked="false" label="Fix FILE column" />
         </section>
     </inputs>
 


### PR DESCRIPTION
Add an option to replace galaxy file name (i.e. dataset_1.dat) with the file element identifier in the column FILE of the output.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
