### PR TITLE
Add parallel keyword to deseq2

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -46,6 +46,7 @@ args <- commandArgs(trailingOnly = TRUE)
 spec <- matrix(c(
   "quiet", "q", 0, "logical",
   "help", "h", 0, "logical",
+  "cores", "", 1, "integer",
   "batch_factors", "", 1, "character",
   "outfile", "o", 1, "character",
   "countsfile", "n", 1, "character",
@@ -104,6 +105,14 @@ suppressPackageStartupMessages({
   library("RColorBrewer")
   library("gplots")
 })
+
+if (opt$cores > 1) {
+  library("BiocParallel")
+  register(MulticoreParam(opt$cores))
+  parallel = TRUE
+} else {
+  parallel = FALSE
+}
 
 # build or read sample table
 
@@ -273,7 +282,7 @@ if (is.null(opt$fit_type)) {
 if (verbose) cat(paste("using disperion fit type:",fitType,"\n"))
 
 # run the analysis
-dds <- DESeq(dds, fitType=fitType, betaPrior=betaPrior, minReplicatesForReplace=minRep)
+dds <- DESeq(dds, fitType=fitType, betaPrior=betaPrior, minReplicatesForReplace=minRep, parallel=parallel)
 
 # create the generic plots and leave the device open
 if (!is.null(opt$plots)) {

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -46,8 +46,8 @@ args <- commandArgs(trailingOnly = TRUE)
 spec <- matrix(c(
   "quiet", "q", 0, "logical",
   "help", "h", 0, "logical",
-  "cores", "", 1, "integer",
-  "batch_factors", "", 1, "character",
+  "cores", "s", 0, "integer",
+  "batch_factors", "w", 1, "character",
   "outfile", "o", 1, "character",
   "countsfile", "n", 1, "character",
   "rlogfile", "r", 1, "character",

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -1,4 +1,4 @@
-<tool id="deseq2" name="DESeq2" version="2.11.40.4">
+<tool id="deseq2" name="DESeq2" version="2.11.40.5">
     <description>Determines differentially expressed features from count tables</description>
     <requirements>
         <requirement type="package" version="1.20.0">bioconductor-deseq2</requirement>
@@ -41,6 +41,7 @@ echo $(R --version | grep version | grep -v GNU)", DESeq2 version" $(R --vanilla
 #import json
 #import os
 Rscript '${__tool_directory__}/deseq2.R'
+    --cores \${GALAXY_SLOTS:-1}
     -o '$deseq_out'
     #if $pdf:
         -p '$plots'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
