### PR TITLE
Fix bug with advanced + no compress

### DIFF
--- a/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
+++ b/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_fetch_refseq" name="RefSeq data manager" version="0.0.18" tool_type="manage_data">
+<tool id="data_manager_fetch_refseq" name="RefSeq data manager" version="0.0.19" tool_type="manage_data">
     <description>Fetch FASTA data from NCBI RefSeq and update all_fasta data table</description>
     <requirements>
         <requirement type="package">python</requirement>
@@ -6,7 +6,7 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
     python $__tool_directory__/fetch_refseq.py
-      #if str( $advanced.advanced_selector ) == 'advanced':
+      #if str( $advanced.advanced_selector ) == 'advanced' and str( $advanced.compress ) != '':
         '${advanced.compress}'
       #end if
       --galaxy_datamanager_filename '${output_file}'
@@ -69,6 +69,21 @@
                 </assert_contents>
             </output>
         </test>
+        <test>
+            <param name="division_names" value="plastid"/>
+            <param name="mol_types" value="protein"/>
+            <param name="pin_date" value="2018-03-14"/>            
+            <param name="advanced_selector" value="advanced"/>
+            <param name="compress" value="" />
+            <output name="output_file">
+                <assert_contents>
+                    <has_text text="2018-03-14"/>
+                    <has_text text="refseq_plastid"/>
+                    <has_text text="/refseq_plastid."/>
+                </assert_contents>
+            </output>
+        </test>
+
     </tests>
     <help><![CDATA[
 This data manager fetches FASTA format collections of proteins, nucleotides (genomic DNA) and RNA

--- a/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
+++ b/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_fetch_refseq" name="RefSeq data manager" version="0.0.19" tool_type="manage_data">
+<tool id="data_manager_fetch_refseq" name="RefSeq data manager" version="0.0.18" tool_type="manage_data">
     <description>Fetch FASTA data from NCBI RefSeq and update all_fasta data table</description>
     <requirements>
         <requirement type="package">python</requirement>

--- a/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
+++ b/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
@@ -6,8 +6,8 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
     python $__tool_directory__/fetch_refseq.py
-      #if str( $advanced.advanced_selector ) == 'advanced' and str( $advanced.compress ) != '':
-        '${advanced.compress}'
+      #if str( $advanced.advanced_selector ) == 'advanced':
+        ${advanced.compress}
       #end if
       --galaxy_datamanager_filename '${output_file}'
       --division_names ${division_names}


### PR DESCRIPTION
A bug occurs if advanced is selected and compression is not selected - it results in a spurious '' in the command line. This patch fixes that and bumps the tool wrapper version (and adds a test for this case).

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
