### PR TITLE
Fix ShoRAH tests.

### DIFF
--- a/tools/shorah/test-data/shorah-amplicon-out1.txt
+++ b/tools/shorah/test-data/shorah-amplicon-out1.txt
@@ -1,4 +1,4 @@
 Chromosome	Pos	Ref	Var	Freq	Post
-reference	8	C	A	0.36..	1.0000
-reference	28	T	A	0.36..	1.0000
-reference	35	A	C	0.36..	1.0000
+reference	8	C	A	0.3...	1.0000
+reference	28	T	A	0.3...	1.0000
+reference	35	A	C	0.3...	1.0000


### PR DESCRIPTION
Test is failing on master because the current test data has too many significant digits.