### PR TITLE
Jbrowse: replace cdn.rawgit.com by jsdelivr.net

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -872,7 +872,7 @@ if __name__ == '__main__':
             'hideGenomeOptions': root.find('metadata/general/hideGenomeOptions').text,
         },
         'plugins': [{
-            'location': 'https://cdn.rawgit.com/TAMU-CPT/blastview/97572a21b7f011c2b4d9a0b5af40e292d694cbef/',
+            'location': 'https://cdn.jsdelivr.net/gh/TAMU-CPT/blastview@97572a21b7f011c2b4d9a0b5af40e292d694cbef/',
             'name': 'BlastView'
         }],
         'plugins_python': ['BlastView'],
@@ -882,32 +882,32 @@ if __name__ == '__main__':
     if plugins['GCContent'] == 'True':
         extra_data['plugins_python'].append('GCContent')
         extra_data['plugins'].append({
-            'location': 'https://cdn.rawgit.com/elsiklab/gccontent/5c8b0582ecebf9edf684c76af8075fb3d30ec3fa/',
+            'location': 'https://cdn.jsdelivr.net/gh/elsiklab/gccontent@5c8b0582ecebf9edf684c76af8075fb3d30ec3fa/',
             'name': 'GCContent'
         })
 
     if plugins['Bookmarks'] == 'True':
         extra_data['plugins'].append({
-            'location': 'https://cdn.rawgit.com/TAMU-CPT/bookmarks-jbrowse/5242694120274c86e1ccd5cb0e5e943e78f82393/',
+            'location': 'https://cdn.jsdelivr.net/gh/TAMU-CPT/bookmarks-jbrowse@5242694120274c86e1ccd5cb0e5e943e78f82393/',
             'name': 'Bookmarks'
         })
 
     if plugins['ComboTrackSelector'] == 'True':
         extra_data['plugins_python'].append('ComboTrackSelector')
         extra_data['plugins'].append({
-            'location': 'https://cdn.rawgit.com/Arabidopsis-Information-Portal/ComboTrackSelector/52403928d5ccbe2e3a86b0fa5eb8e61c0f2e2f57',
+            'location': 'https://cdn.jsdelivr.net/gh/Arabidopsis-Information-Portal/ComboTrackSelector@52403928d5ccbe2e3a86b0fa5eb8e61c0f2e2f57',
             'icon': 'https://galaxyproject.org/images/logos/galaxy-icon-square.png',
             'name': 'ComboTrackSelector'
         })
 
     if plugins['theme'] == 'Minimalist':
         extra_data['plugins'].append({
-            'location': 'https://cdn.rawgit.com/erasche/jbrowse-minimalist-theme/d698718442da306cf87f033c72ddb745f3077775/',
+            'location': 'https://cdn.jsdelivr.net/gh/erasche/jbrowse-minimalist-theme@d698718442da306cf87f033c72ddb745f3077775/',
             'name': 'MinimalistTheme'
         })
     elif plugins['theme'] == 'Dark':
         extra_data['plugins'].append({
-            'location': 'https://cdn.rawgit.com/erasche/jbrowse-dark-theme/689eceb7e33bbc1b9b15518d45a5a79b2e5d0a26/',
+            'location': 'https://cdn.jsdelivr.net/gh/erasche/jbrowse-dark-theme@689eceb7e33bbc1b9b15518d45a5a79b2e5d0a26/',
             'name': 'DarkTheme'
         })
 

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -13,7 +13,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy2</token>
+  <token name="@WRAPPER_VERSION@">galaxy3</token>
   <xml name="stdio">
     <stdio>
       <exit_code range="1:"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)

A little fix for the current jbrowse tool: now the plugins are loaded from cdn.jsdelivr.net instead of (the dead) rawgit.com. Without this you get a red scary error in the output dataset.

Fixing it in this 1.12.5 version as it is broken, and because the 1.16.1 version in https://github.com/galaxyproject/tools-iuc/pull/1683 no longer supports external plugins for now.