### PR TITLE
update fastp to 0.19.5

### DIFF
--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -72,6 +72,8 @@ $single_paired.adapter_trimming_options.disable_adapter_trimming
 #if str($single_paired.single_paired_selector).startswith('paired'):
     #if str($single_paired.adapter_trimming_options.adapter_sequence2):
         --adapter_sequence_r2 '$single_paired.adapter_trimming_options.adapter_sequence2'
+    #else
+        --detect_adapter_for_pe
     #end if
 #end if
 

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -1,4 +1,4 @@
-<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@.3">
+<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@">
     <description>- fast all-in-one preprocessing for FASTQ files</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -342,7 +342,7 @@ mv first${ext} '${out1}'
             </output>
         </test>
         <!-- Ensure paired collection works -->
-        <test expect_num_outputs="3">
+        <test expect_num_outputs="4">
             <param name="single_paired_selector" value="paired_collection"/>
             <param name="paired_input">
                 <collection type="paired">

--- a/tools/fastp/macros.xml
+++ b/tools/fastp/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@WRAPPER_VERSION@">0.19.3</token>
+    <token name="@WRAPPER_VERSION@">0.19.5</token>
 
     <xml name="adapter_trimming_options">
         <section name="adapter_trimming_options" title="Adapter Trimming Options" expanded="False">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

FOR REVIEWER:
* [ ] .shed.yml file ok
    - [ ] Toolshed user `iuc` has access to associated toolshed repo(s)
* [ ] Indentation is correct (4 spaces)
* [ ] Tool version/build ok
* [ ] `<command/>`
  - [ ] Text parameters, input and output files `'single quoted'`
  - [ ] Use of `<![CDATA[ ... ]]>` tags
  - [ ] Parameters of type `text` or having `optional="true"` attribute are checked with `if str($param)` before being used
* [ ] Data parameters have a `format` attribute containing datatypes recognised by Galaxy
* [ ] Tests
  - [ ] Parameters are reasonably covered
  - [ ] Test files are appropriate
* [ ] Help
  - [ ] Valid restructuredText and uses `<![CDATA[ ... ]]>` tags
* [ ] Complies with other best practice in [Best Practices Doc](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)
