### PR TITLE
Slamdunk: add multiple=True to fastq to work with Alleyoop

### DIFF
--- a/tools/slamdunk/slamdunk.xml
+++ b/tools/slamdunk/slamdunk.xml
@@ -6,38 +6,38 @@
     <expand macro="requirements" />
     <version_command>slamdunk --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-    #import re
+#import re
 
-    #if $reference_source.reference_source_selector == 'history':
-        ln -f -s '$reference_source.ref_file' reference.fa &&
-    #else:
-        ln -f -s '$reference_source.ref_file.fields.path' reference.fa &&
-    #end if
+#if $reference_source.reference_source_selector == 'history':
+    ln -f -s '$reference_source.ref_file' reference.fa &&
+#else:
+    ln -f -s '$reference_source.ref_file.fields.path' reference.fa &&
+#end if
 
-    mkdir ./fastq &&
-    #for $fastq in $reads:
-        #set $fastq_name = re.sub('[^\w\-\.]', '_', str($fastq.element_identifier))
-        ln -s '$fastq' './fastq/${fastq_name}' &&
-    #end for
+mkdir ./fastq &&
+#for $fastq in $reads:
+    #set $fastq_name = re.sub('[^\w\-\.]', '_', str($fastq.element_identifier))
+    ln -s '$fastq' './fastq/${fastq_name}' &&
+#end for
 
-        slamdunk all -r reference.fa -b '$Reference' -o ./out
-           -n $multimapper.multimappers
-           $multimapper.multimap
-           #if $multimapper.filterbed.bedtofilter:
-            -fb $multimapper.filterbed.bedtofilter
-           #end if
-           -5 $quantseq.trim5
-           -a $quantseq.maxpolyA
-           $advanced.endtoend
-           -mq $advanced.minMQ
-           -mi $advanced.minID
-           -nm=$advanced.maxNM
-           -mc $advanced.minCov
-           -mv $advanced.minVar
-           -mbq $advanced.minBaseQual
-        -rl $readLength
-        -c $covThresh
-        ./fastq/*
+    slamdunk all -r reference.fa -b '$Reference' -o ./out
+       -n $multimapper.multimappers
+       $multimapper.multimap
+       #if $multimapper.filterbed.bedtofilter:
+        -fb $multimapper.filterbed.bedtofilter
+       #end if
+       -5 $quantseq.trim5
+       -a $quantseq.maxpolyA
+       $advanced.endtoend
+       -mq $advanced.minMQ
+       -mi $advanced.minID
+       -nm=$advanced.maxNM
+       -mc $advanced.minCov
+       -mv $advanced.minVar
+       -mbq $advanced.minBaseQual
+    -rl $readLength
+    -c $covThresh
+    ./fastq/*
     ]]></command>
     <inputs>
         <expand macro="reference_files" />

--- a/tools/slamdunk/slamdunk.xml
+++ b/tools/slamdunk/slamdunk.xml
@@ -6,11 +6,20 @@
     <expand macro="requirements" />
     <version_command>slamdunk --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
+    #import re
+
     #if $reference_source.reference_source_selector == 'history':
         ln -f -s '$reference_source.ref_file' reference.fa &&
     #else:
         ln -f -s '$reference_source.ref_file.fields.path' reference.fa &&
     #end if
+
+    mkdir ./fastq &&
+    #for $fastq in $reads:
+        #set $fastq_name = re.sub('[^\w\-\.]', '_', str($fastq.element_identifier))
+        ln -s '$fastq' './fastq/${fastq_name}' &&
+    #end for
+
         slamdunk all -r reference.fa -b '$Reference' -o ./out
            -n $multimapper.multimappers
            $multimapper.multimap
@@ -28,11 +37,11 @@
            -mbq $advanced.minBaseQual
         -rl $readLength
         -c $covThresh
-        '$Reads'
+        ./fastq/*
     ]]></command>
     <inputs>
         <expand macro="reference_files" />
-        <param name="Reads" type="data" format="fastqsanger,fastqsanger.gz" label="FASTQ files"/>
+        <param name="reads" type="data" format="fastqsanger,fastqsanger.gz" multiple="True" label="FASTQ files"/>
         <section name="multimapper" title="Multimapper recovery"
             expanded="false">
             <section name="filterbed"
@@ -86,9 +95,15 @@
             help="Maximum read length (before trimming)." />
     </inputs>
     <outputs>
-        <data name="outputBam" format="bam" from_work_dir="./out/filter/*.bam" label="${tool.name} on ${on_string}: BAM"/>
-        <data name="outputTsv" format="tabular" from_work_dir="./out/count/*_tcount.tsv" label="${tool.name} on ${on_string}: Count TSV"/>
-        <data name="outputVcf" format="vcf" from_work_dir="./out/snp/*vcf" label="${tool.name} on ${on_string}: VCF"/>
+        <collection name="outputBam" type="list" label="${tool.name} on ${on_string}: BAM">
+            <discover_datasets pattern="(?P&lt;name&gt;.+)\.bam$" format="bam" directory="./out/filter" visible="false" />
+        </collection>
+        <collection name="outputTsv" type="list" label="${tool.name} on ${on_string}: Count TSV">
+            <discover_datasets pattern="(?P&lt;name&gt;.+)_tcount.tsv$" format="tabular" directory="./out/count" visible="false" />
+        </collection>
+        <collection name="outputVcf" type="list" label="${tool.name} on ${on_string}: VCF">
+            <discover_datasets pattern="(?P&lt;name&gt;.+)_snp.vcf$" format="vcf" directory="./out/snp" visible="false" />
+        </collection>
     </outputs>
     <tests>
         <test>
@@ -96,7 +111,7 @@
             <param name="reference_source_selector" value="history" />
             <param name="ref_file" value="ref.fa" />
             <param name="Reference" value="actb.bed" />
-            <param name="Reads" value="reads.fq" />
+            <param name="reads" value="reads.fq" />
             <param name="readLength" value="100" />
             <section name="quantseq">
                 <param name="trim5" value="0" />
@@ -104,16 +119,22 @@
             <section name="advanced">
                 <param name="minBaseQual" value="27" />
             </section>
-            <output name="outputBam" ftype="bam" file="reads1.bam" compare="sim_size"/>
-            <output name="outputTsv" ftype="tabular" file="reads_slamdunk_mapped_filtered_tcount.tsv"
-                lines_diff="2" />
-            <output name="outputVcf" ftype="vcf" file="reads1_snp.vcf" compare="sim_size"/>
+            <output_collection name="outputBam">
+                <element name="reads_slamdunk_mapped_filtered" ftype="bam" file="reads1.bam" compare="sim_size" />
+            </output_collection>
+            <output_collection name="outputTsv">
+                <element name="reads_slamdunk_mapped_filtered" ftype="tabular" file="reads_slamdunk_mapped_filtered_tcount.tsv"
+                lines_diff="2"  />
+            </output_collection>
+            <output_collection name="outputVcf">
+                <element name="reads_slamdunk_mapped_filtered" ftype="vcf" file="reads1_snp.vcf" compare="sim_size" />
+            </output_collection>
         </test>
         <test>
             <!--Ensure built-in fasta works -->
             <param name="reference_source_selector" value="cached" />
             <param name="Reference" value="actb.bed" />
-            <param name="Reads" ftype="fastqsanger" dbkey="hg38" value="reads.fq" />
+            <param name="reads" ftype="fastqsanger" dbkey="hg38" value="reads.fq" />
             <param name="readLength" value="100" />
             <section name="quantseq">
                 <param name="trim5" value="0" />
@@ -121,10 +142,16 @@
             <section name="advanced">
                 <param name="minBaseQual" value="27" />
             </section>
-            <output name="outputBam" ftype="bam" file="reads1.bam" compare="sim_size"/>
-            <output name="outputTsv" ftype="tabular" file="reads_slamdunk_mapped_filtered_tcount.tsv"
-                lines_diff="2" />
-            <output name="outputVcf" ftype="vcf" file="reads1_snp.vcf" compare="sim_size"/>
+            <output_collection name="outputBam">
+                <element name="reads_slamdunk_mapped_filtered" ftype="bam" file="reads1.bam" compare="sim_size" />
+            </output_collection>
+            <output_collection name="outputTsv">
+                <element name="reads_slamdunk_mapped_filtered" ftype="tabular" file="reads_slamdunk_mapped_filtered_tcount.tsv"
+                lines_diff="2"  />
+            </output_collection>
+            <output_collection name="outputVcf">
+                <element name="reads_slamdunk_mapped_filtered" ftype="vcf" file="reads1_snp.vcf" compare="sim_size" />
+            </output_collection>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/slamdunk/slamdunk.xml
+++ b/tools/slamdunk/slamdunk.xml
@@ -1,4 +1,4 @@
-<tool id="slamdunk" name="Slamdunk" version="@TOOL_VERSION@+galaxy1">
+<tool id="slamdunk" name="Slamdunk" version="@TOOL_VERSION@+galaxy2">
     <description>- streamlining SLAM-seq analysis with ultra-high sensitivity</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
This PR adds `multiple = True` to slamdunk fastq input as otherwise all samples get the same read group ID and SM and then don't work with Alleyoop.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
