### PR TITLE
Goseq: update to v1.32.0

### DIFF
--- a/tools/goseq/goseq.r
+++ b/tools/goseq/goseq.r
@@ -134,7 +134,7 @@ if (repcnt > 0) {
   sink(zz)
   GO.samp=goseq(pwf, genome = genome, id = gene_id, method="Sampling", repcnt=repcnt, use_genes_without_cat = use_genes_without_cat, gene2cat=go_map)
   sink()
-  
+
   GO.samp$p.adjust.over_represented = p.adjust(GO.samp$over_represented_pvalue, method=p_adj_method)
   GO.samp$p.adjust.under_represented = p.adjust(GO.samp$under_represented_pvalue, method=p_adj_method)
   write.table(GO.samp, sampling_tab, sep="\t", row.names = FALSE, quote = FALSE)
@@ -156,15 +156,15 @@ if (!is.null(args$top_plot)) {
   pdf("top10.pdf")
   for (m in names(results)) {
     p <- results[[m]] %>%
-      top_n(10, wt=-p.adjust.over_represented)  %>%
+      top_n(10, wt=-over_represented_pvalue)  %>%
       mutate(hitsPerc=numDEInCat*100/numInCat) %>%
       ggplot(aes(x=hitsPerc,
                    y=substr(term, 1, 40), # only use 1st 40 chars of terms otherwise squashes plot
-                   colour=p.adjust.over_represented,
+                   colour=over_represented_pvalue,
                    size=numDEInCat)) +
       geom_point() +
       expand_limits(x=0) +
-      labs(x="% DE in category", y="Category", colour="adj. P value", size="Count", title=paste("Top over-represented categories in", cats_title), subtitle=paste(m, " method")) +
+      labs(x="% DE in category", y="Category", colour="P value", size="Count", title=paste("Top over-represented categories in", cats_title), subtitle=paste(m, " method")) +
       theme(plot.title = element_text(hjust = 0.5), plot.subtitle = element_text(hjust = 0.5))
     print(p)
   }

--- a/tools/goseq/goseq.xml
+++ b/tools/goseq/goseq.xml
@@ -203,7 +203,7 @@ Rscript '$__tool_directory__/goseq.r'
             <output name="wallenius_tab">
                 <assert_contents>
                     <has_text_matching expression="category.*over_represented_pvalue.*under_represented_pvalue.*numDEInCat.*numInCat.*term.*ontology.*p.adjust.over_represented.*p.adjust.under_represented" />
-                    <has_text_matching expression="GO:0031324.*0.08" />
+                    <has_text_matching expression="GO:0031324.*0.12" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/goseq/goseq.xml
+++ b/tools/goseq/goseq.xml
@@ -1,14 +1,14 @@
-<tool id="goseq" name="goseq" version="1.30.1">
+<tool id="goseq" name="goseq" version="1.32.0">
     <description>tests for overrepresented gene categories</description>
     <requirements>
+        <requirement type="package" version="1.32.0">bioconductor-goseq</requirement>
+        <requirement type="package" version="3.6.0">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.6.0">bioconductor-org.dm.eg.db</requirement>
+        <requirement type="package" version="3.6.0">bioconductor-org.dr.eg.db</requirement>
+        <requirement type="package" version="3.6.0">bioconductor-org.mm.eg.db</requirement>
+        <requirement type="package" version="0.7.8">r-dplyr</requirement>
+        <requirement type="package" version="3.1.0">r-ggplot2</requirement>
         <requirement type="package" version="1.6.0">r-optparse</requirement>
-        <requirement type="package" version="1.30.0">bioconductor-goseq</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.hs.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.dm.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.dr.eg.db</requirement>
-        <requirement type="package" version="3.5.0">bioconductor-org.mm.eg.db</requirement>
-        <requirement type="package" version="0.7.6">r-dplyr</requirement>
-        <requirement type="package" version="3.0.0">r-ggplot2</requirement>
     </requirements>
     <stdio>
         <regex match="Execution halted"


### PR DESCRIPTION
Updates goseq to v1.32.0, updates dependencies, and changes plot of top 10 to raw P value instead of adj P

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
