### PR TITLE
edgeR: update to v3.24.1 and handle single quotes if present in input annotation

### DIFF
--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -261,7 +261,7 @@ if (!is.null(opt$filesPath)) {
     
 } else {
     # Process the single count matrix
-    counts <- read.table(opt$matrixPath, header=TRUE, sep="\t", stringsAsFactors=FALSE)
+    counts <- read.table(opt$matrixPath, header=TRUE, sep="\t", strip.white=TRUE, stringsAsFactors=FALSE)
     row.names(counts) <- counts[, 1]
     counts <- counts[ , -1]
     countsRows <- nrow(counts)
@@ -293,7 +293,7 @@ if (!is.null(opt$filesPath)) {
 
  # if annotation file provided
 if (haveAnno) {
-    geneanno <- read.table(opt$annoPath, header=TRUE, sep="\t", stringsAsFactors=FALSE)
+    geneanno <- read.table(opt$annoPath, header=TRUE, sep="\t", quote= "", strip.white=TRUE, stringsAsFactors=FALSE)
 }
 
 #Create output directory

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -269,6 +269,9 @@ if (!is.null(opt$filesPath)) {
     # Process factors
     if (is.null(opt$factInput)) {
             factorData <- read.table(opt$factFile, header=TRUE, sep="\t", strip.white=TRUE)
+            # check samples names match
+            if(!any(factorData[, 1] %in% colnames(counts)))
+                stop("Sample IDs in factors file and count matrix don't match")
             # order samples as in counts matrix
             factorData <- factorData[match(colnames(counts), factorData[, 1]), ]
             factors <- factorData[, -1, drop=FALSE]

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -1,11 +1,11 @@
-<tool id="edger" name="edgeR" version="3.22.5+galaxy1">
+<tool id="edger" name="edgeR" version="3.24.1">
     <description>
         Perform differential expression of count data
     </description>
 
     <requirements>
-        <requirement type="package" version="3.22.5">bioconductor-edger</requirement>
-        <requirement type="package" version="3.36.5">bioconductor-limma</requirement>
+        <requirement type="package" version="3.24.1">bioconductor-edger</requirement>
+        <requirement type="package" version="3.38.3">bioconductor-limma</requirement>
         <requirement type="package" version="0.2.20">r-rjson</requirement>
         <requirement type="package" version="1.20.2">r-getopt</requirement>
         <requirement type="package" version="1.4.30">r-statmod</requirement>
@@ -424,7 +424,7 @@ cp '$outReport.files_path'/*.tsv output_dir/
                 <element name="edgeR_normcounts" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="GeneID.*Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*15.7535" />
+                        <has_text_matching expression="11304.*15.75" />
                    </assert_contents>
                </element>
             </output_collection>
@@ -503,7 +503,7 @@ cp '$outReport.files_path'/*.tsv output_dir/
                 <element name="edgeR_normcounts" ftype="tabular" >
                     <assert_contents>
                         <has_text_matching expression="Mut1.*Mut2.*Mut3.*WT1.*WT2.*WT3" />
-                        <has_text_matching expression="11304.*Abca4.*15.7535" />
+                        <has_text_matching expression="11304.*Abca4.*15.75" />
                    </assert_contents>
                </element>
             </output_collection>

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -1,4 +1,4 @@
-<tool id="edger" name="edgeR" version="3.22.5">
+<tool id="edger" name="edgeR" version="3.22.5+galaxy1">
     <description>
         Perform differential expression of count data
     </description>


### PR DESCRIPTION
- updates edgeR to v3.24.1 and limma dependency to v3.38.3
- plus a couple of minor changes for more robust handling of potential issues with inputs

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
