### PR TITLE
edgeR: fix for changing FDR method and clarify group naming

### DIFF
--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -526,7 +526,7 @@ for (i in 1:length(contrastData)) {
     flatCount[i] <- sumStatus["NotSig", ]
                                              
     # Write top expressions table
-    top <- topTags(res, n=Inf, sort.by="PValue")
+    top <- topTags(res, adjust.method=opt$pAdjOpt, n=Inf, sort.by="PValue")
     write.table(top, file=topOut[i], row.names=FALSE, sep="\t", quote=FALSE)
     
     linkName <- paste0("edgeR_", contrastData[i], ".tsv")

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -113,14 +113,14 @@ cp '$outReport.files_path'/*.tsv output_dir/
 
             <when value="files">
                 <repeat name="rep_factor" title="Factor" min="1">
-                    <param name="factorName" type="text" label="Name" help="Name of experiment factor of interest (e.g. Genotype). One factor must be entered and there must be two or more groups per factor. Optional additional factors (e.g. Batch) can be entered using the Insert Factor button below, see Help section for more information. NOTE: Please only use letters, numbers or underscores.">
+                    <param name="factorName" type="text" label="Name" help="Name of experiment factor of interest (e.g. Genotype). One factor must be entered and there must be two or more groups per factor. Optional additional factors (e.g. Batch) can be entered using the Insert Factor button below, see Help section for more information. NOTE: Please only use letters, numbers or underscores, and the first character of each factor must be a letter">
                     <sanitizer>
                         <valid initial="string.letters,string.digits"><add value="_" /></valid>
                     </sanitizer>
                     </param>
                     <repeat name="rep_group" title="Group" min="2" default="2">
                         <param name="groupName" type="text" label="Name"
-                        help="Name of group that the counts files belong to (e.g. WT or Mut). NOTE: Please only use letters, numbers or underscores (case sensitive).">
+                        help="Name of group that the counts files belong to (e.g. WT or Mut). NOTE: Please only use letters, numbers or underscores (case sensitive), and the first character of each group must be a letter">
                         <sanitizer>
                             <valid initial="string.letters,string.digits"><add value="_" /></valid>
                         </sanitizer>
@@ -135,7 +135,7 @@ cp '$outReport.files_path'/*.tsv output_dir/
 
                 <conditional name="fact">
                     <param name="ffile" type="select" label="Input factor information from file?"
-                        help="You can choose to input the factor and group information for the samples from a file or manually enter below.">
+                        help="You can choose to input the factor and group information for the samples from a file or manually enter below. NOTE: Please only use letters, numbers or underscores (case sensitive), and the first character of each sample, factor and group must be a letter">
                         <option value="no">No</option>
                         <option value="yes">Yes</option>
                     </param>
@@ -145,12 +145,12 @@ cp '$outReport.files_path'/*.tsv output_dir/
                     <when value="no" >
                         <repeat name="rep_factor" title="Factor" min="1">
                             <param name="factorName" type="text" label="Factor Name"
-                                help="Name of experiment factor of interest (e.g. Genotype). One factor must be entered and there must be two or more groups per factor. Additional factors (e.g. Batch) can be entered using the Insert Factor button below, see Help section below. NOTE: Please only use letters, numbers or underscores.">
+                                help="Name of experiment factor of interest (e.g. Genotype). One factor must be entered and there must be two or more groups per factor. Additional factors (e.g. Batch) can be entered using the Insert Factor button below, see Help section below. NOTE: Please only use letters, numbers or underscores, and the first character of each factor must be a letter">
                                 <validator type="empty_field" />
                                 <validator type="regex" message="Please only use letters, numbers or underscores">^[\w]+$</validator>
                             </param>
                             <param name="groupNames" type="text" label="Groups"
-                                help="Enter the group names for the samples separated with commas e.g. WT,WT,WT,Mut,Mut,Mut. The order of the names must match the order of the samples in the columns of the count matrix. NOTE: Please only use letters, numbers or underscores (case sensitive).">
+                                help="Enter the group names for the samples separated with commas e.g. WT,WT,WT,Mut,Mut,Mut. The order of the names must match the order of the samples in the columns of the count matrix. NOTE: Please only use letters, numbers or underscores (case sensitive), and the first character of each group must be a letter">
                                 <validator type="empty_field" />
                                 <validator type="regex" message="Please only use letters, numbers or underscores, and separate levels by commas">^[\w,]+$</validator>
                             </param>
@@ -635,7 +635,7 @@ This tool uses the `edgeR`_ quasi-likelihood pipeline (edgeR-quasi) for differen
 
 **Counts Data:**
 
-The counts data can either be input as separate counts files (one sample per file) or a single count matrix (one sample per column). The rows correspond to genes, and columns correspond to the counts for the samples. Values must be tab separated, with the first row containing the sample/column labels and the first column containing the row/gene labels. Gene identifiers can be of any type but must be unique and not repeated within a counts file.
+The counts data can either be input as separate counts files (one sample per file) or a single count matrix (one sample per column). The rows correspond to genes, and columns correspond to the counts for the samples. Values must be tab separated, with the first row containing the sample/column labels and the first column containing the row/gene labels. The sample labels must start with a letter. Gene identifiers can be of any type but must be unique and not repeated within a counts file.
 
 Example - **Separate Count Files**:
 
@@ -698,9 +698,9 @@ Example:
     Mut3       Mut          b3
     ========== ============ =========
 
-*Factor Name:* The name of the experimental factor being investigated e.g. Genotype, Treatment. One factor must be entered and spaces must not be used. Optionally, additional factors can be included, these are variables that might influence your experiment e.g. Batch, Gender, Subject. If additional factors are entered, an additive linear model will be used.
+*Factor Name:* The name of the experimental factor being investigated e.g. Genotype, Treatment. One factor must be entered, the name should start with a letter and spaces must not be used. Optionally, additional factors can be included, these are variables that might influence your experiment e.g. Batch, Gender, Subject. If additional factors are entered, an additive linear model will be used.
 
-*Groups:* The names of the groups for the factor. These must be entered in the same order as the samples (to which the groups correspond) are listed in the columns of the counts matrix. Spaces must not be used and if entered into the tool form above, the values should be separated by commas.
+*Groups:* The names of the groups for the factor. These must be entered in the same order as the samples (to which the groups correspond) are listed in the columns of the counts matrix. The names should start with a letter, spaces and hyphens must not be used, and if entered into the tool form above, the values should be separated by commas.
 
 
 **Contrasts of Interest:**

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -1,4 +1,4 @@
-<tool id="edger" name="edgeR" version="3.24.1">
+<tool id="edger" name="edgeR" version="3.24.1+galaxy1">
     <description>
         Perform differential expression of count data
     </description>

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -1,4 +1,4 @@
-<tool id="edger" name="edgeR" version="3.24.1+galaxy1">
+<tool id="edger" name="edgeR" version="3.24.1">
     <description>
         Perform differential expression of count data
     </description>

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -700,8 +700,7 @@ Example:
 
 *Factor Name:* The name of the experimental factor being investigated e.g. Genotype, Treatment. One factor must be entered, the name should start with a letter and spaces must not be used. Optionally, additional factors can be included, these are variables that might influence your experiment e.g. Batch, Gender, Subject. If additional factors are entered, an additive linear model will be used.
 
-*Groups:* The names of the groups for the factor. These must be entered in the same order as the samples (to which the groups correspond) are listed in the columns of the counts matrix. The names should start with a letter, spaces and hyphens must not be used, and if entered into the tool form above, the values should be separated by commas.
-
+*Groups:* The names of the groups for the factor. The names should start with a letter, and only contain letters, numbers and underscores, other characters such as spaces and hyphens must not be used. If entered into the tool form above, the order must be the same as the samples (to which the groups correspond) are listed in the columns of the counts matrix, with the values separated by commas.
 
 **Contrasts of Interest:**
 The contrasts you wish to make between levels.


### PR DESCRIPTION
- Fix for output DE tables if changing FDR method (currently always using BH method), as reported by @bimbam23 here: https://github.com/galaxyproject/tools-iuc/issues/2283
- Clarify group names etc should not start with a number as reported by m93 here: https://help.galaxyproject.org/t/edger-error-for-paired-differential-expression-analysis/543/2

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
