### PR TITLE
Jbrowse: update to 1.16.2 + neatfeatures

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -457,8 +457,10 @@ $trackxml &&
 
                 <conditional name="track_config">
                     <param type="select" label="JBrowse Track Type [Advanced]" name="track_class">
+                        <option value="NeatHTMLFeatures/View/Track/NeatFeatures" selected="true">Neat HTML Features</option>
+                        <option value="NeatCanvasFeatures/View/Track/NeatFeatures">Neat Canvas Features</option>
                         <option value="JBrowse/View/Track/HTMLFeatures">HTML Features</option>
-                        <option value="JBrowse/View/Track/CanvasFeatures" selected="true">Canvas Features</option>
+                        <option value="JBrowse/View/Track/CanvasFeatures">Canvas Features</option>
                         <option value="BlastView/View/Track/CanvasFeatures">Blast Features</option><!-- Disable plugins until https://github.com/GMOD/jbrowse/issues/1288 is fixed -->
                     </param>
                     <when value="JBrowse/View/Track/CanvasFeatures">
@@ -482,19 +484,12 @@ $trackxml &&
                                    truevalue="true"
                                    falsevalue="false"
                                    help="Check this your input files does not contain UTR features, but the UTR can be 'implied' from the difference between the exon and CDS boundaries"/>
-                       </section>
-                   </when>
-                   <when value="JBrowse/View/Track/HTMLFeatures">
-                       <section name="html_options" title="HTMLFeatures Options [Advanced]" expanded="false">
-                           <param label="Transcript type"
-                                  name="transcriptType"
-                                  type="text"
-                                  value=""
-                                  help="If your input files represents transcripts, give the name of the corresponding features here (e.g. 'mRNA' or 'transcript')"
-                                  optional="True"/>
-                      </section>
-                  </when>
-                  <!--when value="BlastView/View/Track/CanvasFeatures" /-->
+                        </section>
+                    </when>
+                    <when value="JBrowse/View/Track/HTMLFeatures" />
+                    <when value="BlastView/View/Track/CanvasFeatures" />
+                    <when value="NeatHTMLFeatures/View/Track/NeatFeatures" />
+                    <when value="NeatCanvasFeatures/View/Track/NeatFeatures" />
                 </conditional>
                 <expand macro="track_styling" />
                 <expand macro="color_selection" />

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -276,10 +276,6 @@ $trackxml &&
                     #if str($track.data_format.track_config.canvas_options.impliedUTRs) != "false":
                     <impliedUTRs>${track.data_format.track_config.canvas_options.impliedUTRs}</impliedUTRs>
                     #end if
-                  #else if $track.data_format.track_config.track_class == 'JBrowse/View/Track/HTMLFeatures':
-                    #if str($track.data_format.track_config.html_options.transcriptType) != "":
-                    <transcriptType>${track.data_format.track_config.html_options.transcriptType}</transcriptType>
-                    #end if
                   #end if
                   #if $track.data_format.match_part.match_part_select:
                     <match>${track.data_format.match_part.name}</match>

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.16.1</token>
+  <token name="@TOOL_VERSION@">1.16.2</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">jbrowse</requirement>

--- a/tools/jbrowse/readme.rst
+++ b/tools/jbrowse/readme.rst
@@ -25,6 +25,11 @@ likely to change at any time! Beware. ;)
 History
 =======
 
+- 1.16.2+galaxy0
+
+    - UPDATED to JBrowse 1.16.2
+    - ADDED support for NeatHTMLFeatures and NeatCanvasFeatures track types
+
 - 1.16.1+galaxy0
 
     - UPDATED to JBrowse 1.16.1


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

A little update to jbrowse 1.16.2 + added NeatHTMLFeature and NeatCanvasFeature track types (recommended now in apollo 2.3)