### PR TITLE
Jbrowse: fix gff3 sorting

### DIFF
--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -614,7 +614,7 @@ class JbrowseConnector(object):
 
         if not os.path.exists(dest):
             # Only index if not already done
-            cmd = "gff3sort.pl --precise '%s' > '%s'" % (data, dest)
+            cmd = "gff3sort.pl --precise '%s' | grep -v \"^$\" > '%s'" % (data, dest)
             self.subprocess_popen(cmd)
 
             cmd = ['bgzip', '-f', dest]

--- a/tools/jbrowse/jbrowse.py
+++ b/tools/jbrowse/jbrowse.py
@@ -614,10 +614,7 @@ class JbrowseConnector(object):
 
         if not os.path.exists(dest):
             # Only index if not already done
-            cmd = "grep ^\"#\" '%s' > '%s'" % (data, dest)
-            self.subprocess_popen(cmd)
-
-            cmd = "grep -v ^\"#\" '%s' | grep -v \"^$\" | grep \"\t\" | sort -k1,1 -k4,4n >> '%s'" % (data, dest)
+            cmd = "gff3sort.pl --precise '%s' > '%s'" % (data, dest)
             self.subprocess_popen(cmd)
 
             cmd = ['bgzip', '-f', dest]

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -14,7 +14,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy1</token>
+  <token name="@WRAPPER_VERSION@">galaxy2</token>
   <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Use gff3sort to properly sort gff files (in some cases `gene` features could be moved after their `mRNA` which jbrowse didn't like at all)