### PR TITLE
Force python version of eutils to py27

### DIFF
--- a/tools/ncbi_entrez_eutils/macros.xml
+++ b/tools/ncbi_entrez_eutils/macros.xml
@@ -835,6 +835,7 @@ permissions.
   </xml>
   <xml name="requirements">
     <requirements>
+      <requirement type="package" version="2.7">python</requirement>
       <requirement type="package" version="1.68">biopython</requirement>
       <requirement type="package" version="1.10">six</requirement>
     </requirements>


### PR DESCRIPTION
Thanks to @pvanheus for the bug reports for this. Sorry.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
