### PR TITLE
Fixes wrong p value when processing g-zipped fastq

### DIFF
--- a/tools/flash/flash.xml
+++ b/tools/flash/flash.xml
@@ -22,7 +22,7 @@
                     '$layout.reads.forward' '$layout.reads.reverse'
                     #set $input = $layout.reads.forward
                 #end if
-                #if $input.dataset.extension == 'fastqsanger':
+                #if $input.is_of_type('fastqsanger'):
                     -p 33
                 #else:
                     -p 64


### PR DESCRIPTION
If you submit fastqsanger.gz, the -p value of the command is 64 instead of the correct 33 and the tool fails.  This should fix that issue.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
