### PR TITLE
Samtools_sort: support for new BAM datatype variants

### DIFF
--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_sort" name="Samtools sort" version="2.0.2">
+<tool id="samtools_sort" name="Samtools sort" version="2.0.3">
     <description>order of storing aligned sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_sort" name="Samtools sort" version="2.0.3">
+<tool id="samtools_sort" name="Samtools sort" profile="18.01" version="2.0.3">
     <description>order of storing aligned sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -26,7 +26,7 @@
              > '${output1}'
     ]]></command>
     <inputs>
-        <param name="input1" type="data" format="sam,bam,cram" label="BAM File" />
+        <param name="input1" type="data" format="sam,unsorted.bam,cram" label="BAM File" />
         <conditional name="prim_key_cond">
             <param name="prim_key_select" type="select" label="Primary sort key">
                 <option value="">coordinate</option>


### PR DESCRIPTION
I have added "unsorted.bam", "qname_sorted.bam" and "qnamed_input_sorted.bam" as input types to samtools_sort. This is needed to support the following workflow:

1. samtools_fixmate, which outputs "qname_sorted.bam"
2. samtools_sort, to coordinate sort, outputs "bam"
3. samtools_markdup

Currently, samtools_sort requires "bam" as input. so the workflow above is not possible to make.

(Automatically changing the output of samtools_fixmate to "bam" in the workflow triggers indexing, which fails (with a very strange error message) due to the file not being coordinate sorted, so that is not a solution)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)