### PR TITLE
JBrowse: fix huge trackList.json

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -130,7 +130,7 @@ $trackxml &&
                       display_name="${dataset.history.get_display_name()}"/>
                   <metadata
                     #for (key, value) in $dataset.get_metadata().items():
-                    #if "_types" not in $key:
+                    #if "_types" not in $key and $value is not None and len(str($value)) < 20000:
                       ${key}="${value}"
                     #end if
                     #end for

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -3,7 +3,7 @@
     <metadata>
         <gencode>11</gencode>
         <genomes>
-              <genome path="/tmp/tmpWtvfKr/files/000/dataset_5.dat">
+              <genome path="/tmp/tmpTx5wXw/files/000/dataset_5.dat">
                 <metadata>
                   <dataset id="7b55dbb89df8f4e5" hid="1"
                       size="171.6 KB"
@@ -42,7 +42,7 @@
     <tracks>
         <track cat="Auto Coloured" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_6.dat" ext="gff3" label="A.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_6.dat" ext="gff3" label="gff3/A.gff">
                 <metadata>
                   <dataset id="fa6d20d0fb68383f" hid="2"
                       size="2.3 KB"
@@ -57,7 +57,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -67,7 +66,7 @@
                       />
                 </metadata>
               </trackFile>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_7.dat" ext="gff3" label="B.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_7.dat" ext="gff3" label="gff3/B.gff">
                 <metadata>
                   <dataset id="683bc220e21425bb" hid="3"
                       size="2.3 KB"
@@ -82,7 +81,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -92,7 +90,7 @@
                       />
                 </metadata>
               </trackFile>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_8.dat" ext="gff3" label="C.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_8.dat" ext="gff3" label="gff3/C.gff">
                 <metadata>
                   <dataset id="a90a30fafe298e1e" hid="4"
                       size="2.3 KB"
@@ -107,7 +105,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -117,7 +114,7 @@
                       />
                 </metadata>
               </trackFile>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_9.dat" ext="gff3" label="D.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_9.dat" ext="gff3" label="gff3/D.gff">
                 <metadata>
                   <dataset id="b842d972534ccb3e" hid="5"
                       size="2.3 KB"
@@ -132,7 +129,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -148,7 +144,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -164,14 +160,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Ignore Scale" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_10.dat" ext="gff3" label="1.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_10.dat" ext="gff3" label="gff3/1.gff">
                 <metadata>
                   <dataset id="5449172d6ff5669b" hid="6"
                       size="2.3 KB"
@@ -186,7 +183,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -202,7 +198,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -218,14 +214,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Scaled Colour" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_10.dat" ext="gff3" label="1.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_10.dat" ext="gff3" label="gff3/1.gff">
                 <metadata>
                   <dataset id="5449172d6ff5669b" hid="6"
                       size="2.3 KB"
@@ -240,7 +237,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -256,7 +252,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -278,14 +274,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Scaled Colour" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_10.dat" ext="gff3" label="1.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_10.dat" ext="gff3" label="gff3/1.gff">
                 <metadata>
                   <dataset id="5449172d6ff5669b" hid="6"
                       size="2.3 KB"
@@ -300,7 +297,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -316,7 +312,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -338,14 +334,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Scaled Colour" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_10.dat" ext="gff3" label="1.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_10.dat" ext="gff3" label="gff3/1.gff">
                 <metadata>
                   <dataset id="5449172d6ff5669b" hid="6"
                       size="2.3 KB"
@@ -360,7 +357,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -376,7 +372,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -400,14 +396,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Scaled Colour" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_10.dat" ext="gff3" label="1.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_10.dat" ext="gff3" label="gff3/1.gff">
                 <metadata>
                   <dataset id="5449172d6ff5669b" hid="6"
                       size="2.3 KB"
@@ -422,7 +419,6 @@
                       data_lines="27"
                       comment_lines="19"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="6"
                       />
@@ -438,7 +434,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -462,14 +458,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Realistic" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_11.dat" ext="gff3" label="interpro.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_11.dat" ext="gff3" label="gff3/interpro.gff">
                 <metadata>
                   <dataset id="9ce08b2254e4d5ed" hid="7"
                       size="103.3 KB"
@@ -484,7 +481,6 @@
                       data_lines="556"
                       comment_lines="2"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="11"
                       />
@@ -500,7 +496,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -516,14 +512,15 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <index>false</index>
                 </gff>
             </options>
         </track>
         <track cat="Realistic" format="gene_calls" visibility="default_off">
             <files>
-              <trackFile path="/tmp/tmpWtvfKr/files/000/dataset_12.dat" ext="gff3" label="2.gff">
+              <trackFile path="/tmp/tmpTx5wXw/files/000/dataset_12.dat" ext="gff3" label="gff3/2.gff">
                 <metadata>
                   <dataset id="80b8022ff3f677b7" hid="8"
                       size="326 bytes"
@@ -538,7 +535,6 @@
                       data_lines="3"
                       comment_lines="3"
                       columns="9"
-                      column_names=""
                       delimiter="__tc__"
                       attributes="4"
                       />
@@ -554,7 +550,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature</className>
+                    <className>feature2</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -570,7 +566,8 @@
                 </menus>
 
                 <gff>
-                    <trackType>JBrowse/View/Track/CanvasFeatures</trackType>
+                    <trackType>NeatHTMLFeatures/View/Track/NeatFeatures</trackType>
+                    <topLevelFeatures>mRNA</topLevelFeatures>
                     <match>cDNA_match</match>
                     <index>false</index>
                 </gff>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

A little bug fix for the jbrowse tool: when you add bam tracks on a genome with many scaffolds/contig, the resulting trackList.json contains all the scaffold/contig names in a reference_names metadata. In my case the trackList.json was 175Mb and I just couldn't load with chrome
So here's a patch to just ignore too big metadata. "Too big" it 20000 chars, but I can change it of course