### PR TITLE
JBrowse: 1.16.4

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -130,7 +130,7 @@ $trackxml &&
                       display_name="${dataset.history.get_display_name()}"/>
                   <metadata
                     #for (key, value) in $dataset.get_metadata().items():
-                    #if "_types" not in $key and $value is not None and len(str($value)) < 20000:
+                    #if "_types" not in $key and $value is not None and len(str($value)) < 5000:
                       ${key}="${value}"
                     #end if
                     #end for
@@ -482,7 +482,7 @@ $trackxml &&
                     </when>
                 </conditional>
                 <expand macro="track_styling"
-                        classname="feature2"
+                        classname="feature"
                         label="product,name,id"
                         description="note,description"
                         height="10px"/>

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.16.2</token>
+  <token name="@TOOL_VERSION@">1.16.4</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">jbrowse</requirement>
@@ -415,8 +415,7 @@ This Galaxy tool relies on the JBrowse, maintained by the GMOD Community. The Ga
           <param label="Top level features"
                  name="topLevelFeatures"
                  type="text"
-                 value="mRNA"
-                 help="Select which top level features should be displayed. If empty, will try to display all features. If your input files represents gene→mRNA→exon/CDS/UTR, you should use mRNA otherwise exons will not be rendered."
+                 help="Select which top level features should be displayed. If empty, will try to display all features. If your input files represents gene→mRNA→exon/CDS/UTR, you should use mRNA if exons don't render."
                  optional="True"/>
       </section>
   </xml>

--- a/tools/jbrowse/readme.rst
+++ b/tools/jbrowse/readme.rst
@@ -25,6 +25,12 @@ likely to change at any time! Beware. ;)
 History
 =======
 
+- 1.16.4+galaxy0
+
+    - UPDATED to JBrowse 1.16.4
+    - ADDED filter too big metadata
+    - CHANGED default value for topLevelFeatures (gene subfeatures are now inferred) and style.className (feature style was fixed)
+
 - 1.16.2+galaxy0
 
     - UPDATED to JBrowse 1.16.2

--- a/tools/jbrowse/test-data/gff3/test.xml
+++ b/tools/jbrowse/test-data/gff3/test.xml
@@ -144,7 +144,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -198,7 +198,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -252,7 +252,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -312,7 +312,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -372,7 +372,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -434,7 +434,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -496,7 +496,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>
@@ -550,7 +550,7 @@
                 <style>
                     <overridePlugins>False</overridePlugins>
                     <overrideDraggable>False</overrideDraggable>
-                    <className>feature2</className>
+                    <className>feature</className>
                     <description>note,description</description>
                     <label>product,name,id</label>
                     <height>10px</height>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

There's a brand new 1.16.4 of jbrowse with a few bug fixes I'm interested in, so here's the update.

Removed the default value topLevelFeatures as it should not be needed anymore in most cases (https://github.com/GMOD/jbrowse/pull/1340)

Also switched back to the `feature` default classname as the styling was fixed too in 1.16.4

I also decreased the threshold for filtering long metadata, I found a 500kb trackList.json which made the page loading veeery slow, it should be better like this.