### PR TITLE
Drop sam input from macs2

### DIFF
--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -138,10 +138,10 @@
                 <option value="Yes">Yes</option>
             </param>
             <when value="No" >
-                <param name="input_treatment_file" argument="-t" type="data" format="bam,sam,bed" label="ChIP-Seq Treatment File" />
+                <param name="input_treatment_file" argument="-t" type="data" format="bam,bed" label="ChIP-Seq Treatment File" />
             </when>
             <when value="Yes">
-                <param name="input_treatment_file" argument="-t" type="data" format="bam,sam,bed" multiple="true" label="ChIP-Seq Treatment File" />
+                <param name="input_treatment_file" argument="-t" type="data" format="bam,bed" multiple="true" label="ChIP-Seq Treatment File" />
             </when>
         </conditional>
 
@@ -157,10 +157,10 @@
                         <option value="Yes">Yes</option>
                     </param>
                     <when value="No" >
-                        <param name="input_control_file" argument="-c" type="data" format="bam,sam,bed" label="ChIP-Seq Control File" />
+                        <param name="input_control_file" argument="-c" type="data" format="bam,bed" label="ChIP-Seq Control File" />
                     </when>
                     <when value="Yes">
-                        <param name="input_control_file" argument="-c" type="data" format="bam,sam,bed" multiple="true" label="ChIP-Seq Control File" />
+                        <param name="input_control_file" argument="-c" type="data" format="bam,bed" multiple="true" label="ChIP-Seq Control File" />
                     </when>
                 </conditional>
             </when>

--- a/tools/macs2/macs2_callpeak.xml
+++ b/tools/macs2/macs2_callpeak.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_callpeak" name="MACS2 callpeak" version="@VERSION_STRING@.5" profile="17.09">
+<tool id="macs2_callpeak" name="MACS2 callpeak" version="@VERSION_STRING@.6" profile="17.09">
     <description>Call peaks from alignment results</description>
     <macros>
         <import>macs2_macros.xml</import>

--- a/tools/macs2/macs2_filterdup.xml
+++ b/tools/macs2/macs2_filterdup.xml
@@ -23,7 +23,7 @@
     ]]>
     </command>
     <inputs>
-        <param name="infile" type="data" format="sam,bam,bed" label="Sequencing alignment file" />
+        <param name="infile" type="data" format="bam,bed" label="Sequencing alignment file" />
         <expand macro="conditional_effective_genome_size" />
         <expand macro="tag_size" />
         <param name="pvalue" type="text" value="1e-5" label="Pvalue cutoff for binomial distribution test" help="Default=1e-5 (--pvalue)" />

--- a/tools/macs2/macs2_filterdup.xml
+++ b/tools/macs2/macs2_filterdup.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_filterdup" name="MACS2 filterdup" version="@VERSION_STRING@.0">
+<tool id="macs2_filterdup" name="MACS2 filterdup" version="@VERSION_STRING@.1">
     <description>Remove duplicate reads at the same position</description>
     <macros>
         <import>macs2_macros.xml</import>

--- a/tools/macs2/macs2_predictd.xml
+++ b/tools/macs2/macs2_predictd.xml
@@ -26,7 +26,7 @@
         Rscript predictd
     ]]></command>
     <inputs>
-        <param name="infiles" type="data" format="bam,sam,bed" multiple="True"
+        <param name="infiles" type="data" format="bam,bed" multiple="True"
                label="ChIP-seq alignment file"
                help="If multiple files are given, then they will all be read and combined. Note that pair-end data is not supposed to work with this command. (-i)" />
         <expand macro="conditional_effective_genome_size" />

--- a/tools/macs2/macs2_predictd.xml
+++ b/tools/macs2/macs2_predictd.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_predictd" name="MACS2 predictd" version="@VERSION_STRING@.0">
+<tool id="macs2_predictd" name="MACS2 predictd" version="@VERSION_STRING@.1">
     <description>Predict 'd' or fragment size from alignment results</description>
     <macros>
         <import>macs2_macros.xml</import>

--- a/tools/macs2/macs2_randsample.xml
+++ b/tools/macs2/macs2_randsample.xml
@@ -24,7 +24,7 @@
         #end if
         ]]></command>
     <inputs>
-        <param name="infile" type="data" format="sam,bam,bed" label="Sequencing alignment file" />
+        <param name="infile" type="data" format="bam,bed" label="Sequencing alignment file" />
         <expand macro="tag_size" />
         <conditional name="method_options">
             <param name="method_options_selector" type="select" label="Select action to be performed">

--- a/tools/macs2/macs2_randsample.xml
+++ b/tools/macs2/macs2_randsample.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_randsample" name="MACS2 randsample" version="@VERSION_STRING@.0">
+<tool id="macs2_randsample" name="MACS2 randsample" version="@VERSION_STRING@.1">
     <description>Randomly sample number or percentage of total reads</description>
     <macros>
         <import>macs2_macros.xml</import>

--- a/tools/macs2/macs2_refinepeak.xml
+++ b/tools/macs2/macs2_refinepeak.xml
@@ -17,7 +17,7 @@
             --ofile '${ outfile }'
     ]]></command>
     <inputs>
-        <param name="infile" type="data" format="sam,bam,bed" label="Sequencing alignment file" />
+        <param name="infile" type="data" format="bam,bed" label="Sequencing alignment file" />
         <param name="bed_infile" type="data" format="bed" label="Candidate peak file in BED format" />
         <param name="cutoff" type="float" label="Cutoff" value="5.0" help="default: 5.0 (--cutoff)"/>
         <param name="winsize" type="integer" value="200" label="Scan window size on both side of the summit" help="default: 200bp (--window-size)" />

--- a/tools/macs2/macs2_refinepeak.xml
+++ b/tools/macs2/macs2_refinepeak.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_refinepeak" name="MACS2 refinepeak" version="@VERSION_STRING@.0">
+<tool id="macs2_refinepeak" name="MACS2 refinepeak" version="@VERSION_STRING@.1">
     <description>Refine peak summits and give scores measuring balance of forward- backward tags (Experimental)</description>
     <macros>
         <import>macs2_macros.xml</import>


### PR DESCRIPTION
As macs2 seems to have difficulties with sam input.
If there's still some use for sam input the implicit conversion
will be used.
Closes https://github.com/galaxyproject/tools-iuc/issues/2313

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
