### PR TITLE
Trinity: fix rdata datatype name

### DIFF
--- a/tools/trinity/analyze_diff_expr.xml
+++ b/tools/trinity/analyze_diff_expr.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@">
+<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@+galaxy1">
     <description>from a Trinity assembly</description>
     <macros>
         <import>macros.xml</import>
@@ -92,7 +92,7 @@
             <data format="tabular" name="results_matrix_log2_sample_cor" from_work_dir="results.matrix.log2.sample_cor.dat"/>
             <data format="pdf" name="results_matrix_log2_sample_cor_matrix" from_work_dir="results.matrix.log2.sample_cor_matrix.pdf"/>
         </collection>
-        <data format="RData" name="rdata" label="${tool.name} on ${on_string}: RData file" from_work_dir="results.matrix.RData"/>
+        <data format="rdata" name="rdata" label="${tool.name} on ${on_string}: RData file" from_work_dir="results.matrix.RData"/>
         <collection name="GOseq_enrichment" type="list" label="${tool.name} on ${on_string}: GOseq enriched and depleted categories">
             <filter>additional_params['GO_enrichment']['examine_GO_enrichment'] == 'yes'</filter>
             <discover_datasets pattern="(?P&lt;name&gt;.+\.subset\.GOseq\.(enriched|depleted))$" ext="tabular" />

--- a/tools/trinity/define_clusters_by_cutting_tree.xml
+++ b/tools/trinity/define_clusters_by_cutting_tree.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_define_clusters_by_cutting_tree" name="Partition genes into expression clusters" version="@WRAPPER_VERSION@">
+<tool id="trinity_define_clusters_by_cutting_tree" name="Partition genes into expression clusters" version="@WRAPPER_VERSION@+galaxy1">
     <description>after differential expression analysis using a Trinity assembly</description>
     <macros>
         <import>macros.xml</import>
@@ -31,7 +31,7 @@
 
     ]]></command>
     <inputs>
-        <param format="RData" name="rdata" argument="-R" type="data" label="RData file" help="RData file produced by 'Extract and cluster differentially expressed transcripts from a Trinity assembly' tool"/>
+        <param format="rdata" name="rdata" argument="-R" type="data" label="RData file" help="RData file produced by 'Extract and cluster differentially expressed transcripts from a Trinity assembly' tool"/>
         <conditional name="method">
             <param name="method_selector" type="select" label="Method for partitioning genes into clusters">
                 <option value="--Ptree">Cut tree based on x percent of max(height) of tree</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

The RData datatype is not in lowercase in trinity, it made it impossible to add a spaghetti between the two tools in workflow editor

done with @r1corre