### PR TITLE
qiime split_libraries: fix datatype of qual output

### DIFF
--- a/tools/qiime/qiime_core/make_otu_heatmap.xml
+++ b/tools/qiime/qiime_core/make_otu_heatmap.xml
@@ -208,7 +208,7 @@ make_otu_heatmap.py
             <param name="height" value="5"/>
             <param name="dpi" value="200"/>
             <param name="obs_md_category" value="taxonomy"/>
-            <output name="svg_output_fp" file="make_otu_heatmap/basic_heatmap.svg" compare="sim_size" />
+            <output name="svg_output_fp" file="make_otu_heatmap/basic_heatmap.svg" compare="sim_size" delta="40000" />
         </test>
         <test>
             <param name="otu_table_fp" value="make_otu_heatmap/otu_table.biom"/>

--- a/tools/qiime/qiime_core/split_libraries.xml
+++ b/tools/qiime/qiime_core/split_libraries.xml
@@ -110,7 +110,7 @@ split_libraries.py
         <data name="sequences" format="fasta" from_work_dir="split_libraries/*.fna" label="${tool.name} on ${on_string}: sequences"/>
         <data name="log" format="txt" from_work_dir="split_libraries/split_library_log.txt" label="${tool.name} on ${on_string}: log"/>
         <data name="histograms" format="txt" from_work_dir="split_libraries/histograms.txt" label="${tool.name} on ${on_string}: histograms"/>
-        <data name="quality" format="qual,qual454,qualillumina,qualsolexa,qualsolid" from_work_dir="split_libraries/*.qual" label="${tool.name} on ${on_string}: quality">
+        <data name="quality" format_source="qual" from_work_dir="split_libraries/*.qual" label="${tool.name} on ${on_string}: quality">
             <filter>add_qual['record_qual_scores']!=""</filter>
         </data>
     </outputs>
@@ -119,7 +119,7 @@ split_libraries.py
             <param name="map" value="split_libraries/mapping_file.txt"/>
             <param name="fasta" value="split_libraries/reads_1.fna,split_libraries/reads_2.fna"/>
             <param name="add_qual_test" value="true"/>
-            <param name="qual" value="split_libraries/reads_1.qual,split_libraries/reads_2.qual"/>
+            <param name="qual" ftype="qualillumina" value="split_libraries/reads_1.qual,split_libraries/reads_2.qual"/>
             <param name="min_qual_score" value="25"/>
             <param name="qual_score_window" value="0"/>
             <param name="discard_bad_windows" value=""/>
@@ -150,7 +150,7 @@ split_libraries.py
             </output>
             <output name="log" file="split_libraries/split_library_log"/>
             <output name="histograms" file="split_libraries/histograms.txt"/>
-            <output name="quality">
+            <output name="quality" ftype="qualillumina">
                 <assert_contents>
                     <has_text text="PC.634_1" />
                     <has_text text="bc_diffs" />

--- a/tools/qiime/qiime_core/split_libraries.xml
+++ b/tools/qiime/qiime_core/split_libraries.xml
@@ -111,7 +111,7 @@ split_libraries.py
         <data name="log" format="txt" from_work_dir="split_libraries/split_library_log.txt" label="${tool.name} on ${on_string}: log"/>
         <data name="histograms" format="txt" from_work_dir="split_libraries/histograms.txt" label="${tool.name} on ${on_string}: histograms"/>
         <data name="quality" format_source="qual" from_work_dir="split_libraries/*.qual" label="${tool.name} on ${on_string}: quality">
-            <filter>add_qual['record_qual_scores']!=""</filter>
+            <filter>'record_qual_scores' in add_qual and add_qual['record_qual_scores']</filter>
         </data>
     </outputs>
     <tests>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/2380

the quality file output gets an invalid datatype, I changed it to use `format_source` and match the datatype of the input quality file.

ping @erasche 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
