### PR TITLE
VCFFilter: Add an assertion for common incorrect operators.

### DIFF
--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -35,7 +35,7 @@ input1.vcf.gz
                 <option value="-f">Info filter (-f)</option>
                 <option value="-g">Genotype filter (-g)</option>
             </param>
-            <param name="filter_value" type="text" value="DP &gt; 10" label="Specify filterting value" help="See explanation of filtering options below">
+            <param name="filter_value" type="text" value="DP &gt; 10" label="Specify filtering value" help="See explanation of filtering options below">
                 <sanitizer>
                     <valid initial="string.printable">
                         <remove value="&apos;"/>
@@ -46,7 +46,7 @@ input1.vcf.gz
                         <add source="&quot;" target=""/>
                     </mapping>
                 </sanitizer>
-                <validator type="expression" message="Invalid operator has provided, check the help section for a list of valid operators.">value is not None and not any(x in value for x in ["&lt;=", "=&lt;", "&gt;=", "=&gt;"])</validator>
+                <validator type="expression" message="Invalid operator provided, valid operators are =, !, &lt;, &gt;, |, &amp;.">value is not None and not any(x in value for x in ["&lt;=", "=&lt;", "&gt;=", "=&gt;"])</validator>
             </param>
         </repeat>
         <param name="filter_sites" argument="--filter-sites" type="boolean" truevalue="--filter-sites" falsevalue="" label="Filter entire records, not just alleles"/>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -46,6 +46,7 @@ input1.vcf.gz
                         <add source="&quot;" target=""/>
                     </mapping>
                 </sanitizer>
+                <validator type="expression" message="Invalid operator has provided, check the help section for a list of valid operators.">value is not None and not any(x in value for x in ["&lt;=", "=&lt;", "&gt;=", "=&gt;"])</validator>
             </param>
         </repeat>
         <param name="filter_sites" argument="--filter-sites" type="boolean" truevalue="--filter-sites" falsevalue="" label="Filter entire records, not just alleles"/>

--- a/tool_collections/vcflib/vcffilter/vcffilter.xml
+++ b/tool_collections/vcflib/vcffilter/vcffilter.xml
@@ -1,4 +1,4 @@
-<tool id="vcffilter2" name="VCFfilter:" version="@WRAPPER_VERSION@+galaxy2">
+<tool id="vcffilter2" name="VCFfilter:" version="@WRAPPER_VERSION@+galaxy3">
     <description>filter VCF data in a variety of attributes</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Operators such as "<=" or ">=" are not accepted by this tool, tool help form clearly says what are the valid operators, but it seems still users provide some unsupported operators.

ping @jennaj 

