### PR TITLE
Maker: allow running with TMP on NFS

### DIFF
--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -35,7 +35,7 @@
             export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
-        mpiexec -n \${GALAXY_SLOTS:-4} maker maker_opts.ctl maker_bopts.ctl maker_exe.ctl < /dev/null
+        mpiexec -n \${GALAXY_SLOTS:-4} maker --ignore_nfs_tmp maker_opts.ctl maker_bopts.ctl maker_exe.ctl < /dev/null
 
         &&
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

So I've tried running Maker on usegalaxy.eu, but got this error:

```
ERROR: Temporary directory set to an NFS location.
TMP=/data/dnb02/galaxy_db/job_working_directory/005/232/5232283/tmp
The temporary directory in MAKER is specifically for
operations that are not NFS-safe. You must set TMP
to a locally mounted directory such as /tmp or add
--ignore_nfs_tmp to the maker command line to
override this error message.
```

So adding the `--ignore_nfs_tmp` option in case (I hope) maker would be able to complete the job even if tmp dir is on nfs...