### PR TITLE
Snap and augustus: update maker dependency

### DIFF
--- a/tools/augustus/augustus_training.xml
+++ b/tools/augustus/augustus_training.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
-<tool id="augustus_training" name="Train Augustus" profile="16.04" version="@VERSION@">
+<tool id="augustus_training" name="Train Augustus" profile="16.04" version="@VERSION@+galaxy1">
     <description>ab-initio gene predictor</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2.31.9">maker</requirement>
+        <requirement type="package" version="2.31.10">maker</requirement>
     </expand>
     <command><![CDATA[
         cp -r "\$AUGUSTUS_CONFIG_PATH/" augustus_dir/ &&

--- a/tools/snap/snap_training.xml
+++ b/tools/snap/snap_training.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
-<tool id="snap_training" name="Train SNAP" profile="16.04" version="@VERSION@">
+<tool id="snap_training" name="Train SNAP" profile="16.04" version="@VERSION@+galaxy1">
     <description>ab-initio gene predictor</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2.31.9">maker</requirement>
+        <requirement type="package" version="2.31.10">maker</requirement>
     </expand>
     <command><![CDATA[
         cp '${maker_gff}' input.gff3 &&


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

A fix for snap and augustus tools used by the Maker tutorial: the 2.31.9 version of maker still depends on perl-threaded which make the tool fail. 2.31.10 is the good one to use now