### PR TITLE
Busco: pin augustus version

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -1,4 +1,4 @@
-<tool id="busco" name="Busco" version="@TOOL_VERSION@+galaxy0">
+<tool id="busco" name="Busco" version="@TOOL_VERSION@+galaxy1">
     <description>assess genome assembly and annotation completeness</description>
     <macros>
         <token name="@TOOL_VERSION@">3.0.2</token>
@@ -6,6 +6,7 @@
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">busco</requirement>
         <requirement type="package" version="3.5.1">r-base</requirement>
+        <requirement type="package" version="3.3.2">augustus</requirement>
     </requirements>
     <command><![CDATA[
 export BUSCO_CONFIG_FILE='busco_config.ini' &&


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Pinning the augustus version as version 3.3 makes busco fail silently (=empty results)