### PR TITLE
Reduce lines_diff for fastqc tests

### DIFF
--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -85,32 +85,32 @@
     <tests>
         <test>
             <param name="input_file" value="1000trimmed.fastq" />
-            <output name="html_file" file="fastqc_report.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data.txt" ftype="txt"/>
         </test>
         <test>
             <param name="input_file" value="1000trimmed.fastq" />
             <param name="contaminants" value="fastqc_contaminants.txt" ftype="tabular" />
-            <output name="html_file" file="fastqc_report_contaminants.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_contaminants.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_contaminants.txt" ftype="txt"/>
         </test>
         <test>
             <param name="input_file" value="1000trimmed.fastq" />
             <param name="adapters" value="fastqc_adapters.txt" ftype="tabular" />
-            <output name="html_file" file="fastqc_report_adapters.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_adapters.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_adapters.txt" ftype="txt"/>
         </test>
         <test>
             <param name="input_file" value="1000trimmed.fastq" />
             <param name="limits" value="fastqc_customlimits.txt" ftype="txt" />
-            <output name="html_file" file="fastqc_report_customlimits.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_customlimits.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_customlimits.txt" ftype="txt"/>
         </test>
         <test>
             <param name="input_file" value="1000trimmed.fastq" ftype="fastq" />
             <param name="kmers" value="3" />
             <param name="limits" value="fastqc_customlimits.txt" ftype="txt" />
-            <output name="html_file" file="fastqc_report_kmer.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_kmer.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_kmer.txt" ftype="txt"/>
             <assert_command>
                 <has_text text="--kmers 3"/>
@@ -119,13 +119,13 @@
         <test>
             <param name="input_file" value="1000trimmed.fastq" />
             <param name="min_length" value="108" />
-            <output name="html_file" file="fastqc_report_min_length.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_min_length.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_min_length.txt" ftype="txt"/>
         </test>
         <test>
             <param name="input_file" value="1000trimmed.fastq" ftype="fastq" />
             <param name="nogroup" value="--nogroup" />
-            <output name="html_file" file="fastqc_report_nogroup.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_nogroup.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_nogroup.txt" ftype="txt"/>
             <assert_command>
                 <has_text text="--nogroup"/>
@@ -133,7 +133,7 @@
         </test>
         <test>
             <param name="input_file" value="hisat_output_1.bam" ftype="bam" />
-            <output name="html_file" file="fastqc_report_hisat.html" ftype="html" lines_diff="100"/>
+            <output name="html_file" file="fastqc_report_hisat.html" ftype="html" lines_diff="2"/>
             <output name="text_file" file="fastqc_data_hisat.txt" ftype="txt"/>
         </test>
     </tests>


### PR DESCRIPTION
Follow-up on commit 6bcb3493aa6126bb1ccf93b7646fbb919bc374a1 .

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
