### PR TITLE
fix bug where 'Per-Base Alignment Quality' select param which fails cmd

### DIFF
--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -251,7 +251,7 @@ ${pasted_data}
 --no-BAQ; BAQ is the Phred-scaled probability of a read base being misaligned. Applying this option greatly helps to reduce false SNPs caused by misalignments.
 --redo-BAQ; ignore existing BQ tags
                         </help>
-			<option value="">Default</option>
+                        <option value="">Default</option>
                         <option value="--no-BAQ">disable BAQ (per-Base Alignment Quality) (no-BAQ)</option>
                         <option value="--redo-BAQ">recalculate BAQ on the fly, ignore existing BQs (redo-BAQ)</option>
                     </param>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
     <description>Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files</description>
     <macros>
         <token name="@EXECUTABLE@">mpileup</token>
@@ -249,11 +249,12 @@ ${pasted_data}
                     <option value="adjust">Set base and mapping quality options</option>
                 </param>
                 <when value="adjust">
-                    <param name="baq" type="select" optional="true" label="per-Base Alignment Quality">
+                    <param name="baq" type="select" label="per-Base Alignment Quality">
                         <help>
 --no-BAQ; BAQ is the Phred-scaled probability of a read base being misaligned. Applying this option greatly helps to reduce false SNPs caused by misalignments.
 --redo-BAQ; ignore existing BQ tags
                         </help>
+			<option value="">Default</option>
                         <option value="--no-BAQ">disable BAQ (per-Base Alignment Quality) (no-BAQ)</option>
                         <option value="--redo-BAQ">recalculate BAQ on the fly, ignore existing BQs (redo-BAQ)</option>
                     </param>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -109,10 +109,7 @@ bcftools @EXECUTABLE@
 -d "${section.max_reads_per_bam}"
 ${section.skip_anomalous_read_pairs}
 #if str( $section.quality.quality_settings ) == "adjust":
-    #if $section.quality.baq:
-        $section.quality.baq
-    #end if
-
+    $section.quality.baq
     -q "${section.quality.minimum_mapping_quality}"
     -Q "${section.quality.minimum_base_quality}"
     -C "${section.quality.coefficient_for_downgrading}"

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -109,7 +109,7 @@ bcftools @EXECUTABLE@
 -d "${section.max_reads_per_bam}"
 ${section.skip_anomalous_read_pairs}
 #if str( $section.quality.quality_settings ) == "adjust":
-    #if str( $section.quality.baq ) != "None":
+    #if $section.quality.baq:
         $section.quality.baq
     #end if
 
@@ -335,6 +335,22 @@ output gVCF blocks of homozygous REF calls, with depth (DP) ranges specified by 
             <param name="input_bam" ftype="bam" value="mpileup.1.bam" />
             <param name="reference_source_selector" value="history" />
             <param name="ref_file" ftype="fasta" value="mpileup.ref.fa" />
+            <param name="output_type" value="v" />
+            <output name="output_file">
+                <assert_contents>
+                    <has_text text="mpileup" />
+                    <has_text text="HG00100" />
+                    <has_text_matching expression="17\t1\t.\tA\t...\t0\t.\tDP=5;" />
+                    <has_text_matching expression="17\t100\t.\tC\t...\t0\t.\tDP=9;" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input_number" value="single" />
+            <param name="input_bam" ftype="bam" value="mpileup.1.bam" />
+            <param name="reference_source_selector" value="history" />
+            <param name="ref_file" ftype="fasta" value="mpileup.ref.fa" />
+            <param name="quality_settings" value="adjust" />
             <param name="output_type" value="v" />
             <output name="output_file">
                 <assert_contents>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -109,7 +109,10 @@ bcftools @EXECUTABLE@
 -d "${section.max_reads_per_bam}"
 ${section.skip_anomalous_read_pairs}
 #if str( $section.quality.quality_settings ) == "adjust":
-    $section.quality.baq
+    #if str( $section.quality.baq ) != "None":
+        $section.quality.baq
+    #end if
+
     -q "${section.quality.minimum_mapping_quality}"
     -Q "${section.quality.minimum_base_quality}"
     -C "${section.quality.coefficient_for_downgrading}"


### PR DESCRIPTION
fix bug where 'Per-Base Alignment Quality' select param where put 'None' when no option was selected causing command to fail.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
