### PR TITLE
fastp: use format_source instead of structured_like

### DIFF
--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -1,4 +1,4 @@
-<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@">
+<tool id="fastp" name="fastp" version="@WRAPPER_VERSION@+galaxy1">
     <description>- fast all-in-one preprocessing for FASTQ files</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -320,7 +320,7 @@ mv first${ext} '${out1}'
         <data name="out2" format_source="in2" label="${tool.name} on ${on_string}: Read 2 Output">
             <filter>single_paired['single_paired_selector'] == "paired"</filter>
         </data>
-        <collection name="output_paired_coll" type="paired" structured_like="paired_input" inherit_format="true" label="Paired-end output of ${tool.name} on ${on_string}">
+        <collection name="output_paired_coll" type="paired" format_source="paired_input" label="Paired-end output of ${tool.name} on ${on_string}">
             <filter>single_paired['single_paired_selector'] == "paired_collection"</filter>
         </collection>
         <data name="report_html" format="html" from_work_dir="fastp.html" label="${tool.name} on ${on_string}: HTML Report">

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -314,19 +314,19 @@ mv first${ext} '${out1}'
     </inputs>
 
     <outputs>
-        <data name="out1" format_source="in1" label="${tool.name} on ${on_string}: Read 1 Output">
+        <data name="out1" format_source="in1" label="${tool.name} on ${on_string}: Read 1 output">
             <filter>single_paired['single_paired_selector'] in ["single", "paired"]</filter>
         </data>
-        <data name="out2" format_source="in2" label="${tool.name} on ${on_string}: Read 2 Output">
+        <data name="out2" format_source="in2" label="${tool.name} on ${on_string}: Read 2 output">
             <filter>single_paired['single_paired_selector'] == "paired"</filter>
         </data>
-        <collection name="output_paired_coll" type="paired" format_source="paired_input['forward']" label="Paired-end output of ${tool.name} on ${on_string}">
+        <collection name="output_paired_coll" type="paired" format_source="paired_input['forward']" label="${tool.name} on ${on_string}: Paired-end output">
             <filter>single_paired['single_paired_selector'] == "paired_collection"</filter>
         </collection>
-        <data name="report_html" format="html" from_work_dir="fastp.html" label="${tool.name} on ${on_string}: HTML Report">
+        <data name="report_html" format="html" from_work_dir="fastp.html" label="${tool.name} on ${on_string}: HTML report">
             <filter>output_options['report_html'] is True</filter>
         </data>
-        <data name="report_json" format="json" from_work_dir="fastp.json" label="${tool.name} on ${on_string}: JSON Report">
+        <data name="report_json" format="json" from_work_dir="fastp.json" label="${tool.name} on ${on_string}: JSON report">
             <filter>output_options['report_json'] is True</filter>
         </data>
     </outputs>

--- a/tools/fastp/fastp.xml
+++ b/tools/fastp/fastp.xml
@@ -320,7 +320,7 @@ mv first${ext} '${out1}'
         <data name="out2" format_source="in2" label="${tool.name} on ${on_string}: Read 2 Output">
             <filter>single_paired['single_paired_selector'] == "paired"</filter>
         </data>
-        <collection name="output_paired_coll" type="paired" format_source="paired_input" label="Paired-end output of ${tool.name} on ${on_string}">
+        <collection name="output_paired_coll" type="paired" format_source="paired_input['forward']" label="Paired-end output of ${tool.name} on ${on_string}">
             <filter>single_paired['single_paired_selector'] == "paired_collection"</filter>
         </collection>
         <data name="report_html" format="html" from_work_dir="fastp.html" label="${tool.name} on ${on_string}: HTML Report">


### PR DESCRIPTION
otherwise multiple grey data sets are generated due to https://github.com/galaxyproject/galaxy/issues/8041

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
