### PR TITLE
Featurecounts: update to v3.4.1 and change default MQ to same as upstream (0)

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -297,10 +297,10 @@
 
             <param name="mapping_quality"
                    type="integer"
-                   value="12"
+                   value="0"
                    argument="-Q"
                    label="Minimum mapping quality per read"
-                   help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 12 by default." />
+                   help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 0 by default." />
 
             <conditional name="exon_exon_junction_read_counting_enabled">
                 <param name="count_exon_exon_junction_reads" argument="-J" type="boolean" truevalue="-J" falsevalue=""

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,9 +1,9 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.3+galaxy2" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.4" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
-        <requirement type="package" version="1.6.3">subread</requirement>
+        <requirement type="package" version="1.6.4">subread</requirement>
         <requirement type="package" version="1.9">samtools</requirement>
-        <requirement type="package" version="8.30">coreutils</requirement>
+        <requirement type="package" version="8.31">coreutils</requirement>
     </requirements>
 
     <version_command>featureCounts -v 2&gt;&amp;1 | grep .</version_command>

--- a/tools/featurecounts/test-data/output_1_summary.tab
+++ b/tools/featurecounts/test-data/output_1_summary.tab
@@ -7,7 +7,7 @@ Unassigned_FragmentLength	0
 Unassigned_Duplicate	0
 Unassigned_MultiMapping	0
 Unassigned_Secondary	0
-Unassigned_Nonjunction	0
+Unassigned_NonSplit	0
 Unassigned_NoFeatures	6078
 Unassigned_Overlapping_Length	0
 Unassigned_Ambiguity	0

--- a/tools/featurecounts/test-data/output_summary_builtin_hg19.tab
+++ b/tools/featurecounts/test-data/output_summary_builtin_hg19.tab
@@ -7,7 +7,7 @@ Unassigned_FragmentLength	0
 Unassigned_Duplicate	0
 Unassigned_MultiMapping	0
 Unassigned_Secondary	0
-Unassigned_Nonjunction	0
+Unassigned_NonSplit	0
 Unassigned_NoFeatures	37
 Unassigned_Overlapping_Length	0
 Unassigned_Ambiguity	0


### PR DESCRIPTION
* update to v3.4.1 (and update coreutils dep to v8.31)
* change default mapping quality from 12 to 0 to be consistent with the upstream featurecounts tool. As had a user confused by this today when they were comparing results to others using the command-line tool and only then discovered Galaxy featurecounts was using a different default for mapping quality vs command-line featurecounts. Is it better to be consistent with the upstream tool?

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
