### PR TITLE
Fix Migmap trying to write to its tool_dependencies folder

### DIFF
--- a/tools/migmap/migmap.xml
+++ b/tools/migmap/migmap.xml
@@ -7,7 +7,7 @@
     <command detect_errors='exit_code'><![CDATA[
 export IGBLAST_PATH=\$(dirname \$(which igblastn)) &&
 mkdir temp_db &&
-ln -s "\${IGBLAST_PATH}/../share/igblast/" ./temp_db/ &&
+cp -r "\${IGBLAST_PATH}/../share/igblast/" ./temp_db &&
 
 #if $input.is_of_type('fasta') :
     ln -s '$input' in.fa &&

--- a/tools/migmap/migmap.xml
+++ b/tools/migmap/migmap.xml
@@ -6,8 +6,10 @@
     </requirements>
     <command detect_errors='exit_code'><![CDATA[
 export IGBLAST_PATH=\$(dirname \$(which igblastn)) &&
-mkdir temp_db &&
-cp -r "\${IGBLAST_PATH}/../share/igblast/" ./temp_db &&
+mkdir -p temp_db/igblast &&
+ln -s "\${IGBLAST_PATH}/../share/igblast/bin/" ./temp_db/igblast &&
+ln -s "\${IGBLAST_PATH}/../share/igblast/internal_data/" ./temp_db/igblast &&
+ln -s "\${IGBLAST_PATH}/../share/igblast/optional_file/" ./temp_db/igblast &&
 
 #if $input.is_of_type('fasta') :
     ln -s '$input' in.fa &&


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Finally got around to fixing a bug I discovered in March, where migmap needed special permissions under the conda environment folder. While the easy fix was to make it writable, quoting @bgruening from our mutual chat  `the bigger problem is that no-one should write into this directory`. 

Also found a reference to a change that prompted this issue in PR #2014, and the fix is quite simple - expand the symlink so that the references can be accessed but temporary database is created in job_directory. At first I thought of reverting to copy, but this created ~120MB of unnecessary data for each job.