### PR TITLE
CutAdapt: add fastq.gz and fastq to inputs for paired-end

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -168,13 +168,13 @@ $read_mod_options.trim_n
             </when>
 
             <when value="paired">
-                <param name="input_1" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data" label="FASTQ/A file #1" help="Should be of datatype &quot;fastq.gz&quot;or &quot;fasta&quot;" />
-                <param name="input_2" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data" label="FASTQ/A file #2" help="Should be of datatype &quot;fastq.gz&quot;or &quot;fasta&quot;" />
+                <param name="input_1" format="fastq.gz,fastq,fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data" label="FASTQ/A file #1" help="Should be of datatype &quot;fastq.gz&quot;or &quot;fasta&quot;" />
+                <param name="input_2" format="fastq.gz,fastq,fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data" label="FASTQ/A file #2" help="Should be of datatype &quot;fastq.gz&quot;or &quot;fasta&quot;" />
                 <expand macro="paired_end_options" />
             </when>
 
             <when value="paired_collection">
-                <param name="input_1" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data_collection" collection_type="paired" label="Paired Collection" help="Should be of datatype &quot;fastq.gz&quot; or &quot;fasta&quot;" />
+                <param name="input_1" format="fastq.gz,fastq,fastqsanger,fastqsanger.gz,fastqsanger.bz2,fasta" type="data_collection" collection_type="paired" label="Paired Collection" help="Should be of datatype &quot;fastq.gz&quot; or &quot;fasta&quot;" />
                 <expand macro="paired_end_options" />
             </when>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR extends formats accepted for paired-end inputs to include fastq.gz and fastq (as it is currently available for single-end inputs).