### PR TITLE
Nanoplot: add batch mode option

### DIFF
--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -7,69 +7,66 @@
         <requirement type="package" version="@TOOL_VERSION@">nanoplot</requirement>
     </requirements>
     <version_command>NanoPlot --version</version_command>
-    <command detect_errors="exit_code">
-        <![CDATA[
-        #set $myfiles = $mode.reads.files
+    <command detect_errors="exit_code"><![CDATA[
+#set $myfiles = $mode.reads.files
 
-        #set reads_temp = []
-        #if $mode.choice == 'combined':
-            #for $i, $f in enumerate($myfiles)
-                #if $f.ext == "fastqsanger":
-                    #set $extension = 'fastq'
-                #else
-                    #set $extension = $f.ext
-                #end if
-                ln -s '$f' './read_${i}.$extension' &&
-                $reads_temp.append("read_" + str($i) + "." + str($extension))
-            #end for
+#set reads_temp = []
+#if $mode.choice == 'combined':
+    #for $i, $f in enumerate($myfiles)
+        #if $f.ext == "fastqsanger":
+            #set $extension = 'fastq'
         #else
-            #if $myfiles.ext == "fastqsanger":
-                #set $extension = 'fastq'
-            #else
-                #set $extension = $myfiles.ext
-            #end if
-            ln -s  '$mode.reads.files' './read.$extension' &&
-            $reads_temp.append("read." + str($extension))
+            #set $extension = $f.ext
         #end if
+        ln -s '$f' './read_${i}.$extension' &&
+        $reads_temp.append("read_" + str($i) + "." + str($extension))
+    #end for
+#else
+    #if $myfiles.ext == "fastqsanger":
+        #set $extension = 'fastq'
+    #else
+        #set $extension = $myfiles.ext
+    #end if
+    ln -s '$mode.reads.files' './read.$extension' &&
+    $reads_temp.append("read." + str($extension))
+#end if
 
-        NanoPlot
-            --threads \${GALAXY_SLOTS:-4}
-            --$mode.reads.type ${' '.join($reads_temp)}
-
-            #if $filter.maxlength
-                --maxlength $filter.maxlength
-            #end if
-            #if $filter.minlength
-                --minlength $filter.minlength
-            #end if
-            #if $filter.downsample
-                --downsample $filter.downsample
-            #end if
-            #if $filter.minqual
-                --minqual $filter.minqual
-           #end if
-            #if $filter.readtype
-                --readtype $filter.readtype
-            #end if
-            #if $customization.color
-                --color $customization.color
-            #end if
-            #if $customization.format
-                --format $customization.format
-            #end if
-            #if $customization.plots
-                --plots ${str($customization.plots).replace(',', ' ')}
-            #end if
-            $filter.drop_outliers
-            $filter.loglength
-            $filter.percentqual
-            $filter.alength
-            $filter.barcoded
-            $customization.noN50
-            $customization.N50
-            -o '.'
-    ]]>
-    </command>
+NanoPlot
+    --threads \${GALAXY_SLOTS:-4}
+    --$mode.reads.type ${' '.join($reads_temp)}
+    #if $filter.maxlength
+        --maxlength $filter.maxlength
+    #end if
+    #if $filter.minlength
+        --minlength $filter.minlength
+    #end if
+    #if $filter.downsample
+        --downsample $filter.downsample
+    #end if
+    #if $filter.minqual
+        --minqual $filter.minqual
+    #end if
+    #if $filter.readtype
+        --readtype $filter.readtype
+    #end if
+    #if $customization.color
+        --color $customization.color
+    #end if
+    #if $customization.format
+        --format $customization.format
+    #end if
+    #if $customization.plots
+        --plots ${str($customization.plots).replace(',', ' ')}
+    #end if
+    $filter.drop_outliers
+    $filter.loglength
+    $filter.percentqual
+    $filter.alength
+    $filter.barcoded
+    $customization.noN50
+    $customization.N50
+    -o '.'
+    ]]></command>
     <inputs>
         <conditional name="mode">
             <param name="choice" type="select" label="Select multifile mode" help="When supplying multiple files, batch mode will run NanoPlot on each file separately, while combined mode will run NanoPlot once on all the reads together. When only supplying a single input file, this setting does not matter.">

--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -9,20 +9,32 @@
     <version_command>NanoPlot --version</version_command>
     <command detect_errors="exit_code">
         <![CDATA[
+        #set $myfiles = $mode.reads.files
 
         #set reads_temp = []
-        #for $i, $f in enumerate($reads.files)
-            #set $extension = $f.ext
-            #if $extension == 'fastqsanger'
+        #if $mode.choice == 'combined':
+            #for $i, $f in enumerate($myfiles)
+                #if $f.ext == "fastqsanger":
+                    #set $extension = 'fastq'
+                #else
+                    #set $extension = $f.ext
+                #end if
+                ln -s '$f' './read_${i}.$extension' &&
+                $reads_temp.append("read_" + str($i) + "." + str($extension))
+            #end for
+        #else
+            #if $myfiles.ext == "fastqsanger":
                 #set $extension = 'fastq'
+            #else
+                #set $extension = $myfiles.ext
             #end if
-            ln -s '$f' './read_${i}.$extension' &&
-            $reads_temp.append("read_" + str($i) + "." + str($extension))
-        #end for
+            ln -s  '$mode.reads.files' './read.$extension' &&
+            $reads_temp.append("read." + str($extension))
+        #end if
 
         NanoPlot
             --threads \${GALAXY_SLOTS:-4}
-            --$reads.type ${' '.join($reads_temp)}
+            --$mode.reads.type ${' '.join($reads_temp)}
 
             #if $filter.maxlength
                 --maxlength $filter.maxlength
@@ -59,71 +71,78 @@
     ]]>
     </command>
     <inputs>
-        <conditional name="reads">
-            <param name="type" type="select" label="Type of the file(s) to work on">
-                <option value="fastq" selected="true">fastq</option>
-                <option value="fasta">fasta</option>
-                <option value="fastq_rich">fastq_rich</option>
-                <option value="fastq_minimal">fastq_minimal</option>
-                <option value="summary">summary</option>
-                <option value="bam">bam</option>
-                <option value="cram">cram</option>
+        <conditional name="mode">
+            <param name="choice" type="select" label="Select multifile mode" help="When supplying multiple files, batch mode will run NanoPlot on each file separately, while combined mode will run NanoPlot once on all the reads together. When only supplying a single input file, this setting does not matter.">
+                <option value="batch">batch</option>
+                <option value="combined" selected="true">combined</option>
             </param>
-            <when value="fastq">
-                <param
-                    type="data"
-                    argument="--fastq"
-                    name="files"
-                    format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"
-                    multiple="true"/>
+            <when value="batch">
+                <conditional name="reads">
+                    <param name="type" type="select" label="Type of the file(s) to work on">
+                        <option value="fastq" selected="true">fastq</option>
+                        <option value="fasta">fasta</option>
+                        <option value="fastq_rich">fastq_rich</option>
+                        <option value="fastq_minimal">fastq_minimal</option>
+                        <option value="summary">summary</option>
+                        <option value="bam">bam</option>
+                        <option value="cram">cram</option>
+                    </param>
+                    <when value="fastq">
+                        <param type="data" argument="--fastq" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"/>
+                    </when>
+                    <when value="fasta">
+                        <param type="data" argument="--fasta" name="files" format="fasta,fasta.gz,vcf_bgzip"/>
+                    </when>
+                    <when value="fastq_rich">
+                        <param type="data" argument="--fastq_rich" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"/>
+                    </when>
+                    <when value="fastq_minimal">
+                        <param type="data" argument="--fastq_minimal" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"/>
+                    </when>
+                    <when value="summary">
+                        <param type="data" argument="--summary" name="files" format="txt,zip"/>
+                    </when>
+                    <when value="bam">
+                        <param type="data" argument="--bam" name="files" format="bam"/>
+                    </when>
+                    <when value="cram">
+                        <param type="data" argument="--cram" name="files" format="cram"/>
+                    </when>
+                </conditional>
             </when>
-            <when value="fasta">
-                <param
-                    type="data"
-                    argument="--fasta"
-                    name="files"
-                    format="fasta,fasta.gz,vcf_bgzip"
-                    multiple="true"/>
-            </when>
-            <when value="fastq_rich">
-                <param
-                    type="data"
-                    argument="--fastq_rich"
-                    name="files"
-                    format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"
-                    multiple="true"/>
-            </when>
-            <when value="fastq_minimal">
-                <param
-                    type="data"
-                    argument="--fastq_minimal"
-                    name="files"
-                    format="fastq,fastq.gz,fastq.bz2,vcf_bgzip"
-                    multiple="true"/>
-            </when>
-            <when value="summary">
-                <param
-                    type="data"
-                    argument="--summary"
-                    name="files"
-                    format="txt,zip"
-                    multiple="true"/>
-            </when>
-            <when value="bam">
-                <param
-                    type="data"
-                    argument="--bam"
-                    name="files"
-                    format="bam"
-                    multiple="true"/>
-            </when>
-            <when value="cram">
-                <param
-                    type="data"
-                    argument="--cram"
-                    name="files"
-                    format="cram"
-                    multiple="true"/>
+            <when value="combined">
+                <conditional name="reads">
+                    <param name="type" type="select" label="Type of the file(s) to work on">
+                        <option value="fastq" selected="true">fastq</option>
+                        <option value="fasta">fasta</option>
+                        <option value="fastq_rich">fastq_rich</option>
+                        <option value="fastq_minimal">fastq_minimal</option>
+                        <option value="summary">summary</option>
+                        <option value="bam">bam</option>
+                        <option value="cram">cram</option>
+                    </param>
+                    <when value="fastq">
+                        <param type="data" argument="--fastq" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip" multiple="true"/>
+                    </when>
+                    <when value="fasta">
+                        <param type="data" argument="--fasta" name="files" format="fasta,fasta.gz,vcf_bgzip" multiple="true"/>
+                    </when>
+                    <when value="fastq_rich">
+                        <param type="data" argument="--fastq_rich" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip" multiple="true"/>
+                    </when>
+                    <when value="fastq_minimal">
+                        <param type="data" argument="--fastq_minimal" name="files" format="fastq,fastq.gz,fastq.bz2,vcf_bgzip" multiple="true"/>
+                    </when>
+                    <when value="summary">
+                        <param type="data" argument="--summary" name="files" format="txt,zip" multiple="true"/>
+                    </when>
+                    <when value="bam">
+                        <param type="data" argument="--bam" name="files" format="bam" multiple="true"/>
+                    </when>
+                    <when value="cram">
+                        <param type="data" argument="--cram" name="files" format="cram" multiple="true"/>
+                    </when>
+                </conditional>
             </when>
         </conditional>
         <section
@@ -399,9 +418,12 @@
     </outputs>
     <tests>
         <test>
-            <conditional name="reads">
-                <param name="type" value="fastq_rich"/>
-                <param name="files" value="reads.fastq.gz" ftype="fastq.gz"/>
+            <conditional name="mode">
+                <param name="choice" value="batch"/>
+                <conditional name="reads">
+                    <param name="type" value="fastq_rich"/>
+                    <param name="files" value="reads.fastq.gz" ftype="fastq.gz"/>
+                </conditional>
             </conditional>
             <section name="filter">
                 <param name="downsample" value="800"/>
@@ -415,9 +437,12 @@
             <output name="read_length" file="HistogramReadlength.png" ftype="png" compare="sim_size" delta="3000"/>
         </test>
         <test>
-            <conditional name="reads">
-                <param name="type" value="bam"/>
-                <param name="files" value="alignment.bam" ftype="bam"/>
+            <conditional name="mode">
+                <param name="choice" value="combined"/>
+                <conditional name="reads">
+                    <param name="type" value="bam"/>
+                    <param name="files" value="alignment.bam" ftype="bam"/>
+                </conditional>
             </conditional>
             <section name="filter">
                 <param name="maxlength" value="2000"/>
@@ -437,15 +462,18 @@
             <output name="read_length" file="bam-LogTransformed_HistogramReadlength.svg" ftype="svg" compare="sim_size"/>
         </test>
         <test><!-- test with multiple input files -->
-            <conditional name="reads">
-                <param name="type" value="fasta"/>
-                <param name="files" ftype="fasta" value="reads1.fasta,reads2.fasta" />
+             <conditional name="mode">
+                <param name="choice" value="combined"/>
+                <conditional name="reads">
+                    <param name="type" value="fasta"/>
+                    <param name="files" ftype="fasta" value="reads1.fasta,reads2.fasta" />
+                </conditional>
             </conditional>
             <output name="output_html" ftype="html">
                 <assert_contents>
                     <has_text text="html"/>
                     <not_has_text text="Aligned read length vs Percent identity plot using dots"/> <!-- bam report specific -->
-                    <has_text text="&lt;td&gt;9.0&lt;/td&gt;"/> <!--check both files used 4+5 reads -->
+                    <has_text text="&lt;td&gt;9.0&lt;/td&gt;"/> <!--check both files were used 4+5 reads -->
                 </assert_contents>
             </output>
         </test>

--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -1,4 +1,4 @@
-<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy0">
+<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy1">
     <description>Plotting suite for Oxford Nanopore sequencing data and alignments</description>
     <macros>
         <token name="@TOOL_VERSION@">1.25.0</token>

--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -70,8 +70,8 @@ NanoPlot
     <inputs>
         <conditional name="mode">
             <param name="choice" type="select" label="Select multifile mode" help="When supplying multiple files, batch mode will run NanoPlot on each file separately, while combined mode will run NanoPlot once on all the reads together. When only supplying a single input file, this setting does not matter.">
-                <option value="batch">batch</option>
-                <option value="combined" selected="true">combined</option>
+                <option value="batch" selected="true">batch</option>
+                <option value="combined">combined</option>
             </param>
             <when value="batch">
                 <conditional name="reads">


### PR DESCRIPTION
Users can now choose what to do when they supply multiple files (or a collection)
 1) batch mode: trigger a separate NanoPlot run for each file
 2) combined mode: run NanoPlot once on all datasets together (previous behaviour)(default)

ping @willemdek11 any opinions on what default should be?


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
