### PR TITLE
Added quotes to names of snippy output dirs for snippy-core

### DIFF
--- a/tools/snippy/snippy-core.xml
+++ b/tools/snippy/snippy-core.xml
@@ -12,7 +12,7 @@
             #set $sample_name = os.path.splitext(os.path.basename(str($indir.name)))[0]
             mkdir '$sample_name' && tar -xf '$indir' -C '$sample_name' --strip-components=1 &&
         #end for
-        #set snippy_dirs = ' '.join(['"{0}"'.format(os.path.splitext(os.path.basename(str($indir.name)))[0]) for $indir in $indirs])
+        #set snippy_dirs = " ".join(["'{0}'".format(os.path.splitext(os.path.basename(str($indir.name)))[0]) for $indir in $indirs])
         snippy-core
             --ref '$ref'
             ${snippy_dirs}

--- a/tools/snippy/snippy-core.xml
+++ b/tools/snippy/snippy-core.xml
@@ -12,7 +12,7 @@
             #set $sample_name = os.path.splitext(os.path.basename(str($indir.name)))[0]
             mkdir '$sample_name' && tar -xf '$indir' -C '$sample_name' --strip-components=1 &&
         #end for
-        #set snippy_dirs = ' '.join([os.path.splitext(os.path.basename(str($indir.name)))[0] for $indir in $indirs])
+        #set snippy_dirs = ' '.join(['"{0}"'.format(os.path.splitext(os.path.basename(str($indir.name)))[0]) for $indir in $indirs])
         snippy-core
             --ref '$ref'
             ${snippy_dirs}


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
This update fixes problems with spaces in the input file names for snippy-core. See issue #2451