### PR TITLE
[Experimental] Refactor data manager logic

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.py
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.py
@@ -2,83 +2,55 @@
 # Dan Blankenberg
 from __future__ import print_function
 
-import optparse
+import argparse
 import os
 import subprocess
 import sys
-from json import dumps, loads
 
-DEFAULT_DATA_TABLE_NAMES = ["bowtie2_indexes"]
+import yaml
 
-
-def get_id_name( params, dbkey, fasta_description=None):
-    # TODO: ensure sequence_id is unique and does not already appear in location file
-    sequence_id = params['param_dict']['sequence_id']
-    if not sequence_id:
-        sequence_id = dbkey
-
-    sequence_name = params['param_dict']['sequence_name']
-    if not sequence_name:
-        sequence_name = fasta_description
-        if not sequence_name:
-            sequence_name = dbkey
-    return sequence_id, sequence_name
+try:
+    from shlex import quote as cmd_quote
+except ImportError:
+    from pipes import quote as cmd_quote
 
 
-def build_bowtie2_index( data_manager_dict, fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_names=DEFAULT_DATA_TABLE_NAMES ):
+def build_bowtie2_index(fasta_filename, target_directory, index_id):
     # TODO: allow multiple FASTA input files
     fasta_base_name = os.path.split( fasta_filename )[-1]
     sym_linked_fasta_filename = os.path.join( target_directory, fasta_base_name )
     os.symlink( fasta_filename, sym_linked_fasta_filename )
-    args = [ 'bowtie2-build', sym_linked_fasta_filename, sequence_id ]
-    threads = os.environ.get('GALAXY_SLOTS')
-    if threads:
-        args.extend(['--threads', threads])
-    proc = subprocess.Popen( args=args, shell=False, cwd=target_directory )
+    args = ['bowtie2-build', sym_linked_fasta_filename, index_id]
+    proc = subprocess.Popen(args=args, shell=False, cwd=target_directory)
     return_code = proc.wait()
     if return_code:
         print("Error building index.", file=sys.stderr)
-        sys.exit( return_code )
-    data_table_entry = dict( value=sequence_id, dbkey=dbkey, name=sequence_name, path=sequence_id )
-    for data_table_name in data_table_names:
-        _add_data_table_entry( data_manager_dict, data_table_name, data_table_entry )
-
-
-def _add_data_table_entry( data_manager_dict, data_table_name, data_table_entry ):
-    data_manager_dict['data_tables'] = data_manager_dict.get( 'data_tables', {} )
-    data_manager_dict['data_tables'][ data_table_name ] = data_manager_dict['data_tables'].get( data_table_name, [] )
-    data_manager_dict['data_tables'][ data_table_name ].append( data_table_entry )
-    return data_manager_dict
+        sys.exit(return_code)
+    return [' '.join(cmd_quote(arg) for arg in args)]
 
 
 def main():
-    parser = optparse.OptionParser()
-    parser.add_option( '-f', '--fasta_filename', dest='fasta_filename', action='store', type="string", default=None, help='fasta_filename' )
-    parser.add_option( '-d', '--fasta_dbkey', dest='fasta_dbkey', action='store', type="string", default=None, help='fasta_dbkey' )
-    parser.add_option( '-t', '--fasta_description', dest='fasta_description', action='store', type="string", default=None, help='fasta_description' )
-    parser.add_option( '-n', '--data_table_name', dest='data_table_name', action='append', type="string", default=None, help='data_table_name' )
-    (options, args) = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('metadata')
+    parser.add_argument( '-t', '--target-directory', default=None)
+    args = parser.parse_args()
 
-    filename = args[0]
+    params = yaml.safe_load(open(args.metadata))
+    params['cmds'] = []
+    if args.target_directory:
+        if not os.path.isdir(args.target_directory):
+            os.mkdir(args.target_directory)
+    else:
+        args.target_directory = os.getcwd()
 
-    params = loads( open( filename ).read() )
-    target_directory = params[ 'output_data' ][0]['extra_files_path']
-    os.mkdir( target_directory )
-    data_manager_dict = {}
-
-    dbkey = options.fasta_dbkey
-
+    dbkey = params['dbkey']
     if dbkey in [ None, '', '?' ]:
         raise Exception( '"%s" is not a valid dbkey. You must specify a valid dbkey.' % ( dbkey ) )
 
-    sequence_id, sequence_name = get_id_name( params, dbkey=dbkey, fasta_description=options.fasta_description )
-
     # build the index
-    build_bowtie2_index( data_manager_dict, options.fasta_filename, params, target_directory, dbkey, sequence_id, sequence_name, data_table_names=options.data_table_name or DEFAULT_DATA_TABLE_NAMES )
-
-    # save info to json file
-    with open(filename, 'w') as json_out:
-        json_out.write( dumps( data_manager_dict, sort_keys=True ) )
+    params['cmds'] += build_bowtie2_index(params['source'], args.target_directory, params['id'])
+    with open(args.metadata, 'w') as fo:
+        yaml.dump(params, fo, allow_unicode=False, default_flow_style=False)
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
@@ -1,18 +1,72 @@
-<tool id="bowtie2_index_builder_data_manager" name="Bowtie2 index" tool_type="manage_data" version="@WRAPPER_VERSION@" profile="18.09">
+<tool id="bowtie2_index_builder_data_manager" name="Bowtie2 index" tool_type="manage_data" version="@WRAPPER_VERSION@+galaxy1" profile="18.09">
     <description>builder</description>
     <requirements>
-        <requirement type="package" version="@WRAPPER_VERSION@">bowtie2</requirement>
+        <requirement type="package" version="5.1.1">pyyaml</requirement>
+        <requirement type="package" version="@DEPENDENCY_VERSION@">bowtie2</requirement>
+        <!--
+        The future:
+        conda-install data managers just like regular dependencies?
+        <requirement type="package" version="@WRAPPER_VERSION@">data_manager_bowtie2
+        -->
     </requirements>
     <macros>
+        <token name="@DEPENDENCY_VERSION@">2.3.4.3</token>
         <token name="@WRAPPER_VERSION@">2.3.4.3</token>
+        <token name="@SET_DEFAULTS@">
+## use the ref genome's ID as default for the index ID
+#if not str($sequence_id).strip():
+  #set $sequence_id = $all_fasta_source.fields.dbkey
+#end if
+## use the ref genome's name as default for the index name
+#if not str($sequence_name).strip():
+  #set $sequence_name = $all_fasta_source.fields.name
+#end if
+        </token>
     </macros>
+    <configfiles>
+        <configfile name="metadata_yaml">
+@SET_DEFAULTS@
+source: '${all_fasta_source.fields.path}'
+dbkey: '${all_fasta_source.fields.dbkey}'
+description: '${all_fasta_source.fields.name}'
+id: '$sequence_id'
+name: '$sequence_name'
+version: 2
+        </configfile>
+        <configfile name="data_table_json">
+@SET_DEFAULTS@
+{
+    "data_tables": {
+        "bowtie2_indexes": [
+            {
+                "value": "$sequence_id",
+                "dbkey": "$all_fasta_source.fields.dbkey",
+                "name": "$sequence_name",
+                "path": "$sequence_id"
+            }
+        ]
+    #if $tophat2:
+        ,
+        "tophat2_indexes": [
+            {
+                "value": "$sequence_id",
+                "dbkey": "$all_fasta_source.fields.dbkey",
+                "name": "$sequence_name",
+                "path": "$sequence_id"
+            }
+        ]
+    #end if
+    }
+}
+        </configfile>
+    </configfiles>
     <command detect_errors="exit_code"><![CDATA[
-        python '$__tool_directory__/bowtie2_index_builder.py'
-        '${out_file}'
-        --fasta_filename '${all_fasta_source.fields.path}'
-        --fasta_dbkey '${all_fasta_source.fields.dbkey}'
-        --fasta_description '${all_fasta_source.fields.name}'
-        --data_table_name bowtie2_indexes ${tophat2}
+python '$__tool_directory__/bowtie2_index_builder.py'
+--target-directory '${out_file.extra_files_path}' '$metadata_yaml'
+&&
+mv '$metadata_yaml' $meta_file
+&&
+mv '$data_table_json' $out_file
     ]]></command>
     <inputs>
         <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
@@ -20,9 +74,10 @@
         </param>
         <param name="sequence_name" type="text" value="" label="Name of sequence" />
         <param name="sequence_id" type="text" value="" label="ID for sequence" />
-        <param name="tophat2" type="boolean" truevalue="--data_table_name tophat2_indexes" falsevalue="" checked="True" label="Also make available for TopHat" help="Adds values to tophat2_indexes tool data table" />
+        <param name="tophat2" type="boolean" truevalue="tophat2_indexes" falsevalue="" checked="True" label="Also make available for TopHat" help="Adds values to tophat2_indexes tool data table" />
     </inputs>
     <outputs>
+        <data name="meta_file" format="txt"/>
         <data name="out_file" format="data_manager_json"/>
     </outputs>
     <tests>

--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
@@ -83,7 +83,7 @@ mv '$data_table_json' $out_file
     <tests>
         <test>
             <param name="all_fasta_source" value="phiX174"/>
-            <output name="out_file" value="bowtie2_data_manager.json"/>
+            <output name="out_file" value="bowtie2_data_manager.json" compare="diff" lines_diff="3"/>
         </test>
     </tests>
 

--- a/data_managers/data_manager_bowtie2_index_builder/test-data/bowtie2_data_manager.json
+++ b/data_managers/data_manager_bowtie2_index_builder/test-data/bowtie2_data_manager.json
@@ -1,1 +1,24 @@
-{"data_tables": {"tophat2_indexes": [{"path": "phiX174", "dbkey": "phiX174", "name": "phiX174", "value": "phiX174"}], "bowtie2_indexes": [{"path": "phiX174", "dbkey": "phiX174", "name": "phiX174", "value": "phiX174"}]}}
+
+
+
+{
+    "data_tables": {
+        "bowtie2_indexes": [
+            {
+                "value": "phiX174",
+                "dbkey": "phiX174",
+                "name": "phiX174",
+                "path": "phiX174"
+            }
+        ]
+        ,
+        "tophat2_indexes": [
+            {
+                "value": "phiX174",
+                "dbkey": "phiX174",
+                "name": "phiX174",
+                "path": "phiX174"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

I'm creating this PR **to get feedback** on an experiment I've been doing after reference data discussions during and after GCC. It's an illustration (based on the bowtie2 data manager) of an idea to separate concerns between data_managers' .py and .xml files.

**What it does and why**:

- After refactoring, the python code no longer contains any Galaxy-specific logic, but concerns itself exclusively with building the requested index.
- The wrapper xml calls the python code through a very much simplified cli - basically only passing a metadata.yaml file. With that the python code could be called with [idc](https://github.com/galaxyproject/idc)-style metadata (thanks @Slugger70!) to generate the same ref data with and independent of Galaxy.
- The DM python code can update the passed in metadata with information only known to itself (like the command line instruction(s) it ran to obtain/generate the ref data.
@natefoo This first version just turns the updated metadata into a separate dataset, but, alternatively, it could also become one of the extra files produced by the DM, which could be used and stored by Galaxy for things like building vignettes for the ref data, _etc_.
- Hopefully, this also makes the architecture of data managers more similar to regular tools in that it would now be possible to conda-package the data manager .py (complete with unit tests) like a regular tool dependency and have the iuc handle only the wrapper part of it.
- As a next step, I'm envisioning a general DM package (available through conda) that would define a DM base class providing logic for handling the metadata.yaml parsing, _etc._, simplifying and standardizing the task of writing new DMs.

I've created https://testtoolshed.g2.bx.psu.edu/view/wolma/ng_data_manager_bowtie2_index_builder/ if anyone wants to see the refactored DM in action though really all it does right now is replicate the existing DM's action and generate the new metadata dataset :smile:

