### PR TITLE
idba_ud: switch to aggressive error checks

### DIFF
--- a/tools/idba_ud/idba_ud.xml
+++ b/tools/idba_ud/idba_ud.xml
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
-    <command><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 
     idba_ud
 


### PR DESCRIPTION
in order to catch oom indicated by

```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
