### PR TITLE
quast: default single core

### DIFF
--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -65,7 +65,7 @@ metaquast
     #end if
 #end if
     --min-contig $min_contig
-    --threads \${GALAXY_SLOTS:-4}
+    --threads \${GALAXY_SLOTS:-1}
     $split_scaffolds
     --labels $labels
     $large


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
