### PR TITLE
Update gffcompare.xml

### DIFF
--- a/tools/gffcompare/gffcompare.xml
+++ b/tools/gffcompare/gffcompare.xml
@@ -79,7 +79,7 @@ $adv_output.K
                     <when value="cached">
                         <param argument="-r" label="Using reference annotation" name="index" type="select">
                             <options from_data_table="gene_sets">
-                                <filter column="1" key="dbkey" ref="gffinputs" type="data_meta" />
+                                <filter column="1" type="sort_by" />
                             </options>
                             <validator message="No reference annotation is available for the build associated with the selected input dataset" type="no_options" />
                         </param>


### PR DESCRIPTION
I propose replacing  `key="dbkey" ref="gffinputs" type="data_meta"` by `type="sort_by"`, otherwise the cached references don't appear until user select input data, which is not convenient when using this wrapper in workflow.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
