### PR TITLE
megahit: fixed project url

### DIFF
--- a/tools/megahit_contig2fastg/megahit_contig2fastg.xml
+++ b/tools/megahit_contig2fastg/megahit_contig2fastg.xml
@@ -71,9 +71,7 @@ MEGAHIT is a single node assembler for large and complex metagenomics NGS reads,
 
 **Project links:**
 
-MEGAHIT: https://github.com/voutcn/megahit
-
-MEGAHIT Toolkit: https://github.com/voutcn/megahit/blob/master/tools/toolkit.cpp
+MEGAHIT and MEGAHIT Toolkit: https://github.com/voutcn/megahit
 
 Graph2Pro-Var: https://github.com/COL-IU/graph2pro-var
 


### PR DESCRIPTION
the link gives a linter error

```
Linting tool /home/travis/build/galaxyproject/tools-iuc/tools/megahit_contig2fastg/megahit_contig2fastg.xml
Applying linter tool_urls... FAIL
.. ERROR: Error '404 Client Error: Not Found for url: https://github.com/voutcn/megahit/blob/master/tools/toolkit.cpp' accessing https://github.com/voutcn/megahit/blob/master/tools/toolkit.cpp
```

also linking to a cpp file seems not useful.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
