### PR TITLE
Update bowtie2_wrapper.xml

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -281,7 +281,6 @@ bowtie2
         -R ${analysis_type.effort_options.R}
     #end if
     #if str( $analysis_type.other_options.other_options_selector ) == "yes":
-        ${analysis_type.other_options.reorder}
         ${analysis_type.other_options.non_deterministic}
         --seed ${analysis_type.other_options.seed}
     #end if
@@ -505,7 +504,6 @@ bowtie2
                         <option value="no" selected="true">No</option>
                     </param>
                     <when value="yes">
-                        <param name="reorder" type="boolean" truevalue="--reorder" falsevalue="" label="Guarantee that output SAM records are printed in an order corresponding to the order of the reads in the original input file. If selected output file will not be coordinate sorted." help="--reorder; Default=False"/>
                         <param name="seed" type="integer" value="0" min="0" label="Use this number as the seed for pseudo-random number generator" help="--seed; Default=0"/>
                         <param name="non_deterministic" type="boolean" truevalue="--non-deterministic" falsevalue="" label="Re-initialize the pseudo-random generator for each read using the current time" help="--non-deterministic; see Help below for explanation of this option; default=False"/>
                     </when>


### PR DESCRIPTION
For reasons the option `--reorder` was two times implemented, but only one time in a useful (no additional sorting) way.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
