### PR TITLE
hisat2: correctly assign datatype to output Fastq datasets when inputs are compressed

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -581,25 +581,121 @@ hisat2
         <!-- Unaligned fastq (L) -->
         <data name="output_unaligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: unaligned reads (L)">
             <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True</filter>
-            <expand macro="dbKeyActions" />
+            <actions>
+              <conditional name="library.type">
+                <when value="single">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired_collection">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+                <when value="paired_interleaved">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+              </conditional>
+              <expand macro="dbKeyActions" />
+	    </actions>
         </data>
 
         <!-- Aligned fastq (L) -->
         <data name="output_aligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: aligned reads (L)">
             <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True</filter>
-            <expand macro="dbKeyActions" />
+            <actions>
+              <conditional name="library.type">
+                <when value="single">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired_collection">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+                <when value="paired_interleaved">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+              </conditional>
+              <expand macro="dbKeyActions" />
+	    </actions>
         </data>
 
         <!-- Unaligned fastq (R) -->
         <data name="output_unaligned_reads_r" format="fastqsanger" label="${tool.name} on ${on_string}: unaligned reads (R)">
             <filter>(library['type'] == 'paired' or library['type'] == 'paired_collection') and (adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True) </filter>
-            <expand macro="dbKeyActions" />
+            <actions>
+              <conditional name="library.type">
+                <when value="single">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired_collection">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+                <when value="paired_interleaved">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+              </conditional>
+              <expand macro="dbKeyActions" />
+	    </actions>
         </data>
 
         <!-- Aligned fastq (R) -->
         <data name="output_aligned_reads_r" format="fastqsanger" label="${tool.name} on ${on_string}: aligned reads (R)">
             <filter>(library['type'] == 'paired' or library['type'] == 'paired_collection') and (adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True) </filter>
-            <expand macro="dbKeyActions" />
+            <actions>
+              <conditional name="library.type">
+                <when value="single">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="ext" />
+                  </action>
+                </when>
+                <when value="paired_collection">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+                <when value="paired_interleaved">
+                  <action type="format">
+                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                  </action>
+                </when>
+              </conditional>
+              <expand macro="dbKeyActions" />
+	    </actions>
         </data>
 
         <!-- Alignment summary file -->

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -575,146 +575,146 @@ hisat2
 
         <!-- BAM -->
         <data name="output_alignments" format="bam" label="${tool.name} on ${on_string}: aligned reads (BAM)">
-	  <actions>
-            <expand macro="dbKeyActions" />
-	  </actions>
+            <actions>
+                <expand macro="dbKeyActions" />
+            </actions>
         </data>
 
         <!-- Unaligned fastq (L) -->
         <data name="output_unaligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: unaligned reads (L)">
             <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True</filter>
             <actions>
-              <conditional name="library.type">
-                <when value="single">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired_collection">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-                <when value="paired_interleaved">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-              </conditional>
-              <expand macro="dbKeyActions" />
-	    </actions>
+                <conditional name="library.type">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                    <when value="paired_interleaved">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+                <expand macro="dbKeyActions" />
+            </actions>
         </data>
 
         <!-- Aligned fastq (L) -->
         <data name="output_aligned_reads_l" format="fastqsanger" label="${tool.name} on ${on_string}: aligned reads (L)">
             <filter>adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True</filter>
             <actions>
-              <conditional name="library.type">
-                <when value="single">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired_collection">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-                <when value="paired_interleaved">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-              </conditional>
-              <expand macro="dbKeyActions" />
-	    </actions>
+                <conditional name="library.type">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                    <when value="paired_interleaved">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+                <expand macro="dbKeyActions" />
+            </actions>
         </data>
 
         <!-- Unaligned fastq (R) -->
         <data name="output_unaligned_reads_r" format="fastqsanger" label="${tool.name} on ${on_string}: unaligned reads (R)">
             <filter>(library['type'] == 'paired' or library['type'] == 'paired_collection') and (adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['unaligned_file'] is True) </filter>
             <actions>
-              <conditional name="library.type">
-                <when value="single">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired_collection">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-                <when value="paired_interleaved">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-              </conditional>
-              <expand macro="dbKeyActions" />
-	    </actions>
+                <conditional name="library.type">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                    <when value="paired_interleaved">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+                <expand macro="dbKeyActions" />
+            </actions>
         </data>
 
         <!-- Aligned fastq (R) -->
         <data name="output_aligned_reads_r" format="fastqsanger" label="${tool.name} on ${on_string}: aligned reads (R)">
             <filter>(library['type'] == 'paired' or library['type'] == 'paired_collection') and (adv['output_options']['output_options_selector'] == "advanced" and adv['output_options']['aligned_file'] is True) </filter>
             <actions>
-              <conditional name="library.type">
-                <when value="single">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                  </action>
-                </when>
-                <when value="paired_collection">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-                <when value="paired_interleaved">
-                  <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                  </action>
-                </when>
-              </conditional>
-              <expand macro="dbKeyActions" />
-	    </actions>
+                <conditional name="library.type">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                    <when value="paired_interleaved">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
+                <expand macro="dbKeyActions" />
+            </actions>
         </data>
 
-        <!-- Alignment summary file -->
-        <data name="summary_file"  format="txt" from_work_dir="summary.txt" label="${tool.name} on ${on_string}: Mapping summary" >
-          <filter>sum['summary_file'] is True</filter>
-	  <actions>
+     <!-- Alignment summary file -->
+    <data name="summary_file" format="txt" from_work_dir="summary.txt" label="${tool.name} on ${on_string}: Mapping summary">
+        <filter>sum['summary_file'] is True</filter>
+        <actions>
             <expand macro="dbKeyActions" />
-	  </actions>
-        </data>
+        </actions>
+    </data>
 
-        <!-- Novel Splice file -->
-        <data name="novel_splicesite_output"  format="tabular" label="${tool.name} on ${on_string}: Novel Splice Sites" >
-          <filter>adv['spliced_options']['spliced_options_selector'] == 'advanced' and adv['spliced_options']['novel_splicesite_outfile'] is True</filter>
-	  <actions>
+    <!-- Novel Splice file -->
+    <data name="novel_splicesite_output" format="tabular" label="${tool.name} on ${on_string}: Novel Splice Sites">
+        <filter>adv['spliced_options']['spliced_options_selector'] == 'advanced' and adv['spliced_options']['novel_splicesite_outfile'] is True</filter>
+        <actions>
             <expand macro="dbKeyActions" />
-	  </actions>
-        </data>
+        </actions>
+    </data>
 
 
     </outputs>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,4 +1,4 @@
-<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy4" profile="17.01">
+<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy5" profile="17.01">
     <description>A fast and sensitive alignment program</description>
     <macros>
         <import>hisat2_macros.xml</import>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -575,7 +575,9 @@ hisat2
 
         <!-- BAM -->
         <data name="output_alignments" format="bam" label="${tool.name} on ${on_string}: aligned reads (BAM)">
+	  <actions>
             <expand macro="dbKeyActions" />
+	  </actions>
         </data>
 
         <!-- Unaligned fastq (L) -->
@@ -701,13 +703,17 @@ hisat2
         <!-- Alignment summary file -->
         <data name="summary_file"  format="txt" from_work_dir="summary.txt" label="${tool.name} on ${on_string}: Mapping summary" >
           <filter>sum['summary_file'] is True</filter>
-          <expand macro="dbKeyActions" />
+	  <actions>
+            <expand macro="dbKeyActions" />
+	  </actions>
         </data>
 
         <!-- Novel Splice file -->
         <data name="novel_splicesite_output"  format="tabular" label="${tool.name} on ${on_string}: Novel Splice Sites" >
           <filter>adv['spliced_options']['spliced_options_selector'] == 'advanced' and adv['spliced_options']['novel_splicesite_outfile'] is True</filter>
-          <expand macro="dbKeyActions" />
+	  <actions>
+            <expand macro="dbKeyActions" />
+	  </actions>
         </data>
 
 

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -29,22 +29,20 @@
     </xml>
 
     <xml name="dbKeyActions">
-        <actions>
-            <conditional name="reference_genome.source">
-                <when value="indexed">
-                    <action type="metadata" name="dbkey">
-                         <option type="from_data_table" name="hisat2_indexes" column="1">
-                            <filter type="param_value" ref="reference_genome.index" column="0"/>
-                        </option>
-                    </action>
-                </when>
-                <when value="history">
-                    <action type="metadata" name="dbkey">
-                        <option type="from_param" name="reference_genome.history_item" param_attribute="dbkey" />
-                    </action>
-                </when>
-            </conditional>
-        </actions>
+      <conditional name="reference_genome.source">
+        <when value="indexed">
+          <action type="metadata" name="dbkey">
+            <option type="from_data_table" name="hisat2_indexes" column="1">
+              <filter type="param_value" ref="reference_genome.index" column="0"/>
+            </option>
+          </action>
+        </when>
+        <when value="history">
+          <action type="metadata" name="dbkey">
+            <option type="from_param" name="reference_genome.history_item" param_attribute="dbkey" />
+          </action>
+        </when>
+      </conditional>
     </xml>
 
 </macros>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -29,20 +29,20 @@
     </xml>
 
     <xml name="dbKeyActions">
-      <conditional name="reference_genome.source">
-        <when value="indexed">
-          <action type="metadata" name="dbkey">
-            <option type="from_data_table" name="hisat2_indexes" column="1">
-              <filter type="param_value" ref="reference_genome.index" column="0"/>
-            </option>
-          </action>
-        </when>
-        <when value="history">
-          <action type="metadata" name="dbkey">
-            <option type="from_param" name="reference_genome.history_item" param_attribute="dbkey" />
-          </action>
-        </when>
-      </conditional>
+        <conditional name="reference_genome.source">
+              <when value="indexed">
+                  <action type="metadata" name="dbkey">
+                      <option type="from_data_table" name="hisat2_indexes" column="1">
+                          <filter type="param_value" ref="reference_genome.index" column="0"/>
+                      </option>
+                  </action>
+              </when>
+              <when value="history">
+                  <action type="metadata" name="dbkey">
+                      <option type="from_param" name="reference_genome.history_item" param_attribute="dbkey" />
+                  </action>
+              </when>
+        </conditional>
     </xml>
 
 </macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

PR which addresses an issue in the `hisat2` tool: when the input Fastqs are in a compressed format (e.g. `fastqsanger.gz` or `fastqsanger.bz`), the tool runs the `hisat2` program so that it produces output Fastqs with the same compression type as the input, but then incorrectly assigned the datatypes of those datasets to `fastqsanger`. This had implications for downstream tools, causing them to fail.

With this patch the correct datatype should be assigned to the output Fastq datasets based on that of the inputs (based on code which performs a similar job in the `bowtie2` tool).
