### PR TITLE
trinity: update README to clarify specification of memory limit

### DIFF
--- a/tools/trinity/README.rst
+++ b/tools/trinity/README.rst
@@ -9,7 +9,14 @@ trinity requires a large amount of memory to perform the assembly: "roughly
 By default, this tool is configured to limit the memory consumption to 1G.
 You might need to lower this limit if the machine(s) executing the jobs have less memory available.
 If you have a lot of reads to assemble and a machine with enough memory, you can increase it.
-In both cases, you can set the GALAXY_MEMORY_MB environmental variable in the destination section of the job_conf.xml file to the amount of available memory (in MB)::
+
+This tool uses the GALAXY_MEMORY_MB environmental variable to limit the its memory usage. If you use a supported cluster type, you just need to limit the memory in the destination section of the job_conf.xml file to the amount of available memory (in MB), for example with a Slurm cluster::
+
+    <destination id="cluster_high_mem" runner="slurm
+        <param id="nativeSpecification">--mem=1024</param>
+    </destination>
+
+If you cluster type does not support memory limit detection, you can also set manually the GALAXY_MEMORY_MB environmental variable in the destination section of the job_conf.xml file to the amount of available memory (in MB)::
 
     <?xml version="1.0"?>
     <!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->

--- a/tools/trinity/README.rst
+++ b/tools/trinity/README.rst
@@ -9,7 +9,7 @@ trinity requires a large amount of memory to perform the assembly: "roughly
 By default, this tool is configured to limit the memory consumption to 1G.
 You might need to lower this limit if the machine(s) executing the jobs have less memory available.
 If you have a lot of reads to assemble and a machine with enough memory, you can increase it.
-In both cases, you can set the GALAXY_MEMORY_MB environmental variable in the destination section of the job_conf.xml file::
+In both cases, you can set the GALAXY_MEMORY_MB environmental variable in the destination section of the job_conf.xml file to the amount of available memory (in MB)::
 
     <?xml version="1.0"?>
     <!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
@@ -22,7 +22,7 @@ In both cases, you can set the GALAXY_MEMORY_MB environmental variable in the de
         </handlers>
         <destinations>
             <destination id="local" runner="local">
-                <env id="GALAXY_MEMORY_MB">1G</env>
+                <env id="GALAXY_MEMORY_MB">1024</env>
             </destination>
         </destinations>
     </job_conf>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

PR to address issue #2513 by updating the `README.rst` instructions for specifying the memory limits for the `trinity` tool (NB there are no functional changes to the tool in this PR).