### PR TITLE
mothur: fix summary.single

### DIFF
--- a/tools/mothur/clearcut.xml
+++ b/tools/mothur/clearcut.xml
@@ -118,13 +118,12 @@ echo 'clearcut(
 
 The clearcut_ command runs clearcut
 
-The clearcut command allows mothur users to run the clearcut_program_ from within mothur. The clearcut program written by Initiative for Bioinformatics and Evolutionary Studies (IBEST) at the University of Idaho. For more information about clearcut please refer to http://bioinformatics.hungry.com/clearcut/
+The clearcut command allows mothur users to run the clearcut program from within mothur. The clearcut program written by Initiative for Bioinformatics and Evolutionary Studies (IBEST) at the University of Idaho. 
 
 Clearcut is a stand-alone reference implementation of relaxed neighbor joining (RNJ).
 
 Clearcut is capable of taking either a distance matrix or a multiple sequence alignment (MSA) as input.  If necessary, Clearcut will compute corrected distances based on a configurable distance correction model (Jukes-Cantor or Kimura).  Clearcut outputs a phylogenetic tree in Newick format and an optional corrected distance matrix.
 
-.. _clearcut_program: http://bioinformatics.hungry.com/clearcut/
 .. _clearcut: https://www.mothur.org/wiki/Clearcut
 
 v.1.20.0: Trivial upgrade to Mothur 1.33

--- a/tools/mothur/list.otulabels.xml
+++ b/tools/mothur/list.otulabels.xml
@@ -77,14 +77,14 @@ echo 'list.otulabels(
 
 **Command Documentation**
 
-The list.otulabels_ command lists otu labels from shared_ or relabund_ file. This list can be used especially with subsampled datasets when used with output from classify.otu_, otu.association_, or corr.axes_ to select specific otus using the get.otus_ or remove.otulabels_ commands
+The list.otulabels_ command lists otu labels from shared_ or relabund_ file. This list can be used especially with subsampled datasets when used with output from classify.otu_, otu.association_, or corr.axes_ to select specific otus using the get.otus_ or remove.otus_ commands
 
 .. _list.otulabels: https://www.mothur.org/wiki/List.otulabels
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _otu.association: https://www.mothur.org/wiki/Otu.association
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
 .. _get.otus: https://www.mothur.org/wiki/Get.otus
-.. _remove.otulabels: https://mothur.org/wiki/Remove.otus
+.. _remove.otus: https://www.mothur.org/wiki/Remove.otus
 .. _shared: https://www.mothur.org/wiki/Shared_file
 .. _relabund: https://www.mothur.org/wiki/Get.relabund
 

--- a/tools/mothur/macros.xml
+++ b/tools/mothur/macros.xml
@@ -15,7 +15,7 @@
             <exit_code range="1:" level="fatal"/>
         </stdio>
     </xml>
-    <token name="@SHELL_OPTIONS@">set -o pipefail;</token>
+    <token name="@SHELL_OPTIONS@">set -o pipefail; export TERM=vt100; </token>
 
 
     <!-- Input parameters -->

--- a/tools/mothur/mimarks.attributes.xml
+++ b/tools/mothur/mimarks.attributes.xml
@@ -47,7 +47,6 @@ echo 'mimarks.attributes(
 
 The mimarks.attributes_ command reads `BioSample Attributes`_ xml and generates source for get.mimarkspackage_ command.
 
-.. _mimarks.attributes: https://www.mothur.org/w/index.php?search=mimarks.attributes
 .. _BioSample Attributes: https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/
 .. _get.mimarkspackage: https://www.mothur.org/wiki/Get.mimarkspackage
 

--- a/tools/mothur/remove.otulabels.xml
+++ b/tools/mothur/remove.otulabels.xml
@@ -103,7 +103,7 @@ The remove.otulabels_ command removes otu labels from the output from classify.o
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
 .. _otu.association: https://www.mothur.org/wiki/Otu.association
-.. _remove.otus: https://www.mothur.org/wiki/Remove.otus
+.. _remove.otulabels: https://www.mothur.org/wiki/Remove.otus
 
     ]]></help>
     <expand macro="citations"/>

--- a/tools/mothur/remove.otulabels.xml
+++ b/tools/mothur/remove.otulabels.xml
@@ -103,7 +103,7 @@ The remove.otulabels_ command removes otu labels from the output from classify.o
 .. _classify.otu: https://www.mothur.org/wiki/Classify.otu
 .. _corr.axes: https://www.mothur.org/wiki/Corr.axes
 .. _otu.association: https://www.mothur.org/wiki/Otu.association
-.. _remove.otulabels: https://mothur.org/wiki/Remove.otus
+.. _remove.otus: https://www.mothur.org/wiki/Remove.otus
 
     ]]></help>
     <expand macro="citations"/>

--- a/tools/mothur/seq.error.xml
+++ b/tools/mothur/seq.error.xml
@@ -163,7 +163,7 @@ echo 'seq.error(
 **Command Documentation**
 
 The seq.error_ command evaluates error rate for sequences by comparing to the fasta-formatted template_alignment_.
-This is demonstrated in https://www.mothur.org/wiki/Schloss_SOP#Error_analysis
+This is demonstrated in https://mothur.org/wiki/miseq_sop/#assessing-error-rates
 
 .. _template_alignment: https://www.mothur.org/wiki/Alignment_database
 .. _seq.error: https://www.mothur.org/wiki/Seq.error

--- a/tools/mothur/summary.single.xml
+++ b/tools/mothur/summary.single.xml
@@ -1,4 +1,4 @@
-<tool profile="16.07" id="mothur_summary_single" name="Summary.single" version="@WRAPPER_VERSION@.0">
+<tool profile="16.07" id="mothur_summary_single" name="Summary.single" version="@WRAPPER_VERSION@.2">
     <description>Summary of calculator values for OTUs</description>
     <macros>
         <import>macros.xml</import>
@@ -50,7 +50,7 @@ echo 'summary.single(
 | mothur
 | tee mothur.out.log
 #if $subsample.use == 'yes' and not ($otu.extension == 'mothur.shared' and not $groupmode):
-    && mv otu.*ave_std.summary otu.ave-std
+    && mv otu.*ave[_-]std.summary otu.ave-std
 #end if
     ]]></command>
     <inputs>
@@ -115,6 +115,13 @@ echo 'summary.single(
         </collection>
     </outputs>
     <tests>
+        <test><!-- test with shared and subsampling -->
+            <param name="otu" value="amazon.an.shared" ftype="mothur.shared"/>
+            <param name="use" value="yes"/>
+            <output name="summary" md5="eaf5304b383c3c5764193ac7f49589db" ftype="tabular"/>
+            <param name="savelog" value="true"/>
+            <expand macro="logfile-test"/>
+        </test>
         <test><!-- test with shared and default params -->
             <param name="otu" value="amazon.an.shared" ftype="mothur.shared"/>
             <output name="summary" md5="eaf5304b383c3c5764193ac7f49589db" ftype="tabular"/>


### PR DESCRIPTION
seems that for some reason summary.single sometimes outputs

otu.groups.ave-std.summary

and sometimes

otu.groups.ave_std.summary

so the last mv fails

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
