### PR TITLE
fixed bug where unaligned and aligned fastqs would be empty

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bowtie2" name="Bowtie2" version="2.3.4.3" profile="18.01">
+<tool id="bowtie2" name="Bowtie2" version="2.3.4.3+galaxy0" profile="18.01">
     <description>- map reads against reference genome</description>
     <macros>
         <import>bowtie2_macros.xml</import>
@@ -314,13 +314,13 @@ bowtie2
 #end if
 
 ## rename unaligned sequence files
-#if $library.type == "paired" and $output_unaligned_reads_l and $output_unaligned_reads_r:
+#if ($library.type == "paired" or $library.type == "paired_collection") and $output_unaligned_reads_l and $output_unaligned_reads_r:
     #from os.path import splitext
     #set _unaligned_root, _unaligned_ext = splitext( str( $output_unaligned_reads_l ) )
     && mv '${ _unaligned_root }.1${_unaligned_ext}' '$output_unaligned_reads_l'
     && mv '${ _unaligned_root }.2${_unaligned_ext}' '$output_unaligned_reads_r'
 #end if
-#if $library.type == "paired" and $output_aligned_reads_l and $output_aligned_reads_r:
+#if ($library.type == "paired" or $library.type == "paired_collection") and $output_aligned_reads_l and $output_aligned_reads_r:
     #from os.path import splitext
     #set _aligned_root, _aligned_ext = splitext( str( $output_aligned_reads_l ) )
     && mv '${ _aligned_root }.1${_aligned_ext}' '$output_aligned_reads_l'

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -281,7 +281,6 @@ bowtie2
         -R ${analysis_type.effort_options.R}
     #end if
     #if str( $analysis_type.other_options.other_options_selector ) == "yes":
-        ${analysis_type.other_options.reorder}
         ${analysis_type.other_options.non_deterministic}
         --seed ${analysis_type.other_options.seed}
     #end if
@@ -505,7 +504,6 @@ bowtie2
                         <option value="no" selected="true">No</option>
                     </param>
                     <when value="yes">
-                        <param name="reorder" type="boolean" truevalue="--reorder" falsevalue="" label="Guarantee that output SAM records are printed in an order corresponding to the order of the reads in the original input file. If selected output file will not be coordinate sorted." help="--reorder; Default=False"/>
                         <param name="seed" type="integer" value="0" min="0" label="Use this number as the seed for pseudo-random number generator" help="--seed; Default=0"/>
                         <param name="non_deterministic" type="boolean" truevalue="--non-deterministic" falsevalue="" label="Re-initialize the pseudo-random generator for each read using the current time" help="--non-deterministic; see Help below for explanation of this option; default=False"/>
                     </when>

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -661,11 +661,11 @@ bowtie2
             <param name="own_file" value="bowtie2-ref.fasta" />
             <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="2"/>
         </test>
-        <test expect_num_outputs="1">
-            <!-- test on paired collection -->
+        <test expect_num_outputs="3">
+            <!-- test on list paired collection -->
             <param name="type" value="paired_collection"/>
             <param name="paired_options_selector" value="no"/>
-            <param name="unaligned_file" value="false"/>
+            <param name="unaligned_file" value="true"/>
             <param name="analysis_type_selector" value="simple"/>
             <param name="source" value="history" />
             <param name="input_1">


### PR DESCRIPTION
fixed bug where unaligned and aligned fastqs would be empty when using a paired_collection

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
