### PR TITLE
Fixed roary to include inverted quotes around input filenames

### DIFF
--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -6,12 +6,9 @@
     </requirements>
 
     <command detect_errors="exit_code"><![CDATA[
-        #for $gff in $gff_input.gffs
-          cp $gff '${gff.element_identifier}.gff' &&
-        #end for
-
         #set $filenames = list()
         #for $gff in $gff_input.gffs
+          cp '$gff' '${gff.element_identifier}.gff' &&
           #set $filename = str($gff.element_identifier) + '.gff'
           $filenames.append(str($filename))
         #end for

--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -7,12 +7,12 @@
 
     <command detect_errors="exit_code"><![CDATA[
         #for $gff in $gff_input.gffs
-          cp $gff "${gff.element_identifier}.gff" &&
+          cp $gff '${gff.element_identifier}.gff' &&
         #end for
 
         #set $filenames = list()
         #for $gff in $gff_input.gffs
-          #set $filename = str($gff.element_identifier) + ".gff"
+          #set $filename = str($gff.element_identifier) + '.gff'
           $filenames.append(str($filename))
         #end for
 
@@ -29,7 +29,7 @@
           -iv '$advanced.mcl'
 
           #for $f in $filenames
-            "$f"
+            '$f'
           #end for
 
     ]]></command>

--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -1,14 +1,19 @@
 <tool id="roary" name="Roary" version="3.12.0+galaxy0">
     <description>the pangenome pipeline - Quickly generate a core gene alignment from gff3 files</description>
-    
+
     <requirements>
       <requirement type="package" version="3.12.0">roary</requirement>
     </requirements>
-    
+
     <command detect_errors="exit_code"><![CDATA[
-        
         #for $gff in $gff_input.gffs
-          cp $gff '${gff.element_identifier}'.gff &&
+          cp $gff "${gff.element_identifier}.gff" &&
+        #end for
+
+        #set $filenames = list()
+        #for $gff in $gff_input.gffs
+          #set $filename = str($gff.element_identifier) + ".gff"
+          $filenames.append(str($filename))
         #end for
 
         roary
@@ -23,10 +28,12 @@
           -t '$advanced.trans_tab'
           -iv '$advanced.mcl'
 
-          *.gff
-          
+          #for $f in $filenames
+            "$f"
+          #end for
+
     ]]></command>
-    
+
     <inputs>
       <conditional name="gff_input">
         <param name="gff_input_selector" type="select" label="Individual gff files or a dataset collection" help="Select between individual gff files or a collection of gff files">
@@ -42,7 +49,7 @@
       </conditional>
       <param name="percent_ident" type="integer" label="minimum percentage identity for blastp" help="Sets the minimum percentage identity for protein matches" value="95"/>
       <param name="core_diff" type="float" label="percentage of isolates a gene must be in to be core" help="The total percentage of the isolates that must have the gene for it to be considered a core gene." value="99.0"/>
-      
+
       <param name="outputs" type="select" multiple="true" display="checkboxes" label="Additional outputs" help="Summary statistics, core gene alignments and Gene Presence/Absence tables are always produced.">
         <option value="abg_nw">Accessory binary genes in newick format</option>
         <option value="abg_fa">Accessory binary genes in fasta format</option>
@@ -60,16 +67,16 @@
         <option value="numnew_rtab">Number of New Genes in Rtab format</option>
         <option value="numuniq_rtab">Number of Unique Genes in Rtab format</option>
       </param>
-      
+
       <section name="advanced" title="Advanced options" expanded="false">
         <param name="maxclust" type="integer" value="50000" label="Maximum number of clusters" help="The maximum number of clusters to assign proteins" />
         <param name="split_para" type="boolean" checked="False" truevalue="-s" falsevalue="" label="Don't split paralogs" help="Click yes so that paralogs aren't split."/>
         <param name="trans_tab" type="integer" value="11" label="Translation table to use [1 or 4 or 11]" help="DNA -> RNA translation table to use. Roary is designed for prokaryotes and so tables 1, 4 or 11 will work, others could be problematic." />
         <param name="mcl" type="float" value="1.5" label="MCL inflation value" help="This is an advanced setting, change only if you know what you are doing and then at your own risk!" />
       </section>
-      
+
     </inputs>
-    
+
     <outputs>
       <data format="tabular" name="sumstats" label="${tool.name} on ${on_string} Summary statistics" from_work_dir="out/summary_statistics.txt" />
       <data format="fasta" name="core_gene_aln" label="${tool.name} on ${on_string} Core Gene Alignment" from_work_dir="out/core_gene_alignment.aln" />
@@ -120,7 +127,7 @@
         <filter>outputs and 'numuniq_rtab' in outputs</filter>
       </data>
     </outputs>
-    
+
     <tests>
       <test>
         <param name="gff_input_selector" value="individual"/>
@@ -135,7 +142,7 @@
         <output name="sumstats" file="test2/summary_statistics.txt" ftype="tabular"/>
       </test>
     </tests>
-    
+
     <help><![CDATA[
 **Roary**
 
@@ -143,35 +150,35 @@ Roary is a high speed stand alone pan genome pipeline, which takes annotated ass
 
 To use Roary, select two or more gff3 files OR a collection of gff3 files
 
-**Options**: 
+**Options**:
 
 
        - Minimum percentage identity for blastp - an integer, default is [95]
 
-       
+
        - Percentage of isolates a gene must be in to be core - a float, default is [99.0]
-       
-       
+
+
 **Advanced Options**:
-       
+
        - Maximum number of clusters - integer, default is [50000]
 
-       
+
        - Don't split paralogs - check box
 
-       
+
        - Translation table - which translation table to use, an integer, default is [11]
 
-       
+
        - Change the MCL inflation value - a float, default is [1.5]
-       
+
 
 For further info see: http://sanger-pathogens.github.io/Roary/
-    
+
     ]]></help>
-    
+
     <citations>
         <citation type="doi">10.1093/bioinformatics/btv421</citation>
     </citations>
-    
+
 </tool>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

See issue #2545 

Hopefully this provides a fix.
