### PR TITLE
pygenometracks: use labels in the config file when off

### DIFF
--- a/tools/pygenometracks/pyGenomeTracks.xml
+++ b/tools/pygenometracks/pyGenomeTracks.xml
@@ -1,4 +1,4 @@
-<tool id="pygenomeTracks" name="@BINARY@" version="@WRAPPER_VERSION@.1">
+<tool id="pygenomeTracks" name="@BINARY@" version="@WRAPPER_VERSION@.2">
     <description>plot genomic data tracks</description>
     <macros>
         <token name="@BINARY@">pyGenomeTracks</token>
@@ -218,9 +218,7 @@ display = $track.track_file_style_conditional.display
 height = $track.track_file_style_conditional.height_bed
 #end if
 
-#if $track.track_file_style_conditional.labels:
 labels = $track.track_file_style_conditional.labels
-#end if
 
 file_type = bed
 #if $track.track_file_style_conditional.fontsize:


### PR DESCRIPTION
Hi,
Sorry, I just noticed that the option plot labels for bed and genes was not written in the config file when set to off whereas the default is on...