### PR TITLE
featurecounts: fix wrong column used in data table

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -152,7 +152,8 @@
             <when value="cached">
                 <param name="reference_gene_sets_builtin" type="select" label="Using locally cached annotation" help="If the annotation file you require is not listed here, please contact the Galaxy administrator">
                     <options from_data_table="gene_sets">
-                        <filter type="data_meta" key="dbkey" ref="alignment" column="0"/>
+                        <filter type="data_meta" key="dbkey" ref="alignment" column="dbkey"/>
+                        <filter type="sort_by" column="2" />
                     </options>
                     <validator type="no_options" message="An annotation file is not available for the build associated with the selected input file"/>
                 </param>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -145,7 +145,7 @@
             <when value="builtin">
                 <param name="bgenome" type="select" label="Select built-in genome" help="Built-in gene annotations for genomes hg38, hg19, mm10 and mm9 are included in featureCounts">
                     <options from_data_table="featurecounts_anno">
-                        <filter type="data_meta" key="dbkey" ref="alignment" column="0"/>
+                        <filter type="data_meta" key="dbkey" ref="alignment" column="dbkey"/>
                     </options>
                 </param>
             </when>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -1,4 +1,4 @@
-<tool id="featurecounts" name="featureCounts" version="1.6.4" profile="16.04">
+<tool id="featurecounts" name="featureCounts" version="1.6.4+galaxy1" profile="16.04">
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <requirements>
         <requirement type="package" version="1.6.4">subread</requirement>


### PR DESCRIPTION
dbkey is in column 2 (i.e. index 1). I prefer to refer by name since this seems less error prone.

Also added sorting filter.

I guess this exists since https://github.com/galaxyproject/tools-iuc/commit/c6719a037ec6339405ae46e5908355772eaaf7d2

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
