### PR TITLE
reference data table columns consistently by name

### DIFF
--- a/tool_collections/samtools/bam_to_cram/samtools_bam_to_cram.xml
+++ b/tool_collections/samtools/bam_to_cram/samtools_bam_to_cram.xml
@@ -42,7 +42,7 @@
             <when value="cached">
                 <param name="ref" type="select" label="Reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter type="data_meta" ref="input" key="dbkey" column="1" />
+                        <filter type="data_meta" ref="input" key="dbkey" column="dbkey" />
                     </options>
                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                 </param>

--- a/tool_collections/samtools/cram_to_bam/samtools_cram_to_bam.xml
+++ b/tool_collections/samtools/cram_to_bam/samtools_cram_to_bam.xml
@@ -44,7 +44,7 @@
             <when value="cached">
                 <param name="input_reference" type="select" label="Reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter type="data_meta" ref="input_alignment" key="dbkey" column="1" />
+                        <filter type="data_meta" ref="input_alignment" key="dbkey" column="dbkey" />
                     </options>
                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                 </param>

--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -42,7 +42,7 @@
                 </param>
                 <param name="index" type="select" label="Using reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter column="1" key="dbkey" ref="input1" type="data_meta" />
+                        <filter column="dbkey" key="dbkey" ref="input1" type="data_meta" />
                         <validator message="No reference genome is available for the build associated with the selected input dataset" type="no_options" />
                     </options>
                 </param>

--- a/tool_collections/samtools/samtools_calmd/samtools_calmd.xml
+++ b/tool_collections/samtools/samtools_calmd/samtools_calmd.xml
@@ -37,7 +37,7 @@ samtools calmd
             <when value="cached">
                 <param name="ref_fasta" type="select" label="Using reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter type="data_meta" column="1" key="dbkey" ref="input_bam" />
+                        <filter type="data_meta" column="dbkey" key="dbkey" ref="input_bam" />
                         <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file" />
                     </options>
                 </param>

--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -171,7 +171,7 @@
             <when value="cached">
                 <param name="ref" type="select" label="Using genome">
                     <options from_data_table="fasta_indexes">
-                        <filter type="data_meta" ref="input" key="dbkey" column="1" />
+                        <filter type="data_meta" ref="input" key="dbkey" column="dbkey" />
                     </options>
                 </param>
             </when>

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -228,7 +228,7 @@
             <when value="cached">
                 <param name="ref" type="select" label="Using reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter column="1" key="dbkey" ref="input" type="data_meta" />
+                        <filter column="dbkey" key="dbkey" ref="input" type="data_meta" />
                         <validator message="No reference genome is available for the build associated with the selected input dataset" type="no_options" />
                     </options>
                 </param>

--- a/tools/bcftools/bcftools_stats.xml
+++ b/tools/bcftools/bcftools_stats.xml
@@ -113,7 +113,7 @@ ${section.verbose}
                 <when value="cached">
                     <param name="fasta_ref" type="select" label="Reference genome">
                         <options from_data_table="fasta_indexes">
-                            <filter type="data_meta" column="1" key="dbkey" ref="input_file" />
+                            <filter type="data_meta" column="dbkey" key="dbkey" ref="input_file" />
                             <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file" />
                         </options>
                     </param>

--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -122,7 +122,7 @@ $vcfs_list_file
         <when value="cached">
             <param name="fasta_ref" type="select" label="Reference genome">
                 <options from_data_table="fasta_indexes">
-                    <filter type="data_meta" column="1" key="dbkey" ref="input_file" />
+                    <filter type="data_meta" column="dbkey" key="dbkey" ref="input_file" />
                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file" />
                 </options>
             </param>

--- a/tools/crossmap/macros.xml
+++ b/tools/crossmap/macros.xml
@@ -28,7 +28,7 @@ CrossMap.py 2>&1 | head -n 1 | grep -E --only-matching 'CrossMap.*'
             <when value="cached">
                 <param name="input_chain" type="select" label="Lift Over To">
                     <options from_data_table="liftOver">
-                        <filter type="data_meta" ref="input" key="dbkey" column="0"/>
+                        <filter type="data_meta" ref="input" key="dbkey" column="dbkey"/>
                     </options>
                 </param>
             </when>

--- a/tools/extract_genomic_dna/extract_genomic_dna.xml
+++ b/tools/extract_genomic_dna/extract_genomic_dna.xml
@@ -52,7 +52,7 @@ python '$__tool_directory__/extract_genomic_dna.py'
             <when value="cached">
                 <param name="reference_genome" type="select" label="Using reference genome">
                     <options from_data_table="twobit">
-                        <filter type="data_meta" key="dbkey" ref="input" column="0"/>
+                        <filter type="data_meta" key="dbkey" ref="input" column="dbkey"/>
                     </options>
                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                 </param>

--- a/tools/gffcompare/gffcompare.xml
+++ b/tools/gffcompare/gffcompare.xml
@@ -3,7 +3,7 @@
     <macros>
         <token name="@GFFCOMPARE_VERSION@">0.11.2</token>
     </macros>
-	<requirements>
+    <requirements>
         <requirement type="package" version="@GFFCOMPARE_VERSION@">gffcompare</requirement>
     </requirements>
     <version_command>gffcompare -v | awk '{print $2}'</version_command>
@@ -49,6 +49,7 @@ gffcompare
 
 $discard_single_exon
 $discard_duplicates
+$no_merge
 -e $max_dist_exon
 -d $max_dist_group
 $chr_stats
@@ -143,7 +144,7 @@ $adv_output.K
         <param argument="-d" help="max. distance (range) for grouping transcript start sites. Default: 100" label="Max distance for transcript grouping" name="max_dist_group" type="integer" value="100" />
         <param name="chr_stats" argument="--chr-stats" type="boolean" checked="false" truevalue="--chr-stats" falsevalue="" label="Show summary and accuracy data separately for each reference sequence in the transcript accuracy data set" />
         <section name="adv_output" title="Options for the combined GTF output file">
-            <param argument="-p"  type="text" value="TCONS" label="name prefix for consensus transcripts" help="for combined.gtf (default: 'TCONS')" />
+            <param argument="-p"  type="text" value="TCONS" label="name prefix for consensus transcripts" help="for combined.gtf" />
             <param argument="-C"  type="boolean" checked="false" truevalue="-C" falsevalue=""  label="discard matching and 'contained' transfrags" help="i.e. collapse intron-redundant transfrags across all query files" />
             <param argument="-A"  type="boolean" checked="false" truevalue="-A" falsevalue=""  label="discard the 'contained' transfrags except intron-redundant transfrags starting with a different 5' exon" help="like -C but does not discard intron-redundant transfrags if they start with a different 5' exon" />
             <param argument="-X"  type="boolean" checked="false" truevalue="-X" falsevalue=""  label="discard the 'contained' transfrags also if ends stick out within the container's introns" help="like -C but also discard contained transfrags if transfrag ends stick out within the container's introns" />
@@ -184,14 +185,14 @@ $adv_output.K
                 <not_has_text text="-Q " />
                 <not_has_text text="--strict-match " />
                 <not_has_text text="-T " />
-                <not_has_text text="-s " />
+                <has_text_matching expression="^.*gffcompare((?!-s).)*$" /> <!-- since ln also has -s a more complicated regexp is needed here to check if -s is not set -->
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
                 <not_has_text text="-D " />
                 <not_has_text text="--no-merge " />
-                <has_text text="-p TCONS " />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
@@ -221,12 +222,12 @@ $adv_output.K
                 <not_has_text text="-R " />
                 <not_has_text text="-Q " />
                 <has_text text="-T " />
-                <has_text text="-s " />
+                <has_text_matching expression="gffcompare.*-s " /> <!-- since ln also has -s a more complicated regexp is needed here to check if -s is set -->
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
-                <has_text text="-p TCONS " />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
@@ -255,12 +256,12 @@ $adv_output.K
                 <not_has_text text="-R " />
                 <not_has_text text="-Q " />
                 <has_text text="-T " />
-                <has_text text="-s " />
+                <has_text_matching expression="gffcompare.*-s " />
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
-                <has_text text="-p TCONS " />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
@@ -287,19 +288,23 @@ $adv_output.K
             <assert_command>
                 <not_has_text text="-R " />
                 <not_has_text text="-Q " />
+                <not_has_text text="--strict-match " />
                 <not_has_text text="-T " />
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
-                <has_text text="-p TCONS " />
+                <not_has_text text="-D " />
+                <not_has_text text="--no-merge " />
+                <not_has_text text="--chr-stats" />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
                 <not_has_text text="-K " />
             </assert_command>
-            <output file="gffcompare_out2.stats" name="transcripts_stats" lines_diff="6" />
-            <output file="gffcompare_out2.loci" name="transcripts_loci" lines_diff="2" />
+            <output file="gffcompare_out2.stats" name="transcripts_stats" />
+            <output file="gffcompare_out2.loci" name="transcripts_loci" />
             <output file="gffcompare_out2.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out2.gtf" name="transcripts_combined" />
             <output_collection name="refmap_output" type="list" count="2">
@@ -346,7 +351,7 @@ $adv_output.K
                 <has_text text="-D " />
                 <has_text text="--no-merge " />
                 <has_text text="--chr-stats" />
-                <not_has_text text="-p TCONS " />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
@@ -382,12 +387,16 @@ $adv_output.K
             <assert_command>
                 <not_has_text text="-R " />
                 <not_has_text text="-Q " />
+                <not_has_text text="--strict-match " />
                 <not_has_text text="-T " />
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
-                <has_text text="-p OTHER " />
+                <not_has_text text="-D " />
+                <not_has_text text="--no-merge " />
+                <not_has_text text="--chr-stats" />
+                <has_text text="-p 'OTHER' " />
                 <has_text text="-C " />
                 <has_text text="-A " />
                 <has_text text="-X " />
@@ -416,19 +425,23 @@ $adv_output.K
             <assert_command>
                 <not_has_text text="-R " />
                 <not_has_text text="-Q " />
+                <not_has_text text="--strict-match " />
                 <has_text text="-T " />
                 <not_has_text text="-M " />
                 <not_has_text text="-N " />
                 <has_text text="-e 100 " />
                 <has_text text="-d 100 " />
-                <has_text text="-p TCONS " />
+                <not_has_text text="-D " />
+                <not_has_text text="--no-merge " />
+                <not_has_text text="--chr-stats" />
+                <has_text text="-p 'TCONS' " />
                 <not_has_text text="-C " />
                 <not_has_text text="-A " />
                 <not_has_text text="-X " />
                 <not_has_text text="-K " />
             </assert_command>
-            <output file="gffcompare_out2.stats" name="transcripts_stats" lines_diff="6" />
-            <output file="gffcompare_out2.loci" name="transcripts_loci" lines_diff="2" />
+            <output file="gffcompare_out2.stats" name="transcripts_stats" lines_diff="2" />
+            <output file="gffcompare_out2.loci" name="transcripts_loci" />
             <output file="gffcompare_out2.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out2.gtf" name="transcripts_combined" />
         </test>
@@ -449,7 +462,7 @@ $adv_output.K
             <param name="discard_single_exon" value="" />
             <param name="max_dist_exon" value="100" />
             <param name="max_dist_group" value="100" />
-            <output file="gffcompare_out3.stats" name="transcripts_stats" lines_diff="6" />
+            <output file="gffcompare_out3.stats" name="transcripts_stats"/>
             <output file="gffcompare_out3.loci" name="transcripts_loci" />
             <output file="gffcompare_out3.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out3.gtf" name="transcripts_annotated" />

--- a/tools/gffcompare/gffcompare.xml
+++ b/tools/gffcompare/gffcompare.xml
@@ -79,7 +79,7 @@ $adv_output.K
                     <when value="cached">
                         <param argument="-r" label="Using reference annotation" name="index" type="select">
                             <options from_data_table="gene_sets">
-                                <filter column="1" key="dbkey" ref="gffinputs" type="data_meta" />
+                                <filter column="dbkey" key="dbkey" ref="gffinputs" type="data_meta" />
                             </options>
                             <validator message="No reference annotation is available for the build associated with the selected input dataset" type="no_options" />
                         </param>
@@ -117,7 +117,7 @@ $adv_output.K
                     <when value="cached">
                         <param argument="-s" label="Using reference genome" name="index" type="select">
                             <options from_data_table="fasta_indexes">
-                                <filter column="1" key="dbkey" ref="gffinputs" type="data_meta" />
+                                <filter column="dbkey" key="dbkey" ref="gffinputs" type="data_meta" />
                             </options>
                             <validator message="No reference genome is available for the build associated with the selected input dataset" type="no_options" />
                         </param>

--- a/tools/gffcompare/gffcompare.xml
+++ b/tools/gffcompare/gffcompare.xml
@@ -304,7 +304,7 @@ $adv_output.K
                 <not_has_text text="-K " />
             </assert_command>
             <output file="gffcompare_out2.stats" name="transcripts_stats" />
-            <output file="gffcompare_out2.loci" name="transcripts_loci" />
+            <output file="gffcompare_out2.loci" name="transcripts_loci" compare="sim_size" />
             <output file="gffcompare_out2.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out2.gtf" name="transcripts_combined" />
             <output_collection name="refmap_output" type="list" count="2">
@@ -441,7 +441,7 @@ $adv_output.K
                 <not_has_text text="-K " />
             </assert_command>
             <output file="gffcompare_out2.stats" name="transcripts_stats" lines_diff="2" />
-            <output file="gffcompare_out2.loci" name="transcripts_loci" />
+            <output file="gffcompare_out2.loci" name="transcripts_loci" compare="sim_size" />
             <output file="gffcompare_out2.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out2.gtf" name="transcripts_combined" />
         </test>
@@ -463,7 +463,7 @@ $adv_output.K
             <param name="max_dist_exon" value="100" />
             <param name="max_dist_group" value="100" />
             <output file="gffcompare_out3.stats" name="transcripts_stats"/>
-            <output file="gffcompare_out3.loci" name="transcripts_loci" />
+            <output file="gffcompare_out3.loci" name="transcripts_loci" compare="sim_size" />
             <output file="gffcompare_out3.tracking" name="transcripts_tracking" />
             <output file="gffcompare_out3.gtf" name="transcripts_annotated" />
         </test>

--- a/tools/gffcompare/test-data/gffcompare_out3.stats
+++ b/tools/gffcompare/test-data/gffcompare_out3.stats
@@ -1,29 +1,29 @@
-# gffcompare v0.10.6 | Command line was:
+# gffcompare v0.11.2 | Command line was:
 #gffcompare -r ref_annotation -R -T -e 100 -d 100 -p TCONS gffcompare_in4_gtf
 #
 
 #= Summary for dataset: gffcompare_in4_gtf 
 #     Query mRNAs :      35 in      29 loci  (15 multi-exon transcripts)
 #            (3 multi-transcript loci, ~1.2 transcripts per locus)
-# Reference mRNAs :      20 in       7 loci  (19 multi-exon)
+# Reference mRNAs :      19 in       6 loci  (19 multi-exon)
 # Super-loci w/ reference transcripts:        6
 #-----------------| Sensitivity | Precision  |
-        Base level:    72.6     |    60.7    |
-        Exon level:    80.0     |    55.7    |
+        Base level:    72.7     |    60.7    |
+        Exon level:    81.0     |    55.7    |
       Intron level:    81.2     |    64.4    |
 Intron chain level:    10.5     |    13.3    |
-  Transcript level:    10.0     |     5.7    |
-       Locus level:    28.6     |     6.9    |
+  Transcript level:    10.5     |     5.7    |
+       Locus level:    33.3     |     6.9    |
 
      Matching intron chains:       2
        Matching transcripts:       2
               Matching loci:       2
 
-          Missed exons:       3/85	(  3.5%)
+          Missed exons:       2/84	(  2.4%)
            Novel exons:      46/122	( 37.7%)
         Missed introns:      11/69	( 15.9%)
          Novel introns:      28/87	( 32.2%)
-           Missed loci:       0/7	(  0.0%)
+           Missed loci:       0/6	(  0.0%)
             Novel loci:      15/29	( 51.7%)
 
  Total union super-loci across all input datasets: 21 

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -128,7 +128,7 @@
                             <when value="cached">
                                 <param name="ref_file" type="select" label="Using reference genome">
                                     <options from_data_table="sam_fa_indexes">
-                                        <filter type="data_meta" key="dbkey" ref="samfile" column="1"/>
+                                        <filter type="data_meta" key="dbkey" ref="samfile" column="value"/>
                                     </options>
                                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                                 </param>

--- a/tools/multigps/multigps.xml
+++ b/tools/multigps/multigps.xml
@@ -282,7 +282,7 @@
                             <when value="cached">
                                 <param name="reference_genome" type="select" label="Using reference genome">
                                     <options from_data_table="all_fasta">
-                                        <filter type="data_meta" key="dbkey" ref="expt" column="1"/>
+                                        <filter type="data_meta" key="dbkey" ref="expt" column="dbkey"/>
                                     </options>
                                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                                 </param>


### PR DESCRIPTION
just for consistency .. none of these were wrong as far a I could tell .. except for gffcompare where the asserts are now actually considered (since we now use this https://github.com/galaxyproject/galaxy/pull/8395).

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)