### PR TITLE
samtools stats: remove plot_bamstats call

### DIFF
--- a/tool_collections/samtools/samtools_flagstat/samtools_flagstat.xml
+++ b/tool_collections/samtools/samtools_flagstat/samtools_flagstat.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_flagstat" name="Samtools flagstat" version="2.0.2">
+<tool id="samtools_flagstat" name="Samtools flagstat" version="2.0.3">
     <description>tabulate descriptive stats for BAM datset</description>
 
     <macros>

--- a/tool_collections/samtools/samtools_flagstat/samtools_flagstat.xml
+++ b/tool_collections/samtools/samtools_flagstat/samtools_flagstat.xml
@@ -45,6 +45,8 @@ Uses ``samtools flagstat`` command to print descriptive information for a BAM da
   25 + 0 singletons (12.50%:nan%)
   0 + 0 with mate mapped to a different chr
   0 + 0 with mate mapped to a different chr (mapQ>=5)
+
+The results of samtools flagstat can be visualized with MultiQC.
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tool_collections/samtools/samtools_idxstats/samtools_idxstats.xml
+++ b/tool_collections/samtools/samtools_idxstats/samtools_idxstats.xml
@@ -62,6 +62,9 @@ In this example there were 604 contigs, each with one line in the output table,
 plus the final row (labelled with an asterisk) representing 50320 unmapped reads.
 In this BAM file, the final column was otherwise zero.
 
+
+The results of samtools ixdstats can be visualized with MultiQC.
+
 ------
 
 Peter J.A. Cock (2013), `Galaxy wrapper <https://github.com/peterjc/pico_galaxy/tree/master/tools/samtools_idxstats>`_ for the samtools idxstats command

--- a/tool_collections/samtools/samtools_idxstats/samtools_idxstats.xml
+++ b/tool_collections/samtools/samtools_idxstats/samtools_idxstats.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_idxstats" name="Samtools idxstats" version="2.0.2">
+<tool id="samtools_idxstats" name="Samtools idxstats" version="2.0.3">
     <description>reports stats of the BAM index file</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -68,11 +68,6 @@
             @REGIONS_MANUAL@
             > '$output'
 
-            #if $cond_plot.select_plot=='yes':
-                && plot-bamstats '$output' $cond_plot.log -p '${html_file.files_path}'/
-                && mv '${html_file.files_path}'/index.html '${html_file}'
-            #end if
-
             #if $split_output_cond.split_output_selector == "yes":
                 #set outputs_to_split = str($split_output_cond.generate_tables).split(',')
                 && mkdir split
@@ -183,16 +178,6 @@
         <param name="sparse" argument="-x/--sparse" type="boolean" truevalue="-x" falsevalue="" checked="False" label="Suppress absence of insertions" help="Suppress outputting IS rows where there are no insertions."/>
         <param name="remove_overlaps" argument="-p/--remove-overlaps" type="boolean" truevalue="-p" falsevalue="" checked="False" label="Remove overlaps of paired-end reads from coverage and base count computations" />
         <param name="cov_threshold" argument="-g/--cov-threshold"  optional="true" type="integer" label="Only bases with coverage above this value will be included in the target percentage computation" />
-        <conditional name="cond_plot">
-            <param name="select_plot" type="select" label="Generate plots with plot-bamstats">
-                <option value="no" selected="True">No</option>
-                <option value="yes">Yes</option>
-            </param>
-            <when value="no"/>
-            <when value="yes">
-                <param name="log" argument="-l/--log-y" type="boolean" truevalue="-l" falsevalue="" checked="False" label="log scale insert size plot" help="Set the Y axis scale of the Insert Size plot to log 10"/>
-            </when>
-        </conditional>
     </inputs>
 
     <outputs>
@@ -204,9 +189,6 @@
             <discover_datasets directory="split" pattern="(?P&lt;designation&gt;.+)\.tab" format="tabular" visible="false"/>
             <filter>split_output_cond['split_output_selector'] == 'yes'</filter>
         </collection>
-        <data format="html" name="html_file" label="${tool.name} on ${on_string}: plot-bamstats">
-            <filter>cond_plot['select_plot']=='yes'</filter>
-        </data>
     </outputs>
     <tests>
         <!-- https://github.com/samtools/samtools/blob/9ce8c64493f7ea3fa69bc5c1ac980b1a8e3dcf1f/test/test.pl#L2402 -->
@@ -357,9 +339,6 @@
                 <param name="addref_select" value="history" />
                 <param name="ref" value="samtools_stats_ref.fa" ftype="fasta" />
             </conditional>
-            <conditional name="cond_plot">
-                <param name="select_plot" value="yes"/>
-            </conditional>
             <output name="output" file="samtools_stats_out1.tab" ftype="tabular" lines_diff="2" />
         </test>
         <test>
@@ -383,6 +362,8 @@
 **What it does**
 
 This tool runs the ``samtools stats`` command.
+
+The results of samtools stats can be visualized with MultiQC (for this the default of a single output file needs to be selected).
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_stats" name="Samtools stats" version="2.0.2+galaxy1">
+<tool id="samtools_stats" name="Samtools stats" version="2.0.2+galaxy2">
     <description>generate statistics for BAM dataset</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_stats/samtools_stats.xml
+++ b/tool_collections/samtools/samtools_stats/samtools_stats.xml
@@ -3,10 +3,7 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements">
-        <requirement type="package" version="5.2.3">gnuplot</requirement>
-        <requirement type="package" version="5.26">perl</requirement>
-    </expand>
+    <expand macro="requirements"/>
     <expand macro="stdio"/>
     <expand macro="version_command"/>
     <command><![CDATA[


### PR DESCRIPTION
To get rid of the gnuplot and perl dependency

advantage: no additional mulled environment needed

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
