### PR TITLE
Consistently use -T in all tools that use samtools sort

### DIFF
--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -26,7 +26,7 @@
             -O bam
             -@ \${GALAXY_SLOTS:-1}
             -o '$output1'
-            -T "${TMPDIR:-.}"
+            -T "\${TMPDIR:-.}"
     ]]></command>
 
     <inputs>

--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -26,7 +26,7 @@
             -O bam
             -@ \${GALAXY_SLOTS:-1}
             -o '$output1'
-            -T "\${TMPDIR:.}"
+            -T "${TMPDIR:-.}"
     ]]></command>
 
     <inputs>

--- a/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
+++ b/tool_collections/samtools/sam_to_bam/sam_to_bam.xml
@@ -26,7 +26,7 @@
             -O bam
             -@ \${GALAXY_SLOTS:-1}
             -o '$output1'
-            -T temp
+            -T "\${TMPDIR:.}"
     ]]></command>
 
     <inputs>

--- a/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
+++ b/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
@@ -10,7 +10,7 @@
 @ADDTHREADS@ 
 ## name sort input file if neccessary
 #if not $input.is_of_type('qname_sorted.bam', 'qname_input_sorted.bam'):
-    samtools sort -@ \$addthreads -n '$input' > input &&
+    samtools sort -@ \$addthreads -n '$input' "\${TMPDIR:.}" > input &&
 #else:
     ln -s '$input' input &&
 #end if

--- a/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
+++ b/tool_collections/samtools/samtools_fastx/samtools_fastx.xml
@@ -10,7 +10,7 @@
 @ADDTHREADS@ 
 ## name sort input file if neccessary
 #if not $input.is_of_type('qname_sorted.bam', 'qname_input_sorted.bam'):
-    samtools sort -@ \$addthreads -n '$input' "\${TMPDIR:.}" > input &&
+    samtools sort -@ \$addthreads -n '$input' -T "\${TMPDIR:-.}" > input &&
 #else:
     ln -s '$input' input &&
 #end if

--- a/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
+++ b/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
@@ -11,7 +11,7 @@
         ## name sort input 
         #if not $bamfile.is_of_type('qname_sorted.bam', 'qnamed_input_sorted.bam'):
             samtools sort
-            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
+            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
             -n 
             -O BAM
             -o namesorted.bam

--- a/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
+++ b/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
@@ -11,7 +11,7 @@
         ## name sort input 
         #if not $bamfile.is_of_type('qname_sorted.bam', 'qnamed_input_sorted.bam'):
             samtools sort
-            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T sorttemp
+            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
             -n 
             -O BAM
             -o namesorted.bam

--- a/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
+++ b/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
@@ -11,7 +11,7 @@
         ## name sort input 
         #if not $bamfile.is_of_type('qname_sorted.bam', 'qnamed_input_sorted.bam'):
             samtools sort
-            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
+            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
             -n 
             -O BAM
             -o namesorted.bam

--- a/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
+++ b/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
@@ -11,7 +11,7 @@
 ## coordinate sort input 
 #if not $bamfile.is_of_type('bam'):
     samtools sort
-    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T sorttemp
+    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
     -O sam
     -o coordsort.sam
     '$bamfile' &&

--- a/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
+++ b/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
@@ -11,7 +11,7 @@
 ## coordinate sort input 
 #if not $bamfile.is_of_type('bam'):
     samtools sort
-    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
+    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
     -O sam
     -o coordsort.sam
     '$bamfile' &&

--- a/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
+++ b/tool_collections/samtools/samtools_markdup/samtools_markdup.xml
@@ -11,7 +11,7 @@
 ## coordinate sort input 
 #if not $bamfile.is_of_type('bam'):
     samtools sort
-    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
+    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
     -O sam
     -o coordsort.sam
     '$bamfile' &&

--- a/tool_collections/samtools/samtools_merge/samtools_merge.xml
+++ b/tool_collections/samtools/samtools_merge/samtools_merge.xml
@@ -15,7 +15,7 @@
 #for $i, $bam in enumerate( $bamfiles ):
     #if $bam.is_of_type('sam', 'cram', ):
         samtools sort
-        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
+        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
         -O sam
         -o ${i}.sam
         '$bam' &&

--- a/tool_collections/samtools/samtools_merge/samtools_merge.xml
+++ b/tool_collections/samtools/samtools_merge/samtools_merge.xml
@@ -15,7 +15,7 @@
 #for $i, $bam in enumerate( $bamfiles ):
     #if $bam.is_of_type('sam', 'cram', ):
         samtools sort
-        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
+        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
         -O sam
         -o ${i}.sam
         '$bam' &&

--- a/tool_collections/samtools/samtools_merge/samtools_merge.xml
+++ b/tool_collections/samtools/samtools_merge/samtools_merge.xml
@@ -15,7 +15,7 @@
 #for $i, $bam in enumerate( $bamfiles ):
     #if $bam.is_of_type('sam', 'cram', ):
         samtools sort
-        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T sorttemp
+        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
         -O sam
         -o ${i}.sam
         '$bam' &&

--- a/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
+++ b/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
@@ -28,7 +28,7 @@
 
     samtools sort
         -O bam
-        -T sorted
+        -T "\${TMPDIR:.}"
         -@ \${GALAXY_SLOTS:-1}
         -o '${output_bam}'
         unsorted_output.bam

--- a/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
+++ b/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
@@ -28,7 +28,7 @@
 
     samtools sort
         -O bam
-        -T "${TMPDIR:-.}"
+        -T "\${TMPDIR:-.}"
         -@ \${GALAXY_SLOTS:-1}
         -o '${output_bam}'
         unsorted_output.bam

--- a/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
+++ b/tool_collections/samtools/samtools_slice_bam/samtools_slice_bam.xml
@@ -28,7 +28,7 @@
 
     samtools sort
         -O bam
-        -T "\${TMPDIR:.}"
+        -T "${TMPDIR:-.}"
         -@ \${GALAXY_SLOTS:-1}
         -o '${output_bam}'
         unsorted_output.bam

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -21,7 +21,7 @@
                 $prim_key_cond.sec_key_select
             #end if
             -O bam
-            -T "\${TMPDIR:.}"
+            -T "${TMPDIR:-.}"
             '${input1}'
              > '${output1}'
     ]]></command>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -21,7 +21,7 @@
                 $prim_key_cond.sec_key_select
             #end if
             -O bam
-            -T "${TMPDIR:-.}"
+            -T "\${TMPDIR:-.}"
             '${input1}'
              > '${output1}'
     ]]></command>

--- a/tool_collections/samtools/samtools_sort/samtools_sort.xml
+++ b/tool_collections/samtools/samtools_sort/samtools_sort.xml
@@ -21,7 +21,7 @@
                 $prim_key_cond.sec_key_select
             #end if
             -O bam
-            -T sorttmp
+            -T "\${TMPDIR:.}"
             '${input1}'
              > '${output1}'
     ]]></command>

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -120,14 +120,14 @@
         ## then sort the output by coordinate, 
         #if not $input.is_of_type('bam') and $outtype == 'bam':
             && samtools sort
-                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T sorttemp
+                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
                 -O bam
                 -o 'tmpsam'
                 outfile
                 && mv tmpsam outfile
             #if $adv_output.outputpassing == 'yes':
                 && samtools sort
-                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T sorttemp
+                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
                     -O bam
                     -o 'tmpsam'
                     inv_outfile

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -120,14 +120,14 @@
         ## then sort the output by coordinate, 
         #if not $input.is_of_type('bam') and $outtype == 'bam':
             && samtools sort
-                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
+                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
                 -O bam
                 -o 'tmpsam'
                 outfile
                 && mv tmpsam outfile
             #if $adv_output.outputpassing == 'yes':
                 && samtools sort
-                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
+                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
                     -O bam
                     -o 'tmpsam'
                     inv_outfile

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -120,14 +120,14 @@
         ## then sort the output by coordinate, 
         #if not $input.is_of_type('bam') and $outtype == 'bam':
             && samtools sort
-                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
+                -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
                 -O bam
                 -o 'tmpsam'
                 outfile
                 && mv tmpsam outfile
             #if $adv_output.outputpassing == 'yes':
                 && samtools sort
-                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:.}"
+                    -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "${TMPDIR:-.}"
                     -O bam
                     -o 'tmpsam'
                     inv_outfile

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -9,7 +9,7 @@
     <expand macro="stdio" />
     <command><![CDATA[
 #if $input.extension == 'bam' and $option == "-bedpe":
-    samtools sort -n '${input}' ./input &&
+    samtools sort -n -T "\${TMPDIR:.}" '${input}' ./input &&
 #else
     ln -s '${input}' ./input.bam &&
 #end if

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -9,7 +9,7 @@
     <expand macro="stdio" />
     <command><![CDATA[
 #if $input.extension == 'bam' and $option == "-bedpe":
-    samtools sort -n -T "\${TMPDIR:.}" '${input}' ./input &&
+    samtools sort -n -T "${TMPDIR:-.}" '${input}' ./input &&
 #else
     ln -s '${input}' ./input.bam &&
 #end if

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -9,7 +9,7 @@
     <expand macro="stdio" />
     <command><![CDATA[
 #if $input.extension == 'bam' and $option == "-bedpe":
-    samtools sort -n -T "${TMPDIR:-.}" '${input}' ./input &&
+    samtools sort -n -T "\${TMPDIR:-.}" '${input}' ./input &&
 #else
     ln -s '${input}' ./input.bam &&
 #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -305,7 +305,7 @@ bowtie2
 
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
-    | samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$output'
+    | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$output'
 #else if $sam_options.reorder:
     | samtools view -bS - -o '$output'
 #else:

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -305,7 +305,7 @@ bowtie2
 
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
-    | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$output'
+    | samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$output'
 #else if $sam_options.reorder:
     | samtools view -bS - -o '$output'
 #else:

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -305,7 +305,7 @@ bowtie2
 
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
-    | samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$output'
+    | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output'
 #else if $sam_options.reorder:
     | samtools view -bS - -o '$output'
 #else:

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -106,7 +106,7 @@ bwa mem
     '${fastq_input.fastq_input1}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$bam_output'
     ]]></command>
 
     <inputs>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -106,7 +106,7 @@ bwa mem
     '${fastq_input.fastq_input1}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$bam_output'
     ]]></command>
 
     <inputs>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -106,7 +106,7 @@ bwa mem
     '${fastq_input.fastq_input1}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$bam_output'
     ]]></command>
 
     <inputs>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -209,7 +209,7 @@
   '${reference_fasta_filename}' first.sai '${input_type.bam_input}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$bam_output'
 ]]>
     </command>
 

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -209,7 +209,7 @@
   '${reference_fasta_filename}' first.sai '${input_type.bam_input}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$bam_output'
 ]]>
     </command>
 

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -209,7 +209,7 @@
   '${reference_fasta_filename}' first.sai '${input_type.bam_input}'
 #end if
 
-| samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '$bam_output'
+| samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '$bam_output'
 ]]>
     </command>
 

--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -78,7 +78,7 @@
     #else:
         $read1 $read2
     #end if
-    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T "${TMPDIR:-.}" -O bam -o output.bam -
+    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:-.}" -O bam -o output.bam -
 ]]>
     </command>
     <inputs>

--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -78,7 +78,7 @@
     #else:
         $read1 $read2
     #end if
-    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T tmp -O bam -o output.bam -
+    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:.}" -O bam -o output.bam -
 ]]>
     </command>
     <inputs>

--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -78,7 +78,7 @@
     #else:
         $read1 $read2
     #end if
-    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:.}" -O bam -o output.bam -
+    | samtools view -u - | samtools sort -@ "\${GALAXY_SLOTS:-4}" -T "${TMPDIR:-.}" -O bam -o output.bam -
 ]]>
     </command>
     <inputs>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -113,7 +113,7 @@
         #end if
 
         #if $extended_parameters.R:
-            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" *.featureCounts.bam
+            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" *.featureCounts.bam
         #end if
         && sed -e 's|${alignment}|${alignment.element_identifier}|g' 'output.summary' > '${output_summary}'
     ]]></command>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -113,7 +113,7 @@
         #end if
 
         #if $extended_parameters.R:
-            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" *.featureCounts.bam
+            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" *.featureCounts.bam
         #end if
         && sed -e 's|${alignment}|${alignment.element_identifier}|g' 'output.summary' > '${output_summary}'
     ]]></command>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -113,7 +113,7 @@
         #end if
 
         #if $extended_parameters.R:
-            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} *.featureCounts.bam
+            && samtools sort -o '$output_bam' -@ \${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" *.featureCounts.bam
         #end if
         && sed -e 's|${alignment}|${alignment.element_identifier}|g' 'output.summary' > '${output_summary}'
     ]]></command>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -63,7 +63,7 @@
         && mv $qc.files_path/*.log raw_qc
         && mv matrix.$outputFormat matrix
         #if $outBam_Boolean:
-            && samtools sort ./unsorted.bam -o sorted.bam
+            && samtools sort -T "\${TMPDIR:.}" ./unsorted.bam -o sorted.bam
         #end if
 
 ]]>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -5,7 +5,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" >
-        <requirement type="package" version="1.6">samtools</requirement>
+        <requirement type="package" version="1.9">samtools</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -63,7 +63,7 @@
         && mv $qc.files_path/*.log raw_qc
         && mv matrix.$outputFormat matrix
         #if $outBam_Boolean:
-            && samtools sort -T "\${TMPDIR:.}" ./unsorted.bam -o sorted.bam
+            && samtools sort -T "${TMPDIR:-.}" ./unsorted.bam -o sorted.bam
         #end if
 
 ]]>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -63,7 +63,7 @@
         && mv $qc.files_path/*.log raw_qc
         && mv matrix.$outputFormat matrix
         #if $outBam_Boolean:
-            && samtools sort -T "${TMPDIR:-.}" ./unsorted.bam -o sorted.bam
+            && samtools sort -T "\${TMPDIR:-.}" ./unsorted.bam -o sorted.bam
         #end if
 
 ]]>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -163,7 +163,7 @@
             <param name='outputFormat' value='h5'/>
             <param name='outBam_Boolean' value="True" />
             <output name="outBam" file="small_test_matrix_result_sorted.bam" ftype="bam"/>
-            <output name="outFileName" file="small_test_matrix_2.h5" ftype="h5" compare="sim_size"/>
+            <output name="outFileName" file="small_test_matrix_2.h5" ftype="h5" compare="sim_size" delta="50000"/>
             <output name="raw_qc" file='raw_qc_report' compare='diff' lines_diff='2'/>
         </test>
     </tests>

--- a/tools/hicexplorer/hicCompareMatrices.xml
+++ b/tools/hicexplorer/hicCompareMatrices.xml
@@ -44,7 +44,7 @@
             <param name="matrix2" value="small_test_matrix.h5"/>
             <param name="operation" value='log2ratio' />
             <param name="outputFormat" value="h5" />
-            <output name="outFileName" file="compare_matrices_log2ratio.h5" ftype="h5" compare="sim_size" delta='2000'/>
+            <output name="outFileName" file="compare_matrices_log2ratio.h5" ftype="h5" compare="sim_size" delta='10000'/>
         </test>
         <test>
             <param name="matrix1" value="pearson_small_50kb.cool"/>

--- a/tools/hicexplorer/hicTransform.xml
+++ b/tools/hicexplorer/hicTransform.xml
@@ -48,7 +48,7 @@
             <param name="outputFormat" value="h5" />
             <output name="obs_exp" file="obs_exp_small_50kb.h5" ftype="h5" compare="sim_size"/>
             <output name="pearson" file="pearson_small_50kb.h5" ftype="h5" compare="sim_size"/>
-            <output name="covariance" file="covariance_small_50kb.h5" ftype="h5" compare="sim_size"/>
+            <output name="covariance" file="covariance_small_50kb.h5" ftype="h5" compare="sim_size" delta="150000"/>
         </test>
         <test>
             <param name="matrix_h5_cooler" value="small_test_matrix_50kb_res.h5"/>

--- a/tools/hicexplorer/hicTransform.xml
+++ b/tools/hicexplorer/hicTransform.xml
@@ -47,7 +47,7 @@
             <param name="matrix_h5_cooler" value="small_test_matrix_50kb_res.h5"/>
             <param name="outputFormat" value="h5" />
             <output name="obs_exp" file="obs_exp_small_50kb.h5" ftype="h5" compare="sim_size"/>
-            <output name="pearson" file="pearson_small_50kb.h5" ftype="h5" compare="sim_size"/>
+            <output name="pearson" file="pearson_small_50kb.h5" ftype="h5" compare="sim_size" delta="50000"/>
             <output name="covariance" file="covariance_small_50kb.h5" ftype="h5" compare="sim_size" delta="150000"/>
         </test>
         <test>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -328,7 +328,7 @@ hisat2
 ##   sorted output to view which only compresses the files (now
 ##   using full parallelism again)
 
-| samtools sort -l 0 -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
+| samtools sort -l 0 -T "\${TMPDIR:.}" -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -328,7 +328,7 @@ hisat2
 ##   sorted output to view which only compresses the files (now
 ##   using full parallelism again)
 
-| samtools sort -l 0 -T "\${TMPDIR:.}" -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
+| samtools sort -l 0 -T "${TMPDIR:-.}" -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -328,7 +328,7 @@ hisat2
 ##   sorted output to view which only compresses the files (now
 ##   using full parallelism again)
 
-| samtools sort -l 0 -T "${TMPDIR:-.}" -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
+| samtools sort -l 0 -T "\${TMPDIR:-.}" -O bam | samtools view -O bam -@ \${GALAXY_SLOTS:-1} -o '${output_alignments}'
 
 ## Rename any output fastq files
 

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -32,9 +32,9 @@
     #end if
 
     #if $samfile.extension == 'bam':
-        samtools sort -n -T "\${TMPDIR:.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
+        samtools sort -n -T "${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
     #else
-        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n -T "\${TMPDIR:.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
+        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n -T "${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
     #end if
 
     htseq-count
@@ -66,7 +66,7 @@
             && samtools view -Su
                 -t '${reference_fasta_filename}.fai'
                 '$__new_file_path__/${samoutfile.id}_tmp.sam'
-            | samtools sort -T "\${TMPDIR:.}" -o '$samoutfile' -
+            | samtools sort -T "${TMPDIR:-.}" -o '$samoutfile' -
         #end if
     #end if
     ]]>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -32,9 +32,9 @@
     #end if
 
     #if $samfile.extension == 'bam':
-        samtools sort -n --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
+        samtools sort -n -T "\${TMPDIR:.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
     #else
-        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
+        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n -T "\${TMPDIR:.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
     #end if
 
     htseq-count
@@ -66,7 +66,7 @@
             && samtools view -Su
                 -t '${reference_fasta_filename}.fai'
                 '$__new_file_path__/${samoutfile.id}_tmp.sam'
-            | samtools sort -o '$samoutfile' -
+            | samtools sort -T "\${TMPDIR:.}" -o '$samoutfile' -
         #end if
     #end if
     ]]>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -32,9 +32,9 @@
     #end if
 
     #if $samfile.extension == 'bam':
-        samtools sort -n -T "${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
+        samtools sort -n -T "\${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' '$samfile' &&
     #else
-        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n -T "${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
+        samtools view -Su -t '${reference_fasta_filename}.fai' '$samfile' | samtools sort -n -T "\${TMPDIR:-.}" --output-fmt=SAM -o '$name_sorted_alignment_filename' - &&
     #end if
 
     htseq-count
@@ -66,7 +66,7 @@
             && samtools view -Su
                 -t '${reference_fasta_filename}.fai'
                 '$__new_file_path__/${samoutfile.id}_tmp.sam'
-            | samtools sort -T "${TMPDIR:-.}" -o '$samoutfile' -
+            | samtools sort -T "\${TMPDIR:-.}" -o '$samoutfile' -
         #end if
     #end if
     ]]>

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -40,7 +40,7 @@
                 #end if
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1}-T "\${TMPDIR:.}" -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1}-T "${TMPDIR:-.}" -o '$pseudobam_output' -
             #end if
             && if [ -f run_info.json ] ; then cat run_info.json ; fi &&
             mkdir outputs &&

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -40,7 +40,7 @@
                 #end if
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1}-T "${TMPDIR:-.}" -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:-.}" -o '$pseudobam_output' -
             #end if
             && if [ -f run_info.json ] ; then cat run_info.json ; fi &&
             mkdir outputs &&

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -40,7 +40,7 @@
                 #end if
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1}-T "\${TMPDIR:.}" -o '$pseudobam_output' -
             #end if
             && if [ -f run_info.json ] ; then cat run_info.json ; fi &&
             mkdir outputs &&

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -40,7 +40,7 @@
                 $reads
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$pseudobam_output' -
             #end if
             && cat run_info.json
         ]]>

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -40,7 +40,7 @@
                 $reads
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:-.}" -o '$pseudobam_output' -
             #end if
             && cat run_info.json
         ]]>

--- a/tools/kallisto/kallisto_quant.xml
+++ b/tools/kallisto/kallisto_quant.xml
@@ -40,7 +40,7 @@
                 $reads
             #end if
             #if $pseudobam:
-                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -o '$pseudobam_output' -
+                | samtools sort -O bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$pseudobam_output' -
             #end if
             && cat run_info.json
         ]]>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -259,7 +259,7 @@
         --action:target=multiple
         $output_format.rplot
         #if str( $output_format.out.format ) == "bam":
-            | samtools sort -@\${GALAXY_SLOTS:-2} -O bam -o '${output}'
+            | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '${output}'
         #else:
             > '${output}'
         #end if

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -259,7 +259,7 @@
         --action:target=multiple
         $output_format.rplot
         #if str( $output_format.out.format ) == "bam":
-            | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:.}" -O bam -o '${output}'
+            | samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '${output}'
         #else:
             > '${output}'
         #end if

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -259,7 +259,7 @@
         --action:target=multiple
         $output_format.rplot
         #if str( $output_format.out.format ) == "bam":
-            | samtools sort -@\${GALAXY_SLOTS:-2} -T "${TMPDIR:-.}" -O bam -o '${output}'
+            | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '${output}'
         #else:
             > '${output}'
         #end if

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -113,13 +113,13 @@
         -a
         | samtools sort
         -@\${GALAXY_SLOTS:-2}
-        -T "${TMPDIR:-.}"
+        -T "\${TMPDIR:-.}"
         -O $io_options.output_format
         -o '$alignment_output'
     #else if $io_options.output_format == 'CRAM':
         -a
         | samtools sort
-        -T "${TMPDIR:-.}"
+        -T "\${TMPDIR:-.}"
         -@\${GALAXY_SLOTS:-2}
         -O $io_options.output_format
         $io_options.eqx

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -113,11 +113,13 @@
         -a
         | samtools sort
         -@\${GALAXY_SLOTS:-2}
+        -T "\${TMPDIR:.}"
         -O $io_options.output_format
         -o '$alignment_output'
     #else if $io_options.output_format == 'CRAM':
         -a
         | samtools sort
+        -T "\${TMPDIR:.}"
         -@\${GALAXY_SLOTS:-2}
         -O $io_options.output_format
         $io_options.eqx

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -113,13 +113,13 @@
         -a
         | samtools sort
         -@\${GALAXY_SLOTS:-2}
-        -T "\${TMPDIR:.}"
+        -T "${TMPDIR:-.}"
         -O $io_options.output_format
         -o '$alignment_output'
     #else if $io_options.output_format == 'CRAM':
         -a
         | samtools sort
-        -T "\${TMPDIR:.}"
+        -T "${TMPDIR:-.}"
         -@\${GALAXY_SLOTS:-2}
         -O $io_options.output_format
         $io_options.eqx

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -21,7 +21,7 @@ mkdir -p ./special_de_output/sample1/ &&
 #end if
 
 #if $input_bam.metadata.ftype == 'sam':
-    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' -T "\${TMPDIR:.}" | stringtie
+    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' -T "${TMPDIR:-.}" | stringtie
 #else
     stringtie '$input_bam'
 #end if

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -21,7 +21,7 @@ mkdir -p ./special_de_output/sample1/ &&
 #end if
 
 #if $input_bam.metadata.ftype == 'sam':
-    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' -T "${TMPDIR:-.}" | stringtie
+    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' -T "\${TMPDIR:-.}" | stringtie
 #else
     stringtie '$input_bam'
 #end if

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -21,7 +21,7 @@ mkdir -p ./special_de_output/sample1/ &&
 #end if
 
 #if $input_bam.metadata.ftype == 'sam':
-    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' | stringtie
+    samtools sort -@ \${GALAXY_SLOTS:-1} '$input_bam' -T "\${TMPDIR:.}" | stringtie
 #else
     stringtie '$input_bam'
 #end if

--- a/tools/telescope/telescope_assign.xml
+++ b/tools/telescope/telescope_assign.xml
@@ -31,7 +31,7 @@
         #if $updated_sam
             &&
             if [ -f outdir/telescope-updated.bam ] ; then
-                samtools sort -T "\${TMPDIR:.}" outdir/telescope-updated.bam > '$updated_alignment' ;
+                samtools sort -T "${TMPDIR:-.}" outdir/telescope-updated.bam > '$updated_alignment' ;
             else
                 echo 'Updated alignment file not found.' ;
                 exit 1 ;

--- a/tools/telescope/telescope_assign.xml
+++ b/tools/telescope/telescope_assign.xml
@@ -31,7 +31,7 @@
         #if $updated_sam
             &&
             if [ -f outdir/telescope-updated.bam ] ; then
-                samtools sort outdir/telescope-updated.bam > '$updated_alignment' ;
+                samtools sort -T "\${TMPDIR:.}" outdir/telescope-updated.bam > '$updated_alignment' ;
             else
                 echo 'Updated alignment file not found.' ;
                 exit 1 ;

--- a/tools/telescope/telescope_assign.xml
+++ b/tools/telescope/telescope_assign.xml
@@ -31,7 +31,7 @@
         #if $updated_sam
             &&
             if [ -f outdir/telescope-updated.bam ] ; then
-                samtools sort -T "${TMPDIR:-.}" outdir/telescope-updated.bam > '$updated_alignment' ;
+                samtools sort -T "\${TMPDIR:-.}" outdir/telescope-updated.bam > '$updated_alignment' ;
             else
                 echo 'Updated alignment file not found.' ;
                 exit 1 ;

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -34,7 +34,7 @@
                 --in-sam
             #end if
             -I '$input_file' -S deduped.bam &&
-            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$output' -O BAM
+            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:-.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to deduplicate in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -34,7 +34,7 @@
                 --in-sam
             #end if
             -I '$input_file' -S deduped.bam &&
-            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$output' -O BAM
+            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to deduplicate in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -34,7 +34,7 @@
                 --in-sam
             #end if
             -I '$input_file' -S deduped.bam &&
-            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -o '$output' -O BAM
+            samtools sort deduped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to deduplicate in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -38,7 +38,7 @@
             #end if
             --output-bam
             -I '$input_file' -S grouped.bam &&
-            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$output' -O BAM
+            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to group in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -38,7 +38,7 @@
             #end if
             --output-bam
             -I '$input_file' -S grouped.bam &&
-            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -T "${TMPDIR:-.}" -o '$output' -O BAM
+            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:-.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to group in SAM or BAM format" />

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -38,7 +38,7 @@
             #end if
             --output-bam
             -I '$input_file' -S grouped.bam &&
-            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -o '$output' -O BAM
+            samtools sort grouped.bam -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:.}" -o '$output' -O BAM
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Reads to group in SAM or BAM format" />


### PR DESCRIPTION
Not doing so may leave behind untracked tmp files when not using
`outputs_to_working_directory`. When the stdout is piped it's not
necessary but more explicit and allows the admin to determine
the sort location on a per job basis.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
