### PR TITLE
seqtk: limit the number of CPUs used by pigz

### DIFF
--- a/tools/seqtk/macros.xml
+++ b/tools/seqtk/macros.xml
@@ -26,7 +26,7 @@
         <param name="in_file" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file"/>
     </xml>
     <token name="@CONDITIONAL_GZIP_OUT@"><![CDATA[
-    #echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_file.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+    #echo "| pigz -p ${GALAXY_SLOTS:-1} --no-name --no-time" if $in_file.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></token>
     <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**

--- a/tools/seqtk/macros.xml
+++ b/tools/seqtk/macros.xml
@@ -26,7 +26,7 @@
         <param name="in_file" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file"/>
     </xml>
     <token name="@CONDITIONAL_GZIP_OUT@"><![CDATA[
-    #echo "| pigz --no-name --no-time" if $in_file.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+    #echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_file.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></token>
     <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**

--- a/tools/seqtk/seqtk_mergefa.xml
+++ b/tools/seqtk/seqtk_mergefa.xml
@@ -15,7 +15,7 @@ $r
 $h
 '$in_fa1'
 '$in_fa2'
-#echo "| pigz --no-name --no-time" if $in_fa1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+#echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fa1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></command>
     <inputs>
         <param name="in_fa1" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #1"/>

--- a/tools/seqtk/seqtk_mergefa.xml
+++ b/tools/seqtk/seqtk_mergefa.xml
@@ -15,7 +15,7 @@ $r
 $h
 '$in_fa1'
 '$in_fa2'
-#echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fa1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+#echo "| pigz -p ${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fa1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></command>
     <inputs>
         <param name="in_fa1" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #1"/>

--- a/tools/seqtk/seqtk_mergepe.xml
+++ b/tools/seqtk/seqtk_mergepe.xml
@@ -10,7 +10,7 @@
 seqtk mergepe
 '$in_fq1'
 '$in_fq2'
- #echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fq1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+ #echo "| pigz -p ${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fq1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></command>
     <inputs>
         <param name="in_fq1" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #1"/>

--- a/tools/seqtk/seqtk_mergepe.xml
+++ b/tools/seqtk/seqtk_mergepe.xml
@@ -10,7 +10,7 @@
 seqtk mergepe
 '$in_fq1'
 '$in_fq2'
- #echo "| pigz --no-name --no-time" if $in_fq1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+ #echo "| pigz -p \${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fq1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
     ]]></command>
     <inputs>
         <param name="in_fq1" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #1"/>


### PR DESCRIPTION
Currently pigz uses all CPUs which is not acceptable on shared systems. 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
