### PR TITLE
Snippy - Removed mapping depth from list of output files

### DIFF
--- a/tools/snippy/snippy.xml
+++ b/tools/snippy/snippy.xml
@@ -1,4 +1,4 @@
-<tool id="snippy" name="snippy" version="@VERSION@+galaxy2">
+<tool id="snippy" name="snippy" version="@VERSION@+galaxy3">
   <description>
       Snippy finds SNPs between a haploid reference genome and your NGS sequence reads.
   </description>

--- a/tools/snippy/snippy.xml
+++ b/tools/snippy/snippy.xml
@@ -115,7 +115,6 @@
             <option value="outlog" selected="False">A log file with the commands run and their outputs</option>
             <option value="outaln" selected="False">A version of the reference but with - at position with depth=0 and N for 0 to depth to --mincov (does not have variants)</option>
             <option value="outcon" selected="False">A version of the reference genome with all variants instantiated</option>
-            <option value="outdep" selected="False">Output of samtools depth for the .bam file</option>
             <option value="outbam" selected="False">The alignments in BAM format. Note that multi-mapping and unmapped reads are not present.</option>
             <option value="outzip" selected="True">Zipped files needed for input into snippy-core</option>
         </param>
@@ -144,9 +143,6 @@
         </data>
         <data format="fasta" name="snpconsensus" label="${tool.name} on ${on_string} consensus fasta" from_work_dir="out/snps.consensus.fa">
             <filter>outputs and 'outcon' in outputs</filter>
-        </data>
-        <data format="tabular" name="snpsdepth" label="${tool.name} on ${on_string} mapping depth" from_work_dir="out/snps.depth">
-            <filter>outputs and 'outdep' in outputs</filter>
         </data>
         <data format="bam" name="snpsbam" label="${tool.name} on ${on_string} mapped reads (bam)" from_work_dir="out/snps.bam">
             <filter>outputs and 'outbam' in outputs</filter>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)


When Snippy transitioned from version 3 to version 4, it stopped outputting the snps depth file. The option to collect it in Galaxyt has now been removed from the interface.