### PR TITLE
Rename output with intended ascii char

### DIFF
--- a/tools/stacks/macros.xml
+++ b/tools/stacks/macros.xml
@@ -316,7 +316,7 @@ $identifier#slurp
         <data format="tabular" name="out_treemix_loci" label="TreeMix format (loci) with ${tool.name} on ${on_string}" from_work_dir="stacks_outputs/batch_1.treemix.log">
             <filter>populations_output['treemix']</filter>
         </data>
-        <data format="tabular" name="out_fastpĥase" label="fastPHASE format with ${tool.name} on ${on_string}" from_work_dir="stacks_outputs/batch_1.un.fastphase.inp">
+        <data format="tabular" name="out_fastphase" label="fastPHASE format with ${tool.name} on ${on_string}" from_work_dir="stacks_outputs/batch_1.un.fastphase.inp">
             <filter>populations_output['fastphase']</filter>
         </data>
         <data format="tabular" name="out_phase" label="PHASE format with ${tool.name} on ${on_string}" from_work_dir="stacks_outputs/batch_1.un.phase.inp">

--- a/tools/stacks/stacks_populations.xml
+++ b/tools/stacks/stacks_populations.xml
@@ -1,4 +1,4 @@
-<tool id="stacks_populations" name="Stacks: populations" version="@WRAPPER_VERSION@.0">
+<tool id="stacks_populations" name="Stacks: populations" version="@WRAPPER_VERSION@.1">
     <description>analyze a population of individual samples ('populations' program)</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Noticed this when a processing script choked on a stacks_population output, and while yes said script should support unicode chars, I'm guessing this wasn't intended, and anyone who will in the future write manual workflows with yaml probably doesn't want to have to copy and paste an `ĥ`