### PR TITLE
data_manager_manual: fix error with Galaxy>=19.05

### DIFF
--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.py
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.py
@@ -45,8 +45,11 @@ def exec_before_job(app, inp_data, out_data, param_dict, tool=None, **kwd):
     tdtm = None
     data_manager = app.data_managers.get_manager(tool.data_manager_id, None)
     for data_table_param in data_tables_param:
-        data_table_name = str(data_table_param.get('data_table_name'))
+        data_table_name = data_table_param.get('data_table_name')
         if data_table_name:
+            # the 'data_table_name' value in data_table_param is a SelectToolParameter,
+            # to get the selected value we need to cast data_table_name to string
+            data_table_name = str(data_table_name)
             # get data table managed by this data Manager
             data_table = app.tool_data_tables.get_tables().get(data_table_name)
             if data_table:

--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.py
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.py
@@ -45,7 +45,7 @@ def exec_before_job(app, inp_data, out_data, param_dict, tool=None, **kwd):
     tdtm = None
     data_manager = app.data_managers.get_manager(tool.data_manager_id, None)
     for data_table_param in data_tables_param:
-        data_table_name = data_table_param.get('data_table_name')
+        data_table_name = str(data_table_param.get('data_table_name'))
         if data_table_name:
             # get data table managed by this data Manager
             data_table = app.tool_data_tables.get_tables().get(data_table_name)


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

I found some errors while testing [biomaj2galaxy](https://github.com/genouest/biomaj2galaxy) with Galaxy 19.05. So this PR fixes part of the problem: the DM code is getting a galaxy.tools.wrappers.SelectToolParameterWrapper while dict keys are strings

I'm preparing a PR for Galaxy too to fix another part of the problem