### PR TITLE
add option to load gff from loc file

### DIFF
--- a/tools/htseq_count/all_gff.loc
+++ b/tools/htseq_count/all_gff.loc
@@ -1,0 +1,1 @@
+sacCer2	sacCer2	S.Cer	${__HERE__}/../htseq-test.gff

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -232,10 +232,14 @@
                 <param name="gff_source" value="history" />
             </conditional>
             <param name="gff_history" value="htseq-test.gff" />
-            <param name="advanced_options_selector" value="advanced" />
-            <param name="samout" value="Yes" />
-	        <conditional name="reference_source">
-                <param name="reference_source_selector" value="history" />
+            <conditional name="advanced_options">
+                <param name="advanced_options_selector" value="advanced" />
+                <conditional name="samout_conditional">
+                    <param name="samout" value="Yes" />
+	                <conditional name="reference_source">
+                        <param name="reference_source_selector" value="history" />
+                    </conditional>
+                </conditional>
             </conditional>
             <param name="ref_file" value="htseq-test_reference.fasta" />
             <output name="counts" file="htseq-test_counts.tsv" />
@@ -248,10 +252,12 @@
                 <param name="gff_source" value="history" />
                 <param name="gff_history" value="htseq-test.gff" />
             </conditional>
-            <param name="advanced_options_selector" value="advanced" />
-            <param name="nonunique" value="all" />
-            <param name="secondary_alignments" value="ignore" />
-            <param name="supplementary_alignments" value="ignore" />
+            <conditional name="advanced_options">
+                <param name="advanced_options_selector" value="advanced" />
+                <param name="nonunique" value="all" />
+                <param name="secondary_alignments" value="ignore" />
+                <param name="supplementary_alignments" value="ignore" />
+            </conditional>
             <output name="counts" file="htseq-test_counts_nonunique.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -57,7 +57,13 @@
     --format=sam
     '$name_sorted_alignment_filename'
 
-    "$gfffile" | awk '{if ($1 ~ "no_feature|ambiguous|too_low_aQual|not_aligned|alignment_not_unique") print $0 | "cat 1>&2"; else print $0}'
+    #if $gff_source_selector.gff_source=="standard":
+        $gff_source_selector.gff_cache.fields.path
+    #else if $gff_source_selector.gff_source=="history":
+        $gff_source_selector.gff_history
+    #end if
+
+    | awk '{if ($1 ~ "no_feature|ambiguous|too_low_aQual|not_aligned|alignment_not_unique") print $0 | "cat 1>&2"; else print $0}'
          > '$counts'
         2> '$othercounts'
 
@@ -74,7 +80,22 @@
 
     <inputs>
         <param format="sam,bam" name="samfile" type="data" label="Aligned SAM/BAM File"/>
-        <param format="gff" name="gfffile" type="data" label="GFF File"/>
+        <conditional name="gff_source_selector">
+            <param name="gff_source" type="select" label="Will you select a reference gff from your history or use a standard gff file?" help="Standard gff files are available for model organisms">
+              <option value="standard" selected="true">Use a standard gff file</option>
+              <option value="history">Use one from the history</option>
+            </param>
+            <when value="standard">
+               <param name="gff_cache" type="select" label="Select a standard gff file" help="If a gff file for your genome of choice is not listed, contact the admin">
+                  <options from_data_table="all_gff"/>
+               </param>
+            </when>
+            <when value="history">
+               <param name="gff_history" type="data" format="gff" label="Select the gff file" />
+            </when>
+        </conditional>
+
+
         <param name="mode" type="select" label="Mode" argument="--mode">
             <help>Mode to handle reads overlapping more than one feature.</help>
             <option value="union" selected="True">Union</option>
@@ -161,42 +182,48 @@
             <filter>advanced_options['advanced_options_selector'] == 'advanced' and  advanced_options['samout_conditional']['samout'] == "Yes"</filter>
         </data>
     </outputs>
-
     <tests>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="reference_source_selector" value="history" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.bam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <param name="samout" value="No" />
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
         <test expect_num_outputs="3">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <param name="advanced_options_selector" value="advanced" />
             <param name="samout" value="Yes" />
             <param name="reference_source_selector" value="history" />
@@ -207,12 +234,21 @@
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gfffile" value="htseq-test.gff" />
+            <param name="gff_source" value="history" />
+            <param name="gff_history" value="htseq-test.gff" />
             <param name="advanced_options_selector" value="advanced" />
             <param name="nonunique" value="all" />
             <param name="secondary_alignments" value="ignore" />
             <param name="supplementary_alignments" value="ignore" />
             <output name="counts" file="htseq-test_counts_nonunique.tsv" />
+            <output name="othercounts" file="htseq-test_othercounts.tsv" />
+        </test>
+        <test expect_num_outputs="2">
+            <param name="samfile" value="htseq-test.sam" />
+            <param name="reference_source_selector" value="history" />
+            <param name="gff_source" value="standard" />                    
+            <param name="gff_cache" value="sacCer2" /> 
+            <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
     </tests>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -58,9 +58,9 @@
     '$name_sorted_alignment_filename'
 
     #if $gff_source_selector.gff_source=="standard":
-        $gff_source_selector.gff_cache.fields.path
+        '$gff_source_selector.gff_cache.fields.path'
     #else if $gff_source_selector.gff_source=="history":
-        $gff_source_selector.gff_history
+        '$gff_source_selector.gff_history'
     #end if
 
     | awk '{if ($1 ~ "no_feature|ambiguous|too_low_aQual|not_aligned|alignment_not_unique") print $0 | "cat 1>&2"; else print $0}'

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -1,7 +1,7 @@
-<tool id="htseq_count" name="htseq-count" version="0.11.1" profile="16.04">
+<tool id="htseq_count" name="htseq-count" version="0.11.2" profile="16.04">
     <description> - Count aligned reads in a BAM file that overlap features in a GFF file</description>
     <requirements>
-        <requirement type="package" version="0.11.1">htseq</requirement>
+        <requirement type="package" version="0.11.2">htseq</requirement>
         <requirement type="package" version="1.7">samtools</requirement>
     </requirements>
 

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -185,9 +185,11 @@
     <tests>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="reference_source_selector" value="history" />
-            <param name="gff_source" value="history" />
-            <param name="gff_history" value="htseq-test.gff" />
+            <conditional name="reference_source">
+                <param name="reference_source_selector" value="history" />
+            </conditional>
+	        <param name="gff_source" value="history" />
+	        <param name="gff_history" value="htseq-test.gff" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>
@@ -207,26 +209,34 @@
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
-            <param name="gff_source" value="history" />
-            <param name="gff_history" value="htseq-test.gff" />
+            <conditional name="gff_source_selector">
+                <param name="gff_source" value="history" />
+                <param name="gff_history" value="htseq-test.gff" />
+            </conditional>
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test-paired.bam" />
-            <param name="gff_source" value="history" />
-            <param name="gff_history" value="htseq-test.gff" />
+            <conditional name="gff_source_selector">
+                <param name="gff_source" value="history" />
+                <param name="gff_history" value="htseq-test.gff" />
+            </conditional>
             <param name="samout" value="No" />
             <output name="counts" file="htseq-test-paired_counts.tsv" />
             <output name="othercounts" file="htseq-test-paired_othercounts.tsv" />
         </test>
         <test expect_num_outputs="3">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gff_source" value="history" />
+            <conditional name="gff_source_selector">
+                <param name="gff_source" value="history" />
+            </conditional>
             <param name="gff_history" value="htseq-test.gff" />
             <param name="advanced_options_selector" value="advanced" />
             <param name="samout" value="Yes" />
-            <param name="reference_source_selector" value="history" />
+	        <conditional name="reference_source">
+                <param name="reference_source_selector" value="history" />
+            </conditional>
             <param name="ref_file" value="htseq-test_reference.fasta" />
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
@@ -234,8 +244,10 @@
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="gff_source" value="history" />
-            <param name="gff_history" value="htseq-test.gff" />
+            <conditional name="gff_source_selector">
+                <param name="gff_source" value="history" />
+                <param name="gff_history" value="htseq-test.gff" />
+            </conditional>
             <param name="advanced_options_selector" value="advanced" />
             <param name="nonunique" value="all" />
             <param name="secondary_alignments" value="ignore" />
@@ -245,9 +257,12 @@
         </test>
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
-            <param name="reference_source_selector" value="history" />
-            <param name="gff_source" value="cached_gff_file" />                    
-            <param name="gff_cache" value="sacCer2" /> 
+            <conditional name="reference_source"/>
+                <param name="reference_source_selector" value="history" />
+            <conditional name="gff_source_selector">
+                <param name="gff_source" value="cached_gff_file" />
+                <param name="gff_cache" value="sacCer2" /> 
+            </conditional>
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />
         </test>

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -1,7 +1,7 @@
-<tool id="htseq_count" name="htseq-count" version="0.9.1" profile="16.04">
+<tool id="htseq_count" name="htseq-count" version="0.11.1" profile="16.04">
     <description> - Count aligned reads in a BAM file that overlap features in a GFF file</description>
     <requirements>
-        <requirement type="package" version="0.9.1">htseq</requirement>
+        <requirement type="package" version="0.11.1">htseq</requirement>
         <requirement type="package" version="1.7">samtools</requirement>
     </requirements>
 

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -57,7 +57,7 @@
     --format=sam
     '$name_sorted_alignment_filename'
 
-    #if $gff_source_selector.gff_source=="standard":
+    #if $gff_source_selector.gff_source=="cached_gff_file":
         '$gff_source_selector.gff_cache.fields.path'
     #else if $gff_source_selector.gff_source=="history":
         '$gff_source_selector.gff_history'
@@ -81,12 +81,12 @@
     <inputs>
         <param format="sam,bam" name="samfile" type="data" label="Aligned SAM/BAM File"/>
         <conditional name="gff_source_selector">
-            <param name="gff_source" type="select" label="Will you select a reference gff from your history or use a standard gff file?" help="Standard gff files are available for model organisms">
-              <option value="standard">Use a standard gff file</option>
+            <param name="gff_source" type="select" label="Will you select a reference gff from your history or use a server-cached gff file?" help="Standard gff files are available for model organisms">
+              <option value="cached_gff_file">Use a cached gff file</option>
               <option value="history" selected="true">Use one from the history</option>
             </param>
-            <when value="standard">
-               <param name="gff_cache" type="select" label="Select a standard gff file" help="If a gff file for your genome of choice is not listed, contact the admin">
+            <when value="cached_gff_file">
+               <param name="gff_cache" type="select" label="Select a cached gff file" help="If a gff file for your genome of choice is not listed, contact the admin">
                   <options from_data_table="all_gff"/>
                </param>
             </when>
@@ -246,7 +246,7 @@
         <test expect_num_outputs="2">
             <param name="samfile" value="htseq-test.sam" />
             <param name="reference_source_selector" value="history" />
-            <param name="gff_source" value="standard" />                    
+            <param name="gff_source" value="cached_gff_file" />                    
             <param name="gff_cache" value="sacCer2" /> 
             <output name="counts" file="htseq-test_counts.tsv" />
             <output name="othercounts" file="htseq-test_othercounts.tsv" />

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -82,8 +82,8 @@
         <param format="sam,bam" name="samfile" type="data" label="Aligned SAM/BAM File"/>
         <conditional name="gff_source_selector">
             <param name="gff_source" type="select" label="Will you select a reference gff from your history or use a standard gff file?" help="Standard gff files are available for model organisms">
-              <option value="standard" selected="true">Use a standard gff file</option>
-              <option value="history">Use one from the history</option>
+              <option value="standard">Use a standard gff file</option>
+              <option value="history" selected="true">Use one from the history</option>
             </param>
             <when value="standard">
                <param name="gff_cache" type="select" label="Select a standard gff file" help="If a gff file for your genome of choice is not listed, contact the admin">

--- a/tools/htseq_count/test-data/cached_locally/all_gff.loc
+++ b/tools/htseq_count/test-data/cached_locally/all_gff.loc
@@ -1,0 +1,1 @@
+sacCer2	sacCer2	S.Cer	${__HERE__}/../htseq-test.gff

--- a/tools/htseq_count/tool-data/all_gff.loc.sample
+++ b/tools/htseq_count/tool-data/all_gff.loc.sample
@@ -1,0 +1,17 @@
+#This file lists the locations and dbkeys of all the gff files
+#under the "genome" directory (a directory that contains a directory
+#for each build). 
+#This file has the format (white space characters are TAB characters):
+#
+#<unique_build_id>	<dbkey>		<display_name>	<file_path>
+#
+#So, all_gff.loc could look something like this:
+#
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3		/path/to/genome/apiMel3/apiMel3_annotation.gff3
+#hg19canon	hg19		Human (Homo sapiens): hg19 Canonical		/path/to/genome/hg19/hg19canon_annotation.gff
+#hg19full	hg19		Human (Homo sapiens): hg19 Full			/path/to/genome/hg19/hg19full_annotation.gff
+#
+#Your all_gff.loc file should contain an entry for each individual
+#gff file. So there will be multiple fasta files for each build,
+#such as with hg19 above.
+#

--- a/tools/htseq_count/tool_data_table_conf.xml.test
+++ b/tools/htseq_count/tool_data_table_conf.xml.test
@@ -2,6 +2,6 @@
     <!-- Locations of GFF files -->
     <table name="all_gff" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
-        <file path="tool-data/all_gff.loc" />
+        <file path="${__HERE__}/test-data/cached_locally/all_gff.loc" />
     </table>
 </tables>


### PR DESCRIPTION
It's just wise to, when providing the genomes to map to, also provide access to quality annotation files that go with them. 