### PR TITLE
bracken: fix wrapper version number

### DIFF
--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.5</token>
-    <token name="@WRAPPER_VERSION@">@TOOL_VERSION@+galaxy0</token>
+    <token name="@WRAPPER_VERSION@">2.5+galaxy0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bracken</requirement>

--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,13 +1,12 @@
 <macros>
     <token name="@TOOL_VERSION@">2.5</token>
-    <token name="@WRAPPER_VERSION@">2.5+galaxy0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bracken</requirement>
         </requirements>
     </xml>
     <xml name="version">
-        <version_command>echo @WRAPPER_VERSION@</version_command>
+        <version_command>echo @TOOL_VERSION@</version_command>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Macro was being used to define `@WRAPPER_VERSION@` for tool, but that wasn't being correctly expanded.

See: https://toolshed.g2.bx.psu.edu/repository?repository_id=0357fb68688c419f&changeset_revision=b7b1c8bf7ae0