### PR TITLE
Fix bracken version macro

### DIFF
--- a/tools/bracken/est-abundance.xml
+++ b/tools/bracken/est-abundance.xml
@@ -1,4 +1,4 @@
-<tool id="est_abundance" name="Estimate Abundance at Taxonomic Level" version="@VERSION@+galaxy0">
+<tool id="est_abundance" name="Estimate Abundance at Taxonomic Level" version="@TOOL_VERSION@+galaxy0">
     <description>Bayesian Reestimation of Abundance with KrakEN</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Wrong macro was being used in bracken `est_abundance` tool.