### PR TITLE
Simplify implicit snippy dependencies.

### DIFF
--- a/tools/snippy/snippy.xml
+++ b/tools/snippy/snippy.xml
@@ -54,7 +54,7 @@
         #end if
 
         mkdir -p ${dir_name} && cp -r out/reference out/snps.tab out/snps.aligned.fa out/snps.vcf ${dir_name}/ &&
-        tar -czf out.tgz ${dir_name}
+        tar -cf - ${dir_name} | gzip > out.tgz
         #if "outcon" in str($outputs) and $adv.rename_cons
           && sed -i 's/>.*/>${dir_name}/' out/snps.consensus.fa
         #end if


### PR DESCRIPTION
It's biocontainer doesn't work for this tool because tar doesn't support ``-z`` in the container.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
