### PR TITLE
added python3 requirement to unicycler tool

### DIFF
--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -9,6 +9,7 @@
         <edam_operation>operation_0525</edam_operation>
     </edam_operations>
     <requirements>
+        <requirement type="package" version="3">python</requirement>
         <requirement type="package" version="@VERSION@">unicycler</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Installation of Unicycler with miniconda2.7 failed with following error. Including python3 in the requirement fixes this issue. But I am not sure whether this is the right way to solve this problem.  

```
: The following specifications were found to be in conflict:
  - python 2.7*
  - unicycler 0.4.8* -> python >=3.7,<3.8.0a0
Use "conda info <package>" to see the dependencies for each package.
```

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
