### PR TITLE
trinity_analyze_diff_expr - update qvalue

### DIFF
--- a/tools/trinity/analyze_diff_expr.xml
+++ b/tools/trinity/analyze_diff_expr.xml
@@ -4,7 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2.16.0">bioconductor-qvalue</requirement>
+        <requirement type="package" version="2.18.0">bioconductor-qvalue</requirement>
         <requirement type="package" version="1.36.0">bioconductor-goseq</requirement>
         <requirement type="package" version="2.0.8">r-cluster</requirement>
         <requirement type="package" version="1.1.25">r-fastcluster</requirement>

--- a/tools/trinity/analyze_diff_expr.xml
+++ b/tools/trinity/analyze_diff_expr.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@+galaxy2">
     <description>from a Trinity assembly</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

The conda package `bioconductor-qvalue==2.16.0` is buggy :
https://github.com/bioconda/bioconda-recipes/pull/18762

