### PR TITLE
Add explicit dependency on python for data managers

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="bowtie2_index_builder_data_manager" name="Bowtie2 index" tool_type="manage_data" version="@WRAPPER_VERSION@" profile="18.09">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="@WRAPPER_VERSION@">bowtie2</requirement>
     </requirements>
     <macros>

--- a/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager/bowtie_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="bowtie_index_builder_data_manager" name="Bowtie index" tool_type="manage_data" version="1.2.0">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="1.2.0">bowtie</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
+++ b/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
@@ -2,6 +2,7 @@
 <tool id="bracken_build_database" name="Bracken Database Builder" tool_type="manage_data" version="2.5+galaxy0" profile="19.01">
     <description>bracken database builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.5">bracken</requirement>
         <requirement type="package" version="2.0.8_beta">kraken2</requirement>
     </requirements>

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -10,6 +10,7 @@
     </macros>
     <description>database builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.0.8_beta">kraken2</requirement>
     </requirements>
     <version_command>kraken2 -version | head -n 1 | awk '{print $NF}'</version_command>

--- a/data_managers/data_manager_build_kraken_database/data_manager/kraken_database_builder.xml
+++ b/data_managers/data_manager_build_kraken_database/data_manager/kraken_database_builder.xml
@@ -2,6 +2,7 @@
 <tool id="kraken_database_builder" name="Kraken" tool_type="manage_data" version="1.1">
     <description>database builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="1.1">kraken</requirement>
     </requirements>
     <version_command>kraken -version | awk '{print $NF}'</version_command>

--- a/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.xml
+++ b/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="bwa_mem_index_builder_data_manager" name="BWA-MEM index" tool_type="manage_data" version="0.0.4" profile="19.05">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="0.7.17">bwa</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_bwameth_index_builder/data_manager/bwameth_index_builder.xml
+++ b/data_managers/data_manager_bwameth_index_builder/data_manager/bwameth_index_builder.xml
@@ -4,6 +4,7 @@
         <token name="@TOOL_VERSION@">0.2.2</token>
     </macros>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="@TOOL_VERSION@">bwameth</requirement>
     </requirements>
     <command detect_errors="aggressive"><![CDATA[

--- a/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
+++ b/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <tool id="dada2_fetcher" name="dada2 data manager" tool_type="manage_data" version="0.0.7">
     <description>Download reference databases</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code"><![CDATA[
     python '$__tool_directory__/data_manager.py'
     --out '$out_file'

--- a/data_managers/data_manager_fetch_busco/data_manager/busco_fetcher.xml
+++ b/data_managers/data_manager_fetch_busco/data_manager/busco_fetcher.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <tool id="busco_fetcher" name="Busco" tool_type="manage_data" version="1.0.0">
     <description>dataset dowloader</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code">
     <![CDATA[
         python '$__tool_directory__/data_manager.py' --out '${out_file}'

--- a/data_managers/data_manager_fetch_gene_annotation/data_manager/gene_annotation_fetcher.xml
+++ b/data_managers/data_manager_fetch_gene_annotation/data_manager/gene_annotation_fetcher.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <tool id="gene_annotation_fetcher_data_manager" name="Gene Annotation Fetch" tool_type="manage_data" version="1.0.1">
     <description>gene annotation fetcher</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code">
     <![CDATA[
         python '$__tool_directory__/data_manager.py' --out '${out_file}'

--- a/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml
+++ b/data_managers/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml
@@ -1,5 +1,8 @@
 <tool id="data_manager_fetch_genome_all_fasta_dbkey" name="Create DBKey and Reference Genome" version="0.0.3" tool_type="manage_data">
     <description>fetching</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code"><![CDATA[
        python '$__tool_directory__/data_manager_fetch_genome_all_fasta_dbkeys.py'
        '${out_file}'

--- a/data_managers/data_manager_fetch_ncbi_taxonomy/data_manager/ncbi_taxonomy_fetcher.xml
+++ b/data_managers/data_manager_fetch_ncbi_taxonomy/data_manager/ncbi_taxonomy_fetcher.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <tool id="ncbi_taxonomy_fetcher" name="NCBI" tool_type="manage_data" version="1.0.0">
     <description>taxonomy downloader</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code">
     <![CDATA[
         python '$__tool_directory__/data_manager.py' --out '${out_file}'

--- a/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
+++ b/data_managers/data_manager_fetch_refseq/data_manager/fetch_refseq.xml
@@ -1,7 +1,7 @@
 <tool id="data_manager_fetch_refseq" name="RefSeq data manager" version="0.0.18" tool_type="manage_data">
     <description>Fetch FASTA data from NCBI RefSeq and update all_fasta data table</description>
     <requirements>
-        <requirement type="package">python</requirement>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package">requests</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.xml
+++ b/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="gatk_picard_index_builder" name="Generate GATK-sorted Picard indexes" tool_type="manage_data" version="0.0.1">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="0.1.18">samtools</requirement>
         <requirement type="package" version="1.56.0">picard</requirement>
     </requirements>

--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.xml
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.xml
@@ -5,6 +5,7 @@
         <token name="@DB_VERSION@">200</token>
     </macros>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="@VERSION@">gemini</requirement>
     </requirements>
     <command detect_errors="exit_code">

--- a/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
+++ b/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="hisat2_index_builder_data_manager" name="HISAT2 index" tool_type="manage_data" version="2.1.0" profile="19.05">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.1.0">hisat2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
+++ b/data_managers/data_manager_humann2_database_downloader/data_manager/data_manager_humann2_download.xml
@@ -4,6 +4,7 @@
         <token name="@VERSION@">0.11.1</token>
     </macros>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="@VERSION@">humann2</requirement>
     </requirements>
     <stdio>

--- a/data_managers/data_manager_kallisto_index_builder/data_manager/kallisto_index_builder.xml
+++ b/data_managers/data_manager_kallisto_index_builder/data_manager/kallisto_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="kallisto_index_builder_data_manager" name="Kallisto" tool_type="manage_data" version="0.43.1">
     <description>index builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="0.43.1">kallisto</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.xml
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.xml
@@ -1,6 +1,9 @@
 <tool id="data_manager_manual" name="Manual Data Manager" version="0.0.2" tool_type="manage_data" profile_version="19.01">
     <options sanitize="False" />
     <description>Entry Builder</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/data_manager_manual.py'
         '${out_file}'

--- a/data_managers/data_manager_metaphlan2_database_downloader/data_manager/data_manager_metaphlan2_download.xml
+++ b/data_managers/data_manager_metaphlan2_database_downloader/data_manager/data_manager_metaphlan2_download.xml
@@ -2,6 +2,7 @@
     <description>Download MetaPhlAn2 database</description>
 
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.6.0">metaphlan2</requirement>
     </requirements>
 

--- a/data_managers/data_manager_picard_index_builder/data_manager/picard_index_builder.xml
+++ b/data_managers/data_manager_picard_index_builder/data_manager/picard_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="picard_index_builder_data_manager" name="Picard index" tool_type="manage_data" version="2.7.1">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.7.1">picard</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_plant_tribes_scaffolds_downloader/data_manager/data_manager_plant_tribes_scaffolds_download.xml
+++ b/data_managers/data_manager_plant_tribes_scaffolds_downloader/data_manager/data_manager_plant_tribes_scaffolds_download.xml
@@ -1,5 +1,8 @@
 <tool id="data_manager_plant_tribes_scaffolds_download" name="PlantTribes Scaffolds Download" version="1.1.0" tool_type="manage_data">
     <description></description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <stdio>
         <exit_code range=":-1" level="fatal" description="Error: Cannot open file" />
         <exit_code range="1:" level="fatal" description="Error" />

--- a/data_managers/data_manager_qiime_database_downloader/data_manager/data_manager_qiime_download.xml
+++ b/data_managers/data_manager_qiime_database_downloader/data_manager/data_manager_qiime_download.xml
@@ -1,6 +1,7 @@
 <tool id="data_manager_qiime_download" name="Download QIIME reference databases" version="1.9.1" tool_type="manage_data">
     <description></description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="2.13.0">requests</requirement>
     </requirements>
     <stdio>

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
@@ -1,6 +1,9 @@
 <tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.2" tool_type="manage_data">
     <options sanitize="False" />
     <description>fetching</description>
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/data_manager_rsync.py'
         '${out_file}'

--- a/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.xml
+++ b/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.xml
@@ -1,6 +1,7 @@
 <tool id="sam_fasta_index_builder" name="SAM FASTA index" tool_type="manage_data" version="0.0.3" profile="19.05">
     <description>builder</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="1.9">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
@@ -1,6 +1,7 @@
 <tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3r" tool_type="manage_data">
     <description>Read the list of available SnpEff databases</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="4.3.1r">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
@@ -1,6 +1,7 @@
 <tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3r" tool_type="manage_data">
     <description>Download a new database</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="4.3.1r">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
+++ b/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
@@ -1,6 +1,7 @@
 <tool id="data_manager_snpsift_dbnsfp" name="SnpSift dbNSFP" version="4.1.0" tool_type="manage_data">
     <description>Install a dbNSFP variant annotation database</description>
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="0.8.3">pysam</requirement>
     </requirements>
     <stdio>

--- a/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.xml
+++ b/data_managers/data_manager_star_index_builder/data_manager/rna_star_index_builder.xml
@@ -1,6 +1,8 @@
 <tool id="rna_star_index_builder_data_manager" name="rnastar index2" tool_type="manage_data" version="@IDX_VERSION@+galaxy1" profile="17.01">
     <description>builder</description>
-
+    <requirements>
+        <requirement type="package" version="3.7">python</requirement>
+    </requirements>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/data_managers/data_manager_twobit_builder/data_manager/twobit_builder.xml
+++ b/data_managers/data_manager_twobit_builder/data_manager/twobit_builder.xml
@@ -1,5 +1,6 @@
 <tool id="twobit_builder_data_manager" name="TwoBit" tool_type="manage_data" version="0.0.3">
     <requirements>
+        <requirement type="package" version="3.7">python</requirement>
         <requirement type="package" version="377">ucsc-fatotwobit</requirement>
     </requirements>
     <description>builder</description>


### PR DESCRIPTION
Most of the data managers did not have a python version defined, and as a result, the containers built for them would fail with "missing python". This PR adds an explicit dependency on python 3.7. `data_manager_fetch_refseq` had a python dependency defined but not an explicit version, so I specified 3.7.
`data_manager_fetch_mothur_reference_data` has an explicit dependency on 2.7 since the code still uses old style print statements. This will need to be updated in a separate PR.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
