### PR TITLE
Work around case-sensitivity bug in bcftools norm

### DIFF
--- a/tools/bcftools/bcftools_norm.xml
+++ b/tools/bcftools/bcftools_norm.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy2">
     <description>Left-align and normalize indels; check if REF alleles match the reference; split multiallelic sites into multiple rows; recover multiallelics from multiple rows</description>
     <macros>
         <token name="@EXECUTABLE@">norm</token>
@@ -7,6 +7,9 @@
     </macros>
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
+        <!-- gawk only required for current bcftools norm bug workaround
+        Remove once fixed (see command section below -->
+        <requirement type="package" version="5.0.1">gawk</requirement>
     </expand>
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[
@@ -14,6 +17,17 @@
 @PREPARE_INPUT_FILE@
 #set $section = $reference_source
 @PREPARE_FASTA_REF@
+
+## The next two lines are a workaround for a bug in bcftools norm up to version
+## 1.9, which caused indel normalization to be case-sensitive
+## see:
+## https://github.com/samtools/bcftools/commit/65b211da1f5cdbf1c7c11eb610481a736fa88bda
+## https://github.com/samtools/bcftools/commit/77b0a27a156803e382d60651ff94ea0bd95fad0f
+## With the next release of bcftools, this should be fixed and, at that point,
+## the time-consuming on-the-fly uppercasing should be removed again.
+awk '{ if ($0 !~ />/) {print toupper($0)} else {print $0} }' '$input_fa_ref' > ref_upper.fa &&
+#set $input_fa_ref = 'ref_upper.fa'
+
 #set $section = $sec_restrict
 @PREPARE_TARGETS_FILE@
 @PREPARE_REGIONS_FILE@


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
