### PR TITLE
maxbin2:  add idba out/err only if present (and update bioconda recipe)

### DIFF
--- a/tools/maxbin2/maxbin2.xml
+++ b/tools/maxbin2/maxbin2.xml
@@ -1,4 +1,4 @@
-<tool id="maxbin2" name="MaxBin2" version="@MAXBIN_VERSION@+galaxy1">
+<tool id="maxbin2" name="MaxBin2" version="@MAXBIN_VERSION@+galaxy2">
     <description>clusters metagenomic contigs into bins</description>
     <macros>
         <token name="@MAXBIN_VERSION@">2.2.7</token>

--- a/tools/maxbin2/maxbin2.xml
+++ b/tools/maxbin2/maxbin2.xml
@@ -49,16 +49,16 @@
     #end if
     -thread \${GALAXY_SLOTS:-1}
 
-    && tar -xf out.marker_of_each_bin.tar.gz
+    && gzip -cd out.marker_of_each_bin.tar.gz | tar -xf -
 
-	## redirect the idba out and err file content to stdout and err
-	## since this is also wanted in case the error case ';' is used here to 
-	## separate commands
+    ## redirect the idba out and err file content to stdout and err
+    ## since this is also wanted in case the error case ';' is used here to 
+    ## separate commands
     #if $intype_cond.intype_select == 'rds' and $intype_cond.reassembly != ""
         ; echo "==== IDBA stdout ===="
-        && cat out.idba.out
+        && if [[ -f out.idba.out ]]; then cat out.idba.out; fi
         && echo "==== IDBA stderr ====" 1>&2
-        && cat out.idba.err 1>&2
+        && if [[ -f out.idba.err ]]; then cat out.idba.err 1>&2; fi
     #end if
     ]]></command>
     <inputs>
@@ -142,7 +142,8 @@
         </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="4"><!-- test w contigs and reads as input -->
+        <!-- test w contigs and reads as input -->
+        <test expect_num_outputs="4">
             <param name="contig" value="Bin_Sample3_contigs.fasta" ftype="fasta" />
             <conditional name="intype_cond">
                 <param name="intype_select" value="rds"/>


### PR DESCRIPTION
- replaced by `gzip -cd | tar -xf -`
- additionally add idba out/err only if present

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
