### PR TITLE
newick display: add imagemagick dependency

### DIFF
--- a/tools/newick_utils/newick_display.xml
+++ b/tools/newick_utils/newick_display.xml
@@ -1,4 +1,4 @@
-<tool id="newick_display" name="Newick Display" version="1.6">
+<tool id="newick_display" name="Newick Display" version="1.6+galaxy1">
     <description>visualize a phylogenetic tree</description>
     <edam_operations>
         <edam_operation>operation_0567</edam_operation>
@@ -36,15 +36,7 @@ nw_display
     -w  $width
     $radial
 
-    '$fileNewick' > output.svg
-
-#if $outformat == 'png':
-    && convert output.svg output.png
-    && mv output.png '$output'
-#else:
-    && mv output.svg '$output'
-#end if
-
+    '$fileNewick' > '$output'
     ]]></command>
     <inputs>
         <param name="fileNewick" format="txt,newick,nw,nwk,nhx,mothur.tre" type="data" label="Newick file"/>
@@ -80,14 +72,12 @@ nw_display
         <param name="radial" type="boolean" truevalue="-r" falsevalue="" checked="False" label="Draw a radial tree" />
         <param name="outformat" type="select" label="Choose an output format">
             <option value="svg" selected="true">SVG</option>
-            <option value="png">PNG</option>
             <option value="txt">Text</option>
         </param>
     </inputs>
     <outputs>
         <data name="output" format="svg" label="${tool.name} on ${on_string}: Tree Graph" >
             <change_format>
-                <when input="outformat" value="png" format="png"/>
                 <when input="outformat" value="txt" format="txt"/>
             </change_format>
         </data>
@@ -104,13 +94,6 @@ nw_display
             <param name="radial" value="-r"/>
             <param name="branchlength" value="true"/>
             <output name="output" file="tree2.svg" ftype="svg" lines_diff="2"/>
-        </test>
-        <test><!-- test with png output format -->
-            <param name="fileNewick" value="tree.nwk"/>
-            <param name="radial" value="-r"/>
-            <param name="branchlength" value="true"/>
-            <param name="outformat" value="png"/>
-            <output name="output" file="tree.png" ftype="png" compare="sim_size" delta="15000"/>
         </test>
          <test><!-- test with txt output format -->
             <param name="fileNewick" value="tree.nwk"/>

--- a/tools/newick_utils/newick_display.xml
+++ b/tools/newick_utils/newick_display.xml
@@ -5,6 +5,7 @@
     </edam_operations>
     <requirements>
         <requirement type="package" version="1.6">newick_utils</requirement>
+        <requirement type="package" version="7.0.9_6">imagemagick</requirement>
     </requirements>
     <command detect_errors="aggressive"><![CDATA[
 nw_display
@@ -36,7 +37,13 @@ nw_display
     -w  $width
     $radial
 
-    '$fileNewick' > '$output'
+    '$fileNewick'
+
+    #if $outformat == 'png':
+        | convert - 'png:$output'
+    #else:
+        > '$output'
+    #end if
     ]]></command>
     <inputs>
         <param name="fileNewick" format="txt,newick,nw,nwk,nhx,mothur.tre" type="data" label="Newick file"/>
@@ -72,12 +79,14 @@ nw_display
         <param name="radial" type="boolean" truevalue="-r" falsevalue="" checked="False" label="Draw a radial tree" />
         <param name="outformat" type="select" label="Choose an output format">
             <option value="svg" selected="true">SVG</option>
+            <option value="png">PNG</option>
             <option value="txt">Text</option>
         </param>
     </inputs>
     <outputs>
         <data name="output" format="svg" label="${tool.name} on ${on_string}: Tree Graph" >
             <change_format>
+                <when input="outformat" value="png" format="png"/>
                 <when input="outformat" value="txt" format="txt"/>
             </change_format>
         </data>
@@ -95,7 +104,14 @@ nw_display
             <param name="branchlength" value="true"/>
             <output name="output" file="tree2.svg" ftype="svg" lines_diff="2"/>
         </test>
-         <test><!-- test with txt output format -->
+        <test><!-- test with png output format -->
+            <param name="fileNewick" value="tree.nwk"/>
+            <param name="radial" value="-r"/>
+            <param name="branchlength" value="true"/>
+            <param name="outformat" value="png"/>
+            <output name="output" file="tree.png" ftype="png" compare="sim_size" delta="15000"/>
+        </test>
+        <test><!-- test with txt output format -->
             <param name="fileNewick" value="tree.nwk"/>
             <param name="outformat" value="txt"/>
             <output name="output" file="tree.txt" ftype="txt"/>


### PR DESCRIPTION
imagemagick requirement was missing anyway. since for some reason
neither imagemagick not graphicsmagick can convert the image I
suggest to stick to svg only for now.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
