### PR TITLE
samtools: remove unnecessary symlink in global test-data

### DIFF
--- a/tool_collections/samtools/test-data/cached_locally/cached_locally
+++ b/tool_collections/samtools/test-data/cached_locally/cached_locally
@@ -1,1 +1,0 @@
-../../test-data/cached_locally


### PR DESCRIPTION
Original error in the container tests: 

```
/home/runner/work/tools-iuc/tools-iuc/tool_collections/samtools/bam_to_cram/test-data/cached_locally/chr_m.fasta: No such file or directory
```

Might also because `tool_collections/samtools/bam_to_cram/test-data/cached_locally`  is a symlink to `tool_collections/samtools/test-data/cached_locally` and for some reason the files in the destination did not make it in the test environment. (a local `planemo t` was successful). 

But I think this symlink can go anyway.


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
