### PR TITLE
circos: add tar requirement

### DIFF
--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -62,13 +62,13 @@ touch circos/conf/karyotype-colors.conf &&
     #end if
 #end if
 
-cp -s '$circos_conf' circos/conf/circos.conf &&
-cp -s '$ticks_conf' circos/conf/ticks.conf &&
-cp -s '$ideogram_conf' circos/conf/ideogram.conf &&
-cp -s '$data_conf'  circos/conf/data.conf &&
-cp -s '$highlight_conf'  circos/conf/highlight.conf &&
-cp -s '$links_conf'  circos/conf/links.conf &&
-cp -s '$test_case_conf' circos/conf/galaxy_test_case.json &&
+cp '$circos_conf' circos/conf/circos.conf &&
+cp '$ticks_conf' circos/conf/ticks.conf &&
+cp '$ideogram_conf' circos/conf/ideogram.conf &&
+cp '$data_conf'  circos/conf/data.conf &&
+cp '$highlight_conf'  circos/conf/highlight.conf &&
+cp '$links_conf'  circos/conf/links.conf &&
+cp '$test_case_conf' circos/conf/galaxy_test_case.json &&
 
 ## Highlights
 #for $hi, $data in enumerate($sec_highlight.data):

--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -64,7 +64,7 @@ touch circos/conf/karyotype-colors.conf &&
 
 ln -s '$circos_conf' circos/conf/circos.conf &&
 ln -s '$ticks_conf' circos/conf/ticks.conf &&
-ls -s '$ideogram_conf' circos/conf/ideogram.conf &&
+ln -s '$ideogram_conf' circos/conf/ideogram.conf &&
 ln -s '$data_conf'  circos/conf/data.conf &&
 ln -s '$highlight_conf'  circos/conf/highlight.conf &&
 ln -s '$links_conf'  circos/conf/links.conf &&

--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -86,7 +86,7 @@ cp '${data.data_source}' circos/data/highlight-${hi}.txt &&
 #end for
 
 #if $outputs.tar == "yes"
-    tar cvfz circos.tar.gz circos >/dev/null
+	tar c circos | gzip - > circos.tar.gz
 #else
     echo ''
 #end if

--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -62,13 +62,13 @@ touch circos/conf/karyotype-colors.conf &&
     #end if
 #end if
 
-ln -s '$circos_conf' circos/conf/circos.conf &&
-ln -s '$ticks_conf' circos/conf/ticks.conf &&
-ln -s '$ideogram_conf' circos/conf/ideogram.conf &&
-ln -s '$data_conf'  circos/conf/data.conf &&
-ln -s '$highlight_conf'  circos/conf/highlight.conf &&
-ln -s '$links_conf'  circos/conf/links.conf &&
-ln -s '$test_case_conf' circos/conf/galaxy_test_case.json &&
+cp -s '$circos_conf' circos/conf/circos.conf &&
+cp -s '$ticks_conf' circos/conf/ticks.conf &&
+cp -s '$ideogram_conf' circos/conf/ideogram.conf &&
+cp -s '$data_conf'  circos/conf/data.conf &&
+cp -s '$highlight_conf'  circos/conf/highlight.conf &&
+cp -s '$links_conf'  circos/conf/links.conf &&
+cp -s '$test_case_conf' circos/conf/galaxy_test_case.json &&
 
 ## Highlights
 #for $hi, $data in enumerate($sec_highlight.data):

--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -86,13 +86,11 @@ cp '${data.data_source}' circos/data/highlight-${hi}.txt &&
 #end for
 
 #if $outputs.tar == "yes"
-	tar c circos | gzip - > circos.tar.gz
-#else
-    echo ''
+    tar -czf circos.tar.gz circos &&
 #end if
 
 #if $outputs.svg == "yes" or $outputs.png == "yes":
-    && circos -conf circos/conf/circos.conf -noparanoid
+    circos -conf circos/conf/circos.conf -noparanoid
 #end if
     ]]></command>
     <configfiles>

--- a/tools/circos/circos.xml
+++ b/tools/circos/circos.xml
@@ -62,13 +62,13 @@ touch circos/conf/karyotype-colors.conf &&
     #end if
 #end if
 
-mv '$circos_conf' circos/conf/circos.conf &&
-mv '$ticks_conf' circos/conf/ticks.conf &&
-mv '$ideogram_conf' circos/conf/ideogram.conf &&
-mv '$data_conf'  circos/conf/data.conf &&
-mv '$highlight_conf'  circos/conf/highlight.conf &&
-mv '$links_conf'  circos/conf/links.conf &&
-mv '$test_case_conf' circos/conf/galaxy_test_case.json &&
+ln -s '$circos_conf' circos/conf/circos.conf &&
+ln -s '$ticks_conf' circos/conf/ticks.conf &&
+ls -s '$ideogram_conf' circos/conf/ideogram.conf &&
+ln -s '$data_conf'  circos/conf/data.conf &&
+ln -s '$highlight_conf'  circos/conf/highlight.conf &&
+ln -s '$links_conf'  circos/conf/links.conf &&
+ln -s '$test_case_conf' circos/conf/galaxy_test_case.json &&
 
 ## Highlights
 #for $hi, $data in enumerate($sec_highlight.data):

--- a/tools/circos/macros.xml
+++ b/tools/circos/macros.xml
@@ -12,6 +12,7 @@
         <requirement type="package" version="1.70">biopython</requirement>
         <requirement type="package" version="0.3.13">pybigwig</requirement>
         <requirement type="package" version="0.23">circos-tools</requirement>
+        <requirement type="package" version="1.32">tar</requirement>
         <yield />
       </requirements>
   </xml>

--- a/tools/circos/macros.xml
+++ b/tools/circos/macros.xml
@@ -12,7 +12,7 @@
         <requirement type="package" version="1.70">biopython</requirement>
         <requirement type="package" version="0.3.13">pybigwig</requirement>
         <requirement type="package" version="0.23">circos-tools</requirement>
-        <requirement type="package" version="1.32">tar</requirement>
+        <requirement type="package" version="1.29">tar</requirement>
         <yield />
       </requirements>
   </xml>

--- a/tools/circos/macros.xml
+++ b/tools/circos/macros.xml
@@ -2,7 +2,7 @@
 <macros>
   <token name="@CIRCOS_VERSION@">0.69.8</token>
 
-  <token name="@WRAPPER_VERSION@">@CIRCOS_VERSION@+galaxy1</token>
+  <token name="@WRAPPER_VERSION@">@CIRCOS_VERSION@+galaxy2</token>
 
   <xml name="requirements">
       <requirements>

--- a/tools/circos/tableviewer.xml
+++ b/tools/circos/tableviewer.xml
@@ -14,7 +14,7 @@ parse-table -file '$table' -conf '$parse_table_conf' > tmp &&
 
 make-conf -dir circos/data < tmp &&
 
-tar c circos | gzip - > circos.tar.gz &&
+tar -czf circos.tar.gz circos &&
 cd circos &&
 circos -conf etc/circos.conf &&
 mv circos.png ../ &&

--- a/tools/circos/tableviewer.xml
+++ b/tools/circos/tableviewer.xml
@@ -14,7 +14,7 @@ parse-table -file '$table' -conf '$parse_table_conf' > tmp &&
 
 make-conf -dir circos/data < tmp &&
 
-tar cvfz circos.tar.gz circos &&
+tar c circos | gzip - > circos.tar.gz &&
 cd circos &&
 circos -conf etc/circos.conf &&
 mv circos.png ../ &&


### PR DESCRIPTION
seems that another problem is that the generated configfiles are moved to working/... which seems not to work in the container tests. 

`mv: can't remove '/tmp/tmpzvg40cuz/job_working_directory/000/2/tmpnuxq8_9j': Read-only file system`

We could try to cp or symlink? Or should this be fixes in another way

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
