### PR TITLE
Add python 3.7 dependency to bwa_mem index builder

### DIFF
--- a/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.xml
+++ b/data_managers/data_manager_bwa_mem_index_builder/data_manager/bwa_mem_index_builder.xml
@@ -1,7 +1,8 @@
-<tool id="bwa_mem_index_builder_data_manager" name="BWA-MEM index" tool_type="manage_data" version="0.0.4" profile="19.05">
+<tool id="bwa_mem_index_builder_data_manager" name="BWA-MEM index" tool_type="manage_data" version="0.0.5" profile="19.05">
     <description>builder</description>
     <requirements>
         <requirement type="package" version="0.7.17">bwa</requirement>
+        <requirement type="package" version="3.7">python</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/bwa_mem_index_builder.py'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)