### PR TITLE
transtermhp: add fix for env variable not set in containers

### DIFF
--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -10,6 +10,11 @@
     ln -s '$reference_genome.genome_fasta' genomeref.fa &&
 #end if
 
+## fix for TRANSTERMHP not set on containers
+if [[ -z "\$TRANSTERMHP" ]]; then
+    TRANSTERMHP="$(dirname $(command -v transterm))/../data/expterm.dat"
+fi
+
 python '$__tool_directory__/transtermhp.py' \$TRANSTERMHP
 
 #if $reference_genome.source == 'cached':

--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -6,14 +6,14 @@
     <expand macro="requirements"/>
     <expand macro="stdio"/>
     <command><![CDATA[
+## fix for TRANSTERMHP not set on containers
+if [[ -z "\$TRANSTERMHP" ]]; then
+    TRANSTERMHP="\$(dirname \$(command -v transterm))/../data/expterm.dat";
+fi
+
 #if $reference_genome.source == 'history':
     ln -s '$reference_genome.genome_fasta' genomeref.fa &&
 #end if
-
-## fix for TRANSTERMHP not set on containers
-if [[ -z "\$TRANSTERMHP" ]]; then
-    TRANSTERMHP="\$(dirname \$(command -v transterm))/../data/expterm.dat"
-fi
 
 python '$__tool_directory__/transtermhp.py' \$TRANSTERMHP
 

--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -9,7 +9,7 @@
 ## fix for TRANSTERMHP not set on containers
 if [[ -z "\$TRANSTERMHP" ]]; then
     TRANSTERMHP="\$(dirname \$(command -v transterm))/../data/expterm.dat";
-fi
+fi && 
 
 #if $reference_genome.source == 'history':
     ln -s '$reference_genome.genome_fasta' genomeref.fa &&

--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -7,10 +7,7 @@
     <expand macro="stdio"/>
     <command><![CDATA[
 ## fix for TRANSTERMHP not set on containers
-if [[ -z "\$TRANSTERMHP" ]]; then
-    TRANSTERMHP="\$(dirname \$(command -v transterm))/../data/expterm.dat";
-fi && 
-
+TRANSTERMHP=\${TRANSTERMHP:-\$(dirname \$(command -v transterm))/../data/expterm.dat} &&
 #if $reference_genome.source == 'history':
     ln -s '$reference_genome.genome_fasta' genomeref.fa &&
 #end if

--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -12,7 +12,7 @@
 
 ## fix for TRANSTERMHP not set on containers
 if [[ -z "\$TRANSTERMHP" ]]; then
-    TRANSTERMHP="$(dirname $(command -v transterm))/../data/expterm.dat"
+    TRANSTERMHP="\$(dirname \$(command -v transterm))/../data/expterm.dat"
 fi
 
 python '$__tool_directory__/transtermhp.py' \$TRANSTERMHP


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
