### PR TITLE
Match twobit table definition to data_manager definition

### DIFF
--- a/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
+++ b/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <tables>
     <table name="twobit" comment_char="#" allow_duplicate_entries="False">
-        <columns>dbkey, path</columns>
+        <columns>value, path</columns>
         <file path="tool-data/twobit.loc" />
     </table>
 </tables>

--- a/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
+++ b/tools/extract_genomic_dna/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <tables>
     <table name="twobit" comment_char="#" allow_duplicate_entries="False">
-        <columns>dbkey, value</columns>
+        <columns>dbkey, path</columns>
         <file path="tool-data/twobit.loc" />
     </table>
 </tables>


### PR DESCRIPTION
I wonder how this was uploaded previously though.


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)