### PR TITLE
Update Seurat to 3.1.2, bug fixes

### DIFF
--- a/tools/seurat/Seurat.R
+++ b/tools/seurat/Seurat.R
@@ -23,7 +23,7 @@
 #' ---
 
 #+ echo=F, warning = F, message=F
-options( show.error.messages=F, error = function () { cat( geterrmessage(), file=stderr() ); q( "no", 1, F ) } )
+options(show.error.messages = F, error = function(){cat(geterrmessage(), file = stderr()); q("no", 1, F)})
 showcode <- as.logical(params$showcode)
 warn <-  as.logical(params$warn)
 varstate <- as.logical(params$varstate)
@@ -33,7 +33,7 @@ PCplots <- as.logical(params$PCplots)
 tsne <- as.logical(params$tsne)
 heatmaps <- as.logical(params$heatmaps)
 
-# we need that to not crash galaxy with an UTF8 error on German LC settings.
+# we need that to not crash Galaxy with an UTF-8 error on German LC settings.
 loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
 
 
@@ -57,52 +57,52 @@ print(paste0("Minimum percent of cells", min_pct))
 print(paste0("Logfold change threshold", logfc_threshold))
 
 #+ echo = FALSE
-if(showcode == TRUE){print("Read in data, generate inital Seurat object")}
+if(showcode == TRUE) print("Read in data, generate inital Seurat object")
 #+ echo = `showcode`, warning = `warn`, message = F
-counts <- read.delim(params$counts, row.names=1)
+counts <- read.delim(params$counts, row.names = 1)
 seuset <- Seurat::CreateSeuratObject(counts = counts, min.cells = min_cells, min.features = min_genes)
 
 #+ echo = FALSE
-if(showcode == TRUE && vlnfeat == TRUE){print("Raw data vizualization")}
+if(showcode == TRUE && vlnfeat == TRUE) print("Raw data vizualization")
 #+ echo = `showcode`, warning = `warn`, include=`vlnfeat` 
-Seurat::VlnPlot(object = seuset, features = c("nFeature_RNA", "nCount_RNA"), axis="v")
+Seurat::VlnPlot(object = seuset, features = c("nFeature_RNA", "nCount_RNA"))
 Seurat::FeatureScatter(object = seuset, feature1 = "nCount_RNA", feature2 = "nFeature_RNA")
 
 #+ echo = FALSE
-if(showcode == TRUE){print("Filter and normalize for UMI counts")}
+if(showcode == TRUE) print("Filter and normalize for UMI counts")
 #+ echo = `showcode`, warning = `warn`
 seuset <- subset(seuset, subset = `nCount_RNA` > low_thresholds & `nCount_RNA` < high_thresholds)
-seuset <- Seurat::NormalizeData(seuset, normalizeation.method = "LogNormalize", scale.factor = 10000)
+seuset <- Seurat::NormalizeData(seuset, normalization.method = "LogNormalize", scale.factor = 10000)
 
 #+ echo = FALSE
-if(showcode == TRUE && featplot == TRUE){print("Variable Genes")}
+if(showcode == TRUE && featplot == TRUE) print("Variable Genes")
 #+ echo = `showcode`, warning = `warn`, include = `featplot`
 seuset <- Seurat::FindVariableFeatures(object = seuset, selection.method = "mvp")
 Seurat::VariableFeaturePlot(seuset, cols = c("black", "red"), selection.method = "disp")
 seuset <- Seurat::ScaleData(object = seuset, vars.to.regress = "nCount_RNA")
 
 #+ echo = FALSE
-if(showcode == TRUE && PCplots == TRUE){print("PCA Visualization")}
+if(showcode == TRUE && PCplots == TRUE) print("PCA Visualization")
 #+ echo = `showcode`, warning = `warn`, include = `PCplots`
-seuset <- Seurat::RunPCA(seuset, npcs=numPCs)
+seuset <- Seurat::RunPCA(seuset, npcs = numPCs)
 Seurat::VizDimLoadings(seuset, dims = 1:2)
-Seurat::DimPlot(seuset, dims = c(1,2), reduction="pca")
-Seurat::DimHeatmap(seuset, dims=1:numPCs, nfeatures=30, reduction="pca")
+Seurat::DimPlot(seuset, dims = c(1,2), reduction = "pca")
+Seurat::DimHeatmap(seuset, dims = 1:numPCs, nfeatures = 30, reduction = "pca")
 seuset <- Seurat::JackStraw(seuset, dims=numPCs, reduction = "pca", num.replicate = 100)
 seuset <- Seurat::ScoreJackStraw(seuset, dims = 1:numPCs)
 Seurat::JackStrawPlot(seuset, dims = 1:numPCs)
 Seurat::ElbowPlot(seuset, ndims = numPCs, reduction = "pca")
 
 #+ echo = FALSE
-if(showcode == TRUE && tsne == TRUE){print("tSNE")}
+if(showcode == TRUE && tsne == TRUE) print("tSNE")
 #+ echo = `showcode`, warning = `warn`, include = `tsne`
 seuset <- Seurat::FindNeighbors(object = seuset)
 seuset <- Seurat::FindClusters(object = seuset)
 seuset <- Seurat::RunTSNE(seuset, dims = 1:numPCs, resolution = resolution)
-Seurat::DimPlot(seuset, reduction="tsne")
+Seurat::DimPlot(seuset, reduction = "tsne")
 
 #+ echo = FALSE
-if(showcode == TRUE && heatmaps == TRUE){print("Marker Genes")}
+if(showcode == TRUE && heatmaps == TRUE) print("Marker Genes")
 #+ echo = `showcode`, warning = `warn`, include = `heatmaps`
 markers <- Seurat::FindAllMarkers(seuset, only.pos = TRUE, min.pct = min_pct, logfc.threshold = logfc_threshold)
 top10 <- dplyr::group_by(markers, cluster)

--- a/tools/seurat/seurat.xml
+++ b/tools/seurat/seurat.xml
@@ -1,8 +1,13 @@
-<tool id="seurat" name="Seurat" version="2.3.4">
+<tool id="seurat" name="Seurat" version="@TOOL_VERSION@">
     <description>- toolkit for exploration of single-cell RNA-seq data</description>
+    <macros>
+        <token name="@TOOL_VERSION@">3.1.2</token>
+    </macros>
     <requirements>
-        <requirement type="package" version="3.1.0">r-seurat</requirement>
-        <requirement type="package" version="1.16">r-rmarkdown</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">r-seurat</requirement>
+        <requirement type="package" version="2.0">r-rmarkdown</requirement>
+        <!-- Need to pin pandoc due to https://github.com/rstudio/rmarkdown/issues/1740 -->
+        <requirement type="package" version="2.7.3">pandoc</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 #if "vln" in $meta.plots:

--- a/tools/seurat/test-data/out.html
+++ b/tools/seurat/test-data/out.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
 
 <head>
 
 <meta charset="utf-8" />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
 
 <meta name="author" content="Performed using Galaxy" />
 
-<meta name="date" content="2019-12-08" />
+<meta name="date" content="2019-12-16" />
 
 <title>Seurat Analysis</title>
 
@@ -332,6 +331,7 @@ summary {
   border: none;
   display: inline-block;
   border-radius: 4px;
+  background-color: transparent;
 }
 
 .tabset-dropdown > .nav-tabs.nav-tabs-open > li {
@@ -365,17 +365,17 @@ summary {
 
 <h1 class="title toc-ignore">Seurat Analysis</h1>
 <h4 class="author">Performed using Galaxy</h4>
-<h4 class="date">2019-12-08</h4>
+<h4 class="date">2019-12-16</h4>
 
 </div>
 
 
 <pre><code>## [1] &quot;Read in data, generate inital Seurat object&quot;</code></pre>
-<pre class="r"><code>counts &lt;- read.delim(params$counts, row.names=1)
+<pre class="r"><code>counts &lt;- read.delim(params$counts, row.names = 1)
 seuset &lt;- Seurat::CreateSeuratObject(counts = counts, min.cells = min_cells, min.features = min_genes)</code></pre>
 <pre><code>## [1] &quot;Filter and normalize for UMI counts&quot;</code></pre>
 <pre class="r"><code>seuset &lt;- subset(seuset, subset = `nCount_RNA` &gt; low_thresholds &amp; `nCount_RNA` &lt; high_thresholds)
-seuset &lt;- Seurat::NormalizeData(seuset, normalizeation.method = &quot;LogNormalize&quot;, scale.factor = 10000)</code></pre>
+seuset &lt;- Seurat::NormalizeData(seuset, normalization.method = &quot;LogNormalize&quot;, scale.factor = 10000)</code></pre>
 <pre><code>## [1] &quot;Variable Genes&quot;</code></pre>
 <pre class="r"><code>seuset &lt;- Seurat::FindVariableFeatures(object = seuset, selection.method = &quot;mvp&quot;)
 Seurat::VariableFeaturePlot(seuset, cols = c(&quot;black&quot;, &quot;red&quot;), selection.method = &quot;disp&quot;)</code></pre>


### PR DESCRIPTION
Also:
- Update rmarkdown dependency to 2.0
- Add a requirement to pin pandoc to 2.7.3 due to a bug in rmarkdown with pandoc >=2.8 https://github.com/rstudio/rmarkdown/issues/1740
- Use @TOOL_VERSION@ macro (we forgot to bump the tool version when upgrading from Seurat 2 to 3, bad!!)
- 2 bug fixes
- Update test output data

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
