### PR TITLE
Add delta to idr image comparison

### DIFF
--- a/tools/idr/idr.xml
+++ b/tools/idr/idr.xml
@@ -95,7 +95,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out1.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out1.png" ftype="png" />
+            <output name="idr_plot" file="idr_out1.png" ftype="png" compare="sim_size" delta="1000"/>
         </test>
         <test>
             <param name="primus" value="idr_input2.1.bed" ftype="bed" />
@@ -103,7 +103,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out2.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out2.png" ftype="png" />
+            <output name="idr_plot" file="idr_out2.png" ftype="png" compare="sim_size" delta="1000"/>
         </test>
         <test>
             <param name="primus" value="idr_input3.1.bed" ftype="bed" />
@@ -112,7 +112,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out3.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out3.png" ftype="png" />
+            <output name="idr_plot" file="idr_out3.png" ftype="png" compare="sim_size" delta="1000"/>
         </test>
         <test>
             <param name="primus" value="idr_input4.1.gff" ftype="gff" />
@@ -121,7 +121,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out4.gff" ftype="gff" />
-            <output name="idr_plot" file="idr_out4.png" ftype="png" />
+            <output name="idr_plot" file="idr_out4.png" ftype="png" compare="sim_size" delta="1000"/>
         </test>
      </tests>
     <help>


### PR DESCRIPTION
just updates the test comparison, I don't think bumping the tool version is necessary

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
