### PR TITLE
Fix bowtie2 data manager

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager/bowtie2_index_builder.xml
@@ -1,11 +1,10 @@
-<tool id="bowtie2_index_builder_data_manager" name="Bowtie2 index" tool_type="manage_data" version="@WRAPPER_VERSION@" profile="18.09">
+<tool id="bowtie2_index_builder_data_manager" name="Bowtie2 index" tool_type="manage_data" version="@WRAPPER_VERSION@.1+galaxy1" profile="18.09">
     <description>builder</description>
     <requirements>
         <requirement type="package" version="@WRAPPER_VERSION@">bowtie2</requirement>
-        <requirement type="package" version="3.7">python</requirement>
     </requirements>
     <macros>
-        <token name="@WRAPPER_VERSION@">2.3.5.1</token>
+        <token name="@WRAPPER_VERSION@">2.3.5</token>
     </macros>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/bowtie2_index_builder.py'


### PR DESCRIPTION
There is no 2.3.5.1 version on bioconda, and bowtie2 ships with python.
Given that we uploaded this version I added .1+galaxy1 as the version.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
