### PR TITLE
Fix containerized codeml, always copy script

### DIFF
--- a/tools/codeml/codeml.xml
+++ b/tools/codeml/codeml.xml
@@ -1,4 +1,4 @@
-<tool name="codeML" id="codeml" version="1.0">
+<tool name="codeML" id="codeml" version="1.1" profile="18.01">
     <description>
         Detects positive selection (paml package)
     </description>
@@ -14,9 +14,8 @@
     <version_command><![CDATA[ codeml /dev/null 2>&1 | tail -1 ]]></version_command>
 
     <command><![CDATA[
+cp '$codeml_ctl' '$ctl' &&
 codeml '$codeml_ctl'
-&&
-mv '$codeml_ctl' '$ctl'
     ]]></command>
 
     <configfiles>

--- a/tools/codeml/codeml.xml
+++ b/tools/codeml/codeml.xml
@@ -1,4 +1,4 @@
-<tool name="codeML" id="codeml" version="1.1" profile="18.01">
+<tool name="codeML" id="codeml" version="@WRAPPER_VERSION@" profile="18.01">
     <description>
         Detects positive selection (paml package)
     </description>
@@ -8,7 +8,7 @@
     </macros>
 
     <requirements>
-        <requirement type="package" version="4.9">paml</requirement>
+        <requirement type="package" version="@WRAPPER_VERSION@">paml</requirement>
     </requirements>
 
     <version_command><![CDATA[ codeml /dev/null 2>&1 | tail -1 ]]></version_command>

--- a/tools/codeml/codeml.xml
+++ b/tools/codeml/codeml.xml
@@ -1,4 +1,4 @@
-<tool name="codeML" id="codeml" version="@WRAPPER_VERSION@" profile="18.01">
+<tool name="codeML" id="codeml" version="@WRAPPER_VERSION@+galaxy1" profile="18.01">
     <description>
         Detects positive selection (paml package)
     </description>

--- a/tools/codeml/macros.xml
+++ b/tools/codeml/macros.xml
@@ -1,4 +1,5 @@
 <macros>
+    <token name="@WRAPPER_VERSION@">4.9</token>
     <xml name="FSsites_br0" >
         <param argument="NSsites" type="select" label="Site model ; fix_alpha !=1 and alpha !=0 are not compatible with NSsites !=0" >
             <option value="0" selected="true">0 : e.g. basic model if model=0</option>


### PR DESCRIPTION
before running codeml, so that one can see the script if the tool run
fails. Use cp instead of mv since configfiles are mount :ro in
containers.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
