### PR TITLE
tetyper: Optionally read variant profiles from tool data table

### DIFF
--- a/tools/tetyper/test-data/tetyper_snp_profiles.loc
+++ b/tools/tetyper/test-data/tetyper_snp_profiles.loc
@@ -1,0 +1,6 @@
+# Tab separated with three columns:
+# - value (Galaxy records this in the Galaxy DB)
+# - name (Galaxy shows this in the UI)
+# - path (path to the snp_profiles.txt file)
+#
+Tn4401b_snp_profiles	"Tn4401b SNP Profiles"	${__HERE__}/Tn4401b_snp_profiles.txt

--- a/tools/tetyper/test-data/tetyper_struct_profiles.loc
+++ b/tools/tetyper/test-data/tetyper_struct_profiles.loc
@@ -1,0 +1,6 @@
+# Tab separated with three columns:
+# - value (Galaxy records this in the Galaxy DB)
+# - name (Galaxy shows this in the UI)
+# - path (path to the struct_profiles.txt file)
+#
+Tn4401b_struct_profiles	"Tn4401b Structural Variant Profiles"	${__HERE__}/Tn4401b_struct_profiles.txt

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -23,16 +23,16 @@
             --min_qual '${min_qual}'
             #if $snp_profiles_source.snp_profiles_source_selector:
                 #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
-                    --snp_profiles = '$snp_profiles_source.snp_profiles.fields.path'
-                #else:
-                    --snp_profiles = '$snp_profiles_source.snp_profiles'
+                    --snp_profiles '$snp_profiles_source.snp_profiles.fields.path'
+                #elif str( $snp_profiles_source.snp_profiles_source_selector ) == 'history':
+                    --snp_profiles '$snp_profiles_source.snp_profiles'
                 #end if
             #end if
             #if $struct_profiles_source.struct_profiles_source_selector:
                 #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
-                    --struct_profiles = '$struct_profiles_source.struct_profiles.fields.path'
-                #else:
-                    --struct_profiles = '$struct_profiles_source.struct_profiles'
+                    --struct_profiles '$struct_profiles_source.struct_profiles.fields.path'
+                #elif str( $struct_profiles_source.struct_profiles_source_selector ) == 'history':
+                    --struct_profiles '$struct_profiles_source.struct_profiles'
                 #end if
             #end if
             --outprefix output

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -60,7 +60,7 @@
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="snp_profiles" type="select" format="tabular" optional="true">
+                <param name="snp_profiles" type="select" format="tabular" label="SNP Profile" optional="true">
                     <options from_data_table="tetyper_snp_profiles">
                         <validator type="no_options" message="No TETyper SNP profiles are available" />
                     </options>
@@ -76,7 +76,7 @@
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="struct_profiles" type="select" format="tabular" optional="true">
+                <param name="struct_profiles" type="select" format="tabular" label="Structural Variant Profile" optional="true">
                     <options from_data_table="tetyper_struct_profiles">
                         <validator type="no_options" message="No TETyper structural variant profiles are available" />
                     </options>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -60,7 +60,7 @@
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="snp_profiles" type="select" format="tabular">
+                <param name="snp_profiles" type="select" format="tabular" optional="true">
                     <options from_data_table="tetyper_snp_profiles">
                         <validator type="no_options" message="No TETyper SNP profiles are available" />
                     </options>
@@ -76,7 +76,7 @@
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="struct_profiles" type="select" format="tabular">
+                <param name="struct_profiles" type="select" format="tabular" optional="true">
                     <options from_data_table="tetyper_struct_profiles">
                         <validator type="no_options" message="No TETyper structural variant profiles are available" />
                     </options>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -122,8 +122,10 @@
                 <param name="forward_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_1.fastq" />
                 <param name="reverse_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_2.fastq" />
             </conditional>
-            <param name="snp_profiles" value="Tn4401b_snp_profiles.txt" />
-            <param name="struct_profiles" value="Tn4401b_struct_profiles.txt" />
+            <param name="snp_profiles_source.snp_profiles_source_selector" value="history" />
+            <param name="snp_profiles_source.snp_profiles" value="Tn4401b_snp_profiles.txt" />
+            <param name="struct_profiles_source.struct_profiles_source_selector" value="history" />
+            <param name="struct_profiles_source.struct_profiles" value="Tn4401b_struct_profiles.txt" />
             <output name="summary" file="output_summary_2.txt" />
         </test>
     </tests>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -1,4 +1,4 @@
-<tool id="tetyper" name="TETyper" version="@TOOL_VERSION@+galaxy0">
+<tool id="tetyper" name="TETyper" version="@TOOL_VERSION@+galaxy1">
     <description>Transposable Element Typer</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1</token>
@@ -21,10 +21,20 @@
             --min_each_strand '${min_each_strand}'
             --min_mapped_len '${min_mapped_len}'
             --min_qual '${min_qual}'
-            #if $snp_profiles
+            #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
+              #set $snp_profiles = str( $snp_profiles_source.snp_profiles.fields.path )
+            #else:
+              #set $snp_profiles = str( $snp_profiles_source.snp_profiles )
+            #end if
+            #if str( $snp_profiles ) != 'None'
               --snp_profiles '${snp_profiles}'
             #end if
-            #if $struct_profiles
+            #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
+              #set $struct_profiles = str( $struct_profiles_source.struct_profiles.fields.path )
+            #else:
+              #set $struct_profiles = str( $struct_profiles_source.struct_profiles )
+            #end if
+            #if str( $struct_profiles ) != 'None'
               --struct_profiles '${struct_profiles}'
             #end if
             --outprefix output
@@ -44,14 +54,46 @@
                 <param format="fastq,fastq.gz" name="reverse_input" type="data" label="Reverse strand" help="FASTQ dataset"/>
             </when>
         </conditional>
+        <conditional name="snp_profiles_source">
+            <param name="snp_profiles_source_selector" type="select" label="Select a SNP profile from your history or use one from a tool data table?"
+                   help="Screening files must be stored in the 'tetyper_snp_profiles' tool data table">
+                <option value="tool_data_table">From tool data table</option>
+                <option value="history" selected="true">From history</option>
+            </param>
+            <when value="tool_data_table">
+                <param name="snp_profiles" type="select" format="tabular">
+	            <options from_data_table="tetyper_snp_profiles">
+	                <validator type="no_options" message="No TETyper SNP profiles are available" />
+                    </options>
+	        </param>
+            </when>
+            <when value="history">
+                <param name="snp_profiles" type="data" format="tabular" label="SNP Profile" help="A three-column tabular file with SNP profile definitions" optional="true"/>
+            </when>
+        </conditional>
+        <conditional name="struct_profiles_source">
+            <param name="struct_profiles_source_selector" type="select" label="Select a structural variant profile from your history or use one from a tool data table?"
+                   help="Files must be stored in the 'tetyper_struct_profiles' tool data table">
+                <option value="tool_data_table">From tool data table</option>
+                <option value="history" selected="true">From history</option>
+            </param>
+            <when value="tool_data_table">
+                <param name="struct_profiles" type="select" format="tabular">
+	            <options from_data_table="tetyper_struct_profiles">
+	                <validator type="no_options" message="No TETyper structural variant profiles are available" />
+                    </options>
+	        </param>
+            </when>
+            <when value="history">
+                <param name="struct_profiles" type="data" format="tabular" label="Structural Variant Profile" help="A two-column tabular file with structural variant profile definitions" optional="true"/>
+            </when>
+        </conditional>
         <param name="reference" type="data" format="fasta" label="Transposable Element Reference"/>
         <param name="flank_length" type="integer" min="4" value="5" max="16" label="Flank Length" help="Length of flanking region to extract."/>
         <param name="min_reads" type="integer" min="1" value="10" max="100" label="Minimum Reads" help="Minimum read number for including a specific flanking sequence."/>
         <param name="min_each_strand" type="integer" min="1" value="1" max="100" label="Minimum Reads (each strand)" help="Minimum read number for each strand for including a specific flanking sequence."/>
         <param name="min_mapped_len" type="integer" min="8" value="30" max="100" label="Minimum Mapped Length" help="Minimum length of mapping for a read to be used in determining flanking sequences. Higher values are more robust to spurious mapping. Lower values will recover more reads."/>
         <param name="min_qual" type="integer" min="0" value="10" max="100" label="Minimum quality" help="Minimum quality value across extracted flanking sequence." />
-        <param name="snp_profiles" type="data" format="text" label="SNP Profiles" optional="true" />
-        <param name="struct_profiles" type="data" format="text" label="Structural Variant Profiles" optional="true" />
         <param name="include_log" type="boolean" label="Include log in output"/>
     </inputs>
     <outputs>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -55,8 +55,7 @@
             </when>
         </conditional>
         <conditional name="snp_profiles_source">
-            <param name="snp_profiles_source_selector" type="select" label="Select a SNP profile from your history or use one from a tool data table?"
-                   help="Screening files must be stored in the 'tetyper_snp_profiles' tool data table">
+            <param name="snp_profiles_source_selector" type="select" label="Select a SNP profile from your history or use one from a tool data table?">
                 <option value="tool_data_table">From tool data table</option>
                 <option value="history" selected="true">From history</option>
             </param>
@@ -72,8 +71,7 @@
             </when>
         </conditional>
         <conditional name="struct_profiles_source">
-            <param name="struct_profiles_source_selector" type="select" label="Select a structural variant profile from your history or use one from a tool data table?"
-                   help="Files must be stored in the 'tetyper_struct_profiles' tool data table">
+            <param name="struct_profiles_source_selector" type="select" label="Select a structural variant profile from your history or use one from a tool data table?">
                 <option value="tool_data_table">From tool data table</option>
                 <option value="history" selected="true">From history</option>
             </param>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -21,19 +21,15 @@
             --min_each_strand '${min_each_strand}'
             --min_mapped_len '${min_mapped_len}'
             --min_qual '${min_qual}'
-            #if $snp_profiles_source.snp_profiles_source_selector:
-                #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
-                    --snp_profiles '$snp_profiles_source.snp_profiles.fields.path'
-                #elif str( $snp_profiles_source.snp_profiles_source_selector ) == 'history':
-                    --snp_profiles '$snp_profiles_source.snp_profiles'
-                #end if
+            #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
+                --snp_profiles '$snp_profiles_source.snp_profiles.fields.path'
+            #elif str( $snp_profiles_source.snp_profiles_source_selector ) == 'history':
+                --snp_profiles '$snp_profiles_source.snp_profiles'
             #end if
-            #if $struct_profiles_source.struct_profiles_source_selector:
-                #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
-                    --struct_profiles '$struct_profiles_source.struct_profiles.fields.path'
-                #elif str( $struct_profiles_source.struct_profiles_source_selector ) == 'history':
-                    --struct_profiles '$struct_profiles_source.struct_profiles'
-                #end if
+            #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
+                --struct_profiles '$struct_profiles_source.struct_profiles.fields.path'
+            #elif str( $struct_profiles_source.struct_profiles_source_selector ) == 'history':
+                --struct_profiles '$struct_profiles_source.struct_profiles'
             #end if
             --outprefix output
         ]]>
@@ -53,11 +49,13 @@
             </when>
         </conditional>
         <conditional name="snp_profiles_source">
-            <param name="snp_profiles_source_selector" type="select" optional="true"
+            <param name="snp_profiles_source_selector" type="select"
                    label="Select a SNP profile from your history or use one from a tool data table?">
-                <option value="tool_data_table">From tool data table</option>
-                <option value="history">From history</option>
+                <option value="No" selected="true">No SNP profile</option>
+                <option value="tool_data_table">SNP profile from tool data table</option>
+                <option value="history">SNP profile from history</option>
             </param>
+            <when value="No"/>
             <when value="tool_data_table">
                 <param name="snp_profiles" type="select" format="tabular" label="SNP Profile">
                     <options from_data_table="tetyper_snp_profiles">
@@ -71,11 +69,13 @@
             </when>
         </conditional>
         <conditional name="struct_profiles_source">
-            <param name="struct_profiles_source_selector" type="select" optional="true"
+            <param name="struct_profiles_source_selector" type="select"
                    label="Select a structural variant profile from your history or use one from a tool data table?">
-                <option value="tool_data_table">From tool data table</option>
-                <option value="history" selected="true">From history</option>
+                <option value="No" selected="true">No structural variant profile</option>
+                <option value="tool_data_table">Structural variant profile from tool data table</option>
+                <option value="history" selected="true">Structural variant profile from history</option>
             </param>
+            <when value="No"/>
             <when value="tool_data_table">
                 <param name="struct_profiles" type="select" format="tabular"
                        label="Structural Variant Profile">

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -55,35 +55,41 @@
             </when>
         </conditional>
         <conditional name="snp_profiles_source">
-            <param name="snp_profiles_source_selector" type="select" label="Select a SNP profile from your history or use one from a tool data table?">
+            <param name="snp_profiles_source_selector" type="select" optional="true"
+                   label="Select a SNP profile from your history or use one from a tool data table?">
                 <option value="tool_data_table">From tool data table</option>
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="snp_profiles" type="select" format="tabular" label="SNP Profile" optional="true">
+                <param name="snp_profiles" type="select" format="tabular" label="SNP Profile">
                     <options from_data_table="tetyper_snp_profiles">
                         <validator type="no_options" message="No TETyper SNP profiles are available" />
                     </options>
                 </param>
             </when>
             <when value="history">
-                <param name="snp_profiles" type="data" format="tabular" label="SNP Profile" help="A three-column tabular file with SNP profile definitions" optional="true"/>
+                <param name="snp_profiles" type="data" format="tabular" label="SNP Profile"
+                       help="A three-column tabular file with SNP profile definitions"/>
             </when>
         </conditional>
         <conditional name="struct_profiles_source">
-            <param name="struct_profiles_source_selector" type="select" label="Select a structural variant profile from your history or use one from a tool data table?">
+            <param name="struct_profiles_source_selector" type="select" optional="true"
+                   label="Select a structural variant profile from your history or use one from a tool data table?">
                 <option value="tool_data_table">From tool data table</option>
                 <option value="history" selected="true">From history</option>
             </param>
             <when value="tool_data_table">
-                <param name="struct_profiles" type="select" format="tabular" label="Structural Variant Profile" optional="true">
+                <param name="struct_profiles" type="select" format="tabular"
+                       label="Structural Variant Profile">
                     <options from_data_table="tetyper_struct_profiles">
                         <validator type="no_options" message="No TETyper structural variant profiles are available" />
                     </options>
                 </param>
             </when>
             <when value="history">
-                <param name="struct_profiles" type="data" format="tabular" label="Structural Variant Profile" help="A two-column tabular file with structural variant profile definitions" optional="true"/>
+                <param name="struct_profiles" type="data" format="tabular"
+                       label="Structural Variant Profile"
+                       help="A two-column tabular file with structural variant profile definitions"/>
             </when>
         </conditional>
         <param name="reference" type="data" format="fasta" label="Transposable Element Reference"/>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -58,7 +58,7 @@
             <param name="snp_profiles_source_selector" type="select" optional="true"
                    label="Select a SNP profile from your history or use one from a tool data table?">
                 <option value="tool_data_table">From tool data table</option>
-                <option value="history" selected="true">From history</option>
+                <option value="history">From history</option>
             </param>
             <when value="tool_data_table">
                 <param name="snp_profiles" type="select" format="tabular" label="SNP Profile">

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -130,7 +130,7 @@
             </conditional>
             <output name="summary" file="output_summary_2.txt" />
         </test>
-                <test>
+        <test>
             <param name="reference" value="Tn4401b-1.fasta" />
             <conditional name="collection_paired">
                 <param name="selector" value="paired" />

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -132,6 +132,23 @@
             </conditional>
             <output name="summary" file="output_summary_2.txt" />
         </test>
+                <test>
+            <param name="reference" value="Tn4401b-1.fasta" />
+            <conditional name="collection_paired">
+                <param name="selector" value="paired" />
+                <param name="forward_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_1.fastq" />
+                <param name="reverse_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_2.fastq" />
+            </conditional>
+            <conditional name="snp_profiles_source">
+                <param name="snp_profiles_source_selector" value="tool_data_table" />
+                <param name="snp_profiles" value="Tn4401b_snp_profiles" />
+            </conditional>
+            <conditional name="struct_profiles_source">
+                <param name="struct_profiles_source_selector" value="tool_data_table" />
+                <param name="struct_profiles" value="Tn4401b_struct_profiles" />
+            </conditional>
+            <output name="summary" file="output_summary_2.txt" />
+        </test>
     </tests>
     <help>
       <![CDATA[

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -21,21 +21,19 @@
             --min_each_strand '${min_each_strand}'
             --min_mapped_len '${min_mapped_len}'
             --min_qual '${min_qual}'
-            #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
-              #set $snp_profiles = str( $snp_profiles_source.snp_profiles.fields.path )
-            #else:
-              #set $snp_profiles = str( $snp_profiles_source.snp_profiles )
+            #if $snp_profiles_source.snp_profiles_source_selector:
+                #if str( $snp_profiles_source.snp_profiles_source_selector ) == "tool_data_table":
+                    --snp_profiles = '$snp_profiles_source.snp_profiles.fields.path'
+                #else:
+                    --snp_profiles = '$snp_profiles_source.snp_profiles'
+                #end if
             #end if
-            #if str( $snp_profiles ) != 'None'
-              --snp_profiles '${snp_profiles}'
-            #end if
-            #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
-              #set $struct_profiles = str( $struct_profiles_source.struct_profiles.fields.path )
-            #else:
-              #set $struct_profiles = str( $struct_profiles_source.struct_profiles )
-            #end if
-            #if str( $struct_profiles ) != 'None'
-              --struct_profiles '${struct_profiles}'
+            #if $struct_profiles_source.struct_profiles_source_selector:
+                #if str( $struct_profiles_source.struct_profiles_source_selector ) == "tool_data_table":
+                    --struct_profiles = '$struct_profiles_source.struct_profiles.fields.path'
+                #else:
+                    --struct_profiles = '$struct_profiles_source.struct_profiles'
+                #end if
             #end if
             --outprefix output
         ]]>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -122,10 +122,14 @@
                 <param name="forward_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_1.fastq" />
                 <param name="reverse_input" value="ERR1911133_Tn4401b-1_mapped_subsampled_2.fastq" />
             </conditional>
-            <param name="snp_profiles_source.snp_profiles_source_selector" value="history" />
-            <param name="snp_profiles_source.snp_profiles" value="Tn4401b_snp_profiles.txt" />
-            <param name="struct_profiles_source.struct_profiles_source_selector" value="history" />
-            <param name="struct_profiles_source.struct_profiles" value="Tn4401b_struct_profiles.txt" />
+            <conditional name="snp_profiles_source">
+                <param name="snp_profiles_source_selector" value="history" />
+                <param name="snp_profiles" value="Tn4401b_snp_profiles.txt" />
+            </conditional>
+            <conditional name="struct_profiles_source">
+                <param name="struct_profiles_source_selector" value="history" />
+                <param name="struct_profiles" value="Tn4401b_struct_profiles.txt" />
+            </conditional>
             <output name="summary" file="output_summary_2.txt" />
         </test>
     </tests>

--- a/tools/tetyper/tetyper.xml
+++ b/tools/tetyper/tetyper.xml
@@ -62,10 +62,10 @@
             </param>
             <when value="tool_data_table">
                 <param name="snp_profiles" type="select" format="tabular">
-	            <options from_data_table="tetyper_snp_profiles">
-	                <validator type="no_options" message="No TETyper SNP profiles are available" />
+                    <options from_data_table="tetyper_snp_profiles">
+                        <validator type="no_options" message="No TETyper SNP profiles are available" />
                     </options>
-	        </param>
+                </param>
             </when>
             <when value="history">
                 <param name="snp_profiles" type="data" format="tabular" label="SNP Profile" help="A three-column tabular file with SNP profile definitions" optional="true"/>
@@ -79,10 +79,10 @@
             </param>
             <when value="tool_data_table">
                 <param name="struct_profiles" type="select" format="tabular">
-	            <options from_data_table="tetyper_struct_profiles">
-	                <validator type="no_options" message="No TETyper structural variant profiles are available" />
+                    <options from_data_table="tetyper_struct_profiles">
+                        <validator type="no_options" message="No TETyper structural variant profiles are available" />
                     </options>
-	        </param>
+                </param>
             </when>
             <when value="history">
                 <param name="struct_profiles" type="data" format="tabular" label="Structural Variant Profile" help="A two-column tabular file with structural variant profile definitions" optional="true"/>

--- a/tools/tetyper/tool-data/tetyper_snp_profiles.loc.sample
+++ b/tools/tetyper/tool-data/tetyper_snp_profiles.loc.sample
@@ -1,0 +1,7 @@
+# Expect three columns, tab separated, as follows:
+# - value (Galaxy records this in the Galaxy DB, must be unique, suggest using a UUID)
+# - name (Galaxy shows this in the UI)
+# - path to snp_profiles.txt file
+#
+# e.g.
+# c4269788-80f0-4ed5-9ff4-5fe30484678d<tab>SNP Profiles<tab>/path/to/tetyper/snp_profiles.txt

--- a/tools/tetyper/tool-data/tetyper_struct_profiles.loc.sample
+++ b/tools/tetyper/tool-data/tetyper_struct_profiles.loc.sample
@@ -1,0 +1,7 @@
+# Expect three columns, tab separated, as follows:
+# - value (Galaxy records this in the Galaxy DB, must be unique, suggest using a UUID)
+# - name (Galaxy shows this in the UI)
+# - path to struct_profiles.txt file
+#
+# e.g.
+# e6987a4f-c54b-490e-a32d-67e91e0c2328<tab>Structural Variant Profiles<tab>/path/to/tetyper/struct_profiles.txt

--- a/tools/tetyper/tool_data_table_conf.xml.sample
+++ b/tools/tetyper/tool_data_table_conf.xml.sample
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<tables>
+    <table name="tetyper_snp_profiles" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="tool-data/tetyper_snp_profiles.loc" />
+    </table>
+        <table name="tetyper_struct_profiles" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="tool-data/tetyper_struct_profiles.loc" />
+    </table>
+</tables>

--- a/tools/tetyper/tool_data_table_conf.xml.test
+++ b/tools/tetyper/tool_data_table_conf.xml.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<tables>
+    <table name="tetyper_snp_profiles" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/tetyper_snp_profiles.loc" />
+    </table>
+    <table name="tetyper_struct_profiles" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/tetyper_struct_profiles.loc" />
+    </table>
+</tables>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
