### PR TITLE
Fix bctools_remove_spurious_events test, run containerized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 sudo: required
 language: python
 cache: pip
+services:
+  - docker
 
 python: 2.7
 
@@ -118,7 +120,7 @@ script:
   - set -e
   - |
     if [ -s changed_tools_chunk.list ]; then
-        planemo test --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
+        planemo test --biocontainers --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
     elif [ -s changed_repositories_chunk.list ]; then
         while read -r DIR; do
             if [[ "$DIR" =~ ^data_managers.* ]]; then
@@ -126,6 +128,6 @@ script:
             else
                 TESTPATH="$DIR"
             fi
-            planemo test --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$TESTPATH"
+            planemo test --biocontainers --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$TESTPATH"
         done < changed_repositories_chunk.list
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
-  - export GALAXY_RELEASE=release_19.09
+  - export GALAXY_RELEASE=release_20.01
   # - export PLANEMO_CONDA_PREFIX="$HOME/conda"
   - unset JAVA_HOME
 

--- a/tools/bctools/rm_spurious_events.xml
+++ b/tools/bctools/rm_spurious_events.xml
@@ -1,4 +1,4 @@
-<tool id="bctools_remove_spurious_events" name="Remove spurious" version="@VERSION@+galaxy1">
+<tool id="bctools_remove_spurious_events" name="Remove spurious" version="@VERSION@+galaxy2">
     <description>crosslinking events</description>
     <macros>
         <import>macros.xml</import>
@@ -23,7 +23,7 @@
         <test>
             <param name="events" value="merged_pcr_dupes_spurious.bed"/>
             <param name="threshold" value="0.5"/>
-            <output name="events_filtered" file="merged_pcr_dupes_spurious_filtered_thresh05.bed"/>
+            <output name="events_filtered" file="merged_pcr_dupes_spurious_filtered_thresh05.bed" lines_diff="2"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/bctools/rm_spurious_events.xml
+++ b/tools/bctools/rm_spurious_events.xml
@@ -1,4 +1,4 @@
-<tool id="bctools_remove_spurious_events" name="Remove spurious" version="@VERSION@+galaxy2">
+<tool id="bctools_remove_spurious_events" name="Remove spurious" version="@VERSION@+galaxy1">
     <description>crosslinking events</description>
     <macros>
         <import>macros.xml</import>
@@ -23,7 +23,7 @@
         <test>
             <param name="events" value="merged_pcr_dupes_spurious.bed"/>
             <param name="threshold" value="0.5"/>
-            <output name="events_filtered" file="merged_pcr_dupes_spurious_filtered_thresh05.bed" lines_diff="2"/>
+            <output name="events_filtered" file="merged_pcr_dupes_spurious_filtered_thresh05.bed" sort="true"/>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
Allows for this diff:
```
--- local_file
+++ history_data
@@ -1,6 +1,6 @@
+chr1	10	20	AAAAA	100	+
 chr1	10	20	AAAAA	5	-
 chr1	10	20	AAAAA	5	-
 chr1	10	20	AAAAA	4	-
 chr1	10	20	AAAAA	3	-
-chr1	10	20	AAAAA	100	+
 chrX	20	30	TTTTT	7	+
```

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
