### PR TITLE
Fix stacks_assembleprereads

### DIFF
--- a/tools/stacks/stacks_assembleperead.xml
+++ b/tools/stacks/stacks_assembleperead.xml
@@ -1,9 +1,11 @@
-<tool id="stacks_assembleperead" name="Stacks: assemble read pairs by locus" version="@WRAPPER_VERSION@.0">
+<tool id="stacks_assembleperead" name="Stacks: assemble read pairs by locus" version="@WRAPPER_VERSION@.1">
     <description>run the STACKS sort_read_pairs.pl and exec_velvet.pl wrappers</description>
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements"/>
+    <expand macro="requirements">
+        <requirement type="package" version="4.6.0">findutils</requirement>
+    </expand>
     <expand macro="stdio"/>
     <command><![CDATA[
 

--- a/tools/stacks/stacks_assembleperead.xml
+++ b/tools/stacks/stacks_assembleperead.xml
@@ -3,16 +3,12 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements">
-        <requirement type="package" version="4.6.0">findutils</requirement>
-    </expand>
+    <expand macro="requirements" />
     <expand macro="stdio"/>
     <command><![CDATA[
 
         mkdir stacks_inputs reads stacks_outputs
-
         &&
-
         #for $input_file in $stacks_col
             #set $ext = ""
             #if not str($input_file.element_identifier).endswith('.tsv')
@@ -53,7 +49,7 @@
 
         #if $velvet.use_velvet == "yes"
             ## remove possible empty files
-            && find stacks_outputs -type f -size 0 -delete
+            && find stacks_outputs -type f -size 0 -exec rm {} \;
 
             &&
             mkdir assembled


### PR DESCRIPTION
Needs findutils, busybox find fails with
```
find: unrecognized: -delete
```


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)