### PR TITLE
Adding `findutils` requirement to JBrowse

### DIFF
--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -15,7 +15,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy6</token>
+  <token name="@WRAPPER_VERSION@">galaxy7</token>
   <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**
 

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -10,6 +10,7 @@
       <requirement type="package" version="1.9">samtools</requirement>
       <requirement type="package" version="3.13">pyyaml</requirement>
       <requirement type="package" version="0.2.6">tabix</requirement>
+      <requirement type="package" version="4.6.0">findutils</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
`jbrowse.py` uses subprocess module to call `find` with `-xtype` flag, but the `find` command in the biocontainer does not support that flag. Adding the `findutils` dependency guarantees the existence of the proper `find`, although might not be necessary in all environments (eg: works without the requirement when using Ubuntu base image, but doesn't work in the container which I believe uses CentOS base). Tested by running `planemo mull` after adding the requirement and it worked (temporary container with the added dependency at `cloudve/jbrowse:1.16.5`)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
