### PR TITLE
tb-profiler: Remove deprecated advanced params

### DIFF
--- a/tools/tb-profiler/tb_profiler_profile.xml
+++ b/tools/tb-profiler/tb_profiler_profile.xml
@@ -1,4 +1,4 @@
-<tool id="tb_profiler_profile" name="TB-Profiler Profile" version="@TOOL_VERSION@+galaxy0">
+<tool id="tb_profiler_profile" name="TB-Profiler Profile" version="@TOOL_VERSION@+galaxy1">
     <description>Infer strain types and drug resistance markers from sequences</description>
     <macros>
         <import>macros.xml</import>
@@ -41,13 +41,10 @@
 
             --threads "\${GALAXY_SLOTS:-1}"
         #if $advanced.options == 'yes'
-            '${advanced.call_whole_genome}'
-            --call_method '${advanced.call_method}'
-            --min_gene_frac '${advanced.min_gene_frac}'
             --mapper '${advanced.mapper}'
             --min_depth '${advanced.min_depth}'
-            --af '${min_allel_freq}'
-            --reporting_af '${min_allel_freq_reporting}'
+            --af '${advanced.min_allele_freq}'
+            --reporting_af '${advanced.min_allele_freq_reporting}'
         #end if
 
         #if $output_format == "pdf"
@@ -105,24 +102,14 @@
             <when value="no">
             </when>
             <when value="yes">
-                <param label="Quality required for calls to be accepted" type="select" argument="--call_method">
-                    <option value="low" selected="true">Low</option>
-                    <option value="high">High</option>
-                    <option value="optimise">Optimise</option>
-                </param>
-                <param label="Call variants on the whole genome" type="boolean" argument="--call_whole_genome" 
-                    truevalue="--call_whole_genome" falsevalue="" help="Call variants on whole genome (Useful if you need to use whole genome variants later)" />
-                <param label="Minimum coverage fraction to infer deletion" type="float" help="Used to infer a deletion if the fraction of a gene covered falls below this value." argument="--min_gene_frac" value="0.9" />
-
-                <param name="min_depth" label="Min Depth" type="integer" value="10" help="Minimum depth required to call variant. Bases with depth below this cutoff will be marked as missing (default: 10)"/>
                 <param name="mapper" label="Mapper" type="select" help="Mapping tools to use (default: bwa)">
                     <option value="bwa" selected="true">bwa</option>
                     <option value="minimap2">minimap2</option>
                     <option value="bowtie2">bowtie2</option>
                 </param>
-                <param name="min_gene_frac" label="Minimum Gene Fraction" type="float" value="0.9" help="Used to infer a deletion if the fraction of a gene covered falls below this value. Also used to see if sample is high quality to continue by checking the fraction for rpoB (where deletion should not occur). (default: 0.9)" />
-                <param name="min_allel_freq" argument="--af" type="float" value="0.1" label="Minimum allele frequency to call variants" help=" Minimum allele frequency to call variants (default: 0.1)" />
-                <param name="min_allel_freq_reporting" argument="--reporting_af" value="0.1" label="Reporting Minimum allele frequency to call variants" type="float" help=" Minimum allele frequency to call variants (default: 0.1)"/>
+                <param name="min_depth" label="Min Depth" type="integer" value="10" help="Minimum depth required to call variant. Bases with depth below this cutoff will be marked as missing (default: 10)"/>
+                <param name="min_allele_freq" argument="--af" type="float" value="0.1" label="Minimum allele frequency to call variants" help=" Minimum allele frequency to call variants (default: 0.1)" />
+                <param name="min_allele_freq_reporting" argument="--reporting_af" value="0.1" label="Reporting Minimum allele frequency to call variants" type="float" help=" Minimum allele frequency to call variants (default: 0.1)"/>
             </when>
         </conditional>
     </inputs>
@@ -162,6 +149,24 @@
             <param name="output_format" value="txt" />
             <param name="platform" value="illumina" />
             <param name="options" value="no" />
+            <output name="output_txt">
+                <assert_contents>
+                    <has_line line="Drug-resistance: Drug-resistant" />
+                    <has_line line="lineage2.2.2&#009;1.000&#009;East-Asian (Beijing)&#009;Beijing-RD105/RD207&#009;RD105;RD207" />
+                    <has_line line="Rifampicin&#009;R&#009;rpoB p.Asp435Val (1.00)" />
+                    <has_line line="763031&#009;Rv0667&#009;rpoB&#009;c.3225T>C&#009;1.000" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input_select" value="single_fastq"/>
+            <param name="fastq" ftype="fastq.gz" value="rif_resistant.fastq.gz" />
+            <param name="output_format" value="txt" />
+            <param name="platform" value="illumina" />
+            <param name="options" value="yes" />
+            <param name="call_whole_genome" value="true" />
+            <param name="min_allele_freq" value="0.25" />
+            <param name="min_allele_freq_reporting" value="0.33" />
             <output name="output_txt">
                 <assert_contents>
                     <has_line line="Drug-resistance: Drug-resistant" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Some advanced parameters (`--min_gene_frac`, `--call_method`, `--call_whole_genome`) are not supported in the current tb-profiler and have been removed.

https://github.com/jodyphelan/TBProfiler/blob/e124e43fccdeb0f822760819a0e3fea514669c92/tb-profiler#L324-L348

Fixed a typo (`allel`->`allele`) in two parameters.
