### PR TITLE
Fix mummerplot

### DIFF
--- a/tools/mummer4/delta-filter.xml
+++ b/tools/mummer4/delta-filter.xml
@@ -1,4 +1,4 @@
-<tool id="mummer_delta_filter" name="Delta-Filter" version="@MUMMER_VERSION@">
+<tool id="mummer_delta_filter" name="Delta-Filter" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Filters alignment (delta) file from nucmer</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/mummer4/dnadiff.xml
+++ b/tools/mummer4/dnadiff.xml
@@ -1,4 +1,4 @@
-<tool id="mummer_dnadiff" name="DNAdiff" version="@MUMMER_VERSION@">
+<tool id="mummer_dnadiff" name="DNAdiff" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Evaluate similarities/differences between two sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/mummer4/macros.xml
+++ b/tools/mummer4/macros.xml
@@ -1,4 +1,5 @@
 <macros>
+    <token name="@MUMMER_GNUPLOT_MANUAL@"><![CDATA[&& gnuplot < out.gp]]></token>
     <xml name="citation">
         <citations>
             <citation type="bibtex">
@@ -12,7 +13,11 @@
             }</citation>
         </citations>
     </xml>
+    <xml name="gnuplot_requirement">
+        <requirement type="package" version="5.2.7">gnuplot</requirement>
+    </xml>
     <token name="@MUMMER_VERSION@">4.0.0beta2</token>
+    <token name="@WRAPPER_VERSION@">+galaxy0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@MUMMER_VERSION@">mummer4</requirement>

--- a/tools/mummer4/mummer.xml
+++ b/tools/mummer4/mummer.xml
@@ -1,10 +1,10 @@
-<tool id="mummer_mummer" name="Mummer" version="@MUMMER_VERSION@">
+<tool id="mummer_mummer" name="Mummer" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Align two or more sequences</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.2.3">gnuplot</requirement>
+        <expand macro="gnuplot_requirement"/>
     </expand>
     <command detect_errors="exit_code">
         <![CDATA[
@@ -47,6 +47,7 @@
                         -y [$mumplot.range.min_y:$mumplot.range.max_y]
                     #end if
                     '$output'
+                    @MUMMER_GNUPLOT_MANUAL@
             #end if
         ]]>
     </command>

--- a/tools/mummer4/mummerplot.xml
+++ b/tools/mummer4/mummerplot.xml
@@ -1,10 +1,10 @@
-<tool id="mummer_mummerplot" name="Mummerplot" version="@MUMMER_VERSION@">
+<tool id="mummer_mummerplot" name="Mummerplot" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Generate 2-D dotplot of aligned sequences</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.2.3">gnuplot</requirement>
+        <expand macro="gnuplot_requirement"/>
     </expand>
     <command detect_errors="exit_code">
         <![CDATA[
@@ -34,6 +34,7 @@
                 -y [$range.min_y:$range.max_y]
             #end if
             '$delta'
+            @MUMMER_GNUPLOT_MANUAL@
         ]]>
     </command>
     <inputs>

--- a/tools/mummer4/nucmer.xml
+++ b/tools/mummer4/nucmer.xml
@@ -1,10 +1,10 @@
-<tool id="mummer_nucmer" name="Nucmer" version="@MUMMER_VERSION@">
+<tool id="mummer_nucmer" name="Nucmer" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Align two or more sequences</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.2.3">gnuplot</requirement>
+        <expand macro="gnuplot_requirement"/>
     </expand>
     <command detect_errors="exit_code">
         <![CDATA[
@@ -56,8 +56,9 @@
                         -y [$mumplot.range.min_y:$mumplot.range.max_y]
                     #end if
                     'out.delta'
+                    @MUMMER_GNUPLOT_MANUAL@
             #end if
-        ]]>   	
+        ]]>
     </command> 
     <inputs>
         <param name="reference_sequence" type="data" format="fasta" label="Reference Sequence" help="FastA or multi-FastA" />

--- a/tools/mummer4/show-coords.xml
+++ b/tools/mummer4/show-coords.xml
@@ -1,4 +1,4 @@
-<tool id="mummer_show_coords" name="Show-Coords" version="@MUMMER_VERSION@">
+<tool id="mummer_show_coords" name="Show-Coords" version="@MUMMER_VERSION@@WRAPPER_VERSION@">
     <description>Parse delta file and report coordinates and other information</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Bump gnuplot to 5.2.7 (5.2.3 has missing libxrender), work around mummer4 bug

Also needs a new extended base image for mummer+gnuplot. (conda-forge doesn't annotate extended-base, so we can't do this automatically)

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
