### PR TITLE
Bump up lines_diff for jbrowse test 4

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -880,7 +880,7 @@ $trackxml &&
       </repeat>
 
       <param name="uglyTestingHack" value="enabled" />
-      <output name="output" file="gff3/test.xml" lines_diff="240" />
+      <output name="output" file="gff3/test.xml" lines_diff="260" />
     </test>
     <test>
         <param name="reference_genome|genome_type_select" value="history"/>


### PR DESCRIPTION
history and dataset ids don't match up when testing more than one repo
againt a test database.


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)