### PR TITLE
iqtree: handle '+' character in custom models

### DIFF
--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -632,6 +632,34 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
+        <test>
+            <param name='s' value='example.phy' />
+            <output name='iqtree'>
+                <assert_contents>
+                    <has_text_matching expression=".*Human.*Whale.*" />
+                </assert_contents>
+            </output>
+            <output name='treefile'>
+                <assert_contents>
+                    <has_text_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name='s' value='example.phy' />
+            <param name='opt_custommodel' value='true' />
+            <param name='m' value='GTR+G' />
+            <output name='iqtree'>
+                <assert_contents>
+                    <has_text_matching expression=".*Human.*Whale.*" />
+                </assert_contents>
+            </output>
+            <output name='treefile'>
+                <assert_contents>
+                    <has_text_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 IQ-TREE

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -432,7 +432,6 @@ IQ-TREE also works for codon, binary and morphogical data.
                 <param argument="-allnni" type="boolean" truevalue="-allnni" falsevalue="" checked="false" label="Turn on more thorough and slower NNI search"/>
                 <param argument="-djc" type="boolean" truevalue="-djc" falsevalue="" checked="false" label="Avoid computing ML pairwise distances and BIONJ tree."/>
                 <param argument="-g" type="data" format="txt" optional="true" label="Specify a topological constraint tree file in NEWICK format" help="The constraint tree can be a multifurcating tree and need not to include all taxa."/>
-                <param argument="-fast" type="boolean" truevalue="-fast" falsevalue="" checked="false" label="Fast search" help="Fast search to resemble FastTree"/>
             </section>
             <section name="single_branch" expanded="False" title="Single branch tests">
                 <param argument="-alrt" type="integer" optional="true" label="Specify number of replicates (&gt;=1000) to perform SH-like approximate likelihood ratio test (SH-aLRT) (Guindon et al., 2010)" help="If number of replicates is set to 0 (-alrt 0), then the parametric aLRT test (Anisimova and Gascuel 2006) is performed, instead of SH-aLRT."/>
@@ -638,20 +637,6 @@ IQ-TREE also works for codon, binary and morphogical data.
             <param name='s' value='example.phy' />
             <param name='opt_custommodel' value='true' />
             <param name='m' value='GTR+G{0.9}' />
-            <output name='iqtree'>
-                <assert_contents>
-                    <has_text_matching expression=".*Human.*Whale.*" />
-                </assert_contents>
-            </output>
-            <output name='treefile'>
-                <assert_contents>
-                    <has_text_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
-                </assert_contents>
-            </output>
-        </test>
-        <test>
-            <param name='s' value='example.phy' />
-            <param name='fast' value='true' />
             <output name='iqtree'>
                 <assert_contents>
                     <has_text_matching expression=".*Human.*Whale.*" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -189,6 +189,8 @@ $tree_parameters.tree_search.djc
     -g '$tree_parameters.tree_search.g'
 #end if
 
+$tree_parameters.tree_search.fast
+
 #if str($tree_parameters.single_branch.alrt) != ''
     -alrt '$tree_parameters.single_branch.alrt'
 #end if
@@ -430,6 +432,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 <param argument="-allnni" type="boolean" truevalue="-allnni" falsevalue="" checked="false" label="Turn on more thorough and slower NNI search"/>
                 <param argument="-djc" type="boolean" truevalue="-djc" falsevalue="" checked="false" label="Avoid computing ML pairwise distances and BIONJ tree."/>
                 <param argument="-g" type="data" format="txt" optional="true" label="Specify a topological constraint tree file in NEWICK format" help="The constraint tree can be a multifurcating tree and need not to include all taxa."/>
+                <param argument="-fast" type="boolean" truevalue="-fast" falsevalue="" checked="false" label="Fast search" help="Fast search to resemble FastTree"/>
             </section>
             <section name="single_branch" expanded="False" title="Single branch tests">
                 <param argument="-alrt" type="integer" optional="true" label="Specify number of replicates (&gt;=1000) to perform SH-like approximate likelihood ratio test (SH-aLRT) (Guindon et al., 2010)" help="If number of replicates is set to 0 (-alrt 0), then the parametric aLRT test (Anisimova and Gascuel 2006) is performed, instead of SH-aLRT."/>
@@ -635,6 +638,20 @@ IQ-TREE also works for codon, binary and morphogical data.
             <param name='s' value='example.phy' />
             <param name='opt_custommodel' value='true' />
             <param name='m' value='GTR+G{0.9}' />
+            <output name='iqtree'>
+                <assert_contents>
+                    <has_text_matching expression=".*Human.*Whale.*" />
+                </assert_contents>
+            </output>
+            <output name='treefile'>
+                <assert_contents>
+                    <has_text_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name='s' value='example.phy' />
+            <param name='fast' value='true' />
             <output name='iqtree'>
                 <assert_contents>
                     <has_text_matching expression=".*Human.*Whale.*" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -189,8 +189,6 @@ $tree_parameters.tree_search.djc
     -g '$tree_parameters.tree_search.g'
 #end if
 
-$tree_parameters.tree_search.fast
-
 #if str($tree_parameters.single_branch.alrt) != ''
     -alrt '$tree_parameters.single_branch.alrt'
 #end if

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -1,4 +1,4 @@
-<tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@.2" >
+<tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@.3" >
     <description>Phylogenomic / evolutionary tree construction from multiple sequences</description>
     <macros>
         <import>iqtree_macros.xml</import>
@@ -304,7 +304,13 @@ Note that -st CODON is always necessary when using codon models and you also nee
                     <when value="true">
                         <param argument="-m" type="text" label="Model">
                             <sanitizer>
-                                <valid initial="string.ascii_uppercase,+" />
+                                <valid initial="string.ascii_uppercase,string.digits">
+                                    <add value="+" />
+                                    <add value="*" />
+                                    <add value="{" />
+                                    <add value="}" />
+                                    <add value="." />
+                                </valid>
                             </sanitizer>
                         </param>
                     </when>
@@ -634,21 +640,8 @@ IQ-TREE also works for codon, binary and morphogical data.
         </test>
         <test>
             <param name='s' value='example.phy' />
-            <output name='iqtree'>
-                <assert_contents>
-                    <has_text_matching expression=".*Human.*Whale.*" />
-                </assert_contents>
-            </output>
-            <output name='treefile'>
-                <assert_contents>
-                    <has_text_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
-                </assert_contents>
-            </output>
-        </test>
-        <test>
-            <param name='s' value='example.phy' />
             <param name='opt_custommodel' value='true' />
-            <param name='m' value='GTR+G' />
+            <param name='m' value='GTR+G{0.9}' />
             <output name='iqtree'>
                 <assert_contents>
                     <has_text_matching expression=".*Human.*Whale.*" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -303,15 +303,8 @@ Note that -st CODON is always necessary when using codon models and you also nee
                     <param name="opt_custommodel" type="boolean" checked="false" label="Use Custom Model" help="See http://www.iqtree.org/doc/Substitution-Models"/>
                     <when value="true">
                         <param argument="-m" type="text" label="Model">
-                            <sanitizer>
-                                <valid initial="string.ascii_uppercase,string.digits">
-                                    <add value="+" />
-                                    <add value="*" />
-                                    <add value="{" />
-                                    <add value="}" />
-                                    <add value="." />
-                                </valid>
-                            </sanitizer>
+                            <expand macro="sanitize_query"
+                                    validinitial="string.ascii_uppercase,string.digits,string.punctuation" />
                         </param>
                     </when>
                     <when value="false">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Fixes #2834 