### PR TITLE
Adding scHiCExplorer wrapper

### DIFF
--- a/tools/schicexplorer/scHicCorrectMatrices.xml
+++ b/tools/schicexplorer/scHicCorrectMatrices.xml
@@ -1,0 +1,200 @@
+<tool id="schicexplorer_schiccorrectmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+    <description>correct with KR algorithm single-cell Hi-C interaction matrices</description>
+    <macros>
+        <token name="@BINARY@">scHicCorrectMatrices</token>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements" />
+    <command detect_errors="exit_code"><![CDATA[
+        @BINARY@
+
+        --matrix '$matrix_mcooler'
+       
+
+        --outFileName corrected.mcool
+
+        --threads @THREADS@
+
+
+
+    ]]></command>
+    <inputs>
+        <expand macro="matrix_mcooler_macro"/>
+    </inputs>
+    <outputs>
+        <data name="outFileName" from_work_dir="corrected.mcool" format="mcool" label="${tool.name} on ${on_string}: KR corrected matrix"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name='matrix_mcooler' value='test_matrix.mcool' />
+            <output name="outFileName" ftype="mcool">
+                <assert_contents>
+                    <has_h5_keys keys='Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/chrom, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/end, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/start, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms/length, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms/name, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/indexes, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/indexes/bin1_offset, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/indexes/chrom_offset, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/pixels, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/pixels/bin1_id, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/pixels/bin2_id, 
+                    Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/pixels/count, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz, 
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/bins, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/bins/chrom,
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/bins/end, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/bins/start, 
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/chroms, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/chroms/length, 
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/chroms/name, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/indexes, 
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/indexes/bin1_offset, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/indexes/chrom_offset,
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/pixels, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/pixels/bin1_id,
+                    Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/pixels/bin2_id, Diploid_1_CGTACTAG_ACTGCATA_R1fastqgz/pixels/count, 
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/bins, 
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/bins/chrom, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/bins/end,
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/bins/start, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/chroms, 
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/chroms/length, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/chroms/name,
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/indexes, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/indexes/bin1_offset,
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/indexes/chrom_offset, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/pixels, 
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/pixels/bin1_id, Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/pixels/bin2_id, 
+                    Diploid_1_CGTACTAG_CGTCTAAT_R1fastqgz/pixels/count, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz, 
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/bins, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/bins/chrom, 
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/bins/end, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/bins/start, 
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/chroms, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/chroms/length,
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/chroms/name, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/indexes, 
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/indexes/bin1_offset, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/pixels, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/pixels/bin1_id,
+                    Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/pixels/bin2_id, Diploid_1_CGTACTAG_CTAAGCCT_R1fastqgz/pixels/count,
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/bins, 
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/bins/chrom, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/bins/end,
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/bins/start, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/chroms,
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/chroms/length, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/chroms/name,
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/indexes, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/indexes/bin1_offset, 
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/indexes/chrom_offset, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/pixels, 
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/pixels/bin1_id, Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/pixels/bin2_id,
+                    Diploid_1_CGTACTAG_CTCTCTAT_R1fastqgz/pixels/count, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz, 
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/bins, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/bins/chrom,
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/bins/end, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/bins/start,
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/chroms, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/chroms/length,
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/chroms/name, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/indexes,
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/indexes/bin1_offset, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/pixels, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/pixels/bin1_id, 
+                    Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/pixels/bin2_id, Diploid_1_CGTACTAG_GTAAGGAG_R1fastqgz/pixels/count, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/bins, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/bins/chrom, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/bins/end, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/bins/start, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/chroms, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/chroms/length, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/chroms/name, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/indexes, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/indexes/bin1_offset, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/pixels, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/pixels/bin1_id, 
+                    Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/pixels/bin2_id, Diploid_1_CGTACTAG_TATCCTCT_R1fastqgz/pixels/count, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/bins, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/bins/chrom, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/bins/end, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/bins/start, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/chroms, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/chroms/length, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/chroms/name, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/indexes, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/indexes/bin1_offset, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/indexes/chrom_offset,
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/pixels, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/pixels/bin1_id, 
+                    Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/pixels/bin2_id, Diploid_1_CGTACTAG_TCTCTCCG_R1fastqgz/pixels/count, 
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/bins, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/bins/chrom, 
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/bins/end, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/bins/start,
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/chroms, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/chroms/length, 
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/chroms/name, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/indexes, 
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/indexes/bin1_offset, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/indexes/chrom_offset,
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/pixels, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/pixels/bin1_id, 
+                    Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/pixels/bin2_id, Diploid_1_TAAGGCGA_AAGGAGTA_R1fastqgz/pixels/count, 
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/bins, 
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/bins/chrom, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/bins/end, 
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/bins/start, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/chroms, 
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/chroms/length, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/chroms/name,
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/indexes, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/indexes/bin1_offset,
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/indexes/chrom_offset, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/pixels, 
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/pixels/bin1_id, Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/pixels/bin2_id,
+                    Diploid_1_TAAGGCGA_CGTCTAAT_R1fastqgz/pixels/count, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/bins, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/bins/chrom, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/bins/end, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/bins/start, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/chroms, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/chroms/length, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/chroms/name, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/indexes,
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/indexes/bin1_offset, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/pixels, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/pixels/bin1_id, 
+                    Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/pixels/bin2_id, Diploid_1_TAAGGCGA_CTAAGCCT_R1fastqgz/pixels/count,
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/bins, 
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/bins/chrom, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/bins/end, 
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/bins/start, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/chroms, 
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/chroms/length, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/chroms/name,
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/indexes, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/indexes/bin1_offset,
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/indexes/chrom_offset, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/pixels,
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/pixels/bin1_id, Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/pixels/bin2_id,
+                    Diploid_2_AAGAGGCA_AAGGAGTA_R1fastqgz/pixels/count, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz, 
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/bins, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/bins/chrom,
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/bins/end, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/bins/start,
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/chroms, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/chroms/length,
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/chroms/name, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/indexes, 
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/indexes/bin1_offset, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/pixels, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/pixels/bin1_id, 
+                    Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/pixels/bin2_id, Diploid_2_AAGAGGCA_ACTGCATA_R1fastqgz/pixels/count,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/bins, 
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/bins/chrom, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/bins/end,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/bins/start, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/chroms,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/chroms/length, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/chroms/name,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/indexes, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/indexes/bin1_offset,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/indexes/chrom_offset, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/pixels, 
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/pixels/bin1_id, Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/pixels/bin2_id,
+                    Diploid_2_AAGAGGCA_CGTCTAAT_R1fastqgz/pixels/count, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz, 
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/bins, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/bins/chrom, 
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/bins/end, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/bins/start, 
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/chroms, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/chroms/length, 
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/chroms/name, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/indexes,
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/indexes/bin1_offset, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/indexes/chrom_offset,
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/pixels, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/pixels/bin1_id,
+                    Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/pixels/bin2_id, Diploid_2_AAGAGGCA_CTAAGCCT_R1fastqgz/pixels/count, 
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/bins,
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/bins/chrom, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/bins/end, 
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/bins/start, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/chroms,
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/chroms/length, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/chroms/name, 
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/indexes, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/indexes/bin1_offset,
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/indexes/chrom_offset, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/pixels,
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/pixels/bin1_id, Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/pixels/bin2_id,
+                    Diploid_2_AAGAGGCA_CTCTCTAT_R1fastqgz/pixels/count, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz,
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/bins, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/bins/chrom,
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/bins/end, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/bins/start, 
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/chroms, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/chroms/length,
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/chroms/name, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/indexes, 
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/indexes/bin1_offset, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/indexes/chrom_offset, 
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/pixels, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/pixels/bin1_id,
+                    Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/pixels/bin2_id, Diploid_2_AAGAGGCA_GTAAGGAG_R1fastqgz/pixels/count,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/bins,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/bins/chrom, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/bins/end,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/bins/start, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/chroms, 
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/chroms/length, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/chroms/name,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/indexes, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/indexes/bin1_offset, 
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/indexes/chrom_offset, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/pixels,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/pixels/bin1_id, Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/pixels/bin2_id,
+                    Diploid_2_AAGAGGCA_TATCCTCT_R1fastqgz/pixels/count, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/bins, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/bins/chrom, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/bins/end, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/bins/start, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/chroms, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/chroms/length, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/chroms/name, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/indexes, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/indexes/bin1_offset, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/indexes/chrom_offset,
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/pixels, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/pixels/bin1_id, 
+                    Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/pixels/bin2_id, Diploid_2_AAGAGGCA_TCTCTCCG_R1fastqgz/pixels/count, 
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/bins, 
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/bins/chrom, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/bins/end,
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/bins/start, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/chroms, 
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/chroms/length, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/chroms/name,
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes/bin1_offset,
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes/chrom_offset, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels, 
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/bin1_id, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/bin2_id, 
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/count'/>
+                </assert_contents>
+            </output>
+        </test>
+       
+    </tests>
+    <help><![CDATA[
+
+Correct all matrices
+====================
+
+scHicCorrectmatrices is a tool to correct with HiCExplorer's KR algorithm all Hi-C matrices stored in the mcool file.
+
+For more information about scHiCExplorer please consider our documentation on readthedocs.io_
+
+.. _readthedocs.io: http://schicexplorer.readthedocs.io/
+]]></help>
+    
+    <expand macro="citations" />
+
+</tool>

--- a/tools/schicexplorer/scHicCorrectMatrices.xml
+++ b/tools/schicexplorer/scHicCorrectMatrices.xml
@@ -7,16 +7,9 @@
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
         @BINARY@
-
         --matrix '$matrix_mcooler'
-       
-
         --outFileName corrected.mcool
-
         --threads @THREADS@
-
-
-
     ]]></command>
     <inputs>
         <expand macro="matrix_mcooler_macro"/>
@@ -181,7 +174,6 @@
                 </assert_contents>
             </output>
         </test>
-       
     </tests>
     <help><![CDATA[
 
@@ -194,7 +186,5 @@ For more information about scHiCExplorer please consider our documentation on re
 
 .. _readthedocs.io: http://schicexplorer.readthedocs.io/
 ]]></help>
-    
     <expand macro="citations" />
-
 </tool>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

@bgruening This adds the missing scHicCorrectMatrices wrapper. Please do review+merge and installation until the paper hand-in date at latest. Thanks!