### PR TITLE
Add cronjob that tests entire tools-iuc repo every monday morning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,239 @@
+name: Run Galaxy Tool Linting and Tests
+on:
+  schedule:
+    # Run at midnight every monday
+    - cron: '0 * * * 1'
+env:
+  GALAXY_RELEASE: release_20.01
+jobs:
+  setup:
+    name: Cache planemo setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64' # (x64 or x86)
+    - name: setup planemo
+      run: 'git clone --recursive --depth 1 https://github.com/galaxyproject/planemo && python -m pip install --pre planemo/ && rm -rf planemo'
+    - name: fake a planemo run to update cache
+      run: 'touch tool.xml && PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_branch $GALAXY_RELEASE'
+    - name: Cache .cache/pip
+      uses: actions/cache@v1
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_${{ matrix.python-version }}_${{ env.GALAXY_RELEASE }}
+  test:
+    name: Lint & test tools
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39]
+        python-version: [3.7]
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+    # checkout the repository to master
+    # and use it as the current working directory
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64' # (x64 or x86)
+    - name: Cache .cache/pip
+      uses: actions/cache@v1
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_${{ matrix.python-version }}_${{ env.GALAXY_RELEASE }}
+    - name: setup planemo
+      run: 'git clone --recursive --depth 1 https://github.com/galaxyproject/planemo && python -m pip install --pre planemo/ && rm -rf planemo'
+    - name: planemo ci_find_tools
+      run: 'planemo ci_find_repos --chunk_count 40 --chunk ${{ matrix.chunk  }} --exclude test_repositories --exclude packages --exclude deprecated --exclude_from .tt_skip --exclude_from .tt_biocontainer_skip --output tool.list'
+    - name: set tool list
+      id: tools
+      run: echo "::set-output name=tool_list::$(tr '\n' ' ' < tool.list)"
+    - name: show repo list
+      run: 'cat tool.list'
+    - name: planemo test tools biocontainers
+      run: |
+           while read -r DIR; do
+               if [[ "$DIR" =~ ^data_managers.* ]]; then
+                   TESTPATH=$(planemo ci_find_tools "$DIR")
+               else
+                   TESTPATH="$DIR"
+               fi
+               PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy --no_conda_auto_init --galaxy_branch $GALAXY_RELEASE --biocontainers --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$DIR"/tool_test_output.json "$TESTPATH" || true
+               docker system prune --all --force --volumes || true
+           done < tool.list
+    - name: Merge tool_test_output.json files
+      run: |
+        find . -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
+    - name: Create tool_test_output.html
+      run: 'planemo test_reports tool_test_output.json --test_output tool_test_output.html'
+    - name: Copy artifacts into place
+      run: mkdir upload && mv tool_test_output.json tool_test_output.html upload
+    - uses: actions/upload-artifact@v1
+      with:
+        name: 'Tool test output ${{ matrix.chunk  }}'
+        path: upload
+
+  combine_outputs:
+    name: Combine chunked test results
+    needs: test
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 0
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 1
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 2
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 3
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 4
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 5
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 6
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 7
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 8
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 9
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 10
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 11
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 12
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 13
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 14
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 15
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 16
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 17
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 18
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 19
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 20
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 21
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 22
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 23
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 24
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 25
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 26
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 27
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 28
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 29
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 30
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 31
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 32
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 33
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 34
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 35
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 36
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 37
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 38
+      - uses: actions/download-artifact@v1
+        with:
+          name: Tool test output 39
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      - name: setup planemo
+        run: 'git clone --recursive --depth 1 https://github.com/galaxyproject/planemo && python -m pip install --pre planemo/ && rm -rf planemo'
+      - name: combine outputs
+        run: |
+          find . -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
+      - name: Create tool_test_output.html
+        run: 'planemo test_reports tool_test_output.json --test_output tool_test_output.html'
+      - name: Copy artifacts into place
+        run: mkdir upload && mv tool_test_output.json tool_test_output.html upload
+      - uses: actions/upload-artifact@v1
+        with:
+          name: 'All tool test results'
+          path: upload

--- a/.tt_biocontainer_skip
+++ b/.tt_biocontainer_skip
@@ -1,0 +1,2 @@
+tools/maker
+tools/qiime


### PR DESCRIPTION
Job execution is fully containerized, uses postgres as database and Galaxy and planemo runs on python 3.7.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
