### PR TITLE
Update rsync data manager path modifications

### DIFF
--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
@@ -40,7 +40,7 @@ TOOL_DATA_TABLE_CONF_XML_URLS = {'main': "https://raw.githubusercontent.com/gala
                                  'test': "https://raw.githubusercontent.com/galaxyproject/usegalaxy-playbook/master/env/test/files/galaxy/config/tool_data_table_conf.xml"}
 
 # Replace data table source entries with local temporary location
-GALAXY_DATA_CANONICAL_PATH = "/galaxy/data/"
+GALAXY_DATA_CANONICAL_PATH = "/cvmfs/data.galaxyproject.org/"
 TOOL_DATA_TABLE_CONF_XML_REPLACE_SOURCE = '<file path="%slocation/' % (GALAXY_DATA_CANONICAL_PATH)
 TOOL_DATA_TABLE_CONF_XML_REPLACE_TARGET = '<file path="%s/'
 

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.py
@@ -32,7 +32,6 @@ log = logging.getLogger(_log_name)
 RSYNC_CMD = 'rsync'
 RSYNC_SERVER = "rsync://datacache.g2.bx.psu.edu/"
 LOCATION_DIR = "location"
-INDEX_DIR = "indexes"
 
 # Pull the Tool Data Table files from github
 # FIXME: These files should be accessible from the rsync server directly.
@@ -202,7 +201,6 @@ def load_data_tables_from_url(url=None, site='main', data_table_class=None):
     if not url:
         url = TOOL_DATA_TABLE_CONF_XML_URLS.get(site, None)
     assert url, ValueError('You must provide either a URL or a site=name.')
-
     cached_data_table = TOOL_DATA_TABLES_LOADED_BY_URL.get(url, None)
     refresh, attribs = data_table_needs_refresh(cached_data_table, url)
     if refresh:
@@ -314,7 +312,7 @@ def get_data_for_path(path, data_root_dir):
     if path.startswith(GALAXY_DATA_CANONICAL_PATH):
         path = path[len(GALAXY_DATA_CANONICAL_PATH):]
     make_path = path
-    rsync_source = rsync_urljoin(rsync_urljoin(RSYNC_SERVER, INDEX_DIR), path)
+    rsync_source = rsync_urljoin(RSYNC_SERVER, path)
     if rsync_source.endswith('/'):
         rsync_source = rsync_source[:-1]
     try:
@@ -326,7 +324,7 @@ def get_data_for_path(path, data_root_dir):
         if not head:
             head = tail
         make_path = head
-        rsync_source = rsync_urljoin(rsync_urljoin(RSYNC_SERVER, INDEX_DIR), head)  # if we error here, likely due to a connection issue
+        rsync_source = rsync_urljoin(RSYNC_SERVER, head)  # if we error here, likely due to a connection issue
         if rsync_source.endswith('/'):
             rsync_source = rsync_source[:-1]
         dir_list = rsync_list_dir(rsync_source + "/")

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.3" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.4" tool_type="manage_data" profile="19.05">
     <options sanitize="False" />
     <description>fetching</description>
     <requirements>

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.5" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.4" tool_type="manage_data" profile="19.05">
     <options sanitize="False" />
     <description>fetching</description>
     <requirements>

--- a/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
+++ b/data_managers/data_manager_rsync_g2/data_manager/data_manager_rsync.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.4" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_rsync_g2" name="Rsync with g2" version="0.0.5" tool_type="manage_data" profile="19.05">
     <options sanitize="False" />
     <description>fetching</description>
     <requirements>

--- a/data_managers/data_manager_rsync_g2/test-data/sacCer2_rsync_all_fasta.data_manager_json
+++ b/data_managers/data_manager_rsync_g2/test-data/sacCer2_rsync_all_fasta.data_manager_json
@@ -1,1 +1,1 @@
-{"data_tables": {"all_fasta": [{"dbkey": "sacCer2", "name": "Yeast (Saccharomyces cerevisiae): sacCer2", "path": "/cvmfs/data.galaxyproject.org/byhand/sacCer2/seq/sacCer2.fa", "value": "sacCer2"}]}}
+{"data_tables": {"all_fasta": [{"dbkey": "sacCer2", "name": "Yeast (Saccharomyces cerevisiae): sacCer2", "path": "byhand/sacCer2/seq/sacCer2.fa", "value": "sacCer2"}]}}


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

As it stands, the location files specify the cvmfs path, so the data manager explodes when trying to match that against /galaxy/data/

This will resolve a [question](https://help.galaxyproject.org/t/unable-to-determine-location-of-rsync-data-for-all-fasta-human-b38/2870) posted on galaxy help.

Additionally, the files in `rsync://datacache.g2.bx.psu.edu/location` were specifying paths under `rsync://datacache.g2.bx.psu.edu/byhand`, which did not match the code's `indexes/` prefix, so it was attempting to fetch data from `rsync://datacache.g2.bx.psu.edu/byhand/indexes`.