### PR TITLE
Fix snpeff data managers (older builds are missing python)

### DIFF
--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.py
@@ -9,15 +9,15 @@ import sys
 def fetch_databases(data_manager_dict, target_directory):
     if not os.path.exists(target_directory):
         os.makedirs(target_directory)
-    databases_path = os.path.join( target_directory, 'databases.out' )
+    databases_path = os.path.join(target_directory, 'databases.out')
     databases_output = open(databases_path, 'w')
     args = ['snpEff', 'databases']
     return_code = subprocess.call(args=args, shell=False, stdout=databases_output.fileno())
     if return_code:
-        sys.exit( return_code )
+        sys.exit(return_code)
     databases_output.close()
-    data_manager_dict['data_tables'] = data_manager_dict.get( 'data_tables', {} )
-    data_manager_dict['data_tables']['snpeffv_databases'] = data_manager_dict['data_tables'].get( 'snpeffv_databases', [] )
+    data_manager_dict['data_tables'] = data_manager_dict.get('data_tables', {})
+    data_manager_dict['data_tables']['snpeffv_databases'] = data_manager_dict['data_tables'].get('snpeffv_databases', [])
     data_table_entries = []
     with open(databases_path, 'r') as fh:
         for i, line in enumerate(fh):
@@ -41,16 +41,16 @@ def main():
 
     filename = args[0]
 
-    params = json.loads( open( filename ).read() )
-    target_directory = params[ 'output_data' ][0]['extra_files_path']
-    os.mkdir( target_directory )
+    params = json.loads(open(filename).read())
+    target_directory = params['output_data'][0]['extra_files_path']
+    os.mkdir(target_directory)
     data_manager_dict = {}
 
     # Create Defuse Reference Data
-    data_manager_dict = fetch_databases( data_manager_dict, target_directory)
+    data_manager_dict = fetch_databases(data_manager_dict, target_directory)
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open(filename, 'w').write(json.dumps(data_manager_dict, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
@@ -1,7 +1,7 @@
-<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3r" tool_type="manage_data">
+<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3r" tool_type="manage_data" profile="18.09">
     <description>Read the list of available SnpEff databases</description>
     <requirements>
-        <requirement type="package" version="4.3.1r">snpeff</requirement>
+        <requirement type="package" version="4.3.1t">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python '$__tool_directory__/data_manager_snpEff_databases.py' '$out_file'
@@ -16,7 +16,7 @@ python '$__tool_directory__/data_manager_snpEff_databases.py' '$out_file'
             <output name="out_file">
                 <assert_contents>
                     <!-- Check that a genome was added -->
-                    <has_text text="GRCh38.76" />
+                    <has_text text="GRCh38.86" />
                 </assert_contents>
             </output>
         </test>

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_databases.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3r" tool_type="manage_data" profile="18.09">
+<tool id="data_manager_snpeff_databases" name="SnpEff Databases" version="4.3.1t" tool_type="manage_data" profile="18.09">
     <description>Read the list of available SnpEff databases</description>
     <requirements>
         <requirement type="package" version="4.3.1t">snpeff</requirement>

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
@@ -19,7 +19,7 @@ def fetch_databases(genome_list=None):
     args = ['snpEff', 'databases']
     return_code = subprocess.call(args=args, shell=False, stdout=databases_output.fileno())
     if return_code:
-        sys.exit( return_code )
+        sys.exit(return_code)
     databases_output.close()
     try:
         fh = open(databases_path, 'r')
@@ -34,7 +34,7 @@ def fetch_databases(genome_list=None):
                 description = fields[1].strip()
                 snpDBs[genome_version] = description
     except Exception as e:
-        stop_err( 'Error parsing %s %s\n' % (databases_path, str( e )) )
+        stop_err('Error parsing %s %s\n' % (databases_path, str(e)))
     else:
         fh.close()
     return snpDBs
@@ -59,7 +59,7 @@ def getSnpeffVersion():
     args = ['snpEff', '-h']
     return_code = subprocess.call(args=args, shell=False, stderr=stderr_fh.fileno())
     if return_code != 255:
-        sys.exit( return_code )
+        sys.exit(return_code)
     stderr_fh.close()
     fh = open(stderr_path, 'r')
     for line in fh:
@@ -90,7 +90,7 @@ def download_database(data_manager_dict, target_directory, genome_version, organ
     args = ['snpEff', 'download', '-dataDir', data_dir, '-v', genome_version]
     return_code = subprocess.call(args=args, shell=False)
     if return_code:
-        sys.exit( return_code )
+        sys.exit(return_code)
     # search data_dir/genome_version for files
     regulation_pattern = 'regulation_(.+).bin'
     genome_path = os.path.join(data_dir, genome_version)
@@ -103,42 +103,42 @@ def download_database(data_manager_dict, target_directory, genome_version, organ
                     # if snpEffectPredictor.bin download succeeded
                     name = genome_version + (' : ' + organism if organism else '')
                     data_table_entry = dict(key=key, version=snpeff_version, value=genome_version, name=name, path=data_dir)
-                    _add_data_table_entry( data_manager_dict, 'snpeffv_genomedb', data_table_entry )
+                    _add_data_table_entry(data_manager_dict, 'snpeffv_genomedb', data_table_entry)
                 else:
                     m = re.match(regulation_pattern, fname)
                     if m:
                         name = m.groups()[0]
                         data_table_entry = dict(key=key, version=snpeff_version, genome=genome_version, value=name, name=name)
-                        _add_data_table_entry( data_manager_dict, 'snpeffv_regulationdb', data_table_entry )
+                        _add_data_table_entry(data_manager_dict, 'snpeffv_regulationdb', data_table_entry)
     return data_manager_dict
 
 
-def _add_data_table_entry( data_manager_dict, data_table, data_table_entry ):
-    data_manager_dict['data_tables'] = data_manager_dict.get( 'data_tables', {} )
-    data_manager_dict['data_tables'][data_table] = data_manager_dict['data_tables'].get( data_table, [] )
-    data_manager_dict['data_tables'][data_table].append( data_table_entry )
+def _add_data_table_entry(data_manager_dict, data_table, data_table_entry):
+    data_manager_dict['data_tables'] = data_manager_dict.get('data_tables', {})
+    data_manager_dict['data_tables'][data_table] = data_manager_dict['data_tables'].get(data_table, [])
+    data_manager_dict['data_tables'][data_table].append(data_table_entry)
     return data_manager_dict
 
 
 def main():
     parser = optparse.OptionParser()
-    parser.add_option( '-g', '--genome_version', dest='genome_version', action='store', type="string", default=None, help='genome_version' )
-    parser.add_option( '-o', '--organism', dest='organism', action='store', type="string", default=None, help='organism name' )
+    parser.add_option('-g', '--genome_version', dest='genome_version', action='store', type="string", default=None, help='genome_version')
+    parser.add_option('-o', '--organism', dest='organism', action='store', type="string", default=None, help='organism name')
     (options, args) = parser.parse_args()
 
     filename = args[0]
 
-    params = json.loads( open( filename ).read() )
-    target_directory = params[ 'output_data' ][0]['extra_files_path']
-    os.mkdir( target_directory )
+    params = json.loads(open(filename).read())
+    target_directory = params['output_data'][0]['extra_files_path']
+    os.mkdir(target_directory)
     data_manager_dict = {}
 
     # Create SnpEff Reference Data
     for genome_version, organism in zip(options.genome_version.split(','), getOrganismNames(options.genome_version, options.organism).split(',')):
-        download_database( data_manager_dict, target_directory, genome_version, organism )
+        download_database(data_manager_dict, target_directory, genome_version, organism)
 
     # save info to json file
-    open( filename, 'wb' ).write( json.dumps( data_manager_dict ) )
+    open(filename, 'w').write(json.dumps(data_manager_dict, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
@@ -23,7 +23,7 @@ python '$__tool_directory__/data_manager_snpEff_download.py'
             <output name="out_file">
                 <assert_contents>
                     <!-- Check that a genome was added -->
-                    <has_text text="GRCh38.76" />
+                    <has_text text="GRCh38.86" />
                     <has_text text="snpeffv_regulationdb" />
                 </assert_contents>
             </output>

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3r" tool_type="manage_data" profile="18.09">
+<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3.1t" tool_type="manage_data" profile="18.09">
     <description>Download a new database</description>
     <requirements>
         <requirement type="package" version="4.3.1t">snpeff</requirement>

--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.xml
@@ -1,7 +1,7 @@
-<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3r" tool_type="manage_data">
+<tool id="data_manager_snpeff_download" name="SnpEff Download" version="4.3r" tool_type="manage_data" profile="18.09">
     <description>Download a new database</description>
     <requirements>
-        <requirement type="package" version="4.3.1r">snpeff</requirement>
+        <requirement type="package" version="4.3.1t">snpeff</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python '$__tool_directory__/data_manager_snpEff_download.py'
@@ -19,7 +19,7 @@ python '$__tool_directory__/data_manager_snpEff_download.py'
     </outputs>
     <tests>
         <test>
-            <param name="genome_version" value="GRCh38.76"/>
+            <param name="genome_version" value="GRCh38.86"/>
             <output name="out_file">
                 <assert_contents>
                     <!-- Check that a genome was added -->


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)