### PR TITLE
trinity: bump to 2.9.1

### DIFF
--- a/tools/trinity/align_and_estimate_abundance.xml
+++ b/tools/trinity/align_and_estimate_abundance.xml
@@ -41,8 +41,6 @@
         --est_method $method.est_method
         #if $method.est_method == "RSEM":
             --aln_method $method.aln_method
-        #else if $method.est_method == "salmon":
-            --salmon_idx_type $method.salmon_idx_type
         #end if
 
         #if $inputs.paired_or_single == "paired":
@@ -133,10 +131,6 @@
                 </param>
             </when>
             <when value="salmon">
-                <param type="select" name="salmon_idx_type" argument="--salmon_idx_type" label="Index type">
-                    <option value="quasi">Quasi</option>
-                    <option value="fmd">FMD</option>
-                </param>
             </when>
             <when value="kallisto">
             </when>

--- a/tools/trinity/analyze_diff_expr.xml
+++ b/tools/trinity/analyze_diff_expr.xml
@@ -1,4 +1,4 @@
-<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@+galaxy2">
+<tool id="trinity_analyze_diff_expr" name="Extract and cluster differentially expressed transcripts" version="@WRAPPER_VERSION@">
     <description>from a Trinity assembly</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -7,7 +7,7 @@
         </requirements>
     </xml>
 
-    <token name="@WRAPPER_VERSION@">2.8.5</token>
+    <token name="@WRAPPER_VERSION@">2.9.1</token>
 
     <token name="@COMMAND_PAIRED_STRAND_JACCARD@">
         #if $pool.inputs.strand.is_strand_specific:


### PR DESCRIPTION
according to the changelog
https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/Changelog.txt
no changes should be necessary. But this seems to be incomplete:

- remove --salmon_idx_type which seems gone

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
