### PR TITLE
Fix ScanPy default stdout

### DIFF
--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -282,7 +282,7 @@ sc.tl.dpt(
     </outputs>
     <tests>
         <test>
-            <!-- test 1 -->
+            <!-- test 0 -->
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.louvain"/>
@@ -308,7 +308,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.louvain.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.leiden"/>
@@ -329,7 +329,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.leiden.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.pca"/>
@@ -383,7 +383,7 @@ sc.tl.dpt(
         </test>
         -->
         <test>
-            <!-- test 3 -->
+            <!-- test 2 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.pca"/>
@@ -410,7 +410,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.pca.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 4 -->
+            <!-- test 3 -->
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.diffmap"/>
@@ -423,7 +423,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 5 -->
+            <!-- test 4 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.tsne"/>
@@ -446,7 +446,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.tsne.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 6 -->
+            <!-- test 5 -->
             <param name="adata" value="pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.umap"/>
@@ -479,7 +479,7 @@ sc.tl.dpt(
             </output>
         </test>
         <test>
-            <!-- test 7 -->
+            <!-- test 6 -->
             <param name="adata" value="pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad"/>
             <conditional name="method">
                 <param name="method" value="tl.draw_graph"/>
@@ -494,7 +494,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.draw_graph.pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 8 -->
+            <!-- test 7 -->
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad"/>
             <conditional name="method">
                 <param name="method" value="tl.paga"/>
@@ -511,7 +511,7 @@ sc.tl.dpt(
             <output name="anndata_out" file="tl.paga.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 9 -->
+            <!-- test 8 -->
             <param name="adata" value="tl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.dpt"/>

--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -276,6 +276,7 @@ sc.tl.dpt(
                 </param>
             </when>
         </conditional>            
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <expand macro="anndata_outputs"/>

--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -296,6 +296,9 @@ sc.tl.dpt(
                 <param name="directed" value="true"/>
                 <param name="use_weights" value="false"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.louvain"/>
@@ -321,6 +324,9 @@ sc.tl.dpt(
                 <param name="use_weights" value="false"/>
                 <param name="n_iterations" value="-1"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.leiden"/>
@@ -348,6 +354,9 @@ sc.tl.dpt(
                 </conditional>
                 <param name="use_highly_variable" value="false"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.pca"/>
@@ -404,6 +413,9 @@ sc.tl.dpt(
                 </conditional>
                 <param name="use_highly_variable" value="false"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.pca"/>
@@ -425,6 +437,9 @@ sc.tl.dpt(
                 <param name="method" value="tl.diffmap"/>
                 <param name="n_comps" value="15"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.diffmap"/>
@@ -445,6 +460,9 @@ sc.tl.dpt(
                 <param name="random_state" value="0"/>
                 <param name="use_fast_tsne" value="true"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.tsne"/>
@@ -473,6 +491,9 @@ sc.tl.dpt(
                 <param name="init_pos" value="spectral"/>
                 <param name="random_state" value="0"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.umap"/>
@@ -501,6 +522,9 @@ sc.tl.dpt(
                 <param name="layout" value="fa"/>
                 <param name="random_state" value="0"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.draw_graph"/>
@@ -519,6 +543,9 @@ sc.tl.dpt(
                 <param name="use_rna_velocity" value="False"/>
                 <param name="model" value="v1.2"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.paga"/>
@@ -539,6 +566,9 @@ sc.tl.dpt(
                 <param name="min_group_size" value="0.01"/>
                 <param name="allow_kendall_tau_shift" value="True"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.dpt"/>

--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -295,16 +295,18 @@ sc.tl.dpt(
                 <param name="directed" value="true"/>
                 <param name="use_weights" value="false"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.louvain"/>
-                <has_text_matching expression="adata=adata"/>
-                <has_text_matching expression="flavor = 'vtraag'"/>
-                <has_text_matching expression="resolution=1.0"/>
-                <has_text_matching expression="random_state=10"/>
-                <has_text_matching expression="key_added='louvain'"/>
-                <has_text_matching expression="directed=True"/>
-                <has_text_matching expression="use_weights=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.louvain"/>
+                    <has_text_matching expression="adata=adata"/>
+                    <has_text_matching expression="flavor = 'vtraag'"/>
+                    <has_text_matching expression="resolution=1.0"/>
+                    <has_text_matching expression="random_state=10"/>
+                    <has_text_matching expression="key_added='louvain'"/>
+                    <has_text_matching expression="directed=True"/>
+                    <has_text_matching expression="use_weights=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.louvain.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -318,14 +320,16 @@ sc.tl.dpt(
                 <param name="use_weights" value="false"/>
                 <param name="n_iterations" value="-1"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.leiden"/>
-                <has_text_matching expression="resolution=1"/>
-                <has_text_matching expression="random_state=10"/>
-                <has_text_matching expression="key_added='leiden'"/>
-                <has_text_matching expression="use_weights=False"/>
-                <has_text_matching expression="n_iterations=-1"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.leiden"/>
+                    <has_text_matching expression="resolution=1"/>
+                    <has_text_matching expression="random_state=10"/>
+                    <has_text_matching expression="key_added='leiden'"/>
+                    <has_text_matching expression="use_weights=False"/>
+                    <has_text_matching expression="n_iterations=-1"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.leiden.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -343,17 +347,19 @@ sc.tl.dpt(
                 </conditional>
                 <param name="use_highly_variable" value="false"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.pca"/>
-                <has_text_matching expression="n_comps=50"/>
-                <has_text_matching expression="dtype='float32'"/>
-                <has_text_matching expression="copy=False"/>
-                <has_text_matching expression="chunked=False"/>
-                <has_text_matching expression="zero_center=True"/>
-                <has_text_matching expression="svd_solver='auto'"/>
-                <has_text_matching expression="random_state=0"/>
-                <has_text_matching expression="use_highly_variable=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.pca"/>
+                    <has_text_matching expression="n_comps=50"/>
+                    <has_text_matching expression="dtype='float32'"/>
+                    <has_text_matching expression="copy=False"/>
+                    <has_text_matching expression="chunked=False"/>
+                    <has_text_matching expression="zero_center=True"/>
+                    <has_text_matching expression="svd_solver='auto'"/>
+                    <has_text_matching expression="random_state=0"/>
+                    <has_text_matching expression="use_highly_variable=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.pca.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <!--<test>
@@ -397,16 +403,18 @@ sc.tl.dpt(
                 </conditional>
                 <param name="use_highly_variable" value="false"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.pca"/>
-                <has_text_matching expression="n_comps=50"/>
-                <has_text_matching expression="dtype='float32'"/>
-                <has_text_matching expression="copy=False"/>
-                <has_text_matching expression="chunked=False"/>
-                <has_text_matching expression="zero_center=True"/>
-                <has_text_matching expression="svd_solver='auto'"/>
-                <has_text_matching expression="use_highly_variable=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.pca"/>
+                    <has_text_matching expression="n_comps=50"/>
+                    <has_text_matching expression="dtype='float32'"/>
+                    <has_text_matching expression="copy=False"/>
+                    <has_text_matching expression="chunked=False"/>
+                    <has_text_matching expression="zero_center=True"/>
+                    <has_text_matching expression="svd_solver='auto'"/>
+                    <has_text_matching expression="use_highly_variable=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.pca.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -416,10 +424,12 @@ sc.tl.dpt(
                 <param name="method" value="tl.diffmap"/>
                 <param name="n_comps" value="15"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.diffmap"/>
-                <has_text_matching expression="n_comps=15"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.diffmap"/>
+                    <has_text_matching expression="n_comps=15"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -434,15 +444,17 @@ sc.tl.dpt(
                 <param name="random_state" value="0"/>
                 <param name="use_fast_tsne" value="true"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.tsne"/>
-                <has_text_matching expression="n_pcs=10"/>
-                <has_text_matching expression="perplexity=30.0"/>
-                <has_text_matching expression="early_exaggeration=12.0"/>
-                <has_text_matching expression="learning_rate=1000.0"/>
-                <has_text_matching expression="random_state=0"/>
-                <has_text_matching expression="use_fast_tsne=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.tsne"/>
+                    <has_text_matching expression="n_pcs=10"/>
+                    <has_text_matching expression="perplexity=30.0"/>
+                    <has_text_matching expression="early_exaggeration=12.0"/>
+                    <has_text_matching expression="learning_rate=1000.0"/>
+                    <has_text_matching expression="random_state=0"/>
+                    <has_text_matching expression="use_fast_tsne=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.tsne.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -460,18 +472,20 @@ sc.tl.dpt(
                 <param name="init_pos" value="spectral"/>
                 <param name="random_state" value="0"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.umap"/>
-                <has_text_matching expression="min_dist=0.5"/>
-                <has_text_matching expression="spread=1.0"/>
-                <has_text_matching expression="n_components=2"/>
-                <has_text_matching expression="maxiter=2"/>
-                <has_text_matching expression="alpha=1.0"/>
-                <has_text_matching expression="gamma=1.0"/>
-                <has_text_matching expression="negative_sample_rate=5"/>
-                <has_text_matching expression="init_pos='spectral'"/>
-                <has_text_matching expression="random_state=0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.umap"/>
+                    <has_text_matching expression="min_dist=0.5"/>
+                    <has_text_matching expression="spread=1.0"/>
+                    <has_text_matching expression="n_components=2"/>
+                    <has_text_matching expression="maxiter=2"/>
+                    <has_text_matching expression="alpha=1.0"/>
+                    <has_text_matching expression="gamma=1.0"/>
+                    <has_text_matching expression="negative_sample_rate=5"/>
+                    <has_text_matching expression="init_pos='spectral'"/>
+                    <has_text_matching expression="random_state=0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size">
                 <assert_contents>
                     <has_h5_keys keys="X, obs, obsm, uns, var" />
@@ -486,11 +500,13 @@ sc.tl.dpt(
                 <param name="layout" value="fa"/>
                 <param name="random_state" value="0"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.draw_graph"/>
-                <has_text_matching expression="layout='fa'"/>
-                <has_text_matching expression="random_state=0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.draw_graph"/>
+                    <has_text_matching expression="layout='fa'"/>
+                    <has_text_matching expression="random_state=0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.draw_graph.pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -502,12 +518,14 @@ sc.tl.dpt(
                 <param name="use_rna_velocity" value="False"/>
                 <param name="model" value="v1.2"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.paga"/>
-                <has_text_matching expression="groups='paul15_clusters'"/>
-                <has_text_matching expression="use_rna_velocity=False"/>
-                <has_text_matching expression="model='v1.2'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.paga"/>
+                    <has_text_matching expression="groups='paul15_clusters'"/>
+                    <has_text_matching expression="use_rna_velocity=False"/>
+                    <has_text_matching expression="model='v1.2'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.paga.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -520,13 +538,15 @@ sc.tl.dpt(
                 <param name="min_group_size" value="0.01"/>
                 <param name="allow_kendall_tau_shift" value="True"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.dpt"/>
-                <has_text_matching expression="n_dcs=15"/>
-                <has_text_matching expression="n_branchings=1"/>
-                <has_text_matching expression="min_group_size=0.01"/>
-                <has_text_matching expression="allow_kendall_tau_shift=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.dpt"/>
+                    <has_text_matching expression="n_dcs=15"/>
+                    <has_text_matching expression="n_branchings=1"/>
+                    <has_text_matching expression="min_group_size=0.01"/>
+                    <has_text_matching expression="allow_kendall_tau_shift=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -231,7 +231,7 @@ sc.pp.downsample_counts(
                 </conditional>
             </conditional>
             <assert_stdout>
-                <has_text_matching expression="n_obs × n_vars = 336 × 11"/>
+                <has_text_matching expression="336 × 11"/>
             </assert_stdout>
             <output name="hidden_output">
                 <assert_contents>
@@ -278,33 +278,34 @@ sc.pp.downsample_counts(
             </output>
             <output name="anndata_out" file="pp.filter_genes.krumsiek11-min_counts.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
-        <test>
-            <!-- test 3 -->
-            <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
-            <conditional name="method">
-                <param name="method" value="tl.filter_rank_genes_groups"/>
-                <param name="key" value="rank_genes_groups"/>
-                <param name="use_raw" value="False"/>
-                <param name="log" value="False"/>
-                <param name="key_added" value="rank_genes_groups_filtered"/>
-                <param name="min_in_group_fraction" value="0.25"/>
-                <param name="max_out_group_fraction" value="0.5"/>
-                <param name="min_fold_change" value="3"/>
-            </conditional>
-            <output name="hidden_output">
-                <assert_contents>
-                    <has_text_matching expression="tl.filter_rank_genes_groups"/>
-                    <has_text_matching expression="key='rank_genes_groups'"/>
-                    <has_text_matching expression="use_raw=False"/>
-                    <has_text_matching expression="log=False"/>
-                    <has_text_matching expression="key_added='rank_genes_groups_filtered'"/>
-                    <has_text_matching expression="min_in_group_fraction=0.25"/>
-                    <has_text_matching expression="max_out_group_fraction=0.5"/>
-                    <has_text_matching expression="min_fold_change=3"/>
-                </assert_contents>
-            </output>
-            <output name="anndata_out" file="pp.filter_rank_genes_groups.h5ad" ftype="h5ad" compare="sim_size"/>
-        </test>
+        <!-- <test> -->
+        <!--     <!-\- test 3 -\-> -->
+        <!--     <!-\- Input dataset appears to be missing rank_genes_groups key... -\-> -->
+        <!--     <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" /> -->
+        <!--     <conditional name="method"> -->
+        <!--         <param name="method" value="tl.filter_rank_genes_groups"/> -->
+        <!--         <param name="key" value="rank_genes_groups"/> -->
+        <!--         <param name="use_raw" value="False"/> -->
+        <!--         <param name="log" value="False"/> -->
+        <!--         <param name="key_added" value="rank_genes_groups_filtered"/> -->
+        <!--         <param name="min_in_group_fraction" value="0.25"/> -->
+        <!--         <param name="max_out_group_fraction" value="0.5"/> -->
+        <!--         <param name="min_fold_change" value="3"/> -->
+        <!--     </conditional> -->
+        <!--     <output name="hidden_output"> -->
+        <!--         <assert_contents> -->
+        <!--             <has_text_matching expression="tl.filter_rank_genes_groups"/> -->
+        <!--             <has_text_matching expression="key='rank_genes_groups'"/> -->
+        <!--             <has_text_matching expression="use_raw=False"/> -->
+        <!--             <has_text_matching expression="log=False"/> -->
+        <!--             <has_text_matching expression="key_added='rank_genes_groups_filtered'"/> -->
+        <!--             <has_text_matching expression="min_in_group_fraction=0.25"/> -->
+        <!--             <has_text_matching expression="max_out_group_fraction=0.5"/> -->
+        <!--             <has_text_matching expression="min_fold_change=3"/> -->
+        <!--         </assert_contents> -->
+        <!--     </output> -->
+        <!--     <output name="anndata_out" file="pp.filter_rank_genes_groups.h5ad" ftype="h5ad" compare="sim_size"/> -->
+        <!-- </test> -->
         <test>
             <!-- test 4 -->
             <param name="adata" value="blobs.h5ad"/>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -221,7 +221,7 @@ sc.pp.downsample_counts(
     </outputs>
     <tests>
         <test>
-            <!-- test 1 -->
+            <!-- test 0 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.filter_cells"/>
@@ -237,7 +237,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.filter_cells.krumsiek11-min_counts.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.filter_cells"/>
@@ -254,7 +254,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.filter_cells.krumsiek11-max_genes.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 3 -->
+            <!-- test 2 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.filter_genes"/>
@@ -270,7 +270,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.filter_genes.krumsiek11-min_counts.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 4 -->
+            <!-- test 3 -->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.filter_rank_genes_groups"/>
@@ -295,7 +295,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.filter_rank_genes_groups.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 5 -->
+            <!-- test 4 -->
             <param name="adata" value="blobs.h5ad"/>
             <conditional name="method">
                 <param name="method" value="pp.highly_variable_genes"/>
@@ -320,7 +320,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.highly_variable_genes.seurat.blobs.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 6 -->
+            <!-- test 5 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.highly_variable_genes"/>
@@ -341,7 +341,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.highly_variable_genes.krumsiek11-cell_ranger.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 7 -->
+            <!-- test 6 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.subsample"/>
@@ -359,7 +359,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.subsample.krumsiek11_fraction.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 8 -->
+            <!-- test 7 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.subsample"/>
@@ -377,7 +377,7 @@ sc.pp.downsample_counts(
             <output name="anndata_out" file="pp.subsample.krumsiek11_n_obs.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 9 -->
+            <!-- test 8 -->
             <param name="adata" value="random-randint.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.downsample_counts"/>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -215,6 +215,7 @@ sc.pp.downsample_counts(
                 <param argument="replace" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Sample the counts with replacement?"/>
             </when>
         </conditional>
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <expand macro="anndata_outputs"/>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -231,9 +231,14 @@ sc.pp.downsample_counts(
                 </conditional>
             </conditional>
             <assert_stdout>
-                <has_text_matching expression="sc.pp.filter_cells"/>
-                <has_text_matching expression="min_counts=3"/>
+                <has_text_matching expression="n_obs × n_vars = 336 × 11"/>
             </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.filter_cells"/>
+                    <has_text_matching expression="min_counts=3"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.filter_cells.krumsiek11-min_counts.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -246,11 +246,13 @@ sc.pp.downsample_counts(
                     <param name="max_genes" value="100"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.filter_cells"/>
-                <has_text_matching expression="adata"/>
-                <has_text_matching expression="max_genes=100"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.filter_cells"/>
+                    <has_text_matching expression="adata"/>
+                    <has_text_matching expression="max_genes=100"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.filter_cells.krumsiek11-max_genes.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -263,10 +265,12 @@ sc.pp.downsample_counts(
                     <param name="min_counts" value="3"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.filter_genes"/>
-                <has_text_matching expression="min_counts=3"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.filter_genes"/>
+                    <has_text_matching expression="min_counts=3"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.filter_genes.krumsiek11-min_counts.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -282,16 +286,18 @@ sc.pp.downsample_counts(
                 <param name="max_out_group_fraction" value="0.5"/>
                 <param name="min_fold_change" value="3"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="tl.filter_rank_genes_groups"/>
-                <has_text_matching expression="key='rank_genes_groups'"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="key_added='rank_genes_groups_filtered'"/>
-                <has_text_matching expression="min_in_group_fraction=0.25"/>
-                <has_text_matching expression="max_out_group_fraction=0.5"/>
-                <has_text_matching expression="min_fold_change=3"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="tl.filter_rank_genes_groups"/>
+                    <has_text_matching expression="key='rank_genes_groups'"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="key_added='rank_genes_groups_filtered'"/>
+                    <has_text_matching expression="min_in_group_fraction=0.25"/>
+                    <has_text_matching expression="max_out_group_fraction=0.5"/>
+                    <has_text_matching expression="min_fold_change=3"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.filter_rank_genes_groups.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -308,15 +314,17 @@ sc.pp.downsample_counts(
                 <param name="n_bins" value="20"/>
                 <param name="subset" value="false"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.highly_variable_genes"/>
-                <has_text_matching expression="flavor='seurat'"/>
-                <has_text_matching expression="min_mean=0.0125"/>
-                <has_text_matching expression="max_mean=3"/>
-                <has_text_matching expression="min_disp=0.5"/>
-                <has_text_matching expression="n_bins=20"/>
-                <has_text_matching expression="subset=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.highly_variable_genes"/>
+                    <has_text_matching expression="flavor='seurat'"/>
+                    <has_text_matching expression="min_mean=0.0125"/>
+                    <has_text_matching expression="max_mean=3"/>
+                    <has_text_matching expression="min_disp=0.5"/>
+                    <has_text_matching expression="n_bins=20"/>
+                    <has_text_matching expression="subset=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.highly_variable_genes.seurat.blobs.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -331,13 +339,15 @@ sc.pp.downsample_counts(
                 <param name="n_bins" value="20"/>
                 <param name="subset" value="true"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.highly_variable_genes"/>
-                <has_text_matching expression="flavor='cell_ranger'"/>
-                <has_text_matching expression="n_top_genes=2"/>
-                <has_text_matching expression="n_bins=20"/>
-                <has_text_matching expression="subset=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.highly_variable_genes"/>
+                    <has_text_matching expression="flavor='cell_ranger'"/>
+                    <has_text_matching expression="n_top_genes=2"/>
+                    <has_text_matching expression="n_bins=20"/>
+                    <has_text_matching expression="subset=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.highly_variable_genes.krumsiek11-cell_ranger.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -351,11 +361,13 @@ sc.pp.downsample_counts(
                 </conditional>
                 <param name="random_state" value="0"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.subsample"/>
-                <has_text_matching expression="fraction=0.5"/>
-                <has_text_matching expression="random_state=0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.subsample"/>
+                    <has_text_matching expression="fraction=0.5"/>
+                    <has_text_matching expression="random_state=0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.subsample.krumsiek11_fraction.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -369,11 +381,13 @@ sc.pp.downsample_counts(
                 </conditional>
                 <param name="random_state" value="0"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.subsample"/>
-                <has_text_matching expression="n_obs=10"/>
-                <has_text_matching expression="random_state=0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.subsample"/>
+                    <has_text_matching expression="n_obs=10"/>
+                    <has_text_matching expression="random_state=0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.subsample.krumsiek11_n_obs.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -385,12 +399,14 @@ sc.pp.downsample_counts(
                 <param name="random_state" value="0"/>
                 <param name="replace" value="false"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.downsample_counts"/>
-                <has_text_matching expression="total_counts=20000"/>
-                <has_text_matching expression="random_state=0"/>
-                <has_text_matching expression="replace=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.downsample_counts"/>
+                    <has_text_matching expression="total_counts=20000"/>
+                    <has_text_matching expression="random_state=0"/>
+                    <has_text_matching expression="replace=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.downsample_counts.random-randint.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -234,6 +234,9 @@ sc.pp.downsample_counts(
             <assert_stdout>
                 <has_text_matching expression="336 × 11"/>
             </assert_stdout>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.filter_cells"/>
@@ -252,6 +255,9 @@ sc.pp.downsample_counts(
                     <param name="max_genes" value="100"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.filter_cells"/>
@@ -271,6 +277,9 @@ sc.pp.downsample_counts(
                     <param name="min_counts" value="3"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.filter_genes"/>
@@ -321,6 +330,9 @@ sc.pp.downsample_counts(
                 <param name="n_bins" value="20"/>
                 <param name="subset" value="false"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.highly_variable_genes"/>
@@ -346,6 +358,9 @@ sc.pp.downsample_counts(
                 <param name="n_bins" value="20"/>
                 <param name="subset" value="true"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.highly_variable_genes"/>
@@ -368,6 +383,9 @@ sc.pp.downsample_counts(
                 </conditional>
                 <param name="random_state" value="0"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.subsample"/>
@@ -388,6 +406,9 @@ sc.pp.downsample_counts(
                 </conditional>
                 <param name="random_state" value="0"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.subsample"/>
@@ -406,6 +427,9 @@ sc.pp.downsample_counts(
                 <param name="random_state" value="0"/>
                 <param name="replace" value="false"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.downsample_counts"/>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -467,7 +467,7 @@ sc.pp.sqrt(
     </outputs>
     <tests>
         <test>
-            <!-- test 1 -->
+            <!-- test 0 -->
             <param name="adata" value="sparce_csr_matrix.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.calculate_qc_metrics"/>
@@ -485,7 +485,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.calculate_qc_metrics.sparce_csr_matrix.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="pp.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.neighbors"/>
@@ -510,7 +510,7 @@ sc.pp.sqrt(
             </output>
         </test>
         <test>
-            <!-- test 3 -->
+            <!-- test 2 -->
             <param name="adata" value="pp.recipe_weinreb17.paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.neighbors"/>
@@ -530,7 +530,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 4 -->
+            <!-- test 3 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.score_genes"/>
@@ -554,7 +554,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="tl.score_genes.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 5 -->
+            <!-- test 4 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.score_genes_cell_cycle"/>
@@ -581,7 +581,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="tl.score_genes_cell_cycle.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 6 -->
+            <!-- test 5 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.rank_genes_groups"/>
@@ -608,7 +608,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="tl.rank_genes_groups.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 7 -->
+            <!-- test 6 -->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.rank_genes_groups"/>
@@ -652,7 +652,7 @@ sc.pp.sqrt(
             </output>
         </test>
         <test>
-            <!-- test 8 -->
+            <!-- test 7 -->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.rank_genes_groups"/>
@@ -731,7 +731,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.log1p.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>-->
         <test>
-            <!-- test 9 -->
+            <!-- test 8 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.log1p"/>
@@ -742,7 +742,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.log1p.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 10 -->
+            <!-- test 9 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.scale"/>
@@ -755,7 +755,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.scale.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 11 -->
+            <!-- test 10 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.scale"/>
@@ -770,7 +770,7 @@ sc.pp.sqrt(
             <output name="anndata_out" file="pp.scale_max_value.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 12 -->
+            <!-- test 11 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.sqrt"/>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -476,12 +476,14 @@ sc.pp.sqrt(
                 <param name="qc_vars" value="mito,negative"/>
                 <param name="percent_top" value=""/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.calculate_qc_metrics" />
-                <has_text_matching expression="expr_type='counts'" />
-                <has_text_matching expression="var_type='genes'" />
-                <has_text_matching expression="qc_vars=\['mito', 'negative'\]" />
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.calculate_qc_metrics" />
+                    <has_text_matching expression="expr_type='counts'" />
+                    <has_text_matching expression="var_type='genes'" />
+                    <has_text_matching expression="qc_vars=\['mito', 'negative'\]" />
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.calculate_qc_metrics.sparce_csr_matrix.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -495,14 +497,16 @@ sc.pp.sqrt(
                 <param name="pp_neighbors_method" value="umap"/>
                 <param name="metric" value="euclidean"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.neighbors"/>
-                <has_text_matching expression="n_neighbors=15"/>
-                <has_text_matching expression="knn=True"/>
-                <has_text_matching expression="random_state=0"/>
-                <has_text_matching expression="method='umap'"/>
-                <has_text_matching expression="metric='euclidean'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.neighbors"/>
+                    <has_text_matching expression="n_neighbors=15"/>
+                    <has_text_matching expression="knn=True"/>
+                    <has_text_matching expression="random_state=0"/>
+                    <has_text_matching expression="method='umap'"/>
+                    <has_text_matching expression="metric='euclidean'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size">
                 <assert_contents>
                     <has_h5_keys keys="X, obs, obsm, uns, var" />
@@ -519,14 +523,16 @@ sc.pp.sqrt(
                 <param name="pp_neighbors_method" value="gauss"/>
                 <param name="metric" value="braycurtis"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.neighbors"/>
-                <has_text_matching expression="n_neighbors=15"/>
-                <has_text_matching expression="knn=True"/>
-                <has_text_matching expression="random_state=0"/>
-                <has_text_matching expression="method='gauss'"/>
-                <has_text_matching expression="metric='braycurtis'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.neighbors"/>
+                    <has_text_matching expression="n_neighbors=15"/>
+                    <has_text_matching expression="knn=True"/>
+                    <has_text_matching expression="random_state=0"/>
+                    <has_text_matching expression="method='gauss'"/>
+                    <has_text_matching expression="metric='braycurtis'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -541,16 +547,18 @@ sc.pp.sqrt(
                 <param name="use_raw" value="False"/>
                 <param name="score_name" value="score"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.score_genes" />
-                <has_text_matching expression="gene_list=\['Gata2', 'Fog1'\]" />
-                <has_text_matching expression="ctrl_size=2" />
-                <has_text_matching expression="score_name='score'" />
-                <has_text_matching expression="n_bins=2" />
-                <has_text_matching expression="random_state=2" />
-                <has_text_matching expression="use_raw=False" />
-                <has_text_matching expression="copy=False" />
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.score_genes" />
+                    <has_text_matching expression="gene_list=\['Gata2', 'Fog1'\]" />
+                    <has_text_matching expression="ctrl_size=2" />
+                    <has_text_matching expression="score_name='score'" />
+                    <has_text_matching expression="n_bins=2" />
+                    <has_text_matching expression="random_state=2" />
+                    <has_text_matching expression="use_raw=False" />
+                    <has_text_matching expression="copy=False" />
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.score_genes.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -570,14 +578,16 @@ sc.pp.sqrt(
                 <param name="random_state" value="1"/>
                 <param name="use_raw" value="False"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.score_genes_cell_cycle"/>
-                <has_text_matching expression="s_genes=\['Gata2', 'Fog1', 'EgrNab'\]"/>
-                <has_text_matching expression="g2m_genes=\['Gata2', 'Fog1', 'EgrNab'\]"/>
-                <has_text_matching expression="n_bins=2"/>
-                <has_text_matching expression="random_state=1"/>
-                <has_text_matching expression="use_raw=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.score_genes_cell_cycle"/>
+                    <has_text_matching expression="s_genes=\['Gata2', 'Fog1', 'EgrNab'\]"/>
+                    <has_text_matching expression="g2m_genes=\['Gata2', 'Fog1', 'EgrNab'\]"/>
+                    <has_text_matching expression="n_bins=2"/>
+                    <has_text_matching expression="random_state=1"/>
+                    <has_text_matching expression="use_raw=False"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.score_genes_cell_cycle.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -596,15 +606,17 @@ sc.pp.sqrt(
                     <param name="corr_method" value="benjamini-hochberg"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.rank_genes_groups"/>
-                <has_text_matching expression="groupby='cell_type'"/>
-                <has_text_matching expression="use_raw=True"/>
-                <has_text_matching expression="reference='rest'"/>
-                <has_text_matching expression="n_genes=100"/>
-                <has_text_matching expression="method='t-test_overestim_var'"/>
-                <has_text_matching expression="corr_method='benjamini-hochberg'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.rank_genes_groups"/>
+                    <has_text_matching expression="groupby='cell_type'"/>
+                    <has_text_matching expression="use_raw=True"/>
+                    <has_text_matching expression="reference='rest'"/>
+                    <has_text_matching expression="n_genes=100"/>
+                    <has_text_matching expression="method='t-test_overestim_var'"/>
+                    <has_text_matching expression="corr_method='benjamini-hochberg'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.rank_genes_groups.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -736,9 +748,11 @@ sc.pp.sqrt(
             <conditional name="method">
                 <param name="method" value="pp.log1p"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.log1p"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.log1p"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.log1p.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -748,10 +762,12 @@ sc.pp.sqrt(
                 <param name="method" value="pp.scale"/>
                 <param name="zero_center" value="true"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.scale"/>
-                <has_text_matching expression="zero_center=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.scale"/>
+                    <has_text_matching expression="zero_center=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.scale.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -762,11 +778,13 @@ sc.pp.sqrt(
                 <param name="zero_center" value="true"/>
                 <param name="max_value" value="10"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.scale"/>
-                <has_text_matching expression="zero_center=True"/>
-                <has_text_matching expression="max_value=10.0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.scale"/>
+                    <has_text_matching expression="zero_center=True"/>
+                    <has_text_matching expression="max_value=10.0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.scale_max_value.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -775,9 +793,11 @@ sc.pp.sqrt(
             <conditional name="method">
                 <param name="method" value="pp.sqrt"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.sqrt"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.sqrt"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.sqrt.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -477,6 +477,9 @@ sc.pp.sqrt(
                 <param name="qc_vars" value="mito,negative"/>
                 <param name="percent_top" value=""/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.calculate_qc_metrics" />
@@ -498,6 +501,9 @@ sc.pp.sqrt(
                 <param name="pp_neighbors_method" value="umap"/>
                 <param name="metric" value="euclidean"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.neighbors"/>
@@ -524,6 +530,9 @@ sc.pp.sqrt(
                 <param name="pp_neighbors_method" value="gauss"/>
                 <param name="metric" value="braycurtis"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.neighbors"/>
@@ -548,6 +557,9 @@ sc.pp.sqrt(
                 <param name="use_raw" value="False"/>
                 <param name="score_name" value="score"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.score_genes" />
@@ -579,6 +591,9 @@ sc.pp.sqrt(
                 <param name="random_state" value="1"/>
                 <param name="use_raw" value="False"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.score_genes_cell_cycle"/>
@@ -607,6 +622,9 @@ sc.pp.sqrt(
                     <param name="corr_method" value="benjamini-hochberg"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.rank_genes_groups"/>
@@ -643,6 +661,9 @@ sc.pp.sqrt(
                     <param name="c" value="1.0"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.rank_genes_groups"/>
@@ -695,6 +716,9 @@ sc.pp.sqrt(
                     <param name="c" value="1.0"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.tl.rank_genes_groups"/>
@@ -753,6 +777,9 @@ sc.pp.sqrt(
             <conditional name="method">
                 <param name="method" value="pp.log1p"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.log1p"/>
@@ -767,6 +794,9 @@ sc.pp.sqrt(
                 <param name="method" value="pp.scale"/>
                 <param name="zero_center" value="true"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.scale"/>
@@ -783,6 +813,9 @@ sc.pp.sqrt(
                 <param name="zero_center" value="true"/>
                 <param name="max_value" value="10"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.scale"/>
@@ -798,6 +831,9 @@ sc.pp.sqrt(
             <conditional name="method">
                 <param name="method" value="pp.sqrt"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.sqrt"/>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -461,6 +461,7 @@ sc.pp.sqrt(
             </when>
             <when value="pp.sqrt"/>
         </conditional>
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <expand macro="anndata_outputs"/>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -642,21 +642,23 @@ sc.pp.sqrt(
                     <param name="c" value="1.0"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.rank_genes_groups"/>
-                <has_text_matching expression="groupby='louvain'"/>
-                <has_text_matching expression="use_raw=True"/>
-                <has_text_matching expression="reference='rest'"/>
-                <has_text_matching expression="n_genes=100"/>
-                <has_text_matching expression="method='logreg'"/>
-                <has_text_matching expression="solver='newton-cg'"/>
-                <has_text_matching expression="penalty='l2'"/>
-                <has_text_matching expression="fit_intercept=True"/>
-                <has_text_matching expression="max_iter=100"/>
-                <has_text_matching expression="multi_class='auto'"/>
-                <has_text_matching expression="tol=0.0001"/>
-                <has_text_matching expression="C=1.0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.rank_genes_groups"/>
+                    <has_text_matching expression="groupby='louvain'"/>
+                    <has_text_matching expression="use_raw=True"/>
+                    <has_text_matching expression="reference='rest'"/>
+                    <has_text_matching expression="n_genes=100"/>
+                    <has_text_matching expression="method='logreg'"/>
+                    <has_text_matching expression="solver='newton-cg'"/>
+                    <has_text_matching expression="penalty='l2'"/>
+                    <has_text_matching expression="fit_intercept=True"/>
+                    <has_text_matching expression="max_iter=100"/>
+                    <has_text_matching expression="multi_class='auto'"/>
+                    <has_text_matching expression="tol=0.0001"/>
+                    <has_text_matching expression="C=1.0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.rank_genes_groups.newton-cg.pbmc68k_reduced.h5ad" ftype="h5ad" compare="sim_size">
                 <assert_contents>
                     <has_h5_keys keys="X, obs, obsm, raw.X, raw.var, uns, var" />
@@ -692,21 +694,23 @@ sc.pp.sqrt(
                     <param name="c" value="1.0"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.tl.rank_genes_groups"/>
-                <has_text_matching expression="groupby='louvain'"/>
-                <has_text_matching expression="use_raw=True"/>
-                <has_text_matching expression="reference='rest'"/>
-                <has_text_matching expression="n_genes=100"/>
-                <has_text_matching expression="method='logreg'"/>
-                <has_text_matching expression="solver='liblinear'"/>
-                <has_text_matching expression="penalty='l2'"/>
-                <has_text_matching expression="dual=False"/>
-                <has_text_matching expression="fit_intercept=True"/>
-                <has_text_matching expression="intercept_scaling=1.0"/>
-                <has_text_matching expression="tol=0.0001"/>
-                <has_text_matching expression="C=1.0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.tl.rank_genes_groups"/>
+                    <has_text_matching expression="groupby='louvain'"/>
+                    <has_text_matching expression="use_raw=True"/>
+                    <has_text_matching expression="reference='rest'"/>
+                    <has_text_matching expression="n_genes=100"/>
+                    <has_text_matching expression="method='logreg'"/>
+                    <has_text_matching expression="solver='liblinear'"/>
+                    <has_text_matching expression="penalty='l2'"/>
+                    <has_text_matching expression="dual=False"/>
+                    <has_text_matching expression="fit_intercept=True"/>
+                    <has_text_matching expression="intercept_scaling=1.0"/>
+                    <has_text_matching expression="tol=0.0001"/>
+                    <has_text_matching expression="C=1.0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="tl.rank_genes_groups.liblinear.krumsiek11.h5ad" ftype="h5ad" compare="sim_size">
                 <assert_contents>
                     <has_h5_keys keys="X, obs, obsm, raw.X, raw.var, uns, var" />

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -22,13 +22,16 @@
     <token name="@CMD@"><![CDATA[
 cp '$adata' 'anndata.h5ad' &&
 cat '$script_file' > '$hidden_output' &&
-python '$script_file' >> '$hidden_output' 2>&1 &&
+python '$script_file' >> '$hidden_output' &&
 ls . >> '$hidden_output' &&
 touch 'anndata_info.txt' &&
 cat 'anndata_info.txt' @CMD_prettify_stdout@
     ]]>
     </token>
     <token name="@CMD_imports@"><![CDATA[
+import sys
+sys.stderr = open('$hidden_output', 'a')
+
 import scanpy as sc
 import pandas as pd
 import numpy as np

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -24,6 +24,7 @@ cp '$adata' 'anndata.h5ad' &&
 cat '$script_file' > '$hidden_output' &&
 python '$script_file' >> '$hidden_output' 2>&1 &&
 ls . >> '$hidden_output' &&
+touch 'anndata_info.txt' &&
 cat 'anndata_info.txt' @CMD_prettify_stdout@
     ]]>
     </token>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -24,7 +24,7 @@ cp '$adata' 'anndata.h5ad' &&
 cat '$script_file' > '$hidden_output' &&
 python '$script_file' >> '$hidden_output' 2>&1 &&
 ls . >> '$hidden_output' &&
-cat 'anndata_info.txt'
+cat 'anndata_info.txt' @CMD_prettify_stdout@
     ]]>
     </token>
     <token name="@CMD_imports@"><![CDATA[
@@ -55,6 +55,8 @@ with open('anndata_info.txt','w') as ainfo:
     print(adata, file=ainfo)
 ]]>
     </token>
+    <token name="@CMD_prettify_stdout@"><![CDATA[ | sed -r '1 s|AnnData object with (.+) = (.*)\s*|\1: \2|g' | sed "s|'||g"  | sed -r 's|^\s*(.*):\s(.*)|[\1]\n-    \2|g' | sed 's|, |\n-    |g'
+    ]]></token>
     <xml name="svd_solver">
         <param name="svd_solver" type="select" label="SVD solver to use" help="">
             <option value="auto">Automatically chosen depending on the size of the problem</option>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -55,7 +55,7 @@ adata = sc.read('anndata.h5ad')
     </xml>
     <token name="@CMD_anndata_write_outputs@"><![CDATA[
 adata.write('anndata.h5ad')
-with open('anndata_info.txt','w') as ainfo:
+with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
     print(adata, file=ainfo)
 ]]>
     </token>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -51,7 +51,7 @@ adata = sc.read('anndata.h5ad')
     </xml>
     <xml name="anndata_outputs">
         <data name="anndata_out" format="h5ad" from_work_dir="anndata.h5ad" label="${tool.name} (${method.method}) on ${on_string}: Annotated data matrix"/>
-        <data name="hidden_output" format="txt" label="Log file" hidden="true" >
+        <data name="hidden_output" format="txt" label="Log file" >
             <filter>advanced_common['show_log']</filter>
         </data>
     </xml>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -21,9 +21,10 @@
     </xml>
     <token name="@CMD@"><![CDATA[
 cp '$adata' 'anndata.h5ad' &&
-cat '$script_file' &&
-python '$script_file' &&
-ls .
+cat '$script_file' > '$hidden_output' &&
+python '$script_file' >> '$hidden_output' 2>&1 &&
+ls . >> '$hidden_output' &&
+cat 'anndata_info.txt'
     ]]>
     </token>
     <token name="@CMD_imports@"><![CDATA[
@@ -41,9 +42,17 @@ adata = sc.read('anndata.h5ad')
     </token>
     <xml name="anndata_outputs">
         <data name="anndata_out" format="h5ad" from_work_dir="anndata.h5ad" label="${tool.name} (${method.method}) on ${on_string}: Annotated data matrix"/>
+        <data name="hidden_output" format="txt" label="Log file" hidden="true" >
+            <!-- The purpose of this is to consolidate all unnecessary logging information into a hidden
+                 output file that:
+                 a) Galaxy can see and can therefore test its contents against, and
+                 b) The user can not see -->
+        </data>
     </xml>
     <token name="@CMD_anndata_write_outputs@"><![CDATA[
 adata.write('anndata.h5ad')
+with open('anndata_info.txt','w') as ainfo:
+    print(adata, file=ainfo)
 ]]>
     </token>
     <xml name="svd_solver">

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -44,13 +44,15 @@ import numpy as np
 adata = sc.read('anndata.h5ad')
 ]]>
     </token>
+    <xml name="inputs_common_advanced">
+        <section name="advanced_common" title="Advanced Options" expanded="false">
+            <param name="show_log" type="boolean" checked="false" label="Output Log?" />
+        </section>
+    </xml>
     <xml name="anndata_outputs">
         <data name="anndata_out" format="h5ad" from_work_dir="anndata.h5ad" label="${tool.name} (${method.method}) on ${on_string}: Annotated data matrix"/>
         <data name="hidden_output" format="txt" label="Log file" hidden="true" >
-            <!-- The purpose of this is to consolidate all unnecessary logging information into a hidden
-                 output file that:
-                 a) Galaxy can see and can therefore test its contents against, and
-                 b) The user can not see -->
+            <filter>advanced_common['show_log']</filter>
         </data>
     </xml>
     <token name="@CMD_anndata_write_outputs@"><![CDATA[

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -115,6 +115,7 @@ sc.pp.recipe_seurat(
                 <expand macro="param_log"/>
             </when>
         </conditional>
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <expand macro="anndata_outputs"/>

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -132,12 +132,14 @@ sc.pp.recipe_seurat(
                 <param name="layers" value="all"/>
                 <param name="layer_norm" value="None"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.normalize_total"/>
-                <has_text_matching expression="exclude_highly_expressed=False"/>
-                <has_text_matching expression="key_added='n_counts'"/>
-                <has_text_matching expression="layers='all'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.normalize_total"/>
+                    <has_text_matching expression="exclude_highly_expressed=False"/>
+                    <has_text_matching expression="key_added='n_counts'"/>
+                    <has_text_matching expression="layers='all'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.normalize_total.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -148,11 +150,13 @@ sc.pp.recipe_seurat(
                 <param name="n_top_genes" value="1000"/>
                 <param name="log" value="True"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.recipe_zheng17"/>
-                <has_text_matching expression="n_top_genes=1000"/>
-                <has_text_matching expression="log=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.recipe_zheng17"/>
+                    <has_text_matching expression="n_top_genes=1000"/>
+                    <has_text_matching expression="log=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.recipe_zheng17.random-randint.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -167,15 +171,17 @@ sc.pp.recipe_seurat(
                 <param name="svd_solver" value="randomized"/>
                 <param name="random_state" value="0"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.recipe_weinreb17"/>
-                <has_text_matching expression="log=True"/>
-                <has_text_matching expression="mean_threshold=0.01"/>
-                <has_text_matching expression="cv_threshold=2.0"/>
-                <has_text_matching expression="n_pcs=50"/>
-                <has_text_matching expression="svd_solver='randomized'"/>
-                <has_text_matching expression="random_state=0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.recipe_weinreb17"/>
+                    <has_text_matching expression="log=True"/>
+                    <has_text_matching expression="mean_threshold=0.01"/>
+                    <has_text_matching expression="cv_threshold=2.0"/>
+                    <has_text_matching expression="n_pcs=50"/>
+                    <has_text_matching expression="svd_solver='randomized'"/>
+                    <has_text_matching expression="random_state=0"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.recipe_weinreb17.paul15_subsample.updated.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
@@ -185,13 +191,14 @@ sc.pp.recipe_seurat(
                 <param name="method" value="pp.recipe_seurat"/>
                 <param name="log" value="True"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.recipe_seurat"/>
-                <has_text_matching expression="log=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.recipe_seurat"/>
+                    <has_text_matching expression="log=True"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.recipe_seurat.recipe_zheng17.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
-        
     </tests>
     <help><![CDATA[
 Normalize total counts per cell (`pp.normalize_per_cell`)

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -121,7 +121,7 @@ sc.pp.recipe_seurat(
     </outputs>
     <tests>
         <test>
-            <!-- test 1 -->
+            <!-- test 0 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.normalize_total"/>
@@ -141,7 +141,7 @@ sc.pp.recipe_seurat(
             <output name="anndata_out" file="pp.normalize_total.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="random-randint.h5ad"/>
             <conditional name="method">
                 <param name="method" value="pp.recipe_zheng17"/>
@@ -156,7 +156,7 @@ sc.pp.recipe_seurat(
             <output name="anndata_out" file="pp.recipe_zheng17.random-randint.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 3 -->
+            <!-- test 2 -->
             <param name="adata" value="paul15_subsample.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.recipe_weinreb17"/>
@@ -179,7 +179,7 @@ sc.pp.recipe_seurat(
             <output name="anndata_out" file="pp.recipe_weinreb17.paul15_subsample.updated.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 4 -->
+            <!-- test 3 -->
             <param name="adata" value="pp.recipe_zheng17.random-randint.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.recipe_seurat"/>

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -133,6 +133,9 @@ sc.pp.recipe_seurat(
                 <param name="layers" value="all"/>
                 <param name="layer_norm" value="None"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.normalize_total"/>
@@ -151,6 +154,9 @@ sc.pp.recipe_seurat(
                 <param name="n_top_genes" value="1000"/>
                 <param name="log" value="True"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.recipe_zheng17"/>
@@ -172,6 +178,9 @@ sc.pp.recipe_seurat(
                 <param name="svd_solver" value="randomized"/>
                 <param name="random_state" value="0"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.recipe_weinreb17"/>
@@ -192,6 +201,9 @@ sc.pp.recipe_seurat(
                 <param name="method" value="pp.recipe_seurat"/>
                 <param name="log" value="True"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.recipe_seurat"/>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -82,7 +82,7 @@ sc.pl.violin(
     log=$method.log,
     use_raw=$method.use_raw,
     @CMD_conditional_stripplot@
-    multi_panel=$method.violin_plot.multi_panel.multi_panel, 
+    multi_panel=$method.violin_plot.multi_panel.multi_panel,
     #if $method.violin_plot.multi_panel.multi_panel == "True" and str($method.violin_plot.multi_panel.width) != '' and str($method.violin_plot.multi_panel.height) != ''
     figsize=($method.violin_plot.multi_panel.width, $method.violin_plot.multi_panel.height),
     #end if
@@ -551,7 +551,7 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param argument="palette" type="select" optional="true" label="Colors to use for the different levels of the hue variable" help="See https://seaborn.pydata.org/tutorial/color_palettes.html for more details.">
                         <expand macro="seaborn_color_palette_options"/>
                     </param>
-                    <param argument="saturation" type="float" value="1" label="Proportion of the original saturation to draw colors at" help="Large patches often look better with slightly desaturated colors, but set this to 1 if you want the plot colors to perfectly match the input color spec."/>            
+                    <param argument="saturation" type="float" value="1" label="Proportion of the original saturation to draw colors at" help="Large patches often look better with slightly desaturated colors, but set this to 1 if you want the plot colors to perfectly match the input color spec."/>
                 </section>
             </when>
             <when value="pl.pca">
@@ -641,7 +641,7 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <expand macro="inputs_paga"/>
             </when>
             <when value="pl.paga_path">
-                <param argument="nodes" type="text" value="" label="A path through nodes of the abstracted graph" 
+                <param argument="nodes" type="text" value="" label="A path through nodes of the abstracted graph"
                     help="Each node is represented by its indice (within .categories) for the groups that have been used to run PAGA. Comma-separated"/>
                 <param argument="keys" type="text" value="" label="Keys for accessing variables" help="One or a list of comma-separated index or key from '.var_names' or fields of '.obs'"/>
                 <expand macro="param_use_raw"/>
@@ -1613,7 +1613,7 @@ sc.pl.rank_genes_groups_stacked_violin(
         </test>!-->
         <!--<test>
              test pl.paga_path
-        </test>!-->  
+        </test>!-->
         <test>
             <!-- test 19: pl.rank_genes_groups !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
@@ -1892,7 +1892,7 @@ More details on the `scanpy documentation
 Generic: Stacked violin plots (`pl.stacked_violin`)
 ===================================================
 
-Makes a compact image composed of individual violin plots (from `seaborn.violinplot`) 
+Makes a compact image composed of individual violin plots (from `seaborn.violinplot`)
 stacked on top of each other. Useful to visualize gene expression per cluster.
 
 More details on the `scanpy documentation

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -759,6 +759,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="size" value="1"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.scatter"/>
@@ -805,6 +808,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="title" value="A title"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.scatter"/>
@@ -851,6 +857,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="origin" value="upper"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.heatmap"/>
@@ -905,6 +914,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.dotplot"/>
@@ -958,6 +970,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.violin"/>
@@ -1016,6 +1031,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.stacked_violin"/>
@@ -1063,6 +1081,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="snap" value="False"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.matrixplot"/>
@@ -1096,6 +1117,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="row_cluster" value="False"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.clustermap"/>
@@ -1122,6 +1146,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.5"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.highest_expr_genes"/>
@@ -1142,6 +1169,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="log" value="false"/>
                 <param name="highly_variable_genes" value="true"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.highly_variable_genes"/>
@@ -1186,6 +1216,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.pca"/>
@@ -1218,6 +1251,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="method" value="pl.pca_loadings"/>
                 <param name="components" value="1,2,3"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.pca_loadings"/>
@@ -1235,6 +1271,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="n_pcs" value="5"/>
                 <param name="log" value="False"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.pca_variance_ratio"/>
@@ -1265,6 +1304,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="hspace" value="0.25"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.pca_overview"/>
@@ -1313,6 +1355,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.tsne"/>
@@ -1367,6 +1412,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.umap"/>
@@ -1419,6 +1467,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.diffmap"/>
@@ -1470,6 +1521,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.draw_graph"/>
@@ -1518,6 +1572,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="color_map" value="viridis"/>
                 </conditional>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.dpt_timeseries"/>
@@ -1568,6 +1625,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="ncols" value="4"/>
                 <param name="sharey" value="true"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups"/>
@@ -1600,6 +1660,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="scale" value="width"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups_violin"/>
@@ -1636,6 +1699,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups_dotplot"/>
@@ -1668,6 +1734,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="origin" value="upper"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups_heatmap"/>
@@ -1700,6 +1769,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="snap" value="False"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups_matrixplot"/>
@@ -1744,6 +1816,9 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pl.rank_genes_groups_stacked_violin"/>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -706,6 +706,7 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <expand macro="pl_stacked_violin"/>
             </when>
         </conditional>
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <data name="out_png" format="png" from_work_dir="*.png" label="${tool.name} (${method.method}) on ${on_string}">
@@ -730,10 +731,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <filter>format == 'svg' and method['method'] == 'pl.rank_genes_groups_violin'</filter>
         </collection>
         <data name="hidden_output" format="txt" label="Log file" hidden="true" >
-            <!-- The purpose of this is to consolidate all unnecessary logging information into a hidden
-                 output file that:
-                 a) Galaxy can see and can therefore test its contents against, and
-                 b) The user can not see -->
+            <filter>advanced_common['show_log']</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -729,6 +729,12 @@ sc.pl.rank_genes_groups_stacked_violin(
             <discover_datasets pattern="rank_genes_groups_(?P&lt;designation&gt;.*).svg" format="svg"/>
             <filter>format == 'svg' and method['method'] == 'pl.rank_genes_groups_violin'</filter>
         </collection>
+        <data name="hidden_output" format="txt" label="Log file" hidden="true" >
+            <!-- The purpose of this is to consolidate all unnecessary logging information into a hidden
+                 output file that:
+                 a) Galaxy can see and can therefore test its contents against, and
+                 b) The user can not see -->
+        </data>
     </outputs>
     <tests>
         <test>
@@ -755,21 +761,23 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="size" value="1"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.scatter"/>
-                <has_text_matching expression="basis='umap'" />
-                <has_text_matching expression="color=\['HES4'\]"/>
-                <has_text_matching expression="use_raw=True"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="color_map='inferno'"/>
-                <has_text_matching expression="palette='inferno'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="size=1.0"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.scatter"/>
+                    <has_text_matching expression="basis='umap'" />
+                    <has_text_matching expression="color=\['HES4'\]"/>
+                    <has_text_matching expression="use_raw=True"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="color_map='inferno'"/>
+                    <has_text_matching expression="palette='inferno'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="size=1.0"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.scatter.umap.pbmc68k_reduced.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -799,21 +807,23 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="title" value="A title"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.scatter"/>
-                <has_text_matching expression="x='EKLF'" />
-                <has_text_matching expression="y='Cebpa'"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="palette='bwr'"/>
-                <has_text_matching expression="frameon=False"/>
-                <has_text_matching expression="size=1.0"/>
-                <has_text_matching expression="title='A title'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.scatter"/>
+                    <has_text_matching expression="x='EKLF'" />
+                    <has_text_matching expression="y='Cebpa'"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="palette='bwr'"/>
+                    <has_text_matching expression="frameon=False"/>
+                    <has_text_matching expression="size=1.0"/>
+                    <has_text_matching expression="title='A title'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.scatter.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -843,20 +853,22 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="origin" value="upper"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.heatmap"/>
-                <has_text_matching expression="var_names=adata.var_names" />
-                <has_text_matching expression="groupby='cell_type'"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="num_categories=7"/>
-                <has_text_matching expression="dendrogram=True"/>
-                <has_text_matching expression="figsize=\(10, 3\)"/>
-                <has_text_matching expression="swap_axes=True"/>
-                <has_text_matching expression="show_gene_labels=False"/>
-                <has_text_matching expression="cmap='YlGnBu'"/>
-                <has_text_matching expression="origin='upper'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.heatmap"/>
+                    <has_text_matching expression="var_names=adata.var_names" />
+                    <has_text_matching expression="groupby='cell_type'"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="num_categories=7"/>
+                    <has_text_matching expression="dendrogram=True"/>
+                    <has_text_matching expression="figsize=\(10, 3\)"/>
+                    <has_text_matching expression="swap_axes=True"/>
+                    <has_text_matching expression="show_gene_labels=False"/>
+                    <has_text_matching expression="cmap='YlGnBu'"/>
+                    <has_text_matching expression="origin='upper'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.heatmap.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -895,22 +907,24 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.dotplot"/>
-                <has_text_matching expression="var_names=\['CD79A', 'MS4A1', 'CD8A', 'CD8B', 'LYZ', 'GNLY', 'NKG7', 'RP3-467N11.1', 'FCGR3A', 'FCER1A', 'CST3', 'POU2AF1', 'LINC00402'\]" />
-                <has_text_matching expression="groupby='louvain'"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="num_categories=7"/>
-                <has_text_matching expression="dendrogram=True"/>
-                <has_text_matching expression="var_group_positions=\[\(0, 1\), \(11, 12\)\]"/>
-                <has_text_matching expression="var_group_labels=\['B cells', 'dendritic'\]"/>
-                <has_text_matching expression="color_map='hot'"/>
-                <has_text_matching expression="dot_max=0.7"/>
-                <has_text_matching expression="dot_min=0.1"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.dotplot"/>
+                    <has_text_matching expression="var_names=\['CD79A', 'MS4A1', 'CD8A', 'CD8B', 'LYZ', 'GNLY', 'NKG7', 'RP3-467N11.1', 'FCGR3A', 'FCER1A', 'CST3', 'POU2AF1', 'LINC00402'\]" />
+                    <has_text_matching expression="groupby='louvain'"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="num_categories=7"/>
+                    <has_text_matching expression="dendrogram=True"/>
+                    <has_text_matching expression="var_group_positions=\[\(0, 1\), \(11, 12\)\]"/>
+                    <has_text_matching expression="var_group_labels=\['B cells', 'dendritic'\]"/>
+                    <has_text_matching expression="color_map='hot'"/>
+                    <has_text_matching expression="dot_max=0.7"/>
+                    <has_text_matching expression="dot_min=0.1"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.dotplot.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -946,24 +960,26 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.violin"/>
-                <has_text_matching expression="keys=\['n_genes', 'percent_mito', 'n_counts'\]" />
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="stripplot=True"/>
-                <has_text_matching expression="jitter=True"/>
-                <has_text_matching expression="size=1"/>
-                <has_text_matching expression="multi_panel=True"/>
-                <has_text_matching expression="figsize=\(20, 20\)"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="bw='scott'"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="linewidth=0.0"/>
-                <has_text_matching expression="color='AliceBlue'"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="saturation=0.75"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.violin"/>
+                    <has_text_matching expression="keys=\['n_genes', 'percent_mito', 'n_counts'\]" />
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="stripplot=True"/>
+                    <has_text_matching expression="jitter=True"/>
+                    <has_text_matching expression="size=1"/>
+                    <has_text_matching expression="multi_panel=True"/>
+                    <has_text_matching expression="figsize=\(20, 20\)"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="bw='scott'"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="linewidth=0.0"/>
+                    <has_text_matching expression="color='AliceBlue'"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="saturation=0.75"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.violin.pbmc68k_reduced_custom.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1002,25 +1018,27 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.stacked_violin"/>
-                <has_text_matching expression="groupby='cell_type'"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="num_categories=7"/>
-                <has_text_matching expression="dendrogram=True"/>
-                <has_text_matching expression="swap_axes=True"/>
-                <has_text_matching expression="stripplot=True"/>
-                <has_text_matching expression="jitter=True"/>
-                <has_text_matching expression="size=1"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="bw='scott'"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="linewidth=0.0"/>
-                <has_text_matching expression="color='AliceBlue'"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="saturation=0.75"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.stacked_violin"/>
+                    <has_text_matching expression="groupby='cell_type'"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="num_categories=7"/>
+                    <has_text_matching expression="dendrogram=True"/>
+                    <has_text_matching expression="swap_axes=True"/>
+                    <has_text_matching expression="stripplot=True"/>
+                    <has_text_matching expression="jitter=True"/>
+                    <has_text_matching expression="size=1"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="bw='scott'"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="linewidth=0.0"/>
+                    <has_text_matching expression="color='AliceBlue'"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="saturation=0.75"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.stacked_violin.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1047,19 +1065,21 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="snap" value="False"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.matrixplot"/>
-                <has_text_matching expression="var_names=adata.var_names" />
-                <has_text_matching expression="groupby='cell_type'"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="num_categories=7"/>
-                <has_text_matching expression="dendrogram=True"/>
-                <has_text_matching expression="swap_axes=True"/>
-                <has_text_matching expression="cmap='viridis'"/>
-                <has_text_matching expression="edgecolors='face'"/>
-                <has_text_matching expression="snap=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.matrixplot"/>
+                    <has_text_matching expression="var_names=adata.var_names" />
+                    <has_text_matching expression="groupby='cell_type'"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="num_categories=7"/>
+                    <has_text_matching expression="dendrogram=True"/>
+                    <has_text_matching expression="swap_axes=True"/>
+                    <has_text_matching expression="cmap='viridis'"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                    <has_text_matching expression="snap=False"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.matrixplot.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1078,15 +1098,17 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="row_cluster" value="False"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.clustermap"/>
-                <has_text_matching expression="adata=adata" />
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="method='single'"/>
-                <has_text_matching expression="metric='euclidean'"/>
-                <has_text_matching expression="col_cluster=False"/>
-                <has_text_matching expression="row_cluster=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.clustermap"/>
+                    <has_text_matching expression="adata=adata" />
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="method='single'"/>
+                    <has_text_matching expression="metric='euclidean'"/>
+                    <has_text_matching expression="col_cluster=False"/>
+                    <has_text_matching expression="row_cluster=False"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.clustermap.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1102,13 +1124,15 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.5"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.highest_expr_genes"/>
-                <has_text_matching expression="n_top=30" />
-                <has_text_matching expression="gene_symbols='means'" />
-                <has_text_matching expression="color='blue'"/>
-                <has_text_matching expression="saturation=0.5"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.highest_expr_genes"/>
+                    <has_text_matching expression="n_top=30" />
+                    <has_text_matching expression="gene_symbols='means'" />
+                    <has_text_matching expression="color='blue'"/>
+                    <has_text_matching expression="saturation=0.5"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.highest_expr_genes.filter_genes_dispersion.krumsiek11-seurat.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1120,12 +1144,14 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="log" value="false"/>
                 <param name="highly_variable_genes" value="true"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.highly_variable_genes"/>
-                <has_text_matching expression="adata_or_result=adata" />
-                <has_text_matching expression="log=False" />
-                <has_text_matching expression="highly_variable_genes=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.highly_variable_genes"/>
+                    <has_text_matching expression="adata_or_result=adata" />
+                    <has_text_matching expression="log=False" />
+                    <has_text_matching expression="highly_variable_genes=True"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.highly_variable_genes.seurat.blobs.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1162,26 +1188,28 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.pca"/>
-                <has_text_matching expression="save='.pdf'" />
-                <has_text_matching expression="color=\['CD3D', 'CD79A'\]" />
-                <has_text_matching expression="use_raw=False" />
-                <has_text_matching expression="sort_order=True" />
-                <has_text_matching expression="components=\['1,2', '1,3'\]" />
-                <has_text_matching expression="projection='2d'" />
-                <has_text_matching expression="legend_loc='right margin'" />
-                <has_text_matching expression="legend_fontsize=1" />
-                <has_text_matching expression="legend_fontweight='normal'" />
-                <has_text_matching expression="size=1.0" />
-                <has_text_matching expression="palette='viridis'" />
-                <has_text_matching expression="frameon=True" />
-                <has_text_matching expression="ncols=2" />
-                <has_text_matching expression="wspace=0.1" />
-                <has_text_matching expression="hspace=0.25" />
-                <has_text_matching expression="linewidths=0.0" />
-                <has_text_matching expression="edgecolors='face" />
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.pca"/>
+                    <has_text_matching expression="save='.pdf'" />
+                    <has_text_matching expression="color=\['CD3D', 'CD79A'\]" />
+                    <has_text_matching expression="use_raw=False" />
+                    <has_text_matching expression="sort_order=True" />
+                    <has_text_matching expression="components=\['1,2', '1,3'\]" />
+                    <has_text_matching expression="projection='2d'" />
+                    <has_text_matching expression="legend_loc='right margin'" />
+                    <has_text_matching expression="legend_fontsize=1" />
+                    <has_text_matching expression="legend_fontweight='normal'" />
+                    <has_text_matching expression="size=1.0" />
+                    <has_text_matching expression="palette='viridis'" />
+                    <has_text_matching expression="frameon=True" />
+                    <has_text_matching expression="ncols=2" />
+                    <has_text_matching expression="wspace=0.1" />
+                    <has_text_matching expression="hspace=0.25" />
+                    <has_text_matching expression="linewidths=0.0" />
+                    <has_text_matching expression="edgecolors='face" />
+                </assert_contents>
+            </output>
             <output name="out_pdf" file="pl.pca.pbmc68k_reduced.CD3D_CD79A_components_2d.pdf" ftype="pdf" compare="sim_size"/>
         </test>
         <test>
@@ -1192,10 +1220,12 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="method" value="pl.pca_loadings"/>
                 <param name="components" value="1,2,3"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.pca_loadings"/>
-                <has_text_matching expression="components=\[1, 2, 3\]" />
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.pca_loadings"/>
+                    <has_text_matching expression="components=\[1, 2, 3\]" />
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.pca_loadings.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
@@ -1207,11 +1237,13 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="n_pcs" value="5"/>
                 <param name="log" value="False"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.pca_variance_ratio"/>
-                <has_text_matching expression="n_pcs=5" />
-                <has_text_matching expression="log=False" />
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.pca_variance_ratio"/>
+                    <has_text_matching expression="n_pcs=5" />
+                    <has_text_matching expression="log=False" />
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.pca_variance_ratio.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
@@ -1235,21 +1267,23 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="hspace" value="0.25"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.pca_overview"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="size=1.0"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="wspace=0.1"/>
-                <has_text_matching expression="hspace=0.25"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.pca_overview"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="size=1.0"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="wspace=0.1"/>
+                    <has_text_matching expression="hspace=0.25"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.pca_overview.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
@@ -1281,25 +1315,27 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.tsne"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="edges=False"/>
-                <has_text_matching expression="arrows=False"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="size=1.0"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="wspace=0.1"/>
-                <has_text_matching expression="hspace=0.25"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.tsne"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="edges=False"/>
+                    <has_text_matching expression="arrows=False"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="size=1.0"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="wspace=0.1"/>
+                    <has_text_matching expression="hspace=0.25"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.tsne.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1333,28 +1369,30 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.umap"/>
-                <has_text_matching expression="color=\['paul15_clusters'\]"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="edges=True"/>
-                <has_text_matching expression="edges_width=0.1"/>
-                <has_text_matching expression="edges_color='AliceBlue'"/>
-                <has_text_matching expression="arrows=False"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="size=1.0"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="wspace=0.1"/>
-                <has_text_matching expression="hspace=0.25"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.umap"/>
+                    <has_text_matching expression="color=\['paul15_clusters'\]"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="edges=True"/>
+                    <has_text_matching expression="edges_width=0.1"/>
+                    <has_text_matching expression="edges_color='AliceBlue'"/>
+                    <has_text_matching expression="arrows=False"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="size=1.0"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="wspace=0.1"/>
+                    <has_text_matching expression="hspace=0.25"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1383,24 +1421,26 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.diffmap"/>
-                <has_text_matching expression="color=\['paul15_clusters'\]"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="sort_order=True"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontsize=1"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="size=1.0"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="wspace=0.1"/>
-                <has_text_matching expression="hspace=0.25"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.diffmap"/>
+                    <has_text_matching expression="color=\['paul15_clusters'\]"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="sort_order=True"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontsize=1"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="size=1.0"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="wspace=0.1"/>
+                    <has_text_matching expression="hspace=0.25"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1432,25 +1472,27 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.draw_graph"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="edges=True"/>
-                <has_text_matching expression="edges_width=0.1"/>
-                <has_text_matching expression="edges_color='Crimson'"/>
-                <has_text_matching expression="arrows=False"/>
-                <has_text_matching expression="sort_order=False"/>
-                <has_text_matching expression="projection='2d'"/>
-                <has_text_matching expression="legend_loc='right margin'"/>
-                <has_text_matching expression="legend_fontweight='normal'"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="frameon=True"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="wspace=0.1"/>
-                <has_text_matching expression="hspace=0.25"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.draw_graph"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="edges=True"/>
+                    <has_text_matching expression="edges_width=0.1"/>
+                    <has_text_matching expression="edges_color='Crimson'"/>
+                    <has_text_matching expression="arrows=False"/>
+                    <has_text_matching expression="sort_order=False"/>
+                    <has_text_matching expression="projection='2d'"/>
+                    <has_text_matching expression="legend_loc='right margin'"/>
+                    <has_text_matching expression="legend_fontweight='normal'"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="frameon=True"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="wspace=0.1"/>
+                    <has_text_matching expression="hspace=0.25"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.draw_graph.png" ftype="png" compare="sim_size"/>
         </test>
         <!--<test>
@@ -1478,11 +1520,13 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="color_map" value="viridis"/>
                 </conditional>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.dpt_timeseries"/>
-                <has_text_matching expression="color_map='viridis'"/>
-                <has_text_matching expression="as_heatmap=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.dpt_timeseries"/>
+                    <has_text_matching expression="color_map='viridis'"/>
+                    <has_text_matching expression="as_heatmap=True"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.dpt_timeseries.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>
         <!--<test>
@@ -1526,13 +1570,15 @@ sc.pl.rank_genes_groups_stacked_violin(
                 <param name="ncols" value="4"/>
                 <param name="sharey" value="true"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="fontsize=8"/>
-                <has_text_matching expression="ncols=4"/>
-                <has_text_matching expression="sharey=True"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="fontsize=8"/>
+                    <has_text_matching expression="ncols=4"/>
+                    <has_text_matching expression="sharey=True"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.rank_genes_groups.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1556,16 +1602,18 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="scale" value="width"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups_violin"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="split=True"/>
-                <has_text_matching expression="strip=True"/>
-                <has_text_matching expression="jitter=True"/>
-                <has_text_matching expression="size=1"/>
-                <has_text_matching expression="scale='width'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups_violin"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="split=True"/>
+                    <has_text_matching expression="strip=True"/>
+                    <has_text_matching expression="jitter=True"/>
+                    <has_text_matching expression="size=1"/>
+                    <has_text_matching expression="scale='width'"/>
+                </assert_contents>
+            </output>
             <output_collection name="collection_png">
                 <element name="cell_type_Ery" file="pl.rank_genes_groups_violin.Ery.png" ftype="png" compare="sim_size"/>
                 <element name="cell_type_Mk" file="pl.rank_genes_groups_violin.Mk.png" ftype="png" compare="sim_size"/>
@@ -1590,16 +1638,18 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="edgecolors" value="face"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups_dotplot"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="dendrogram=False"/>
-                <has_text_matching expression="color_map='viridis'"/>
-                <has_text_matching expression="linewidths=0.0"/>
-                <has_text_matching expression="edgecolors='face'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups_dotplot"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="dendrogram=False"/>
+                    <has_text_matching expression="color_map='viridis'"/>
+                    <has_text_matching expression="linewidths=0.0"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.rank_genes_groups_dotplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1620,17 +1670,19 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="origin" value="upper"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups_heatmap"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="dendrogram=False"/>
-                <has_text_matching expression="swap_axes=False"/>
-                <has_text_matching expression="show_gene_labels=False"/>
-                <has_text_matching expression="cmap='viridis'"/>
-                <has_text_matching expression="origin='upper'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups_heatmap"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="dendrogram=False"/>
+                    <has_text_matching expression="swap_axes=False"/>
+                    <has_text_matching expression="show_gene_labels=False"/>
+                    <has_text_matching expression="cmap='viridis'"/>
+                    <has_text_matching expression="origin='upper'"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.rank_genes_groups_heatmap.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1650,17 +1702,19 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="snap" value="False"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups_matrixplot"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="dendrogram=False"/>
-                <has_text_matching expression="swap_axes=False"/>
-                <has_text_matching expression="cmap='viridis'"/>
-                <has_text_matching expression="edgecolors='face'"/>
-                <has_text_matching expression="snap=False"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups_matrixplot"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="dendrogram=False"/>
+                    <has_text_matching expression="swap_axes=False"/>
+                    <has_text_matching expression="cmap='viridis'"/>
+                    <has_text_matching expression="edgecolors='face'"/>
+                    <has_text_matching expression="snap=False"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.rank_genes_groups_matrixplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
@@ -1692,24 +1746,26 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <param name="saturation" value="0.75"/>
                 </section>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pl.rank_genes_groups_stacked_violin"/>
-                <has_text_matching expression="n_genes=10"/>
-                <has_text_matching expression="log=False"/>
-                <has_text_matching expression="use_raw=False"/>
-                <has_text_matching expression="dendrogram=True"/>
-                <has_text_matching expression="swap_axes=True"/>
-                <has_text_matching expression="stripplot=True"/>
-                <has_text_matching expression="jitter=True"/>
-                <has_text_matching expression="size=1"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="bw='scott'"/>
-                <has_text_matching expression="scale='width'"/>
-                <has_text_matching expression="linewidth=0.0"/>
-                <has_text_matching expression="color='AliceBlue'"/>
-                <has_text_matching expression="palette='viridis'"/>
-                <has_text_matching expression="saturation=0.75"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pl.rank_genes_groups_stacked_violin"/>
+                    <has_text_matching expression="n_genes=10"/>
+                    <has_text_matching expression="log=False"/>
+                    <has_text_matching expression="use_raw=False"/>
+                    <has_text_matching expression="dendrogram=True"/>
+                    <has_text_matching expression="swap_axes=True"/>
+                    <has_text_matching expression="stripplot=True"/>
+                    <has_text_matching expression="jitter=True"/>
+                    <has_text_matching expression="size=1"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="bw='scott'"/>
+                    <has_text_matching expression="scale='width'"/>
+                    <has_text_matching expression="linewidth=0.0"/>
+                    <has_text_matching expression="color='AliceBlue'"/>
+                    <has_text_matching expression="palette='viridis'"/>
+                    <has_text_matching expression="saturation=0.75"/>
+                </assert_contents>
+            </output>
             <output name="out_png" file="pl.rank_genes_groups_stacked_violin.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -732,7 +732,7 @@ sc.pl.rank_genes_groups_stacked_violin(
     </outputs>
     <tests>
         <test>
-            <!-- test 1: pl.scatter !-->
+            <!-- test 0: pl.scatter !-->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -773,7 +773,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.scatter.umap.pbmc68k_reduced.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 2: pl.scatter !-->
+            <!-- test 1: pl.scatter !-->
             <param name="adata" value="krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -817,7 +817,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.scatter.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 3: pl.heatmap !-->
+            <!-- test 2: pl.heatmap !-->
             <param name="adata" value="krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -860,7 +860,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.heatmap.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 4: pl.dotplot !-->
+            <!-- test 3: pl.dotplot !-->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -914,7 +914,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.dotplot.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 5: pl.violin !-->
+            <!-- test 4: pl.violin !-->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -967,7 +967,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.violin.pbmc68k_reduced_custom.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 6: pl.stacked_violin !-->
+            <!-- test 5: pl.stacked_violin !-->
             <param name="adata" value="krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1024,7 +1024,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.stacked_violin.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 7: pl.matrixplot !-->
+            <!-- test 6: pl.matrixplot !-->
             <param name="adata" value="krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1063,7 +1063,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.matrixplot.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 8: pl.clustermap !-->
+            <!-- test 7: pl.clustermap !-->
             <param name="adata" value="krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1090,7 +1090,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.clustermap.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 9: pl.highest_expr_genes !-->
+            <!-- test 8: pl.highest_expr_genes !-->
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1112,7 +1112,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.highest_expr_genes.filter_genes_dispersion.krumsiek11-seurat.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 10: pl.highly_variable_genes !-->
+            <!-- test 9: pl.highly_variable_genes !-->
             <param name="adata" value="pp.highly_variable_genes.seurat.blobs.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1129,7 +1129,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.highly_variable_genes.seurat.blobs.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 11: pl.pca !-->
+            <!-- test 10: pl.pca !-->
             <param name="adata" value="pbmc68k_reduced.h5ad" />
             <param name="format" value="pdf"/>
             <conditional name="method">
@@ -1185,7 +1185,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_pdf" file="pl.pca.pbmc68k_reduced.CD3D_CD79A_components_2d.pdf" ftype="pdf" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 12: pl.pca_loadings !-->
+            <!-- test 11: pl.pca_loadings !-->
             <param name="adata" value="pp.pca.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1199,7 +1199,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.pca_loadings.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 13: pl.pca_variance_ratio !-->
+            <!-- test 12: pl.pca_variance_ratio !-->
             <param name="adata" value="pp.pca.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1215,7 +1215,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.pca_variance_ratio.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 14: pl.pca_overview !-->
+            <!-- test 13: pl.pca_overview !-->
             <param name="adata" value="pp.pca.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1253,7 +1253,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.pca_overview.pp.pca.krumsiek11.png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 15: pl.tsne !-->
+            <!-- test 14: pl.tsne !-->
             <param name="adata" value="tl.tsne.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1303,7 +1303,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.tsne.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 16: pl.umap !-->
+            <!-- test 15: pl.umap !-->
             <param name="adata" value="tl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1358,7 +1358,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 17: pl.diffmap !-->
+            <!-- test 16: pl.diffmap !-->
             <param name="adata" value="tl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1404,7 +1404,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 18: pl.draw_graph !-->
+            <!-- test 17: pl.draw_graph !-->
             <param name="adata" value="tl.draw_graph.pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1468,7 +1468,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.dpt_groups_pseudotime.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="sim_size"/>
         </test>!-->
         <test>
-            <!-- test 19: pl.dpt_timeseries !-->
+            <!-- test 18: pl.dpt_timeseries !-->
             <param name="adata" value="tl.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1516,7 +1516,7 @@ sc.pl.rank_genes_groups_stacked_violin(
              test pl.paga_path
         </test>!-->  
         <test>
-            <!-- test 20: pl.rank_genes_groups !-->
+            <!-- test 19: pl.rank_genes_groups !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1536,7 +1536,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.rank_genes_groups.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 21: pl.rank_genes_groups_violin !-->
+            <!-- test 20: pl.rank_genes_groups_violin !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1575,7 +1575,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             </output_collection>
         </test>
         <test>
-            <!-- test 22: pl.rank_genes_groups_dotplot !-->
+            <!-- test 21: pl.rank_genes_groups_dotplot !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1603,7 +1603,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.rank_genes_groups_dotplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 23: pl.rank_genes_groups_heatmap !-->
+            <!-- test 22: pl.rank_genes_groups_heatmap !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1634,7 +1634,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.rank_genes_groups_heatmap.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 24: pl.rank_genes_groups_matrixplot !-->
+            <!-- test 23: pl.rank_genes_groups_matrixplot !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1664,7 +1664,7 @@ sc.pl.rank_genes_groups_stacked_violin(
             <output name="out_png" file="pl.rank_genes_groups_matrixplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="sim_size"/>
         </test>
         <test>
-            <!-- test 25: pl.rank_genes_groups_stacked_violin !-->
+            <!-- test 24: pl.rank_genes_groups_stacked_violin !-->
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad" />
             <param name="format" value="png"/>
             <conditional name="method">

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -115,10 +115,12 @@ sc.pp.combat(
                 <param name="method" value="pp.regress_out"/>
                 <param name="keys" value="cell_type"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.regress_out"/>
-                <has_text_matching expression="keys=\['cell_type'\]"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.regress_out"/>
+                    <has_text_matching expression="keys=\['cell_type'\]"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.regress_out.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
         <!--<test>
@@ -141,10 +143,12 @@ sc.pp.combat(
                 <param name="method" value="pp.combat"/>
                 <param name="key" value="blobs"/>
             </conditional>
-            <assert_stdout>
-                <has_text_matching expression="sc.pp.combat"/>
-                <has_text_matching expression="key='blobs'"/>
-            </assert_stdout>
+            <output name="hidden_output">
+                <assert_contents>
+                    <has_text_matching expression="sc.pp.combat"/>
+                    <has_text_matching expression="key='blobs'"/>
+                </assert_contents>
+            </output>
             <output name="anndata_out" file="pp.combat.blobs.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -109,7 +109,7 @@ sc.pp.combat(
     </outputs>
     <tests>
         <test>
-            <!-- test 1 -->
+            <!-- test 0 -->
             <param name="adata" value="krumsiek11.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.regress_out"/>
@@ -135,7 +135,7 @@ sc.pp.combat(
             <output name="anndata_out" file="pp.mnn_correct.krumsiek11.h5ad" ftype="h5ad" compare="sim_size"/>
         </test>-->
         <test>
-            <!-- test 2 -->
+            <!-- test 1 -->
             <param name="adata" value="blobs.h5ad" />
             <conditional name="method">
                 <param name="method" value="pp.combat"/>

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -103,6 +103,7 @@ sc.pp.combat(
                 <param argument="key" type="text" value="batch" label="Key to a categorical annotation from adata.obs that will be used for batch effect removal"/>
             </when>
         </conditional>
+        <expand macro="inputs_common_advanced"/>
     </inputs>
     <outputs>
         <expand macro="anndata_outputs"/>

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -116,6 +116,9 @@ sc.pp.combat(
                 <param name="method" value="pp.regress_out"/>
                 <param name="keys" value="cell_type"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.regress_out"/>
@@ -144,6 +147,9 @@ sc.pp.combat(
                 <param name="method" value="pp.combat"/>
                 <param name="key" value="blobs"/>
             </conditional>
+            <section name="advanced_common">
+                <param name="show_log" value="true" />
+            </section>
             <output name="hidden_output">
                 <assert_contents>
                     <has_text_matching expression="sc.pp.combat"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

The motivation here is to reduce the training time of the *PBMC 3K with ScanPy* training material, where there is a large time bottleneck in performing inspection on the generated H5AD sets. 

Instead of asking users to query their H5AD sets for general information, this PR aims to just print this nicely within the stdout window within the H5AD dataset in the history. The stdout at the moment contains debugging information, so this will be redirected to a seperate hidden output (so it can be still tested against, but not visible to the user).