### PR TITLE
Usability of lofreq call - minor improvements

### DIFF
--- a/tools/lofreq/lofreq_call.xml
+++ b/tools/lofreq/lofreq_call.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_call" name="Call variants" version="@WRAPPER_VERSION@0">
+<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy1">
     <description>with LoFreq</description>
     <macros>
         <import>macros.xml</import>
@@ -9,6 +9,28 @@
         @PREPARE_REF@
         ln -s '$reads' reads.bam &&
         ln -s -f '${reads.metadata.bam_index}' reads.bam.bai &&
+        #if str($call_control.set_call_options) == 'yes':
+            #set $ign_vcfs = []
+            #if str($call_control.source_qual.use_src_qual.src_qual):
+                #for $n, $ign_vcf in enumerate($call_control.source_qual.use_src_qual.ign_vcf):
+                    ## lofreq recognizes compressed vcf input based on its .gz
+                    ## suffix => symlink all datasets with standard extensions.
+                    ## For bgzipped vcfs, also make the index files available.
+                    #if $ign_vcf:
+                        #if $ign_vcf.is_of_type('vcf_bgzip'):
+                            #set $ign_src = 'ign%d.vcf.gz' % $n
+                            ln -s '$ign_vcf' $ign_src &&
+                            ln -s '$ign_vcf.metadata.tabix_index' ${ign_src}.tbi &&
+                        #else:
+                            #set $ign_src = 'ign%d.vcf' % $n
+                            ln -s '$ign_vcf' $ign_src &&
+                        #end if
+                        #silent $ign_vcfs.append($ign_src)
+                    #end if
+                #end for
+            #end if
+            #set $ign_vcfs = ','.join($ign_vcfs)
+        #end if
 
         ## call variants with lofreq
 
@@ -30,21 +52,33 @@
             --max-depth $call_control.coverage.max_depth
             $call_control.pe.use_orphan
             --min-bq $call_control.bc_quals.min_bq
-            --min-alt-bq $call_control.bc_quals.min_alt_bq
-            --def-alt-bq $call_control.bc_quals.def_alt_bq
+            #if $call_control.bc_quals.min_alt_bq > $call_control.bc_quals.min_bq:
+                --min-alt-bq $call_control.bc_quals.min_alt_bq
+            #else:
+                --min-alt-bq $call_control.bc_quals.min_bq
+            #end if
+            #if str($call_control.bc_quals.alt_bq.modify):
+                --def-alt-bq $call_control.bc_quals.alt_bq.def_alt_bq
+            #end if
             ${call_control.align_quals.alnqual.use_alnqual}
             #if str($call_control.align_quals.alnqual.use_alnqual) != '-A -B':
                 ${call_control.align_quals.alnqual.alnqual_choice.alnquals_to_use}
                 ${call_control.align_quals.alnqual.alnqual_choice.extended_baq}
             #end if
             --min-mq $call_control.map_quals.min_mq
-            --max-mq $call_control.map_quals.use_mq.max_mq
-            $call_control.map_quals.use_mq.no_mq
+            #if str($call_control.map_quals.use_mq.no_mq):
+                $call_control.map_quals.use_mq.no_mq
+            #else:
+                #if $call_control.map_quals.use_mq.max_mq > $call_control.map_quals.min_mq:
+                    --max-mq $call_control.map_quals.use_mq.max_mq
+                #else:
+                    --max-mq $call_control.map_quals.min_mq
+                #end if
+            #end if
             #if str($call_control.source_qual.use_src_qual.src_qual):
                 $call_control.source_qual.use_src_qual.src_qual
-                #set $ign_vcfs = ','.join([str($ign_vcf) for $ign_vcf in $call_control.source_qual.use_src_qual.ign_vcf if $ign_vcf])
                 #if $ign_vcfs:
-                    --ign-vcf "$ign_vcfs"
+                    --ign-vcf '$ign_vcfs'
                 #end if
                 --def-nm-q $call_control.source_qual.use_src_qual.def_nm_q
             #end if
@@ -125,9 +159,23 @@
                     <param name="min_alt_bq" argument="--min-alt-bq" type="integer" min="0" value="6"
                     label="Minimum baseQ for alternate bases"
                     help="For variant calling at any given site, do not consider reads that support a non-reference allele at the site if that base has a base quality less than this value (default: 6). Note: this setting will have no effect if the specified value is less than the general Minimum baseQ above." />
-                    <param name="def_alt_bq" argument="--def-alt-bq" type="integer" min="0" value="0"
-                    label="Overwrite baseQs of alternate bases with this value"
-                    help="After filtering reads according to the Minimum baseQ settings above, set the base quality of the non-reference bases in the surviving reads to this new value (default: 0 = keep the original base quality)." />
+                    <conditional name="alt_bq">
+                        <param name="modify" type="select"
+                        label="Base quality to use for alternate bases"
+                        help="After filtering reads according to the Minimum baseQ settings above, you can choose to modify the base qualities of the non-reference bases in the surviving reads before performing further calculations.">
+                            <option value="">Use original base qualities</option>
+                            <option value="avg">Use the median of the reference base qualities at the site</option>
+                            <option value="custom">Use a fixed custom value</option>
+                        </param>
+                        <when value="" />
+                        <when value="avg">
+                            <param name="def_alt_bq" type="hidden" value="-1" />
+                        </when>
+                        <when value="custom">
+                            <param name="def_alt_bq" argument="--def-alt-bq" type="integer" min="1" value="1"
+                                label="Overwrite original base qualities with this value" />
+                        </when>
+                    </conditional>
                 </section>
                 <section name="align_quals" title="Base alignment quality" expanded="true"
                 help="Choose here whether you want to incorporate base and/or indel alignment qualities into lofreq's joint quality model. If you have previously computed and stored (using lofreq alnqual) any of these quality scores into your input dataset, you can tell the tool to reuse them. Alternatively, the tool can calculate the necessary scores on the fly.">
@@ -160,7 +208,7 @@
                         <when value="">
                             <param name="max_mq" argument="--max-mq" type="integer" value="255"
                             label="Maximum mapping quality"
-                            help="For the joint quality model at any site, cap the mapping quality of reads at this value (default: 255 = do not cap mapping qualities). Note: The special MAPQ value 255 is used by many tools to indicate undefined mapping quality, and lofreq call will ignore such reads during variant calling. Capping, however, will turn 255 into a regular MAPQ score. Thus, if you need to avoid using such reads, you should filter out MAPQ 255 reads from your input data with other tools before using lofreq call with MAPQ capping."/>
+                            help="For the joint quality model at any site, cap the mapping quality of reads at this value (default: 255 = do not cap mapping qualities). Notes: 1) You cannot cap mapping qualities at less than the minimum MAPQ defined above. If you try, MAPQs will be capped at that minimum quality instead. 2) The special MAPQ value 255 is used by many tools to indicate undefined mapping quality, and lofreq call will ignore such reads during variant calling. Capping, however, will turn 255 into a regular MAPQ score. Thus, if you need to avoid using such reads, you should filter out MAPQ 255 reads from your input data with other tools before using lofreq call with MAPQ capping."/>
                         </when>
                         <when value="--no-mq">
                             <param name="max_mq" type="hidden" value="" />
@@ -179,7 +227,7 @@
                             <param name="def_nm_q" argument="--def-nm-q" type="integer" min="-1" value="-1"
                             label="Replace non-match base qualities with this value"
                             help="For the calculation of the source quality, replace all base qualities of non-match bases with this value (default: -1 = use original base qualities)." />
-                            <param name="ign_vcf" argument="--ign-vcf" type="data" format="vcf" optional="true" multiple="true"
+                            <param name="ign_vcf" argument="--ign-vcf" type="data" format="vcf,vcf_bgzip" optional="true" multiple="true"
                             label="VCF input(s) with variants to ignore for source quality computation"
                             help="Mismatches caused by known true variants in your samples should not lower the source quality estimate. If any read in your input has a base that is non-reference, but supports one of the known variants in the specified VCF datasets, that base will not be treated as a mismatch." />
                         </when>
@@ -242,6 +290,31 @@
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="ref_selector" value="history" />
             <param name="ref" ftype="fasta" value="pBR322.fa" />
+            <output name="variants" file="call-out1.vcf" lines_diff="4" />
+        </test>
+        <test>
+            <param name="reads" ftype="bam" value="lofreq-in1.bam" />
+            <param name="ref_selector" value="history" />
+            <param name="ref" ftype="fasta" value="pBR322.fa" />
+            <conditional name="call_control">
+                <param name="set_call_options" value="yes" />
+            </conditional>
+            <output name="variants" file="call-out1.vcf" lines_diff="4" />
+        </test>
+        <test>
+            <param name="reads" ftype="bam" value="lofreq-in1.bam" />
+            <param name="ref_selector" value="history" />
+            <param name="ref" ftype="fasta" value="pBR322.fa" />
+            <conditional name="call_control">
+                <param name="set_call_options" value="yes" />
+                <section name="source_qual">
+                    <conditional name="use_src_qual">
+                        <param name="src_qual" value="--src-qual" />
+                        <param name="def_nm_q" value="40" />
+                        <param name="ign_vcf" ftype="vcf" value="call-out1.vcf" />
+                    </conditional>
+                </section>
+            </conditional>
             <output name="variants" file="call-out1.vcf" lines_diff="4" />
         </test>
         <test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

* prevent errors because of --min-bq > --min-alt-bq and --min-mq > --max-mq
* provide option to replace non-ref basequals with median of ref ones
  (i.e., allow --def-alt-bq -1 to be configured)
* enable vcf_bgzip input to --ign-vcf