### PR TITLE
Allow env vars to override the HyPhy mpirun invocation for site-specific needs

### DIFF
--- a/tools/hyphy/macros.xml
+++ b/tools/hyphy/macros.xml
@@ -80,7 +80,7 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@HYPHYMPI@">mpirun -np \${GALAXY_SLOTS:-1} HYPHYMPI</token>
+    <token name="@HYPHYMPI@">\${GALAXY_MPIRUN:-mpirun -np \${GALAXY_SLOTS:-1}} HYPHYMPI</token>
     <token name="@HYPHY_ENVIRONMENT@"><![CDATA[export HYPHY=`which hyphy` &&
 export HYPHY_PATH=`dirname \$HYPHY` &&
 export HYPHY_LIB=`readlink -f \$HYPHY_PATH/../lib/hyphy` &&]]></token>


### PR DESCRIPTION
e.g. to run on Stampede2, we need to use the local [ibrun](https://portal.tacc.utexas.edu/user-guides/stampede2#running-launching-mpi) utility instead of `mpirun`.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
