### PR TITLE
fix binascii.hexlify argument

### DIFF
--- a/tool_collections/galaxy_sequence_utils/fastq_manipulation/fastq_manipulation.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_manipulation/fastq_manipulation.xml
@@ -40,7 +40,7 @@ def match_read(fastq_read):
         #else:
             #continue
         #end if
-    if not re.search(binascii.unhexlify(${ binascii.hexlify(str(match_block['match_type']['match']['match_by']).encode()) }).decode(), search_target):
+    if not re.search(binascii.unhexlify('${ binascii.hexlify(str(match_block['match_type']['match']['match_by']).encode()) }').decode(), search_target):
         return False
     #end for
     return True


### PR DESCRIPTION
fix error TypeError: argument should be bytes, buffer or ASCII string, not 'int'

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
