### PR TITLE
Include tool_data_table_conf.xml.sample in mash_screen

### DIFF
--- a/tools/mash/.shed.yml
+++ b/tools/mash/.shed.yml
@@ -24,3 +24,4 @@ repositories:
       - mash_screen.xml
       - macros.xml
       - test-data
+      - tool_data_table_conf.xml.sample


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Deployment of the new version of `mash_screen` that is capable of reading from the `mash_sketches` tool data table failed because the `tool_data_table_conf.xml.sample` file was not included in the repo.