### PR TITLE
Fix deseq2 dataset discovery

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -354,7 +354,7 @@ if (is.null(opt$many_contrasts)) {
       outDF <- as.data.frame(resSorted)
       outDF$geneID <- rownames(outDF)
       outDF <- outDF[,c("geneID", "baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj")]
-      filename <- paste0(opt$outfile,".",primaryFactor,"_",lvl,"_vs_",ref)
+      filename <- paste0(primaryFactor,"_",lvl,"_vs_",ref)
       write.table(outDF, file=filename, sep="\t", quote=FALSE, row.names=FALSE, col.names=FALSE)
       if (independentFiltering) {
         threshold <- unname(attr(res, "filterThreshold"))

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -1,4 +1,4 @@
-<tool id="deseq2" name="DESeq2" version="2.11.40.6">
+<tool id="deseq2" name="DESeq2" version="2.11.40.6+galaxy1">
     <description>Determines differentially expressed features from count tables</description>
     <macros>
         <import>deseq2_macros.xml</import>
@@ -217,7 +217,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         </data>
         <collection name="split_output" type="list" label="DESeq2 result files on ${on_string}">
             <filter>many_contrasts is True</filter>
-            <discover_datasets pattern="None.(?P&lt;designation&gt;.+_vs_.+)" format="tabular" directory="." visible="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+_vs_.+)" format="tabular" directory="." visible="false"/>
         </collection>
         <data name="plots" format="pdf" label="DESeq2 plots on ${on_string}">
             <filter>pdf == True</filter>
@@ -444,6 +444,44 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <has_text_matching expression="HOXC11\t0.557.*\t0.324.*\t0.437.*\t0.741.*\t0.458.*\t0.999.*"/>
                 </assert_contents>
             </output>
+        </test>
+        <!--Ensure many_contrasts produces output collection -->
+        <test expect_num_outputs="1">
+            <param name="select_data|how" value="group_tags"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="1" value="sailfish/sailfish_quant.sf1.tab" tags="group:primary:treated"/>
+                    <element name="2" value="sailfish/sailfish_quant.sf2.tab" tags="group:primary:treated"/>
+                    <element name="3" value="sailfish/sailfish_quant.sf3.tab" tags="group:primary:treated"/>
+                    <element name="4" value="sailfish/sailfish_quant.sf4.tab" tags="group:primary:untreated"/>
+                    <element name="5" value="sailfish/sailfish_quant.sf5.tab" tags="group:primary:untreated"/>
+                    <element name="6" value="sailfish/sailfish_quant.sf6.tab" tags="group:primary:untreated"/>
+                </collection>
+            </param>
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment"/>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated"/>
+                    <param name="groups" value="primary:treated"/>
+                </repeat>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Untreated"/>
+                    <param name="groups" value="primary:untreated"/>
+                </repeat>
+            </repeat>
+            <param name="pdf" value="False"/>
+            <param name="tximport_selector" value="tximport"/>
+            <param name="txtype" value="sailfish"/>
+            <param name="mapping_format_selector" value="tabular"/>
+            <param name="tabular_file" value="tx2gene.tab"/>
+            <param name="many_contrasts" value="true"/>
+            <output_collection name="split_output" type="list" count="1">
+                <element name="Treatment_Treated_vs_Untreated">
+                    <assert_contents>
+                        <has_text_matching expression="HOXC11\t0.557.*\t0.324.*\t0.437.*\t0.741.*\t0.458.*\t0.999.*"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
Fixes https://help.galaxyproject.org/t/deseq2-returns-results-as-empty-list/3058


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)