### PR TITLE
raxml: set slots and used binary using bash

### DIFF
--- a/tools/raxml/raxml.xml
+++ b/tools/raxml/raxml.xml
@@ -6,14 +6,13 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 ## binary is hard-coded to the pthreads enabled raxml executable if threads > 1
-#set $slots = $getVar('GALAXY_SLOTS', 1)
-#if $slots == 1:
-    raxmlHPC
-    ## Cannot have -T 1
-#else:
-    raxmlHPC-PTHREADS
-    -T $slots
-#end if
+slots=\${GALAXY_SLOTS:-1};
+if [ "\$slots" == "1" ]; then
+    bin="raxmlHPC";
+else
+    bin="raxmlHPC-PTHREADS -T \$slots";
+fi;
+\$bin
 -s '$infile'
 -n galaxy
 #if $search_model_selector.model_type == 'aminoacid':

--- a/tools/raxml/raxml.xml
+++ b/tools/raxml/raxml.xml
@@ -1,4 +1,4 @@
-<tool id="raxml" name="Phyogenetic reconstruction with RaXML" version="8.2.4+galaxy1">
+<tool id="raxml" name="Phyogenetic reconstruction with RaXML" version="8.2.4+galaxy2">
     <description>- Maximum Likelihood based inference of large phylogenetic trees</description>
     <requirements>
         <requirement type="package" version="8.2.4">raxml</requirement>


### PR DESCRIPTION
I think `getVar` only gets cheetah variables.

might fix https://github.com/galaxyproject/tools-iuc/issues/2916

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
