### PR TITLE
Use underscores in kc_align toolshed repo name

### DIFF
--- a/tools/kc-align/.shed.yml
+++ b/tools/kc-align/.shed.yml
@@ -1,6 +1,6 @@
 # .shed.yml supporting automatic pushes.
 owner: iuc
-name: kc-align
+name: kc_align
 homepage_url: https://github.com/davebx/kc-align
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/kc-align
 description: Kc-Align custom tool


### PR DESCRIPTION
`Unexpected HTTP status code: 400: {"err_msg": "Repository names must contain only lower-case letters, numbers and underscore.", "err_code": 400008}`