### PR TITLE
Remove auto_tool_repositories from kc-align

### DIFF
--- a/tools/kc-align/.shed.yml
+++ b/tools/kc-align/.shed.yml
@@ -8,6 +8,3 @@ long_description: Kc-Align is a codon-aware multiple aligner that uses Kalgin2 t
 categories:
   - Sequence Analysis
 type: unrestricted
-auto_tool_repositories:
-  name_template: "{{ tool_id }}"
-  description_template: "Wrapper for Kc-Align: {{ tool_name }}."


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
