### PR TITLE
Fix lofreq indel call options and help

### DIFF
--- a/tools/lofreq/lofreq_call.xml
+++ b/tools/lofreq/lofreq_call.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy1">
+<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy2>
     <description>with LoFreq</description>
     <macros>
         <import>macros.xml</import>
@@ -126,10 +126,10 @@
         </conditional>
         <param name="variant_types" type="select"
         label="Types of variants to call"
-        help="Note: When including indels in the called variants you should preprocess your input data to include indel alignment qualities">
+        help="Note: To have indels included in the called variants you HAVE to preprocess your input data using lofreq indelqual to include indel qualities. In addition, it is highly recommended that you calculate and make use of indel alignment qualities. See the detailed tool help below.">
             <option value="--call-indels">SNVs and indels</option>
             <option value="" selected="True">Only SNVs</option>
-            <option value="--only-indels">Only indels</option>
+            <option value="--call-indels --only-indels">Only indels</option>
         </param>
         <conditional name="call_control">
             <param name="set_call_options" type="select"
@@ -326,6 +326,16 @@
             </conditional>
             <output name="variants" file="call-out2.vcf" lines_diff="4" />
         </test>
+        <test>
+            <param name="reads" ftype="bam" value="indelqual-out3.bam" />
+            <param name="ref_selector" value="history" />
+            <param name="ref" ftype="fasta" value="pBR322.fa" />
+            <param name="variant_types" value="--call-indels --only-indels" />
+            <conditional name="filter_control">
+                <param name="filter_type" value="set_all_off" />
+            </conditional>
+            <output name="variants" file="indel-call-out.vcf" lines_diff="4" />
+        </test>
     </tests>
     <help><![CDATA[
 lofreq call: call variants from BAM file
@@ -364,7 +374,7 @@ combines some or all of the following read and base quality measures:
   responsible for adding indel qualitites, which are required for indel
   calling with lofreq, to your input.
 
-  For doing so, you can use ``lofreq indelqual`` or GATK's BQSR.
+  For doing so, you can use ``lofreq indelqual``.
 
 - Base/indel alignment quality
 

--- a/tools/lofreq/lofreq_call.xml
+++ b/tools/lofreq/lofreq_call.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy2>
+<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy2">
     <description>with LoFreq</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/lofreq/test-data/indel-call-out.vcf
+++ b/tools/lofreq/test-data/indel-call-out.vcf
@@ -1,0 +1,21 @@
+##fileformat=VCFv4.0
+##fileDate=20200320
+##source=lofreq call --verbose --ref reference.fa --call-indels --only-indels --sig 1 --bonf 1 --no-default-filter --no-default-filter -r pBR322:1-2180 -o /tmp/tmppZpVLj/job_working_directory/000/9/working/pp-tmp/lofreq2_call_parallele60ipsuv/0.vcf.gz reads.bam 
+##reference=reference.fa
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw Depth">
+##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##INFO=<ID=SB,Number=1,Type=Integer,Description="Phred-scaled strand bias at this position">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="Counts for ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">
+##INFO=<ID=HRUN,Number=1,Type=Integer,Description="Homopolymer length to the right of report indel position">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+pBR322	725	.	G	GN	0	.	DP=46;AF=0.021739;SB=0;DP4=22,23,0,1;INDEL;HRUN=1
+pBR322	746	.	A	AN	0	.	DP=225;AF=0.004444;SB=3;DP4=116,108,0,1;INDEL;HRUN=1
+pBR322	747	.	T	TN	0	.	DP=230;AF=0.004348;SB=3;DP4=118,111,0,1;INDEL;HRUN=1
+pBR322	751	.	G	GN	0	.	DP=255;AF=0.003922;SB=3;DP4=128,126,0,1;INDEL;HRUN=1
+pBR322	807	.	T	TN	0	.	DP=606;AF=0.001650;SB=0;DP4=300,305,0,1;INDEL;HRUN=3
+pBR322	943	.	C	CCG	0	.	DP=1465;AF=0.000683;SB=0;DP4=709,755,0,1;INDEL;HRUN=1
+pBR322	1152	.	C	CN	0	.	DP=1754;AF=0.000570;SB=0;DP4=926,830,1,0;INDEL;HRUN=2
+pBR322	1271	.	A	AN	0	.	DP=1743;AF=0.000574;SB=0;DP4=890,855,1,0;INDEL;HRUN=2
+pBR322	1376	.	A	ANN	0	.	DP=1691;AF=0.000591;SB=3;DP4=849,843,0,1;INDEL;HRUN=1


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This changeset fixes the broken `--only-indels` option of lofreq call.
It also improves the tool and param help to make it clearer that indels
cannot be called with lofreq without adding indel qualities first with
lofreq indelqual (the mention of GATK as an alternative is outdated
since new versions of GATK don't generate indel quality tags anymore,
and got removed).