### PR TITLE
stacks2: get log also in error case

### DIFF
--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -8,7 +8,7 @@
     </xml>
 
     <token name="@STACKS_VERSION@">2.4</token>
-    <token name="@WRAPPER_VERSION@">1</token>
+    <token name="@WRAPPER_VERSION@">2</token>
     <!-- fix to 18.01 since https://github.com/galaxyproject/galaxy/pull/7032 -->
     <token name="@PROFILE@">18.01</token>
 
@@ -107,12 +107,7 @@ Stacks was developed by Julian Catchen with contributions from Angel Amores, Pau
     <!-- log file handling -->
     <token name="@TEE_APPEND_LOG@"><![CDATA[
         #if $output_log
-            2>> '$output_log' &&
-        #end if
-    ]]></token>
-    <token name="@CAT_LOG_TO_STDERR@"><![CDATA[
-        #if $output_log
-            cat '$output_log' 2>&1
+            2> >(tee -a '$output_log' >&2)
         #end if
     ]]></token>
     <xml name="in_log">

--- a/tools/stacks2/stacks_clonefilter.xml
+++ b/tools/stacks2/stacks_clonefilter.xml
@@ -37,7 +37,6 @@ $retain_oligo
 ## the program outputs empty files for fasta/fastq
 -y gzfastq
 @TEE_APPEND_LOG@
-@CAT_LOG_TO_STDERR@
 
 ## move outputs such that Galaxy can find them
 #if $capture:

--- a/tools/stacks2/stacks_cstacks.xml
+++ b/tools/stacks2/stacks_cstacks.xml
@@ -38,7 +38,6 @@ cstacks
 #end if
 $report_mmatches
 @TEE_APPEND_LOG@
-@CAT_LOG_TO_STDERR@
 
 #if $popmap
     ## When using a popmap, cstacks writes to the input dir

--- a/tools/stacks2/stacks_kmerfilter.xml
+++ b/tools/stacks2/stacks_kmerfilter.xml
@@ -46,7 +46,6 @@ $options_kmer_char.k_dist
     | sed 's/KmerFrequency/# KmerFrequency/' > $kfreqdist
 #end if
 @TEE_APPEND_LOG@
-@CAT_LOG_TO_STDERR@
 
 ## move outputs such that Galaxy can find them
 ## if filtering is on then ...filt...fq is created

--- a/tools/stacks2/stacks_sstacks.xml
+++ b/tools/stacks2/stacks_sstacks.xml
@@ -34,7 +34,6 @@ $x
 
 @GAP_OPTIONS_ONOFF@
 @TEE_APPEND_LOG@
-@CAT_LOG_TO_STDERR@
 
 #if $popmap
     ## When using a popmap, stacks write to the input dir

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -59,11 +59,11 @@ mkdir stacks_inputs stacks_outputs
 
     -o stacks_outputs
 
-    @TEE_APPEND_LOG@
+    @TEE_APPEND_LOG@ &&
 
     #set $ID=$ID+1
 #end for
-@CAT_LOG_TO_STDERR@
+true
 ## If input is in gz format, stacks will output gzipped files (no option to control this)
 #if $inputype.startswith('gz')
     && gunzip stacks_outputs/*.gz


### PR DESCRIPTION
some tools did

```
...
tool 2>> logfile &&
cat logfile 2>&2
...
```

if the tool fails the stderr is not filled and the stdio
error handling misses errors from the inspection of stderr.

replaced it with

```
...
2> >(tee -a '$output_log' >&2)
...
```

Note that I would like to have this merged before https://github.com/galaxyproject/tools-iuc/pull/2859 since some of our users are in the middle of a large analysis using 2.4.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
