### PR TITLE
Load channel labels

### DIFF
--- a/tools/idr_download/idr_download_by_ids.py
+++ b/tools/idr_download/idr_download_by_ids.py
@@ -17,7 +17,7 @@ def warn(message, image_identifier):
 
 def find_channel_index(image, channel_name):
     channel_name = channel_name.lower()
-    for n, channel in enumerate(image.getChannels()):
+    for n, channel in enumerate(image.getChannelLabels()):
         if channel_name == channel.getLabel().lower():
             return n
     # Check map annotation for information (this is necessary for some images)


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

The usage of ``image.getChannels`` will by default start a rendering engine to retrieve metadata. This could lead to some memory issues.
The usage of the ``image.getChannelLabels`` will avoid this memory issue

cc @beatrizserrano @bgruening 