### PR TITLE
githup actions: fix cache names, storing of sha

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,21 +33,23 @@ jobs:
     - name: make dir for workflow artifacts
       run: mkdir ../workflow_artifacts
     - name: Determine latest galaxy commit
+      run: echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
+    - name: Save latest galaxy commit to artifact file and show it
       run: |
-        echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
         echo ${{ env.GALAXY_HEAD_SHA }} > ../workflow_artifacts/galaxy.sha
+        cat ../workflow_artifacts/galaxy.sha
     - name: Cache .cache/pip
       uses: actions/cache@v1
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Cache .planemo
       uses: actions/cache@v1
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install Planemo and flake8
       run: pip install planemo flake8
     - name: Fake a planemo run to update cache
@@ -114,7 +116,7 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_python_${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo lint
@@ -153,7 +155,7 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_python_${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install flake8
       run: pip install flake8
     - name: Flake8
@@ -203,13 +205,13 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_python_${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Cache .planemo
       uses: actions/cache@v1
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo ci_find_tools
@@ -299,7 +301,7 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_python_${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
@@ -350,7 +352,7 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_python_${{ matrix.python-version }}_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install Planemo
       run: pip install planemo
     - name: Deploy on testtoolshed

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,9 +35,7 @@ jobs:
     - name: Determine latest galaxy commit
       run: echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
     - name: Save latest galaxy commit to artifact file and show it
-      run: |
-        echo ${{ env.GALAXY_HEAD_SHA }} > ../workflow_artifacts/galaxy.sha
-        cat ../workflow_artifacts/galaxy.sha
+      run: echo ${{ env.GALAXY_HEAD_SHA }} > ../workflow_artifacts/galaxy.sha
     - name: Cache .cache/pip
       uses: actions/cache@v1
       id: cache-pip


### PR DESCRIPTION
latest galaxy commit sha was not saved in artifacts file (workflow_artifacts/galaxy.sha) since the environment variable seems to be available only after the step where it is set.

pip cache name was inconsistent:
- pip_cache_py
- pip_cache_python_

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
