### PR TITLE
fix time specs in scheduled ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Run Galaxy Tool Linting and Tests
 on:
   schedule:
     # Run at midnight every monday
-    - cron: '0 * * * 1'
+    - cron: '0 0 * * 1'
 env:
   GALAXY_RELEASE: release_20.01
 jobs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
       run: mkdir ../workflow_artifacts
     - name: Determine latest galaxy commit
       run: echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
-    - name: Save latest galaxy commit to artifact file and show it
+    - name: Save latest galaxy commit to artifact file
       run: echo ${{ env.GALAXY_HEAD_SHA }} > ../workflow_artifacts/galaxy.sha
     - name: Cache .cache/pip
       uses: actions/cache@v1


### PR DESCRIPTION
as far as I know

```
0 * * * 0
```

means Sunday 0:00, 1:00, ... 23:00

```
0 0 * * 0
```

should be Sunday 0:00

was always wondering why I got so many mails on sunday...

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
