### PR TITLE
permit anonymous usage of jbrowse

### DIFF
--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -80,22 +80,16 @@ $trackxml &&
                       size="${reference_genome.genome.get_size(nice_size=True)}"
                       edam_format="${reference_genome.genome.datatype.edam_format}"
                       file_ext="${reference_genome.genome.ext}" />
-                  #if $reference_genome.genome.history:
                   <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
                       #if $reference_genome.genome.history.user:
                       user_email="${reference_genome.genome.history.user.email}"
                       user_id="${reference_genome.genome.history.user_id}"
+                      display_name="${reference_genome.genome.history.get_display_name()}"/>
                       #else
                       user_email="anonymous"
                       user_id="-1"
-                      #end if
-                      display_name="${reference_genome.genome.history.get_display_name()}"/>
-                  #else
-                  <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
-                      user_email="anonymous"
-                      user_id="-1"
                       display_name="Unnamed History"/>
-                  #end if
+                      #end if
                   <metadata
                       #for (key, value) in $reference_genome.genome.get_metadata().items():
                       #if "_types" not in $key:
@@ -138,22 +132,16 @@ $trackxml &&
                       size="${dataset.get_size(nice_size=True)}"
                       edam_format="${dataset.datatype.edam_format}"
                       file_ext="${dataset.ext}" />
-                  #if $dataset.history:
                   <history id="${__app__.security.encode_id($dataset.history_id)}"
                       #if $dataset.history.user:
                       user_email="${dataset.history.user.email}"
                       user_id="${dataset.history.user_id}"
+                      display_name="${dataset.history.get_display_name()}"/>
                       #else
                       user_email="anonymous"
                       user_id="-1"
-                      #end if
-                      display_name="${dataset.history.get_display_name()}"/>
-                  #else
-                  <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
-                      user_email="anonymous"
-                      user_id="-1"
                       display_name="Unnamed History"/>
-                  #end if
+                      #end if
                   <metadata
                     #for (key, value) in $dataset.get_metadata().items():
                     #if "_types" not in $key and $value is not None and len(str($value)) < 5000:

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -80,10 +80,22 @@ $trackxml &&
                       size="${reference_genome.genome.get_size(nice_size=True)}"
                       edam_format="${reference_genome.genome.datatype.edam_format}"
                       file_ext="${reference_genome.genome.ext}" />
+                  #if $reference_genome.genome.history:
                   <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
+                      #if $reference_genome.genome.history.user:
                       user_email="${reference_genome.genome.history.user.email}"
                       user_id="${reference_genome.genome.history.user_id}"
+                      #else
+                      user_email="anonymous"
+                      user_id="-1"
+                      #end if
                       display_name="${reference_genome.genome.history.get_display_name()}"/>
+                  #else
+                  <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
+                      user_email="anonymous"
+                      user_id="-1"
+                      display_name="Unnamed History"/>
+                  #end if
                   <metadata
                       #for (key, value) in $reference_genome.genome.get_metadata().items():
                       #if "_types" not in $key:
@@ -126,10 +138,22 @@ $trackxml &&
                       size="${dataset.get_size(nice_size=True)}"
                       edam_format="${dataset.datatype.edam_format}"
                       file_ext="${dataset.ext}" />
+                  #if $dataset.history:
                   <history id="${__app__.security.encode_id($dataset.history_id)}"
+                      #if $dataset.history.user:
                       user_email="${dataset.history.user.email}"
                       user_id="${dataset.history.user_id}"
+                      #else
+                      user_email="anonymous"
+                      user_id="-1"
+                      #end if
                       display_name="${dataset.history.get_display_name()}"/>
+                  #else
+                  <history id="${__app__.security.encode_id($reference_genome.genome.history_id)}"
+                      user_email="anonymous"
+                      user_id="-1"
+                      display_name="Unnamed History"/>
+                  #end if
                   <metadata
                     #for (key, value) in $dataset.get_metadata().items():
                     #if "_types" not in $key and $value is not None and len(str($value)) < 5000:

--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -15,7 +15,7 @@
     </requirements>
   </xml>
   <token name="@DATA_DIR@">\$GALAXY_JBROWSE_SHARED_DIR</token>
-  <token name="@WRAPPER_VERSION@">galaxy0</token>
+  <token name="@WRAPPER_VERSION@">galaxy1</token>
   <token name="@ATTRIBUTION@"><![CDATA[
 **Attribution**
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

In response to your comment @jennaj,

> We (@dannon & @mvdbeek) were wondering if there was a way to adjust Jbrowse to be able run in anonymous (not logged in) sessions. 

this should address your issue.

(Though it would be nicer if galaxy returned a fake 'anonymous' user when trying to access that in the tool form, but I guess very few tools use this "feature".)

@abretaud if you have a chance to review?

Edit: Screenshot of how it looks when anonymous:

![image](https://user-images.githubusercontent.com/458683/80482124-2d0f1a00-8943-11ea-9a9d-f980f6ec030b.png)
