### PR TITLE
Retry fasterq_dump prefetch up to thrice on failure.

### DIFF
--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -34,28 +34,28 @@
     echo "There are \$count fastq" &&
     data=(\$(ls *.fastq)) &&
     if [ "\$count" -eq 1 ]; then
-        @EXTRACT@ "\${data[0]}" > output/"\${acc}"__single.fastqsanger.gz &&
+        @COMPRESS@ "\${data[0]}" > output/"\${acc}"__single.fastqsanger.gz &&
         rm "\${data[0]}";
     elif [ "$adv.split" = "--split-3" ]; then
         if [ -e "\${acc}".fastq ]; then
-            @EXTRACT@ "\${acc}".fastq > outputOther/"\${acc}"__single.fastqsanger.gz;
+            @COMPRESS@ "\${acc}".fastq > outputOther/"\${acc}"__single.fastqsanger.gz;
         fi &&
-        @EXTRACT@ "\${acc}"_1.fastq > output/"\${acc}"_forward.fastqsanger.gz &&
-        @EXTRACT@ "\${acc}"_2.fastq > output/"\${acc}"_reverse.fastqsanger.gz &&
+        @COMPRESS@ "\${acc}"_1.fastq > output/"\${acc}"_forward.fastqsanger.gz &&
+        @COMPRESS@ "\${acc}"_2.fastq > output/"\${acc}"_reverse.fastqsanger.gz &&
         rm "\${acc}"*.fastq;
     elif [ "\$count" -eq 2 ]; then
         #if $adv.skip_technical:
-            @EXTRACT@ "\${data[0]}" > output/"\${acc}"_forward.fastqsanger.gz &&
-            @EXTRACT@ "\${data[1]}" > output/"\${acc}"_reverse.fastqsanger.gz &&
+            @COMPRESS@ "\${data[0]}" > output/"\${acc}"_forward.fastqsanger.gz &&
+            @COMPRESS@ "\${data[1]}" > output/"\${acc}"_reverse.fastqsanger.gz &&
         #else
-            @EXTRACT@ "\${data[0]}" > outputOther/"\${data[0]}"sanger.gz &&
-            @EXTRACT@ "\${data[1]}" > outputOther/"\${data[1]}"sanger.gz &&
+            @COMPRESS@ "\${data[0]}" > outputOther/"\${data[0]}"sanger.gz &&
+            @COMPRESS@ "\${data[1]}" > outputOther/"\${data[1]}"sanger.gz &&
         #end if
         rm "\${data[0]}" &&
         rm "\${data[1]}";
     else
         for file in \${data[*]}; do
-            @EXTRACT@ "\$file" > outputOther/"\$file"sanger.gz &&
+            @COMPRESS@ "\$file" > outputOther/"\$file"sanger.gz &&
             rm "\$file";
         done;
     fi;

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -1,4 +1,4 @@
-<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy1" profile="18.01">
+<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy2" profile="18.01">
     <description>format from NCBI SRA</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -12,13 +12,22 @@
         ln -s '${input.file}' "\$acc" &&
     #end if
     @CONFIGURE_TIMEOUT@
-    fasterq-dump "\$acc" -e \${GALAXY_SLOTS:-1}
-    $adv.split
-    #if str( $adv.minlen ) != "":
-        --min-read-len "$adv.minlen"
-    #end if
-    $adv.skip_technical >> $log 2>&1 
-    &&
+    @CONFIGURE_RETRY@
+    while [ \$SRA_PREFETCH_ATTEMPT -le \$SRA_PREFETCH_RETRIES ] ; do
+        fasterq-dump "\$acc" -e \${GALAXY_SLOTS:-1}
+        $adv.split
+        #if str( $adv.minlen ) != "":
+            --min-read-len "$adv.minlen"
+        #end if
+        $adv.skip_technical >> $log 2>&1 ;
+        if [ \$? == 0 ] ; then
+            break ;
+        else
+            echo "Prefetch attempt \$SRA_PREFETCH_ATTEMPT of \$SRA_PREFETCH_RETRIES exited with code \$?" ;
+            SRA_PREFETCH_ATTEMPT=`expr \$SRA_PREFETCH_ATTEMPT + 1` ;
+            sleep 1 ;
+        fi ;
+    done &&
     mkdir -p output &&
     mkdir -p outputOther &&
     count=`ls *.fastq | wc -l` &&
@@ -81,7 +90,7 @@
              identifier in the nested collection and identifier_1 is either
              forward or reverse (for instance samp1_forward.fq).
         -->
-        
+
             <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fastqsanger.gz" directory="output" ext="fastqsanger.gz" />
         </collection>
         <collection name="output_collection" type='list' label="Single-end data (fasterq-dump)">
@@ -179,7 +188,7 @@ Below we discuss each in detail.
 
 **Uploading data for a single accession**
 
-When you type a single accession number (e.g., `SRR1582967`) into **Accession** box and click **Execute** the tool will fetch data for you. 
+When you type a single accession number (e.g., `SRR1582967`) into **Accession** box and click **Execute** the tool will fetch data for you.
 
 -----
 
@@ -205,7 +214,7 @@ If a SRA dataset is present in the history, it can be converted into fastq datas
 
 **Output**
 
-In every case, fastq datasets produced will be saved in Galaxy's history as a collection_ - a single history element containing multiple datasets. 
+In every case, fastq datasets produced will be saved in Galaxy's history as a collection_ - a single history element containing multiple datasets.
 In fact, three collections will be produced: one containing paired-end data, another containing single-end data, and a third one which contains reads which could not be classified.
 Some collections may be empty if the accessions provided in the list does not contain one of the type of data.
 

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -34,28 +34,28 @@
     echo "There are \$count fastq" &&
     data=(\$(ls *.fastq)) &&
     if [ "\$count" -eq 1 ]; then
-        gzip -c "\${data[0]}" > output/"\${acc}"__single.fastqsanger.gz &&
+        @EXTRACT@ "\${data[0]}" > output/"\${acc}"__single.fastqsanger.gz &&
         rm "\${data[0]}";
     elif [ "$adv.split" = "--split-3" ]; then
         if [ -e "\${acc}".fastq ]; then
-            gzip -c "\${acc}".fastq > outputOther/"\${acc}"__single.fastqsanger.gz;
+            @EXTRACT@ "\${acc}".fastq > outputOther/"\${acc}"__single.fastqsanger.gz;
         fi &&
-        gzip -c "\${acc}"_1.fastq > output/"\${acc}"_forward.fastqsanger.gz &&
-        gzip -c "\${acc}"_2.fastq > output/"\${acc}"_reverse.fastqsanger.gz &&
+        @EXTRACT@ "\${acc}"_1.fastq > output/"\${acc}"_forward.fastqsanger.gz &&
+        @EXTRACT@ "\${acc}"_2.fastq > output/"\${acc}"_reverse.fastqsanger.gz &&
         rm "\${acc}"*.fastq;
     elif [ "\$count" -eq 2 ]; then
         #if $adv.skip_technical:
-            gzip -c "\${data[0]}" > output/"\${acc}"_forward.fastqsanger.gz &&
-            gzip -c "\${data[1]}" > output/"\${acc}"_reverse.fastqsanger.gz &&
+            @EXTRACT@ "\${data[0]}" > output/"\${acc}"_forward.fastqsanger.gz &&
+            @EXTRACT@ "\${data[1]}" > output/"\${acc}"_reverse.fastqsanger.gz &&
         #else
-            gzip -c "\${data[0]}" > outputOther/"\${data[0]}"sanger.gz &&
-            gzip -c "\${data[1]}" > outputOther/"\${data[1]}"sanger.gz &&
+            @EXTRACT@ "\${data[0]}" > outputOther/"\${data[0]}"sanger.gz &&
+            @EXTRACT@ "\${data[1]}" > outputOther/"\${data[1]}"sanger.gz &&
         #end if
         rm "\${data[0]}" &&
         rm "\${data[1]}";
     else
         for file in \${data[*]}; do
-            gzip -c "\$file" > outputOther/"\$file"sanger.gz &&
+            @EXTRACT@ "\$file" > outputOther/"\$file"sanger.gz &&
             rm "\$file";
         done;
     fi;

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -3,6 +3,7 @@
     <token name="@ACCESSIONS_FROM_FILE@">
         grep '^[[:space:]]*[E|S|D]RR[0-9]\{1,\}[[:space:]]*$'
     </token>
+    <token name="@EXTRACT@"><![CDATA[pigz -cqp \${GALAXY_SLOTS:-1}]]></token>
     <token name="@CONFIGURE_TIMEOUT@"><![CDATA[
         vdb-config --restore-defaults && vdb-config -s /http/timeout/read=10000 || true &&
     ]]></token>
@@ -22,6 +23,7 @@
     <macro name="requirements">
         <requirements>
             <requirement type="package" version="2.10.3">sra-tools</requirement>
+            <requirement type="package" version="2.3.4">pigz</requirement>
             <yield/>
         </requirements>
     </macro>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -3,7 +3,7 @@
     <token name="@ACCESSIONS_FROM_FILE@">
         grep '^[[:space:]]*[E|S|D]RR[0-9]\{1,\}[[:space:]]*$'
     </token>
-    <token name="@EXTRACT@"><![CDATA[pigz -cqp \${GALAXY_SLOTS:-1}]]></token>
+    <token name="@COMPRESS@"><![CDATA[pigz -cqp \${GALAXY_SLOTS:-1}]]></token>
     <token name="@CONFIGURE_TIMEOUT@"><![CDATA[
         vdb-config --restore-defaults && vdb-config -s /http/timeout/read=10000 || true &&
     ]]></token>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -6,6 +6,10 @@
     <token name="@CONFIGURE_TIMEOUT@"><![CDATA[
         vdb-config --restore-defaults && vdb-config -s /http/timeout/read=10000 || true &&
     ]]></token>
+    <token name="@CONFIGURE_RETRY@"><![CDATA[
+        export SRA_PREFETCH_RETRIES=3 &&
+        export SRA_PREFETCH_ATTEMPT=1 &&
+    ]]></token>
     <token name="@SET_ACCESSIONS@"><![CDATA[
         #if $input.input_select=="file_list":
             for acc in `@ACCESSIONS_FROM_FILE@ '$input.file_list'` ;


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

With this change, the prefetch operation should succeed more often on larger lists of accessions. A local test run using SRR925743 succeeded on the second attempt.