### PR TITLE
upgrade workflows to use v2 of upload and download artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
       run: 'planemo test_reports tool_test_output.json --test_output tool_test_output.html'
     - name: Copy artifacts into place
       run: mkdir upload && mv tool_test_output.json tool_test_output.html upload
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: 'Tool test output ${{ matrix.chunk  }}'
         path: upload
@@ -100,126 +100,9 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v2
         with:
-          name: Tool test output 0
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 1
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 2
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 3
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 4
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 5
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 6
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 7
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 8
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 9
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 10
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 11
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 12
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 13
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 14
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 15
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 16
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 17
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 18
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 19
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 20
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 21
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 22
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 23
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 24
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 25
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 26
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 27
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 28
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 29
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 30
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 31
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 32
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 33
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 34
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 35
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 36
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 37
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 38
-      - uses: actions/download-artifact@v1
-        with:
-          name: Tool test output 39
+          path: artifacts
       - uses: actions/setup-python@v1
         with:
           python-version: '3.7'
@@ -228,12 +111,12 @@ jobs:
         run: 'git clone --recursive --depth 1 https://github.com/galaxyproject/planemo && python -m pip install --pre planemo/ && rm -rf planemo'
       - name: combine outputs
         run: |
-          find . -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
+          find artifacts -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
       - name: Create tool_test_output.html
         run: 'planemo test_reports tool_test_output.json --test_output tool_test_output.html'
       - name: Copy artifacts into place
         run: mkdir upload && mv tool_test_output.json tool_test_output.html upload
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: 'All tool test results'
           path: upload

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,15 +27,16 @@ jobs:
         echo 'base_ref: ${{ github.base_ref }}'
         echo 'event.before: ${{ github.event.before }}'
         echo 'event.after: ${{ github.event.after }}'
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: make dir for workflow artifacts
-      run: mkdir ../workflow_artifacts
     - name: Determine latest galaxy commit
       run: echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
     - name: Save latest galaxy commit to artifact file
-      run: echo ${{ env.GALAXY_HEAD_SHA }} > ../workflow_artifacts/galaxy.sha
+      run: echo ${{ env.GALAXY_HEAD_SHA }} > galaxy.sha
     - name: Cache .cache/pip
       uses: actions/cache@v1
       id: cache-pip
@@ -55,9 +56,6 @@ jobs:
       run: |
         touch tool.xml
         PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     # The range of commits to check for changes is:
     # - `origin/master...` for all events happening on a feature branch
     # - for events on the master branch we compare against the sha before the event
@@ -77,13 +75,18 @@ jobs:
       if: github.event_name == 'pull_request'
       run: echo ::set-env name=COMMIT_RANGE::"HEAD~.."
     - name: Planemo ci_find_repos
-      run: planemo ci_find_repos --changed_in_commit_range ${{ env.COMMIT_RANGE }} --exclude packages --exclude deprecated --output ../workflow_artifacts/changed_repositories.list
+      run: planemo ci_find_repos --changed_in_commit_range ${{ env.COMMIT_RANGE }} --exclude packages --exclude deprecated --output changed_repositories.list
     - name: Show repo list
-      run: cat ../workflow_artifacts/changed_repositories.list
-    - uses: actions/upload-artifact@v1
+      run: cat changed_repositories.list
+    - uses: actions/upload-artifact@v2
       with:
         name: Workflow artifacts
-        path: ../workflow_artifacts/
+        path: changed_repositories.list
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Workflow artifacts
+        path: galaxy.sha
+
 
   # planemo lint the changed repositories
   lint:
@@ -103,7 +106,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
@@ -142,7 +145,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
@@ -192,7 +195,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
@@ -254,7 +257,7 @@ jobs:
       run: |
         mkdir upload
         mv tool_test_output.json tool_test_output.html upload/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: 'Tool test output ${{ matrix.chunk  }}'
         path: upload
@@ -273,27 +276,14 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
-        name: Tool test output 0
-    - uses: actions/download-artifact@v1
-      with:
-        name: Tool test output 1
-    - uses: actions/download-artifact@v1
-      with:
-        name: Tool test output 2
-    - uses: actions/download-artifact@v1
-      with:
-        name: Tool test output 3
+        path: artifacts
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v1
-      with:
-        name: Workflow artifacts
-        path: ../workflow_artifacts/
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat ../workflow_artifacts/galaxy.sha)
+      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat "artifacts/Workflow artifacts/galaxy.sha")
     - name: Cache .cache/pip
       uses: actions/cache@v1
       id: cache-pip
@@ -305,14 +295,14 @@ jobs:
     - name: Install jq
       run: sudo apt-get install jq
     - name: Combine outputs
-      run: find . -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
+      run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
     - name: Create tool_test_output.html
       run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
     - name: Copy artifacts into place
       run: |
         mkdir upload
         mv tool_test_output.json tool_test_output.html upload/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: 'All tool test results'
         path: upload
@@ -339,7 +329,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/


### PR DESCRIPTION
New versions of the actions simplify the workflows a bit. 

Since they allow now upload of single files we could have single artifacts for `galaxy.sha` and `changed_repos.list`. 

Somehow I would like to have the tools in the final html output sorted, but I could not get this running.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
