### PR TITLE
[WIP]: Fixed some issues with iqtree

### DIFF
--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -262,12 +262,9 @@ $bootstrap_parameters.ultrafast_bootstrap.wbtl
 
 $bootstrap_parameters.ultrafast_bootstrap.bnni
 
-#if str($bootstrap_parameters.nonparametric_bootstrap.b) != ''
-    -b '$bootstrap_parameters.nonparametric_bootstrap.b'
+#if str($bootstrap_parameters.nonparametric_bootstrap.bootstrap_replicates) != ''
+    $bootstrap_parameters.nonparametric_bootstrap.bootstrap_type '$bootstrap_parameters.nonparametric_bootstrap.bootstrap_replicates'
 #end if
-
-$bootstrap_parameters.nonparametric_bootstrap.bc
-$bootstrap_parameters.nonparametric_bootstrap.bo
 
 #if str($miscellaneous_options.fconst) != ''
     -fconst '$miscellaneous_options.fconst'
@@ -489,9 +486,12 @@ IQ-TREE also works for codon, binary and morphogical data.
                 <param argument="-bnni" type="boolean" truevalue="-bnni" falsevalue="" checked="false" label="Perform an additional step to further optimize UFBoot trees by nearest neighbor interchange (NNI) based directly on bootstrap alignments" help="This option is recommended in the presence of severe model violations. It increases computing time by 2-fold but reduces the risk of overestimating branch supports due to severe model violations. Introduced in IQ-TREE 1.6."/>
             </section>
             <section name="nonparametric_bootstrap" expanded="False" title="Nonparametric bootstrap">
-                <param argument="-b" type="integer" optional="true" label="Specify number of bootstrap replicates (recommended &gt;=100)" help="This will perform both bootstrap and analysis on original alignment and provide a consensus tree."/>
-                <param argument="-bc" type="boolean" truevalue="-bc" falsevalue="" checked="false" label="Like -b but omit analysis on original alignment."/>
-                <param argument="-bo" type="boolean" truevalue="-bo" falsevalue="" checked="false" label="Like -b but only perform bootstrap analysis (no analysis on original alignment and no consensus tree)."/>
+                <param name="bootstrap_replicates" type="integer" optional="true" label="Specify number of bootstrap replicates (recommended &gt;=100)" help="This will perform both bootstrap and analysis on original alignment and provide a consensus tree."/>
+                <param name="bootstrap_type" type="select" display="radio" label="Select the type of bootstrap to perform" help="-b: This will perform both bootstrap and analysis on original alignment and provide a consensus tree. -bc: Like -b but omit analysis on original alignment. -bo: Like -b but only perform bootstrap analysis (no analysis on original alignment and no consensus tree).">
+                    <option value="-b" selected="True">-b</option>
+                    <option value="-bc">-bc</option>
+                    <option value="-bo">-bo</option>
+                </param>
             </section>
         </section>
         <section name="miscellaneous_options" expanded="False" title="Miscellaneous options">
@@ -502,12 +502,17 @@ IQ-TREE also works for codon, binary and morphogical data.
         </section>
     </inputs>
     <outputs>
-        <data name="bionj" format="nhx" from_work_dir="*.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
-        <data name="treefile" format="nhx" from_work_dir="*.treefile" label="${tool.name} on ${on_string}: MaxLikelihood Tree" />
-        <data name="contree" format="nhx" from_work_dir="*.contree" label="${tool.name} on ${on_string}: Consensus Tree" />
-        <data name="mldist" format="mldist" from_work_dir="*.mldist" label="${tool.name} on ${on_string}: MaxLikelihood Distance Matrix"/>
-        <data name="splits.nex" format="nex" from_work_dir="*.splits.nex" label="${tool.name} on ${on_string}: Occurence Frequencies in Bootstrap Trees" />
-        <data name="iqtree" format="iqtree" from_work_dir="*.iqtree" label="${tool.name} on ${on_string}: Report and Final Tree" />
+        <data name="bionj" format="nhx" from_work_dir="PREF.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
+        <data name="treefile" format="nhx" from_work_dir="PREF.treefile" label="${tool.name} on ${on_string}: MaxLikelihood Tree" />
+        <data name="contree" format="nhx" from_work_dir="PREF.contree" label="${tool.name} on ${on_string}: Consensus Tree" >
+            <filter>bootstrap_replicates and '-bo' not in bootstrap_type</filter>
+            <filter>bb</filter>
+        </data>
+        <data name="mldist" format="mldist" from_work_dir="PREF.mldist" label="${tool.name} on ${on_string}: MaxLikelihood Distance Matrix"/>
+        <data name="splits_nex" format="nex" from_work_dir="PREF.splits.nex" label="${tool.name} on ${on_string}: Occurence Frequencies in Bootstrap Trees">
+            <filter>bb</filter>
+        </data>
+        <data name="iqtree" format="iqtree" from_work_dir="PREF.iqtree" label="${tool.name} on ${on_string}: Report and Final Tree" />
     </outputs>
     <tests>
         <test>
@@ -547,7 +552,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                         expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*\)\d+:(\d|\.)+,.*" />
                 </assert_contents>
             </output>
-            <output name="splits.nex">
+            <output name="splits_nex">
                 <assert_contents>
                     <has_line line="BEGIN Splits;" />
                     <has_line line="END; [Splits]" />
@@ -576,7 +581,43 @@ IQ-TREE also works for codon, binary and morphogical data.
             <param name="bcor" value="0.99" />
             <param name="nstep" value="100" />
             <param name="beps" value="0.5" />
-            <param name="b" value="2" />
+            <param name="bootstrap_replicates" value="2" />
+            <param name="bootstrap_type" value="-b" />
+            <output name="iqtree">
+                <assert_contents>
+                    <has_text_matching expression="VT\+F\+I(\s+((-|\d|\.)+))+" />
+                </assert_contents>
+            </output>
+            <output name="treefile">
+                <assert_contents>
+                    <has_line_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <!-- bootstrap sans model -->
+            <param name="seed" value="1257" />
+            <param name="st" value="AA" />
+            <param name="s" value="example.phy" />
+            <!-- <param name="m" value="TESTONLY" /> -->
+            <param name="msub" value="nuclear" />
+            <param name="cmin" value="2" />
+            <param name="cmax" value="10" />
+            <param name="merit" value="AICc" />
+            <param name="madd" value="LG4M,LG4X" />
+            <param name="ninit" value="100" />
+            <param name="ntop" value="20" />
+            <param name="nbest" value="5" />
+            <param name="nstop" value="100" />
+            <param name="sprrad" value="6" />
+            <param name="pers" value="0.5" />
+            <param name="minsup" value="0.0" />
+            <param name="nm" value="1000" />
+            <param name="bcor" value="0.99" />
+            <param name="nstep" value="100" />
+            <param name="beps" value="0.5" />
+            <param name="bootstrap_replicates" value="2" />
+            <param name="bootstrap_type" value="-bc" />
             <output name="iqtree">
                 <assert_contents>
                     <has_text_matching expression="VT\+F\+I(\s+((-|\d|\.)+))+" />
@@ -653,6 +694,11 @@ IQ-TREE also works for codon, binary and morphogical data.
         <test>
             <param name="s" value="short.fasta" />
             <param name="short_alignments" value="true" />
+            <output name="iqtree">
+                <assert_contents>
+                    <has_text_matching expression="NC_045512.*MT019531.*MT019532.*" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

We have had trouble running iq-tree over Pulsar. iq-tree runs on the remote host just fine but pulsar cannot find the tool outputs.

**Problem 1: Wildcards**

In the tool xml, the outputs are collected from the working directory with a wildcard. Example:
```
<data name="bionj" format="nhx" from_work_dir="*.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
```
But Pulsar is unable to look for files with a wildcard. :(

However, the output file prefix is set in the command thus:
```
<command detect_errors="exit_code"><![CDATA[
iqtree
    -pre PREF
```
Therefore the outputs can be set to:
```
<data name="bionj" format="nhx" from_work_dir="PREF.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
```
etc.

**Problem 2: Output filtering**

Two of the output files searched for in each run only exist when certain parameters are used.

* The output "contree" only exists when using bootstrapping (either fast or non-parametric)
* The output "splits.nex" only exists when using fast bootstrapping.

This doesn't cause a problem when running locally on Galaxy as it just returns an empty file for each, but on Pulsar it looks for a non-existant file and fails returning an error.

Therefore, these two outputs need to be filtered to suit. But I'm having trouble getting the filters to work! Help please!

**Problem 3: non-parametric bootstrapping parameters ill-formed**

The parameters `-bc` and `-bo` are not boolean parameters as set in the .xml file. They both expect an integer value. They are also mutually exclusive with each other and `-b`.

Therefore, the parameters need to be refactored into an option box and a integer input to represent the type of bootstrapping and the number of replicates respectively.