### PR TITLE
Pinned ggplot2 version for Seurat

### DIFF
--- a/tools/seurat/seurat.xml
+++ b/tools/seurat/seurat.xml
@@ -8,6 +8,8 @@
         <requirement type="package" version="2.0">r-rmarkdown</requirement>
         <!-- Need to pin pandoc due to https://github.com/rstudio/rmarkdown/issues/1740 -->
         <requirement type="package" version="2.7.3">pandoc</requirement>
+        <!-- Need to pin ggplot2 due to https://github.com/galaxyproject/tools-iuc/issues/3008 -->
+        <requirement type="package" version="3.2.1">r-ggplot2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 #if "vln" in $meta.plots:


### PR DESCRIPTION
ggplot2 3.3 breaks Seurat 3.1.2, so this pins the ggplot2 version to the
last working version (3.2.1) Addresses #3008 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
