### PR TITLE
Update Seurat to 3.1.5

### DIFF
--- a/tools/seurat/seurat.xml
+++ b/tools/seurat/seurat.xml
@@ -1,11 +1,11 @@
 <tool id="seurat" name="Seurat" version="@TOOL_VERSION@">
     <description>- toolkit for exploration of single-cell RNA-seq data</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.2</token>
+        <token name="@TOOL_VERSION@">3.1.5</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">r-seurat</requirement>
-        <requirement type="package" version="2.0">r-rmarkdown</requirement>
+        <requirement type="package" version="2.1">r-rmarkdown</requirement>
         <!-- Need to pin pandoc due to https://github.com/rstudio/rmarkdown/issues/1740 -->
         <requirement type="package" version="2.7.3">pandoc</requirement>
     </requirements>


### PR DESCRIPTION
This addresses #3008. 

**Note**: in order to make sure the older (3.1.2) version of Seurat gets fixed, this PR should be accepted *after* #3009 get accepted and pushed to the toolshed.


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
