### PR TITLE
Update orthofinder to 2.2.6

### DIFF
--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -1,7 +1,7 @@
-<tool name="OrthoFinder OnlyGroups" id="orthofinder_onlygroups" version="2.1.2">
+<tool name="OrthoFinder OnlyGroups" id="orthofinder_onlygroups" version="2.2.6">
     <description>finds orthogroups in a set of proteomes</description>
     <requirements>
-        <requirement type="package" version="2.1.2">orthofinder</requirement>
+        <requirement type="package" version="2.2.6">orthofinder</requirement>
         <requirement type="package" version="2.34">util-linux</requirement>
     </requirements>
     <command detect_errors="exit_code">


### PR DESCRIPTION
To fix an error which appears in current release 2.1.2 (resolving of non-binary gene trees)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
