### PR TITLE
Gemini data manager fix

### DIFF
--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -16,7 +16,7 @@ def write_gemini_config(config, config_file):
 
 def main():
     today = datetime.date.today()
-    params = json.loads(open(sys.argv[1] ).read())
+    params = json.loads(open(sys.argv[1]).read())
     target_directory = params['output_data'][0]['extra_files_path']
     os.mkdir(target_directory)
 

--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -83,7 +83,7 @@ def main():
     }
 
     # ... and save it to the json results file
-    with open( sys.argv[1], 'wb' ) as out:
+    with open( sys.argv[1], 'w' ) as out:
         out.write( json.dumps( data_manager_dict ) )
 
 

--- a/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
+++ b/data_managers/data_manager_gemini_database_downloader/data_manager/data_manager_gemini_download.py
@@ -16,9 +16,9 @@ def write_gemini_config(config, config_file):
 
 def main():
     today = datetime.date.today()
-    params = json.loads( open( sys.argv[1] ).read() )
-    target_directory = params[ 'output_data' ][0]['extra_files_path']
-    os.mkdir( target_directory )
+    params = json.loads(open(sys.argv[1] ).read())
+    target_directory = params['output_data'][0]['extra_files_path']
+    os.mkdir(target_directory)
 
     # Generate a minimal configuration file for GEMINI update
     # to instruct the tool to download the annotation data into a
@@ -39,7 +39,7 @@ def main():
         params['param_dict']['gerp_bp'],
         params['param_dict']['cadd']
     )
-    subprocess.check_call( cmd, shell=True, env=gemini_env )
+    subprocess.check_call(cmd, shell=True, env=gemini_env)
 
     # GEMINI tool wrappers that need access to the annotation files
     # are supposed to symlink them into a gemini/data subfolder of
@@ -83,8 +83,8 @@ def main():
     }
 
     # ... and save it to the json results file
-    with open( sys.argv[1], 'w' ) as out:
-        out.write( json.dumps( data_manager_dict ) )
+    with open(sys.argv[1], 'w') as out:
+        out.write(json.dumps(data_manager_dict))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

I think this makes the Gemini data manager python3 compatible. It was trying to write the json dictionary out using `open(outfile, 'wb')`. This kept failing. Works when changed to `open(outfile, 'w')`.
