### PR TITLE
Plot with Scanpy: Changes way in which coloring defaults are set

### DIFF
--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@version@">1.4.4.post1</token>
     <token name="@profile@">19.01</token>
-    <token name="@galaxy_version@"><![CDATA[@version@+galaxy2]]></token>
+    <token name="@galaxy_version@"><![CDATA[@version@+galaxy3]]></token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@version@">scanpy</requirement>
@@ -284,6 +284,7 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
         <option value="winter_r">winter_r</option>
     </xml>
     <xml name="matplotlib_pyplot_colormap">
+        <option value="default">Default (none set)</option>
         <option value="viridis">viridis (Perceptually Uniform Sequential)</option>
         <option value="plasma">plasma (Perceptually Uniform Sequential)</option>
         <option value="inferno">inferno (Perceptually Uniform Sequential)</option>
@@ -643,7 +644,7 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
     </xml>
     <xml name="param_vmax">
         <param argument="vmax" type="float" value="" optional="true" label="Maximum value to normalize luminance data" help="If not set, it is inferred from the data and other keyword arguments"/>
-    </xml>    
+    </xml>
     <xml name="section_matplotlib_pyplot_scatter">
         <section name="matplotlib_pyplot_scatter" title="Parameters for matplotlib.pyplot.scatter">
             <!--<param argument="marker" type="select" label="Marker style" help="">
@@ -726,7 +727,7 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
     size=$method.violin_plot.stripplot.jitter.size,
     #end if
 #end if
-    multi_panel=$method.violin_plot.multi_panel.multi_panel, 
+    multi_panel=$method.violin_plot.multi_panel.multi_panel,
 #if $method.multi_panel.violin_plot.multi_panel == "True" and str($method.violin_plot.multi_panel.width) != '' and str($method.violin_plot.multi_panel.height) != ''
     figsize=($method.violin_plot.multi_panel.width, $method.violin_plot.multi_panel.height)
 #end if

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -284,7 +284,6 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
         <option value="winter_r">winter_r</option>
     </xml>
     <xml name="matplotlib_pyplot_colormap">
-        <option value="default">Default (none set)</option>
         <option value="viridis">viridis (Perceptually Uniform Sequential)</option>
         <option value="plasma">plasma (Perceptually Uniform Sequential)</option>
         <option value="inferno">inferno (Perceptually Uniform Sequential)</option>
@@ -843,13 +842,13 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
     </xml>
     <xml name="param_palette">
         <param argument="palette" type="select" label="Colors to use for plotting categorical annotation groups" help="">
-            <option value="">Default</option>
+            <option value="default">Default</option>
             <expand macro="matplotlib_pyplot_colormap"/>
         </param>
     </xml>
     <xml name="param_color_map">
         <param argument="color_map" type="select" label="Color map to use for continous variables" help="">
-            <option value="">Default</option>
+            <option value="default">Default</option>
             <expand macro="matplotlib_pyplot_colormap"/>
         </param>
     </xml>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -25,6 +25,9 @@ sc.pl.scatter(
     #if $method.type.type == 'xy'
     x='$method.type.x',
     y='$method.type.y',
+    #if str($method.type.color) != ''
+    color='$method.type.color',
+	  #end if
         #if str('$method.type.layers.use_layers') == 'true'
     layers=('$method.type.layers.layer_x', '$method.type.layers.layer_y', '$method.type.layers.layer_color'),
         #end if
@@ -41,15 +44,17 @@ sc.pl.scatter(
     @CMD_params_pl_components@
     projection='$method.plot.projection',
     legend_loc='$method.plot.legend_loc',
-    @CMD_param_legend_fontsize@
-    legend_fontweight='$method.plot.legend_fontweight',
-    color_map='$method.plot.color_map',
-    #if str($method.plot.palette) != ''
+    #if $method.plot.palette != 'default'
     palette='$method.plot.palette',
     #end if
-    frameon=$method.plot.frameon,
+    #if $method.plot.color_map != 'default'
+    color_map='$method.plot.color_map',
+    #end if
+    @CMD_param_legend_fontsize@
+    legend_fontweight='$method.plot.legend_fontweight',
     @CMD_param_title@
-    @CMD_param_size@)
+    @CMD_param_size@
+    frameon=$method.plot.frameon)
 
 #else if $method.method == 'pl.heatmap'
 sc.pl.heatmap(
@@ -414,6 +419,7 @@ sc.pl.rank_genes_groups_stacked_violin(
                     <when value="xy">
                         <param argument="x" type="text" value="" label="x coordinate" help="Index or key from either '.obs' or '.var'"/>
                         <param argument="y" type="text" value="" label="y coordinate" help="Index or key from either '.obs' or '.var'"/>
+                        <param argument="color" type="text" value="" label="Color by" help="Color points by single variable in `.obs` or `.var`"/>
                         <conditional name="layers">
                             <param argument="use_layers" type="select" label="Use the layers attribute?">
                                 <option value="true">Yes</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

In the current version using the default colors and palette in tool the leads to:

```
sc.pl.scatter(
    adata,
    save='.png',
...
    palette='',
    color_map='',
...
    frameon=True)
```

which has the unintended effect of actually not using any color or palette:

![image](https://user-images.githubusercontent.com/368478/82245564-1012a900-993b-11ea-87a9-0201da7323c1.png)

In contrast, with the additions in this PR, when selecting Default you actually allow scanpy to use its default palette and colours, producing the following code:

```
sc.pl.scatter(
    adata,
    save='.png',
    show=False,
    x='n_counts',
    y='n_genes',
    color='individual',
    use_raw=False,
    sort_order=False,
    projection='2d',
    legend_loc='right margin',
    legend_fontsize=10,
    legend_fontweight='normal',
    frameon=True)
```

which doesn't set color and palette to `''`.

This also adds the ability to color by a field in `obs` or `var`, producing:

![image](https://user-images.githubusercontent.com/368478/82245914-b8c10880-993b-11ea-9961-39e4bf8af167.png)
