### PR TITLE
Rectified Typos in BWA-MEM Tool Documentation

### DIFF
--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -114,8 +114,8 @@ One of the recommended best practices in NGS analysis is adding read group infor
 **Specify read group information?** widget. If you are not familiar with read groups you shold know that this is effectively a way to tag reads with an additional ID.
 This allows you to combine BAM files from, for example, multiple BWA runs into a single dataset. This significantly simplifies downstream processing as
 instead of dealing with multiple datasets you only have to handle only one. This is possible because the read group information allows you to identify
-data from different experiments even if they are combined in one file. Many downstream analysis tools such as varinat callers (e.g., FreeBayes or Naive Varinat Caller
-present in Galaxy) are aware of readgtroups and will automatically generate calls for each individual sample even if they are combined within a single file.
+data from different experiments even if they are combined in one file. Many downstream analysis tools such as variant callers (e.g., FreeBayes or Naive Variant Caller
+present in Galaxy) are aware of read groups and will automatically generate calls for each individual sample even if they are combined within a single file.
 
 **Description of read groups fields**
 


### PR DESCRIPTION
Rectified typos in "Read Groups are Important" section. The word variant was misspelled, which is rectified in the commit.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
