### PR TITLE
Fix to Qualimap name issue and addition of 3 raw outputs

### DIFF
--- a/tools/qualimap/qualimap_bamqc.xml
+++ b/tools/qualimap/qualimap_bamqc.xml
@@ -1,4 +1,4 @@
-<tool id="qualimap_bamqc" name="QualiMap BamQC" version="@VERSION@+galaxy2">
+<tool id="qualimap_bamqc" name="QualiMap BamQC" version="@VERSION@+galaxy3">
     <macros>
         <import>qualimap_macros.xml</import>
     </macros>
@@ -132,6 +132,9 @@
             <data name="coverage_histogram" format="tsv" from_work_dir="results/coverage_histogram.txt" />
             <data name="genome_fraction_coverage" format="tsv" from_work_dir="results/genome_fraction_coverage.txt" />
             <data name="duplication_rate_histogram" format="tsv" from_work_dir="results/duplication_rate_histogram.txt" />
+            <data name="homopolymer_indels" format="tsv" from_work_dir="results/homopolymer_indels.txt" />
+            <data name="insert_size_across_reference" format="tsv" from_work_dir="results/insert_size_across_reference.txt" />
+            <data name="insert_size_histogram" format="tsv" from_work_dir="results/insert_size_histogram.txt" />
             <data name="mapped_reads_clipping_profile" format="tsv" from_work_dir="results/mapped_reads_clipping_profile.txt" />
             <data name="mapped_reads_gc-content_distribution" format="tsv" from_work_dir="results/mapped_reads_gc-content_distribution.txt" />
             <data name="mapped_reads_nucleotide_content" format="tsv" from_work_dir="results/mapped_reads_nucleotide_content.txt" />
@@ -140,7 +143,7 @@
         </collection>
     </outputs>
     <tests>
-        <test expect_num_outputs="12">
+        <test expect_num_outputs="15">
             <param name="input1" value="test_mapped_reads.bam"/>
             <output name="output_html" ftype="html">
                 <assert_contents>
@@ -151,7 +154,7 @@
                 <element name="genome_results" file="genome_results_default.txt" ftype="txt" compare="diff" lines_diff="2" />
             </output_collection>
         </test>
-        <test expect_num_outputs="13">
+        <test expect_num_outputs="16">
             <param name="input1" value="test_mapped_reads.bam" />
             <param name="per_base_coverage" value="true" />
             <output name="output_html" ftype="html">
@@ -164,7 +167,7 @@
                 <element name="genome_results" file="genome_results_default.txt" ftype="txt" compare="diff" lines_diff="2" />
             </output_collection>
         </test>
-        <test expect_num_outputs="12">
+        <test expect_num_outputs="15">
             <param name="input1" value="test_mapped_reads.bam"/>
             <conditional name="stats_regions">
                 <param name="region_select" value="custom_regions" />
@@ -179,7 +182,7 @@
                 <element name="genome_results" file="genome_results_inside_features.txt" ftype="txt" compare="diff" lines_diff="2" />
             </output_collection>
         </test>
-        <test expect_num_outputs="13">
+        <test expect_num_outputs="16">
             <param name="input1" value="test_mapped_reads.bam" />
             <conditional name="stats_regions">
                 <param name="region_select" value="custom_regions" />
@@ -196,7 +199,7 @@
                 <element name="genome_results" file="genome_results_inside_features.txt" ftype="txt" compare="diff" lines_diff="2" />
             </output_collection>
         </test>
-        <test expect_num_outputs="13">
+        <test expect_num_outputs="16">
             <param name="input1" value="test_mapped_reads.bam" />
             <conditional name="stats_regions">
                 <param name="region_select" value="custom_regions" />
@@ -469,7 +472,7 @@ This is a *Collection* of 10 individual datasets.
 The *genome_results* dataset provides a plain-text summary of key statistics,
 most of which can also be found in the *Summary* section of the *HTML Report*.
 
-The remaining 9 datasets hold the tabular raw data underlying the plots of the corresponding names in the *HTML Report*.
+The remaining 12 datasets hold the tabular raw data underlying the plots of the corresponding names in the *HTML Report*.
 
 
 Per-base coverage

--- a/tools/qualimap/qualimap_bamqc.xml
+++ b/tools/qualimap/qualimap_bamqc.xml
@@ -40,7 +40,7 @@
             #end if
         #end if
 
-        #set input_name = re.sub('[^\s\w\-]', '_', str($input1.name))
+        #set input_name = re.sub('[^\w]', '_', str($input1.element_identifier))
         ln -s '$input1' '$input_name' &&
 
         qualimap bamqc


### PR DESCRIPTION
No clue if I should increment the version so just let me know of that or of any comments towards this small change.

*edit*: After looking I realized that there were 3 raw outputs missing. I've added them in

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
