### PR TITLE
Sync CI configuration with tools-devteam repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
   setup:
     name: Setup cache
-    if: github.repository == 'galaxyproject/tools-iuc'
+    if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,8 +55,8 @@ jobs:
     - name: Install wheel
       run: pip install wheel
     - name: Install Planemo and flake8
-      run: pip install planemo flake8
-    - name: Fake a planemo run to update cache
+      run: pip install planemo flake8 flake8-import-order
+    - name: Fake a Planemo run to update cache
       if: steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true'
       run: |
         touch tool.xml
@@ -95,7 +95,7 @@ jobs:
         name: Workflow artifacts
         path: galaxy.sha
 
-  # planemo lint the changed repositories
+  # Planemo lint the changed repositories
   lint:
     name: Lint tools
     needs: setup
@@ -134,7 +134,7 @@ jobs:
             planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR";
         done < ../workflow_artifacts/changed_repositories.list
 
-  # flake8 of python scripts in the changed repositories
+  # flake8 of Python scripts in the changed repositories
   flake8:
     name: Lint Python scripts
     needs: setup
@@ -165,15 +165,15 @@ jobs:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
     - name: Install flake8
-      run: pip install flake8
+      run: pip install flake8 flake8-import-order
     - name: Flake8
       run: |
         if [ -s ../workflow_artifacts/changed_repositories.list ]; then
             flake8 $(cat ../workflow_artifacts/changed_repositories.list)
         fi
 
-  # planemo test the changed repositories, each chunk creates an artifact
-  # containing html and json reports for the executed tests
+  # Planemo test the changed repositories, each chunk creates an artifact
+  # containing HTML and JSON reports for the executed tests
   test:
     name: Test tools
     # This job runs on Linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D,E501, W503
+ignore = D,E501,W503
 # For flake8-import-order
 # https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py
 import-order-style = smarkets


### PR DESCRIPTION
Restore flake8-import-order linting, lost when moving from Travis
to GitHub workflows.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
