### PR TITLE
annotatemyids: DESCRIPTION is no longer a valid output column

### DIFF
--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -88,7 +88,6 @@ write.table(result, file='$out_tab', sep="\t", row.names=FALSE, quote=FALSE)
         </param>
         <param name="output_cols" type="select" multiple="True" display="checkboxes" label="Output columns" help="Choose the columns you want in the output table. Note that selecting some columns such as GO or KEGG could make the table very large as some genes may be associated with many terms. Default: ENSEMBL, ENTREZID, SYMBOL, GENENAME">
             <option value="ALIAS">ALIAS</option>
-            <option value="DESCRIPTION">DESCRIPTION</option>
             <option value="ENSEMBL" selected="True">ENSEMBL</option>
             <option value="ENTREZID" selected="True">ENTREZID</option>
             <option value="EVIDENCE">EVIDENCE</option>
@@ -225,7 +224,6 @@ Example:
     Columns available for output include many of the ID columns already described under Inputs above and also:
 
     * **ALIAS**: Commonly used gene symbols
-    * **DESCRIPTION**: The description of the associated gene
     * **EVIDENCE**: Evidence codes for GO associations with a gene of interest
     * **GENENAME**: The full gene name
     * **ONTOLOGY**: For GO Identifiers, which Gene Ontology (BP, CC, or MF)

--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -1,4 +1,4 @@
-<tool id="annotatemyids" name="annotateMyIDs" version="3.7.0+galaxy1">
+<tool id="annotatemyids" name="annotateMyIDs" version="3.7.0+galaxy2">
     <description>annotate a generic set of identifiers</description>
     <requirements>
         <requirement type="package" version="3.7.0">bioconductor-org.hs.eg.db</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

A galaxy user in Australia came across this: if the DESCRIPTION checkbox is checked, the tool runs into an error `Invalid columns: DESCRIPTION. Please use the columns method to see a listing of valid arguments.`

From taking a closer look, DESCRIPTION is not a valid column.  It must have been valid for previous versions of the dbs.  All of the other output column options are still valid.

```
org.Hs.eg.db
[1] "ACCNUM" "ALIAS" "ENSEMBL" "ENSEMBLPROT" "ENSEMBLTRANS"
[6] "ENTREZID" "ENZYME" "EVIDENCE" "EVIDENCEALL" "GENENAME"
[11] "GO" "GOALL" "IPI" "MAP" "OMIM"
[16] "ONTOLOGY" "ONTOLOGYALL" "PATH" "PFAM" "PMID"
[21] "PROSITE" "REFSEQ" "SYMBOL" "UCSCKG" "UNIGENE"
[26] "UNIPROT"
org.Mm.eg.db
[1] "ACCNUM" "ALIAS" "ENSEMBL" "ENSEMBLPROT" "ENSEMBLTRANS"
[6] "ENTREZID" "ENZYME" "EVIDENCE" "EVIDENCEALL" "GENENAME"
[11] "GO" "GOALL" "IPI" "MGI" "ONTOLOGY"
[16] "ONTOLOGYALL" "PATH" "PFAM" "PMID" "PROSITE"
[21] "REFSEQ" "SYMBOL" "UNIGENE" "UNIPROT"
org.Dm.eg.db
[1] "ACCNUM" "ALIAS" "ENSEMBL" "ENSEMBLPROT" "ENSEMBLTRANS"
[6] "ENTREZID" "ENZYME" "EVIDENCE" "EVIDENCEALL" "FLYBASE"
[11] "FLYBASECG" "FLYBASEPROT" "GENENAME" "GO" "GOALL"
[16] "MAP" "ONTOLOGY" "ONTOLOGYALL" "PATH" "PMID"
[21] "REFSEQ" "SYMBOL" "UNIGENE" "UNIPROT"
org.Dr.eg.db
[1] "ACCNUM" "ALIAS" "ENSEMBL" "ENSEMBLPROT" "ENSEMBLTRANS"
[6] "ENTREZID" "ENZYME" "EVIDENCE" "EVIDENCEALL" "GENENAME"
[11] "GO" "GOALL" "IPI" "ONTOLOGY" "ONTOLOGYALL"
[16] "PATH" "PFAM" "PMID" "PROSITE" "REFSEQ"
[21] "SYMBOL" "UNIGENE" "UNIPROT" "ZFIN"
org.Rn.eg.db
[1] "ACCNUM" "ALIAS" "ENSEMBL" "ENSEMBLPROT" "ENSEMBLTRANS"
[6] "ENTREZID" "ENZYME" "EVIDENCE" "EVIDENCEALL" "GENENAME"
[11] "GO" "GOALL" "IPI" "ONTOLOGY" "ONTOLOGYALL"
[16] "PATH" "PFAM" "PMID" "PROSITE" "REFSEQ"
[21] "SYMBOL" "UNIGENE" "UNIPROT"
```