### PR TITLE
Update sra-tools to 2.10.7, retry if no fastq files found

### DIFF
--- a/tools/sra-tools/.shed.yml
+++ b/tools/sra-tools/.shed.yml
@@ -1,9 +1,11 @@
-# .shed.yml supporting automatic pushes.
 owner: iuc
 name: sra_tools
 description:  NCBI Sequence Read Archive toolkit utilities
 long_description: |
-  The Galaxy tool wrappers contained in this tool shed repository rely on software developed by the NCBI Sequence Read Archive: http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software. Use of SRA Toolkit software herin should comply with the GPL v2 or greater. Copyright (C) 2013 Matthew Shirley This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>. INSTALLATION This software release was designed to run under Linux, MacOSX operating systems on Intel x86-compatible 64 bit architectures. Build Requirements: ar bash make gcc, g++ libxml2 libcurl4 zlib On a debian based Linux OS use: apt-get install build-essential libxml2-dev libcurl4-openssl-dev zlib-dev CONTROLLED-ACCESS DATA Encrypted, controlled-access data is not supported in this version of the SRA Toolkit Galaxy tool shed.
+  The SRA Toolkit and SDK from NCBI is a collection of tools and libraries for
+  using data in the INSDC Sequence Read Archives.
+  CONTROLLED-ACCESS DATA Encrypted, controlled-access data is not supported in
+  this version of the SRA Toolkit Galaxy tools.
 categories:
   - Data Source
   - Fastq Manipulation

--- a/tools/sra-tools/README.rst
+++ b/tools/sra-tools/README.rst
@@ -1,43 +1,7 @@
 The Galaxy tool wrappers contained in this tool shed repository rely on software developed by
-the NCBI: http://github.com/ncbi/sra-tools.
+the NCBI: https://github.com/ncbi/sra-tools.
 
-NCBI Sequence Read Archive: http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software.
-Use of SRA Toolkit software herein should comply with the GPL v2 or greater.
-
-Copyright (C) 2013  Matthew Shirley
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# INSTALLATION
-
-This software release was designed to install using the Galaxy toolshed under Linux and MacOS operating systems on Intel x86-compatible 32/64 bit architectures.
-
-*Build Requirements*
-
-- bash
-- make
-- gcc
-- g++
-- libxml2
-
-On a Debian OS use:
-
-    apt-get install build-essential libxml2-dev
-
-On a Mac with [command line tools](https://developer.apple.com/downloads/index.action) installed:
-
-    brew install libxml2
+NCBI Sequence Read Archive Toolkit: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=software
 
 # Installation of Aspera connect ascp binary
 

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -1,4 +1,4 @@
-<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy2" profile="18.01">
+<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy0" profile="18.01">
     <description>format from NCBI SRA</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -6,6 +6,7 @@
     <expand macro="requirements"/>
     <version_command>fasterq-dump --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
+    @COPY_CONFIGFILE@
     @SET_ACCESSIONS@
     #if $input.input_select == "file":
         acc='${input.file.name}' &&
@@ -68,6 +69,7 @@
     #end if
     ]]>
     </command>
+    <expand macro="configfile_hack"/>
     <inputs>
         <expand macro="input_conditional"/>
         <section name="adv" title="Advanced Options" expanded="False">

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -237,7 +237,7 @@ To keep all reads, and maybe do not have the same number of reads in forward and
 .. _fastq-dump: https://ncbi.github.io/sra-tools/fastq-dump.html
 .. _fasterq-dump: https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 .. _collection: https://galaxyproject.org/tutorials/collections/
-.. _link: http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
+.. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
 
 @SRATOOLS_ATTRRIBUTION@
 

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -12,7 +12,6 @@
         acc='${input.file.name}' &&
         ln -s '${input.file}' "\$acc" &&
     #end if
-    @CONFIGURE_TIMEOUT@
     @CONFIGURE_RETRY@
     while [ \$SRA_PREFETCH_ATTEMPT -le \$SRA_PREFETCH_RETRIES ] ; do
         fasterq-dump "\$acc" -e \${GALAXY_SLOTS:-1}
@@ -21,7 +20,7 @@
             --min-read-len "$adv.minlen"
         #end if
         $adv.skip_technical >> $log 2>&1 ;
-        if [ \$? == 0 ] ; then
+        if [ \$? == 0 ] && [ \$(ls *.fastq | wc -l) -ge 1 ]; then
             break ;
         else
             echo "Prefetch attempt \$SRA_PREFETCH_ATTEMPT of \$SRA_PREFETCH_RETRIES exited with code \$?" ;
@@ -31,7 +30,7 @@
     done &&
     mkdir -p output &&
     mkdir -p outputOther &&
-    count=`ls *.fastq | wc -l` &&
+    count="\$(ls *.fastq | wc -l)" &&
     echo "There are \$count fastq" &&
     data=(\$(ls *.fastq)) &&
     if [ "\$count" -eq 1 ]; then

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -9,21 +9,13 @@
     @COPY_CONFIGFILE@
     @SET_ACCESSIONS@
 
-    ## Need to set the home directory to the current working directory,
-    ## else the tool tries to write to home/.ncbi and fails when used
-    ## with a cluster manager.
-    @CONFIGURE_TIMEOUT@
     #if $input.input_select == "file":
         fastq-dump --log-level fatal --accession '${input.file.name}'
     #else:
-        vdb-config -s "/repository/user/main/public/root=\$PWD" &&
         ## Do not use prefetch if region is specified, to avoid downloading
         ## the complete sra file.
         #if ( str( $adv.region ) == "" ) and ( str( $adv.minID ) == "" ) and ( str( $adv.maxID ) == "" ):
             prefetch -X 200000000 "\$acc" &&
-            ## Duplicate vdb-config, in case settings changed between prefetch and
-            ## dump command.
-            vdb-config -s "/repository/user/main/public/root=\$PWD" &&
         #end if
         fastq-dump --accession "\$acc"
         --split-files

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_dump" name="Download and Extract Reads in FASTA/Q" version="@VERSION@+galaxy1" profile="18.01">
+<tool id="fastq_dump" name="Download and Extract Reads in FASTA/Q" version="@VERSION@+galaxy0" profile="18.01">
     <description>format from NCBI SRA</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -6,6 +6,7 @@
     <expand macro="requirements"/>
     <version_command>fastq-dump --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
+    @COPY_CONFIGFILE@
     @SET_ACCESSIONS@
 
     ## Need to set the home directory to the current working directory,
@@ -104,6 +105,7 @@
 
     ]]>
     </command>
+    <expand macro="configfile_hack"/>
     <inputs>
         <expand macro="input_conditional"/>
         <param name="outputformat" type="select" display="radio" label="Select output format" help="Compression will greatly reduce the amount of space occupied by downloaded data. Downstream applications such as a short-read mappers will accept compressed data as input. Consider this example: an uncoimpressed 400 Mb fastq datasets compresses to 100 Mb or 80 Mb by gzip or bzip2, respectively. " argument="--gzip --bzip2">

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -337,7 +337,7 @@ Or a single *interleaved* dataset::
 .. _fastq: https://en.wikipedia.org/wiki/FASTQ_format
 .. _fastq-dump: https://ncbi.github.io/sra-tools/fastq-dump.html
 .. _collection: https://galaxyproject.org/tutorials/collections/
-.. _link: http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
+.. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
 
 @SRATOOLS_ATTRRIBUTION@
 

--- a/tools/sra-tools/sam_dump.xml
+++ b/tools/sra-tools/sam_dump.xml
@@ -1,4 +1,4 @@
-<tool id="sam_dump" name="Download and Extract Reads in BAM" version="@VERSION@+galaxy1" profile="18.01">
+<tool id="sam_dump" name="Download and Extract Reads in BAM" version="@VERSION@+galaxy0" profile="18.01">
     <description>format from NCBI SRA</description>
     <macros>
         <import>sra_macros.xml</import>
@@ -9,6 +9,7 @@
     <version_command>sam-dump --version</version_command>
     <command detect_errors="exit_code">
 <![CDATA[
+        @COPY_CONFIGFILE@
         @SET_ACCESSIONS@
 
         ## Need to set the home directory to the current working directory,
@@ -79,6 +80,7 @@
 
         ]]>
     </command>
+    <expand macro="configfile_hack"/>
     <inputs>
         <expand macro="input_conditional"/>
         <param name="outputformat" type="select" display="radio" label="select output format" help="In vast majority of cases you want to download data in bam format. It is more compact and is accepted by all downstream tools.">

--- a/tools/sra-tools/sam_dump.xml
+++ b/tools/sra-tools/sam_dump.xml
@@ -167,9 +167,9 @@ If a SRA dataset is present in the history, it can be converted into BAM dataset
 -----
 
 .. _BAM: https://samtools.github.io/hts-specs/SAMv1.pdf
-.. _sam-dump: http://ncbi.github.io/sra-tools/sam-dump.html
+.. _sam-dump: https://ncbi.github.io/sra-tools/sam-dump.html
 .. _collection: https://galaxyproject.org/tutorials/collections/
-.. _link: http://www.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
+.. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
 
 @SRATOOLS_ATTRRIBUTION@
     ]]></help>

--- a/tools/sra-tools/sam_dump.xml
+++ b/tools/sra-tools/sam_dump.xml
@@ -12,11 +12,6 @@
         @COPY_CONFIGFILE@
         @SET_ACCESSIONS@
 
-        ## Need to set the home directory to the current working directory,
-        ## else the tool tries to write to home/.ncbi and fails when used
-        ## with a cluster manager.
-        @CONFIGURE_TIMEOUT@
-        vdb-config -s "/repository/user/main/public/root=\$PWD" &&
         ## Do not use prefetch if region is specified, to avoid downloading
         ## the complete sra file.
 
@@ -25,9 +20,6 @@
         #else:
             #if ( str( $adv.region ) == "" ):
                 prefetch -X 200000000 "\$acc" &&
-                ## Duplicate vdb-config, in case settings changed between prefetch and
-                ## dump command.
-                vdb-config -s "/repository/user/main/public/root=\$PWD" &&
             #end if
             sam-dump --log-level fatal --disable-multithreading
         #end if

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -4,9 +4,6 @@
         grep '^[[:space:]]*[E|S|D]RR[0-9]\{1,\}[[:space:]]*$'
     </token>
     <token name="@COMPRESS@"><![CDATA[pigz -cqp \${GALAXY_SLOTS:-1}]]></token>
-    <token name="@CONFIGURE_TIMEOUT@"><![CDATA[
-        vdb-config --restore-defaults && vdb-config -s /http/timeout/read=10000 || true &&
-    ]]></token>
     <token name="@CONFIGURE_RETRY@"><![CDATA[
         export SRA_PREFETCH_RETRIES=3 &&
         export SRA_PREFETCH_ATTEMPT=1 &&
@@ -14,6 +11,11 @@
     <token name="@COPY_CONFIGFILE@"><![CDATA[
     mkdir -p ~/.ncbi || true &&
     cp '$user_settings_mkfg' ~/.ncbi/user-settings.mkfg &&
+    vdb-config -s "/repository/user/main/public/root=\$PWD" &&
+    vdb-config -s "/repository/user/ad/public/root=\$PWD" &&
+    vdb-config -s "/repository/user/default-path=\$PWD" &&
+    vdb-config -s "/repository/user/main/public/root=\$PWD" &&
+    vdb-config -s /http/timeout/read=10000 &&
     ]]></token>
     <token name="@SET_ACCESSIONS@"><![CDATA[
         #if $input.input_select=="file_list":
@@ -36,6 +38,8 @@
             <configfile name="user_settings_mkfg"><![CDATA[
 /LIBS/GUID = "3cdc38d0-711a-49ce-9536-f544eaf69eec"
 /config/default = "false"
+/libs/temp_cache = "."
+/tools/prefetch/download_to_cache = "false"
             ]]></configfile>
         </configfiles>
     </macro>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@VERSION@">2.10.4</token>
+    <token name="@VERSION@">2.10.7</token>
     <token name="@ACCESSIONS_FROM_FILE@">
         grep '^[[:space:]]*[E|S|D]RR[0-9]\{1,\}[[:space:]]*$'
     </token>
@@ -10,6 +10,10 @@
     <token name="@CONFIGURE_RETRY@"><![CDATA[
         export SRA_PREFETCH_RETRIES=3 &&
         export SRA_PREFETCH_ATTEMPT=1 &&
+    ]]></token>
+    <token name="@COPY_CONFIGFILE@"><![CDATA[
+    mkdir -p ~/.ncbi || true &&
+    cp '$user_settings_mkfg' ~/.ncbi/user-settings.mkfg &&
     ]]></token>
     <token name="@SET_ACCESSIONS@"><![CDATA[
         #if $input.input_select=="file_list":
@@ -22,10 +26,18 @@
 
     <macro name="requirements">
         <requirements>
-            <requirement type="package" version="2.10.3">sra-tools</requirement>
+            <requirement type="package" version="@VERSION@">sra-tools</requirement>
             <requirement type="package" version="2.3.4">pigz</requirement>
             <yield/>
         </requirements>
+    </macro>
+    <macro name="configfile_hack">
+        <configfiles>
+            <configfile name="user_settings_mkfg"><![CDATA[
+/LIBS/GUID = "3cdc38d0-711a-49ce-9536-f544eaf69eec"
+/config/default = "false"
+            ]]></configfile>
+        </configfiles>
     </macro>
     <macro name="sanitize_query">
         <sanitizer>

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -9,7 +9,7 @@
         export SRA_PREFETCH_ATTEMPT=1 &&
     ]]></token>
     <token name="@COPY_CONFIGFILE@"><![CDATA[
-    mkdir -p ~/.ncbi || true &&
+    mkdir -p ~/.ncbi &&
     cp '$user_settings_mkfg' ~/.ncbi/user-settings.mkfg &&
     vdb-config -s "/repository/user/main/public/root=\$PWD" &&
     vdb-config -s "/repository/user/ad/public/root=\$PWD" &&


### PR DESCRIPTION
We've been seeing a lot of cases where fasterq-dump would finish with exit code 0, despite not having written any fastq files at all. I hope this (together with various bugfixes in sra-tools) will make this better.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
