### PR TITLE
update bedtools version and add encodepeak

### DIFF
--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -5,10 +5,10 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">2.29.0</token>
+    <token name="@TOOL_VERSION@">2.29.2</token>
     <token name="@SAMTOOLS_VERSION@">1.9</token>
-    <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf</token>
-    <token name="@STD_BEDTOOLS_INPUT_LABEL@">BED/bedGraph/GFF/VCF</token>
+    <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf,encodepeak</token>
+    <token name="@STD_BEDTOOLS_INPUT_LABEL@">BED/bedGraph/GFF/VCF/EncodePeak</token>
     <xml name="stdio">
         <stdio>
             <!-- Anything other than zero is an error -->


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - This PR updates an existing tool or tool collection

This is an update v2.29.0 to v2.29.2 (which is only bug fix) + add encodepeak as `STD_BEDTOOLS_INPUTS`.