### PR TITLE
Update phyml to 3.3.20190909

### DIFF
--- a/tools/phyml/phyml.xml
+++ b/tools/phyml/phyml.xml
@@ -1,7 +1,10 @@
-<tool id="phyml" name="PhyML" version="3.3.20190321">
-    <description>Phylogeny software based on the maximum-likelihood</description>
+<tool id="phyml" name="PhyML" version="@VERSION@">
+    <description>Phylogeny software based on the maximum-likelihood method.</description>
+    <macros>
+        <token name="@VERSION@">3.3.20190909</token>
+    </macros>
     <requirements>
-        <requirement type="package" version="3.3.20190321">phyml</requirement>
+        <requirement type="package" version="@VERSION@">phyml</requirement>
     </requirements>
     <version_command>
         <![CDATA[ phyml --version ]]>

--- a/tools/phyml/test-data/phylip_phyml_stats.txt
+++ b/tools/phyml/test-data/phylip_phyml_stats.txt
@@ -1,13 +1,12 @@
 
  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
-                                  ---  PhyML 3.3.20190321  ---                                             
+                                  ---  PhyML 3.3.20190909  ---                                             
                               http://www.atgc-montpellier.fr/phyml                                          
                              Copyright CNRS - Universite Montpellier                                 
  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
 . Sequence filename: 			phylip
 . Data set: 				#1
-. Tree topology search: 		SPRs
 . Initial tree: 			BioNJ
 . Model of nucleotides substitution: 	HKY85
 . Number of taxa: 			7
@@ -33,7 +32,7 @@
 . Run ID:				none
 . Random seed:				1458308600
 . Subtree patterns aliasing:		no
-. Version:				3.3.20190321
+. Version:				3.3.20190909
 . Time used:				0h0m0s (0 seconds)
 
  oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo


### PR DESCRIPTION
Updates the PhyML tool to use `3.3.20190909`

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
