### PR TITLE
Update shovill to set memory using GALAXY_MEMORY_MB

### DIFF
--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -1,4 +1,4 @@
-<tool id="shovill" name="Shovill" version="@TOOL_VERSION@+galaxy0">
+<tool id="shovill" name="Shovill" version="@TOOL_VERSION@+galaxy1">
     <description>Faster SPAdes assembly of Illumina reads</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.4</token>
@@ -19,6 +19,13 @@
             ln -s '$library.input1.forward' fastq_r1.'$r1_ext' &&
             ln -s '$library.input1.reverse' fastq_r2.'$r2_ext' &&
         #end if
+
+	## Sets the memory used by Shovill according to the following conditions
+	## (1) If SHOVILL_RAM is already set, use this value
+	## (2) Otherwise, set based on GALAXY_MEMORY_MB
+	## (3) Or default to 4 GB if GALAXY_MEMORY_MB is unset
+	GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-4096}/1024)) &&
+	SHOVILL_RAM=\${SHOVILL_RAM:-\${GALAXY_MEMORY_GB}} &&
         
         shovill
             --outdir 'out'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This update sets the memory passed to shovill based on the `GALAXY_MEMORY_MB` environment variable (as described in the [planemo docs](https://planemo.readthedocs.io/en/latest/writing_advanced.html#cluster-usage)).

Previously this was being set via the `SHOVILL_RAM` environment variable. The changes I've made will still support this functionality. Specifically, the memory will be set in the following order:

1. If `SHOVILL_RAM` exists, use this value.
2. Else, derive memory from `GALAXY_MEMORY_MB`
3. Finally, default to 4 GB if `GALAXY_MEMORY_MB` is not set.