### PR TITLE
PR deploy dependencies

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -374,7 +374,7 @@ jobs:
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
-    needs: combine_outputs
+    needs: [lint,flake8,lintr,combine_outputs]
     strategy:
       matrix:
         python-version: [3.7]

--- a/.tt_skip
+++ b/.tt_skip
@@ -3,3 +3,4 @@ deprecated/tools/htseq
 deprecated/tools/rglasso
 deprecated/tools/tool_factory_2
 deprecated/tools/differential_count_models
+tools/enasearch


### PR DESCRIPTION
I also disabled testing for enasearch which made the CI fail for the last weeks.

Wondering if tools in `.tt_skip` and `.biocontainers_skip` really should be excluded from tests in the PR workflow. 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
