### PR TITLE
Turn off sanitizer for compose_text_param

### DIFF
--- a/tools/compose_text_param/compose_text_param.xml
+++ b/tools/compose_text_param/compose_text_param.xml
@@ -1,4 +1,4 @@
-<tool name="Compose text parameter value" id="compose_text_param" version="0.1.0" profile="19.05" tool_type="expression">
+<tool name="Compose text parameter value" id="compose_text_param" version="0.1.1" profile="19.05" tool_type="expression">
     <description>from parameters</description>
     <expression type="ecma5.1">
 {
@@ -18,7 +18,9 @@
                     <option value="float">Float Parameter</option>
                 </param>
                 <when value="text">
-                    <param name="component_value" type="text" label="Enter text that should be part of the computed value"/>
+                    <param name="component_value" type="text" label="Enter text that should be part of the computed value">
+                        <sanitizer sanitize="false"/>
+                    </param>
                 </when>
                  <when value="integer">
                     <param name="component_value" value="" type="integer" label="Enter integer that should be part of the computed value"/>

--- a/tools/compose_text_param/compose_text_param.xml
+++ b/tools/compose_text_param/compose_text_param.xml
@@ -73,9 +73,29 @@
                 </conditional>
             </repeat>
             <output name="output">
-                <assert_contents> 
+                <assert_contents>
                     <!-- <has_line line="'"Text: value, Integer: 1, Float: 1.5"'"/> -->
                     <has_line line="&quot;Text: value, Integer: 1, Float: 1.5&quot;"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="text"/>
+                    <param name="component_value" value="Text: "/>
+                </conditional>
+            </repeat>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="text"/>
+                    <param name="component_value" value="value with; &gt; &amp; and !"/>
+                </conditional>
+            </repeat>
+            <output name="output">
+                <assert_contents>
+                    <!-- <has_line line="'"Text: value, Integer: 1, Float: 1.5"'"/> -->
+                    <has_line line="&quot;Text: value with; &gt; &amp; and !&quot;"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
The text parameter will not appear on the command line, so this is safe.
Will allow creating awk commands using compose_text_param, which failed
due to the sanitizer for @pvanheus.


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)