### PR TITLE
Ebi tools: "Invalid domain parameter" 

### DIFF
--- a/tools/ebi_tools/ebeye_urllib.py
+++ b/tools/ebi_tools/ebeye_urllib.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import os
 import platform
 import re
+import sys
 from gzip import GzipFile
 from io import BytesIO
 from optparse import OptionParser
@@ -81,6 +82,8 @@ def restRequest(url):
             raise Exception('Unsupported Content-Encoding')
         resp.close()
     except HTTPError as ex:
+        print("Error with REST request: %s" % url, file=sys.stderr)
+        print("Response: %s" % ex.read(), file=sys.stderr)
         raise ex
     printDebugMessage('restRequest', 'result: %s' % result, 11)
     printDebugMessage('restRequest', 'End', 11)

--- a/tools/ebi_tools/ebi_metagenomics_run_downloader.xml
+++ b/tools/ebi_tools/ebi_metagenomics_run_downloader.xml
@@ -6,7 +6,7 @@
     </macros>
 
     <expand macro="requirements">
-        <requirement type="package" version="7.49.0">curl</requirement>
+        <requirement type="package" version="7.71.1">curl</requirement>
     </expand>
 
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

I'm trying to fix the ebi_tools tests, with this patch I managed to get the error thrown by EBI:
```
Invalid domain parameter: 'metagenomics_runs' not found.
```

Probably some change in the REST API !? No idea what domain to use instead, it's defined at https://github.com/abretaud/tools-iuc/blob/915688124a9166c7a852d307835f84952e87e9f4/tools/ebi_tools/ebeye_urllib.py#L256