### PR TITLE
Update repeatmasker to 4.0.9

### DIFF
--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -1,12 +1,12 @@
-<tool id="repeatmasker_wrapper" name="RepeatMasker" version="4.0.7+galaxy2" profile="17.01">
+<tool id="repeatmasker_wrapper" name="RepeatMasker" version="4.0.9" profile="17.01">
   <description>screen DNA sequences for interspersed repeats and low complexity regions</description>
 
   <requirements>
-    <requirement type="package" version="4.0.7">repeatmasker</requirement>
+    <requirement type="package" version="4.0.9_p2">repeatmasker</requirement>
   </requirements>
 
   <command detect_errors="exit_code"><![CDATA[
-    RM_PATH=\$(which RepeatMasker) && 
+    RM_PATH=\$(which RepeatMasker) &&
     if [ -z "\$RM_PATH" ] ; then echo "Failed to find RepeatMasker in PATH (\$PATH)" >&2 ; exit 1 ; fi &&
     RM_LIB_PATH=\$(dirname \$RM_PATH)/../share/RepeatMasker/Libraries &&
     mkdir lib &&

--- a/tools/repeatmasker/test-data/small.fasta.cat
+++ b/tools/repeatmasker/test-data/small.fasta.cat
@@ -98,6 +98,6 @@ Gap_init rate = 0.03 (1 / 35), avg. gap size = 1.00 (1 / 1)
 ## Total Length: 14220
 ## Total NonMask ( excluding >20bp runs of N/X bases ): 14220
 ## Total NonSub ( excluding all non ACGT bases ):14220
-RepeatMasker version open-4.0.7 , default mode
-run with rmblastn version 2.2.27+
-RepeatMasker Combined Database: Dfam_Consensus-20170127
+RepeatMasker version open-4.0.9 , default mode
+run with rmblastn version 2.9.0+
+RepeatMasker Combined Database: Dfam-Dfam_3.0

--- a/tools/repeatmasker/test-data/small.fasta.gff
+++ b/tools/repeatmasker/test-data/small.fasta.gff
@@ -1,6 +1,6 @@
 ##gff-version 2
-##date 2018-04-21
-##sequence-region dataset_12.dat
+##date 2020-08-18
+##sequence-region rm_input.fasta
 scaffold_1	RepeatMasker	similarity	613	632	 0.0	+	.	Target "Motif:(GT)n" 1 20
 scaffold_1	RepeatMasker	similarity	780	824	18.3	+	.	Target "Motif:(ATAATA)n" 1 45
 scaffold_1	RepeatMasker	similarity	2231	2274	23.9	+	.	Target "Motif:(CAGA)n" 1 46

--- a/tools/repeatmasker/test-data/small.fasta.stats
+++ b/tools/repeatmasker/test-data/small.fasta.stats
@@ -1,5 +1,5 @@
 ==================================================
-file name: dataset_12.dat           
+file name: rm_input.fasta           
 sequences:             1
 total length:      14220 bp  (14220 bp excl N/X-runs) 
 GC level:         39.94 %
@@ -45,8 +45,8 @@ Low complexity:       0            0 bp    0.00 %
 
 
 The query species was assumed to be homo          
-RepeatMasker Combined Database: Dfam_Consensus-20170127
-                          
-run with rmblastn version 2.2.27+
-The query was compared to unclassified sequences in ".../dataset_2.dat"
+RepeatMasker Combined Database: Dfam-Dfam_3.0
+                                    
+run with rmblastn version 2.9.0+
+The query was compared to unclassified sequences in ".../dataset_257a7a8f-7065-486a-ae21-53e1fceff0f8.dat"
 

--- a/tools/repeatmasker/test-data/small_repbase.fasta.stats
+++ b/tools/repeatmasker/test-data/small_repbase.fasta.stats
@@ -54,7 +54,7 @@ Low complexity:          0            0 bp    0.00 %
 
 
 The query species was assumed to be anopheles genus
-RepeatMasker Combined Database: Dfam_Consensus-20170127
-                          
-run with rmblastn version 2.2.27+
+RepeatMasker Combined Database: Dfam-Dfam_3.0
+                                    
+run with rmblastn version 2.9.0+
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

It seems like repeatmasker 4.0.7 no longer works with recent versions of repbase. So here's the updated wrapper with version 4.0.9.