### PR TITLE
Set the number of megahit threads in Galaxy server

### DIFF
--- a/tools/megahit/megahit_wrapper.xml
+++ b/tools/megahit/megahit_wrapper.xml
@@ -10,7 +10,7 @@
     <version_command>megahit --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
 megahit
-    --num-cpu-threads \${GALAXY_SLOTS:-8}
+    --num-cpu-threads \${GALAXY_SLOTS:-4}
     #if $input_option.choice == 'paired'
         -1 '${input_option.fastq_input1}'
         -2 '${input_option.fastq_input2}'

--- a/tools/megahit/megahit_wrapper.xml
+++ b/tools/megahit/megahit_wrapper.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool id="megahit" name="MEGAHIT" version="@VERSION@.4">
+<tool id="megahit" name="MEGAHIT" version="@VERSION@.5">
     <description>for metagenomics assembly</description>
     <macros>
         <token name="@VERSION@">1.1.3</token>
@@ -10,6 +10,7 @@
     <version_command>megahit --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
 megahit
+    --num-cpu-threads \${GALAXY_SLOTS:-8}
     #if $input_option.choice == 'paired'
         -1 '${input_option.fastq_input1}'
         -2 '${input_option.fastq_input2}'


### PR DESCRIPTION
The added code line limits the number of megahit thread to a reasonable value (all machine cpus if not specified ?)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
