### PR TITLE
Add EGA download tool (Pyega3)

### DIFF
--- a/tools/pyega3/.shed.yml
+++ b/tools/pyega3/.shed.yml
@@ -1,0 +1,10 @@
+name: EGA Download client
+owner: iuc
+categories:
+  - Data Source
+description: EGA python client uses the EGA REST API to download authorized datasets and files.
+long_description: |
+    pyEGA3 uses the EGA REST API to download authorized datasets and files
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/pyega3
+homepage_url: https://github.com/EGA-archive/ega-download-client
+type: unrestricted

--- a/tools/pyega3/README.md
+++ b/tools/pyega3/README.md
@@ -1,9 +1,9 @@
 # PyEGA3
 
-## set up user credentials on Galaxy
+## Set up user credentials on Galaxy
 
 To enable users to set their credentials for this tool,
-make sure the file `confgi/user_preferences_extra.yml` has the following section:
+make sure the file `config/user_preferences_extra.yml` has the following section:
 
 ```
     ega_account:

--- a/tools/pyega3/README.md
+++ b/tools/pyega3/README.md
@@ -1,0 +1,20 @@
+# PyEGA3
+
+## set up user credentials on Galaxy
+
+To enable users to set their credentials for this tool,
+make sure the file `confgi/user_preferences_extra.yml` has the following section:
+
+```
+    ega_account:
+        description: Your EGA (European Genome Archive) account
+        inputs:
+            - name: username
+              label: Username
+              type: text
+              required: False
+            - name: password
+              label: Password
+              type:  password
+              required: False
+```

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,6 +1,6 @@
 <tool id="pyega3" name="EGA Download Client" version="@VERSION@+galaxy0" profile="19.09" >
     <macros>
-        <token name="@VERSION@">3.1.0</token>
+        <token name="@VERSION@">3.4.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@VERSION@">pyega3</requirement>
@@ -15,11 +15,9 @@
 #if $action.action_type == "list_datasets"
     pyega3 -cf '$credentials'
       datasets
-      > '$authorized_datasets'
 #elif $action.action_type == "list_dataset_files"
     pyega3 -cf '$credentials'
       files '$action.dataset_id'
-      > '$dataset_file_list'
 #elif $action.action_type == "download_file"
     pyega3 -cf '$credentials'
       fetch '$action.file_id'
@@ -34,7 +32,6 @@
       #end if
       --saveto '$downloaded_file'
 #end if
-
     ]]></command>
     <configfiles>
         <configfile name="credentials"><![CDATA[
@@ -76,10 +73,10 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="authorized_datasets" format="txt" label="${tool.name}: authorized datasets">
+        <data name="authorized_datasets" format="txt" from_work_dir="pyega3_output.log" label="${tool.name}: authorized datasets">
             <filter> action['action_type'] == 'list_datasets' </filter>
         </data>
-        <data name="dataset_file_list" format="txt" label="${tool.name}: dataset file list">
+        <data name="dataset_file_list" format="txt" from_work_dir="pyega3_output.log" label="${tool.name}: dataset file list">
             <filter> action['action_type'] == 'list_dataset_files' </filter>
         </data>
         <data name="downloaded_file" auto_format="true" label="${tool.name}: ${action.file_id} ${action.range.reference_name} ${action.range.start} ${action.range.end}">
@@ -102,7 +99,7 @@
             <output name="dataset_file_list" ftype="txt">
                 <assert_contents>
                     <has_text text="pyEGA3 - EGA python client version @VERSION@"/>
-                    <has_line_matching expression="^File ID\s+Status\s+Bytes\s+Check sum\s+File name$"/>
+                    <has_line_matching expression="^\[.*\]\s+File ID\s+Status\s+Bytes\s+Check sum\s+File name$"/>
                     <has_text text="EGAF00001753734"/>
                 </assert_contents>
             </output>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -20,21 +20,65 @@
         ]]></configfile>
     </configfiles>
     <command detect_errors="exit_code"><![CDATA[
-        pyega3 -cf '$credentials' datasets > '$authorized_datasets'
+        #set $username = $__user__.extra_preferences.get('ega_account|username', "")
+        #if $username == "":
+            #set $username = "ega-test-data@ebi.ac.uk (default user)"
+        #end if
+        echo "Running as user: $username. Set your credentials via: User -> Preferences -> Manage Information"  &&
+
+        #if $action.action_type == "list_datasets"
+            pyega3 -cf '$credentials' datasets > '$authorized_datasets'
+        #elif $action.action_type == "list_dataset_files"
+            pyega3 -cf '$credentials' files '$action.dataset_id' > '$dataset_file_list'
+        #elif $action.action_type == "download"
+            echo "downloading"
+        #end if
+
     ]]></command>
     <inputs>
+        <conditional name="action">
+            <param name="action_type" type="select" label="What would you like to do?">
+                <option value="list_datasets"> List my authorized datasets </option>
+                <option value="list_dataset_files"> List files in a datasets </option>
+                <option value="download"> Download datasets </option>
+            </param>
+            <when value="list_dataset_files">
+                <param name="dataset_id" type="text" optional="false" label="EGA identifier" help="For example: EGAD00001003338"/>
+            </when>
+            <when value="list_datasets"/>
+            <when value="download"/>
+        </conditional>
     </inputs>
     <outputs>
-        <data name="authorized_datasets" format="txt" label="${tool.name}: authorized datasets"/>
+        <data name="authorized_datasets" format="txt" label="${tool.name}: authorized datasets">
+            <filter> action['action_type'] == 'list_datasets' </filter>
+        </data>
+        <data name="dataset_file_list" format="txt" label="${tool.name}: dataset file list">
+            <filter> action['action_type'] == 'list_dataset_files' </filter>
+        </data>
     </outputs>
     <tests>
         <test><!-- list datasets with default credentials -->
-            <output name="outputdata" ftype="txt">
+            <param name="action_type" value="list_datasets"/>
+            <output name="authorized_datasets" ftype="txt">
                 <assert_contents>
+                    <has_text text="pyEGA3 - EGA python client version @VERSION@"/>
                     <has_text text="EGAD00001003338"/>
                 </assert_contents>
             </output>
         </test>
+        <test><!-- list dataset files with default credentials -->
+            <param name="action_type" value="list_dataset_files"/>
+            <param name="dataset_id" value="EGAD00001003338"/>
+            <output name="dataset_file_list" ftype="txt">
+                <assert_contents>
+                    <has_text text="pyEGA3 - EGA python client version @VERSION@"/>
+                    <has_line_matching expression="^File ID\s+Status\s+Bytes\s+Check sum\s+File name$"/>
+                    <has_text text="EGAF00001753734"/>
+                </assert_contents>
+            </output>
+        </test>
+
     </tests>
     <help><![CDATA[
         TODO: Fill in help.

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,4 +1,4 @@
-<tool id="pyega3" name="EGA Download Client" version="@VERSION@+galaxy0" python_template_version="3.5">
+<tool id="pyega3" name="EGA Download Client" version="@VERSION@+galaxy0" profile="19.09" >
     <macros>
         <token name="@VERSION@">3.1.0</token>
     </macros>
@@ -24,7 +24,7 @@
     pyega3 -cf '$credentials'
       fetch '$action.file_id'
       #if $action.range.reference_name
-        --reference-name $action.range.reference_name
+        --reference-name '$action.range.reference_name'
         #if $action.range.start
           --start $action.range.start
         #end if
@@ -68,7 +68,7 @@
                      <validator type="regex" message="EGA Accession ID must be a string of numbers prefixed by 'EGAD' (datasets) or 'EGAF' (files)">EGAF[0-9]+</validator>
                 </param>
                 <section name="range" title="Request a specific Genomic range?" expanded="false">
-                <param argument="--reference-name" name="reference_name" type="text" optional="true" label="Reference Sequence Name" help="For example 'chr1', '1', or 'chrX'. If unspecified, all data is returned." />
+                <param argument="--reference-name" type="text" optional="true" label="Reference Sequence Name" help="For example 'chr1', '1', or 'chrX'. If unspecified, all data is returned." />
                 <param argument="--start" type="integer" optional="true" min="0" label="Start Position" help="0-based, inclusive. Only used if a reference sequence name was specified"/>
                 <param argument="--end" type="integer" optional="true" min="0" label="End Position" help="0-based, exclusive. Only used if a reference sequence name was specified"/>
                 </section>
@@ -87,7 +87,7 @@
         </data>
     </outputs>
     <tests>
-        <test><!-- list datasets with default credentials -->
+        <test expect_num_outputs="1"><!-- list datasets with default credentials -->
             <param name="action_type" value="list_datasets"/>
             <output name="authorized_datasets" ftype="txt">
                 <assert_contents>
@@ -96,7 +96,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test><!-- list dataset files with default credentials -->
+        <test expect_num_outputs="1"><!-- list dataset files with default credentials -->
             <param name="action_type" value="list_dataset_files"/>
             <param name="dataset_id" value="EGAD00001003338"/>
             <output name="dataset_file_list" ftype="txt">
@@ -107,12 +107,12 @@
                 </assert_contents>
             </output>
         </test>
-        <test> <!-- download a single file -->
+        <test expect_num_outputs="1"> <!-- download a single file -->
             <param name="action_type" value="download_file"/>
             <param name="file_id" value="EGAF00001775036"/>
             <output name="downloaded_file" md5="3b89b96387db5199fef6ba613f70e27c"/>
         </test>
-        <test> <!-- download a single file, with genomic range specified -->
+         <test expect_num_outputs="1"> <!-- download a single file, with genomic range specified -->
             <param name="action_type" value="download_file"/>
             <param name="file_id" value="EGAF00001753756"/>
             <param name="reference_name" value="1"/>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -55,7 +55,7 @@
             <param name="action_type" type="select" label="What would you like to do?">
                 <option value="list_datasets"> List my authorized datasets </option>
                 <option value="list_dataset_files"> List files in a datasets </option>
-                <option value="download_file"> Download a single file </option>
+                <option value="download_file"> Download a file </option>
             </param>
             <when value="list_dataset_files">
                 <param name="dataset_id" type="text" optional="false" label="EGA Dataset Accession ID" help="Identifier starting with 'EGAD'. For example: EGAD00001003338">

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -122,7 +122,11 @@
         </test>
     </tests>
     <help><![CDATA[
-The pyEGA3 download client is a python-based tool for viewing and downloading files from authorized EGA datasets. pyEGA3 uses the EGA Data API and has several key features:
+The pyEGA3 download client is a python-based tool for viewing and downloading files from authorized EGA datasets.
+
+If you have an EGA account, you can set your EGA credentials in the user preferences menu of Galaxy. Otherwise, default EGA credentials with access to an example dataset will be used.
+
+pyEGA3 uses the EGA Data API and has several key features:
 
 - Files are transferred over secure https connections and received unencrypted, so no need for decryption after download.
 - Downloads resume from where they left off in the event that the connection is interrupted.

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,0 +1,42 @@
+<tool id="pyega3" name="EGA Download Client" version="@VERSION@+galaxy0" python_template_version="3.5">
+    <macros>
+        <token name="@VERSION@">3.1.0</token>
+    </macros>
+    <requirements>
+        <requirement type="package" version="@VERSION@">pyega3</requirement>
+    </requirements>
+    <configfiles>
+        <configfile name="credentials"><![CDATA[
+#set $password = $__user__.extra_preferences.get('ega_account|password', "")
+#set $username = $__user__.extra_preferences.get('ega_account|username', "")
+#if $username == "" or $password == "":
+   #set $username = "ega-test-data@ebi.ac.uk"
+   #set $password = "egarocks"
+#end if
+{
+    "username": "$username",
+    "password": "$password"
+}
+        ]]></configfile>
+    </configfiles>
+    <command detect_errors="exit_code"><![CDATA[
+        pyega3 -cf '$credentials' datasets > '$authorized_datasets'
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="authorized_datasets" format="txt" label="${tool.name}: authorized datasets"/>
+    </outputs>
+    <tests>
+        <test><!-- list datasets with default credentials -->
+            <output name="outputdata" ftype="txt">
+                <assert_contents>
+                    <has_text text="EGAD00001003338"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+        TODO: Fill in help.
+    ]]></help>
+</tool>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -5,6 +5,37 @@
     <requirements>
         <requirement type="package" version="@VERSION@">pyega3</requirement>
     </requirements>
+        <command detect_errors="exit_code"><![CDATA[
+#set $username = $__user__.extra_preferences.get('ega_account|username', "")
+#if $username == "":
+    #set $username = "ega-test-data@ebi.ac.uk (default user)"
+#end if
+    echo "Running as user: $username. Set your credentials via: User -> Preferences -> Manage Information"  &&
+
+#if $action.action_type == "list_datasets"
+    pyega3 -cf '$credentials'
+      datasets
+      > '$authorized_datasets'
+#elif $action.action_type == "list_dataset_files"
+    pyega3 -cf '$credentials'
+      files '$action.dataset_id'
+      > '$dataset_file_list'
+#elif $action.action_type == "download_file"
+    pyega3 -cf '$credentials'
+      fetch '$action.file_id'
+      #if $action.range.reference_name
+        --reference-name $action.range.reference_name
+        #if $action.range.start
+          --start $action.range.start
+        #end if
+        #if $action.range.end
+          --end $action.range.end
+        #end if
+      #end if
+      --saveto '$downloaded_file'
+#end if
+
+    ]]></command>
     <configfiles>
         <configfile name="credentials"><![CDATA[
 #set $password = $__user__.extra_preferences.get('ega_account|password', "")
@@ -19,22 +50,6 @@
 }
         ]]></configfile>
     </configfiles>
-    <command detect_errors="exit_code"><![CDATA[
-        #set $username = $__user__.extra_preferences.get('ega_account|username', "")
-        #if $username == "":
-            #set $username = "ega-test-data@ebi.ac.uk (default user)"
-        #end if
-        echo "Running as user: $username. Set your credentials via: User -> Preferences -> Manage Information"  &&
-
-        #if $action.action_type == "list_datasets"
-            pyega3 -cf '$credentials' datasets > '$authorized_datasets'
-        #elif $action.action_type == "list_dataset_files"
-            pyega3 -cf '$credentials' files '$action.dataset_id' > '$dataset_file_list'
-        #elif $action.action_type == "download_file"
-            pyega3 -cf '$credentials' fetch '$action.file_id' --saveto '$downloaded_file'
-        #end if
-
-    ]]></command>
     <inputs>
         <conditional name="action">
             <param name="action_type" type="select" label="What would you like to do?">
@@ -52,6 +67,11 @@
                 <param name="file_id" type="text" optional="false" label="EGA File Accession Identifier" help="Identifier starting with 'EGAF'. For example: EGAF00001753735">
                      <validator type="regex" message="EGA Accession ID must be a string of numbers prefixed by 'EGAD' (datasets) or 'EGAF' (files)">EGAF[0-9]+</validator>
                 </param>
+                <section name="range" title="Request a specific Genomic range?" expanded="false">
+                <param argument="--reference-name" name="reference_name" type="text" optional="true" label="Reference Sequence Name" help="For example 'chr1', '1', or 'chrX'. If unspecified, all data is returned." />
+                <param argument="--start" type="integer" optional="true" min="0" label="Start Position" help="0-based, inclusive. Only used if a reference sequence name was specified"/>
+                <param argument="--end" type="integer" optional="true" min="0" label="End Position" help="0-based, exclusive. Only used if a reference sequence name was specified"/>
+                </section>
             </when>
         </conditional>
     </inputs>
@@ -62,7 +82,7 @@
         <data name="dataset_file_list" format="txt" label="${tool.name}: dataset file list">
             <filter> action['action_type'] == 'list_dataset_files' </filter>
         </data>
-        <data name="downloaded_file" format="auto" label="${tool.name}: ${action.file_id}">
+        <data name="downloaded_file" auto_format="true" label="${tool.name}: ${action.file_id} ${action.range.reference_name} ${action.range.start} ${action.range.end}">
             <filter> action['action_type'] == 'download_file' </filter>
         </data>
     </outputs>
@@ -92,8 +112,26 @@
             <param name="file_id" value="EGAF00001775036"/>
             <output name="downloaded_file" md5="3b89b96387db5199fef6ba613f70e27c"/>
         </test>
+        <test> <!-- download a single file, with genomic range specified -->
+            <param name="action_type" value="download_file"/>
+            <param name="file_id" value="EGAF00001753756"/>
+            <param name="reference_name" value="1"/>
+            <param name="start" value="100"/>
+            <param name="end" value="10000"/>
+            <output name="downloaded_file" ftype="bam" md5="e576a38748feec45aa45191f6e902ce2"/>
+        </test>
     </tests>
     <help><![CDATA[
-        TODO: Fill in help.
+The pyEGA3 download client is a python-based tool for viewing and downloading files from authorized EGA datasets. pyEGA3 uses the EGA Data API and has several key features:
+
+- Files are transferred over secure https connections and received unencrypted, so no need for decryption after download.
+- Downloads resume from where they left off in the event that the connection is interrupted.
+- pyEGA3 supports file segmenting and parallelized download of segments, improving overall performance.
+- After download completes, file integrity is verified using checksums.
+- pyEGA3 implements the GA4GH-compliant htsget protocol for download of genomic ranges for data files with accompanying index files.
+
     ]]></help>
+    <citations>
+        <citation type="doi">10.1038/ng.3312</citation>
+    </citations>
 </tool>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -30,8 +30,8 @@
             pyega3 -cf '$credentials' datasets > '$authorized_datasets'
         #elif $action.action_type == "list_dataset_files"
             pyega3 -cf '$credentials' files '$action.dataset_id' > '$dataset_file_list'
-        #elif $action.action_type == "download"
-            echo "downloading"
+        #elif $action.action_type == "download_file"
+            pyega3 -cf '$credentials' fetch '$action.file_id' --saveto '$downloaded_file'
         #end if
 
     ]]></command>
@@ -40,13 +40,19 @@
             <param name="action_type" type="select" label="What would you like to do?">
                 <option value="list_datasets"> List my authorized datasets </option>
                 <option value="list_dataset_files"> List files in a datasets </option>
-                <option value="download"> Download datasets </option>
+                <option value="download_file"> Download a single file </option>
             </param>
             <when value="list_dataset_files">
-                <param name="dataset_id" type="text" optional="false" label="EGA identifier" help="For example: EGAD00001003338"/>
+                <param name="dataset_id" type="text" optional="false" label="EGA Dataset Accession ID" help="Identifier starting with 'EGAD'. For example: EGAD00001003338">
+                    <validator type="regex" message="EGA dataset ID must be a string of numbers prefixed by 'EGAD'">EGAD[0-9]+</validator>
+                </param>
             </when>
             <when value="list_datasets"/>
-            <when value="download"/>
+            <when value="download_file">
+                <param name="file_id" type="text" optional="false" label="EGA File Accession Identifier" help="Identifier starting with 'EGAF'. For example: EGAF00001753735">
+                     <validator type="regex" message="EGA Accession ID must be a string of numbers prefixed by 'EGAD' (datasets) or 'EGAF' (files)">EGAF[0-9]+</validator>
+                </param>
+            </when>
         </conditional>
     </inputs>
     <outputs>
@@ -55,6 +61,9 @@
         </data>
         <data name="dataset_file_list" format="txt" label="${tool.name}: dataset file list">
             <filter> action['action_type'] == 'list_dataset_files' </filter>
+        </data>
+        <data name="downloaded_file" format="auto" label="${tool.name}: ${action.file_id}">
+            <filter> action['action_type'] == 'download_file' </filter>
         </data>
     </outputs>
     <tests>
@@ -78,7 +87,11 @@
                 </assert_contents>
             </output>
         </test>
-
+        <test> <!-- download a single file -->
+            <param name="action_type" value="download_file"/>
+            <param name="file_id" value="EGAF00001775036"/>
+            <output name="downloaded_file" md5="3b89b96387db5199fef6ba613f70e27c"/>
+        </test>
     </tests>
     <help><![CDATA[
         TODO: Fill in help.


### PR DESCRIPTION
This adds a first implementation of a tool to download data from EGA, using the new python-based client (https://github.com/EGA-archive/ega-download-client)

Users can set their credentials under their user preferences (will PR to Galaxy to add the EGA credentials fields), and if unset, then the EGA test credentials are use (which has some 1000 genomes data)
 
There are enhancements to be made in the future, for example to list all the user's authorized files nicely in a dropdown orso, but for now this lets users obtain a list of their authorized datasets, list the files in a dataset, or download a file (or a specified genomic range of a file) 

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [X] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
