### PR TITLE
set the format of chain file to txt instead of csv

### DIFF
--- a/tools/crossmap/macros.xml
+++ b/tools/crossmap/macros.xml
@@ -7,7 +7,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">0.3.7</token>
-    <token name="@WRAPPER_VERSION@">@TOOL_VERSION@</token>
+    <token name="@WRAPPER_VERSION@">@TOOL_VERSION@_galaxy_1</token>
     <xml name="stdio">
         <stdio>
             <regex match="Aborted (core dumped)" source="stdout" level="fatal"/>
@@ -34,7 +34,7 @@ CrossMap.py 2>&1 | head -n 1 | grep -E --only-matching 'CrossMap.*'
                 </param>
             </when>
             <when value="history">
-                <param name="input_chain" type="data" format="csv" label="LiftOver chain file"/>
+                <param name="input_chain" type="data" format="txt" label="LiftOver chain file"/>
             </when>
         </conditional>
     </xml>

--- a/tools/crossmap/macros.xml
+++ b/tools/crossmap/macros.xml
@@ -7,7 +7,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">0.3.7</token>
-    <token name="@WRAPPER_VERSION@">@TOOL_VERSION@_galaxy_1</token>
+    <token name="@WRAPPER_VERSION@">@TOOL_VERSION@+galaxy1</token>
     <xml name="stdio">
         <stdio>
             <regex match="Aborted (core dumped)" source="stdout" level="fatal"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

I cannot figure out why the asked format for the LiftOver chain file is `cvs` nor why the tests are indeed passing. I don't see either the rational since the LiftOver chain file are most often kind of tabular-like and for sure not cvs.
Anyway this tools in its present version crashes with the test data on several artbio instances under 20.01, whereas it works with the input format `txt`, and importantly this does not affect the current tests (not surprisingly)
