### PR TITLE
Plink 1.9: Remove None response on empty var

### DIFF
--- a/tools/plink/plink.xml
+++ b/tools/plink/plink.xml
@@ -214,7 +214,9 @@
         ##Sex and Founder filter
             #if $functions.sex_founder_filter.filter == 'Yes'
                 $functions.sex_founder_filter.sex_select
-                $functions.sex_founder_filter.no_sex_select
+                #if $functions.sex_founder_filter.no_sex_select:
+                    $functions.sex_founder_filter.no_sex_select
+                #end if
                 $functions.sex_founder_filter.nonfounders
             #end if
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Small fix where setting --filter-founders and not setting no_sex_select adds "None" to command.