### PR TITLE
do not use >1 threads for velveth in velveloptimizer

### DIFF
--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -6,7 +6,8 @@
     </requirements>
     <version_command>VelvetOptimiser.pl --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-        export OMP_NUM_THREADS=$advanced.velveth_threads &&
+        export OMP_NUM_THREADS=1 &&
+        ## export OMP_THREAD_LIMIT=1 &&
         VelvetOptimiser.pl
             -t "\${GALAXY_SLOTS:-1}"
             -s $start_kmer
@@ -110,7 +111,6 @@
             <param name="velvetg_opts" type="text" value="" label="Other velvetg options" help="Add any other required velvetg options from the advanced set"/>
             <param name="minCutoff" type="integer" value="0" label="Minimum coverage cutoff" help="The minimum coverage cutoff to consider in the optimisation"/>
             <param name="maxCutoff" type="float" value="0.8" label="Maximum coverage cutoff" help="The maximum coverage cutoff to consider expressed as a fraction of the calculated expected coverage."/>
-            <param name="velveth_threads" type="integer" value="1" min="1" label="Number of threads used by each velvet run" help="vetvetoptimizer is running multiple velvet calls in parallel. By using values greater one for this option also the separate velvet runs will run multithreaded. Note that this will lead to overutilization of the available CPUs."/>
         </section>
     </inputs>
 

--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -6,8 +6,7 @@
     </requirements>
     <version_command>VelvetOptimiser.pl --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-        export OMP_NUM_THREADS=1 &&
-        ## export OMP_THREAD_LIMIT=1 &&
+        export OMP_NUM_THREADS=$advanced.velveth_threads &&
         VelvetOptimiser.pl
             -t "\${GALAXY_SLOTS:-1}"
             -s $start_kmer
@@ -111,6 +110,7 @@
             <param name="velvetg_opts" type="text" value="" label="Other velvetg options" help="Add any other required velvetg options from the advanced set"/>
             <param name="minCutoff" type="integer" value="0" label="Minimum coverage cutoff" help="The minimum coverage cutoff to consider in the optimisation"/>
             <param name="maxCutoff" type="float" value="0.8" label="Maximum coverage cutoff" help="The maximum coverage cutoff to consider expressed as a fraction of the calculated expected coverage."/>
+            <param name="velveth_threads" type="integer" value="1" min="1" label="Number of threads used by each velvet run" help="vetvetoptimizer is running multiple velvet calls in parallel. By using values greater one for this option also the separate velvet runs will run multithreaded. Note that this will lead to overutilization of the available CPUs."/>
         </section>
     </inputs>
 

--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -6,6 +6,9 @@
     </requirements>
     <version_command>VelvetOptimiser.pl --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
+        ## In Galaxy we do not us mutlithreading for the velvet
+        ## subprocesses, but only run multiple velvet calls in
+        ## parallel. Otherwise CPUs are overutilized.
         export OMP_NUM_THREADS=1 &&
         ## export OMP_THREAD_LIMIT=1 &&
         VelvetOptimiser.pl

--- a/tools/velvet_optimiser/velvetoptimiser.xml
+++ b/tools/velvet_optimiser/velvetoptimiser.xml
@@ -1,4 +1,4 @@
-<tool id="velvetoptimiser" name="VelvetOptimiser" version="2.2.6">
+<tool id="velvetoptimiser" name="VelvetOptimiser" version="2.2.6+galaxy1">
     <description>Automatically optimize Velvet assemblies</description>
     <requirements>
         <requirement type="package" version="1.2.10">velvet</requirement>
@@ -6,8 +6,8 @@
     </requirements>
     <version_command>VelvetOptimiser.pl --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-        export OMP_NUM_THREADS=2 &&
-        export OMP_THREAD_LIMIT=2 &&
+        export OMP_NUM_THREADS=1 &&
+        ## export OMP_THREAD_LIMIT=1 &&
         VelvetOptimiser.pl
             -t "\${GALAXY_SLOTS:-1}"
             -s $start_kmer


### PR DESCRIPTION
velvetoptimizer runs with `-t` already multithreaded (one for each k).
with `OMP_NUM_THREADS` > 1 also each velveth run will be multithreaded.

so overall CPUs are overutilized.

removed `export OMP_THREAD_LIMIT=1` because otherwise the tool gets
stuck.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
