### PR TITLE
Update query_tabular for empty datasets

### DIFF
--- a/tools/query_tabular/load_db.py
+++ b/tools/query_tabular/load_db.py
@@ -213,7 +213,7 @@ def get_column_def(file_path, table_name, skip=0, comment_char='#',
     if not col_names:
         col_names = ['c%d' % i for i in range(1, len(col_types) + 1)]
     if column_names:
-        cnames = [cn.strip() for cn in column_names.split(',')] 
+        cnames = [cn.strip() for cn in column_names.split(',')]
         if load_named_columns:
             col_idx = []
             colnames = []
@@ -232,11 +232,11 @@ def get_column_def(file_path, table_name, skip=0, comment_char='#',
                     if cname and i < len(col_names):
                         col_names[i] = cname
             else:
-                col_names = [x if x else 'c%d' % (i) for i,x in enumerate(cnames)]
+                col_names = [x if x else 'c%d' % (i) for i, x in enumerate(cnames)]
     col_def = []
     for i, col_name in enumerate(col_names):
         if i >= len(col_types):
-            col_types.append('TEXT') 
+            col_types.append('TEXT')
         col_def.append('%s %s' % (col_names[i], col_types[i]))
     return col_names, col_types, col_def, col_idx
 

--- a/tools/query_tabular/load_db.py
+++ b/tools/query_tabular/load_db.py
@@ -189,6 +189,9 @@ def get_column_def(file_path, table_name, skip=0, comment_char='#',
             if linenum == 0 and firstlinenames:
                 col_names = [get_valid_column_name(name) or 'c%d' % (i + 1)
                              for i, name in enumerate(fields)]
+                # guarantee col_types in case of empty data
+                while len(col_types) < len(fields):
+                    col_types.append(None)
                 continue
             if linenum > max_lines:
                 break
@@ -210,23 +213,30 @@ def get_column_def(file_path, table_name, skip=0, comment_char='#',
     if not col_names:
         col_names = ['c%d' % i for i in range(1, len(col_types) + 1)]
     if column_names:
+        cnames = [cn.strip() for cn in column_names.split(',')] 
         if load_named_columns:
             col_idx = []
-            cnames = []
-            for i, cname in enumerate(
-                    [cn.strip() for cn in column_names.split(',')]):
+            colnames = []
+            for i, cname in enumerate(cnames):
+                # guarantee col_types in case of empty data
+                if i >= len(col_types):
+                    col_types.append('TEXT')
                 if cname != '':
                     col_idx.append(i)
-                    cnames.append(cname)
+                    colnames.append(cname)
             col_types = [col_types[i] for i in col_idx]
-            col_names = cnames
+            col_names = colnames
         else:
-            for i, cname in enumerate(
-                    [cn.strip() for cn in column_names.split(',')]):
-                if cname and i < len(col_names):
-                    col_names[i] = cname
+            if col_names:
+                for i, cname in enumerate(cnames):
+                    if cname and i < len(col_names):
+                        col_names[i] = cname
+            else:
+                col_names = [x if x else 'c%d' % (i) for i,x in enumerate(cnames)]
     col_def = []
     for i, col_name in enumerate(col_names):
+        if i >= len(col_types):
+            col_types.append('TEXT') 
         col_def.append('%s %s' % (col_names[i], col_types[i]))
     return col_names, col_types, col_def, col_idx
 

--- a/tools/query_tabular/query_tabular.xml
+++ b/tools/query_tabular/query_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="query_tabular" name="Query Tabular" version="3.1.0">
+<tool id="query_tabular" name="Query Tabular" version="3.1.1">
     <description>using sqlite sql</description>
 
     <macros>
@@ -528,6 +528,57 @@ $sqlquery
             <output name="output1" file="psm_dbmod_output1.tsv" compare="re_match"/>
         </test>
 
+        <test>
+            <repeat name="tables">
+                <param name="table" ftype="tabular" value="netMHC_summary.tsv"/>
+                <section name="input_opts">
+                    <repeat name="linefilters">
+                        <conditional name="filter">
+                            <param name="filter_type" value="regex"/>
+                            <param name="regex_pattern" value="peptide"/>
+                            <param name="regex_action" value="include_find"/>
+                        </conditional>
+                    </repeat>
+                </section>
+                <section name="tbl_opts">
+                    <param name="table_name" value="epitope"/>
+                    <param name="column_names_from_first_line" value="True"/>
+                </section>
+            </repeat>
+            <param name="sqlquery" value="SELECT * FROM epitope"/>
+            <conditional name="query_result">
+                <param name="header" value="yes"/>
+                <param name="header_prefix" value=""/>
+            </conditional>
+            <output name="output" file="netMHC_summary_out1.tsv" ftype="tabular"/>
+        </test>
+
+        <test>
+            <repeat name="tables">
+                <param name="table" ftype="tabular" value="netMHC_summary.tsv"/>
+                <section name="input_opts">
+                    <repeat name="linefilters">
+                        <conditional name="filter">
+                            <param name="filter_type" value="regex"/>
+                            <param name="regex_pattern" value="NOT TO BE FOUND"/>
+                            <param name="regex_action" value="include_find"/>
+                        </conditional>
+                    </repeat>
+                </section>
+                <section name="tbl_opts">
+                    <param name="table_name" value="epitope"/>
+                    <param name="column_names_from_first_line" value="False"/>
+                    <param name="col_names" value="pos,peptide,logscore,,,,Allele"/>
+                </section>
+            </repeat>
+            <param name="sqlquery" value="SELECT pos,peptide,logscore,Allele FROM epitope"/>
+            <conditional name="query_result">
+                <param name="header" value="yes"/>
+                <param name="header_prefix" value=""/>
+            </conditional>
+            <output name="output" file="netMHC_summary_out2.tsv" ftype="tabular"/>
+        </test>
+
     </tests>
     <help><![CDATA[
 =============
@@ -539,6 +590,13 @@ Query Tabular
   Loads tabular datasets into a SQLite_ data base.  
 
   An existing SQLite_ data base can be used as input, and any selected tabular datasets will be added as new tables in that data base.
+
+    **NOTE:** If there are no data rows in an input tabular dataset, query_tabular will fail unless:
+
+      - There is a row header line in the dataset and **Use first line as column names** is selected  
+      - **Specify Column Names** is used to provide column names
+
+        in which case an empty table will be created with those columns
 
 
 @LINEFILTERS_HELP@

--- a/tools/query_tabular/test-data/netMHC_summary_out1.tsv
+++ b/tools/query_tabular/test-data/netMHC_summary_out1.tsv
@@ -1,0 +1,1 @@
+#pos	peptide	logscore	affinity(nM)	Bind Level	Protein Name	Allele

--- a/tools/query_tabular/test-data/netMHC_summary_out2.tsv
+++ b/tools/query_tabular/test-data/netMHC_summary_out2.tsv
@@ -1,0 +1,1 @@
+pos	peptide	logscore	Allele


### PR DESCRIPTION
Allow query_tabular to create empty tables if possible.   This can be useful in workflows.

If there are no data rows in an input tabular dataset, query_tabular will fail unless:

a) There is a row header line in the dataset and Use first line as column names is selected
b) Specify Column Names is used to provide column names

in which case an empty table will be created with those columns.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
