### PR TITLE
unicycler: make gfa output really gfa

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -9,6 +9,5 @@ tools/ncbi_entrez_eutils/einfo.xml
 tools/raven/
 tools/sarscov2formatter/sarscov2formatter.xml
 tools/trinotate
-tools/unicycler
 tools/valet
 tools/vg/convert.xml

--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -242,7 +242,7 @@ $pilon.no_pilon
             </section>
             <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
-                    <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC"/>
+                    <has_line_matching expression="S\t1\t[ATCG]{5386,5386}\tLN:i:5386\tdp:f:1.0"/>
                 </assert_contents>
             </output>
             <output name="assembly" ftype="fasta">
@@ -297,7 +297,7 @@ $pilon.no_pilon
             </section>
             <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
-                    <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC" />
+                    <has_line_matching expression="S\t1\t[ATCG]{5386,5386}\tLN:i:5386\tdp:f:1.0"/>
                 </assert_contents>
             </output>
             <output name="assembly" ftype="fasta">
@@ -344,7 +344,7 @@ $pilon.no_pilon
             </section>
             <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
-                    <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC" />
+                    <has_line_matching expression="S\t1\t[ATCG]{5386,5386}\tLN:i:5386\tdp:f:1.0"/>
                 </assert_contents>
             </output>
             <output name="assembly" ftype="fasta">

--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -1,4 +1,4 @@
-<tool id="unicycler" name="Create assemblies with Unicycler" version="@VERSION@.0">
+<tool id="unicycler" name="Create assemblies with Unicycler" version="@VERSION@.0" profile="20.09">
     <macros>
         <token name="@VERSION@">0.4.8</token>
     </macros>
@@ -204,7 +204,7 @@ $pilon.no_pilon
         </section>
     </inputs>
     <outputs>
-        <data name="assembly_graph" format="tabular" from_work_dir="assembly.gfa" label="${tool.name} on ${on_string}: Final Assembly Graph" />
+        <data name="assembly_graph" format="gfa1" from_work_dir="assembly.gfa" label="${tool.name} on ${on_string}: Final Assembly Graph" />
         <data name="assembly" format="fasta" from_work_dir="assembly.fasta" label="${tool.name} on ${on_string}: Final Assembly"/>
     </outputs>
     <tests>
@@ -240,7 +240,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="tabular">
+            <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
                     <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC"/>
                 </assert_contents>
@@ -295,7 +295,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="tabular">
+            <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
                     <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC" />
                 </assert_contents>
@@ -342,7 +342,7 @@ $pilon.no_pilon
             <section name="lr_align">
                 <param name="scores" value="3,-6,-5,-2"/>
             </section>
-            <output name="assembly_graph" ftype="tabular">
+            <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
                     <has_text text="TATCTGTTACTGAGAAGTTAATGGATGAATTGGCAC" />
                 </assert_contents>
@@ -362,7 +362,7 @@ $pilon.no_pilon
                 <param name="kmers" value="21,23"/>
             </section>
             <param name="long" value="only_long.fasta" ftype="fasta" />
-            <output name="assembly_graph" ftype="tabular">
+            <output name="assembly_graph" ftype="gfa1">
                 <assert_contents>
                     <has_text text="S" />
                 </assert_contents>


### PR DESCRIPTION
Not yet solving https://github.com/galaxyproject/tools-iuc/issues/3203 1st commit just sets the gfa outtype more specific

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
