### PR TITLE
Allow MultiQC runs with certain quasi-empty inputs

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -250,7 +250,7 @@ mkdir multiqc_WDir &&
                 #set $pattern = "picard.analysis.InsertSizeMetrics"
                 @LN_2_FILES@
             #elif str($repeat2.type) == "markdups"
-                #set $pattern = "# MarkDuplicates"
+                #set $pattern = "MarkDuplicates"
                 @LN_2_FILES@
             #elif str($repeat2.type) == "oxogmetrics"
                 #set $pattern = "picard.analysis.CollectOxoGMetrics"

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,4 +1,4 @@
-<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@+galaxy0">
+<tool id="multiqc" name="MultiQC" version="@WRAPPER_VERSION@+galaxy1">
     <description>aggregate results from bioinformatics analyses into a single report</description>
     <macros>
         <token name="@WRAPPER_VERSION@">1.8</token>
@@ -115,7 +115,7 @@ mkdir multiqc_WDir &&
             #end if
         #end for
     #elif str($repeat.software_cond.software) == "bowtie2"
-        #set $pattern = "reads; of these:"
+        #set $pattern = "% overall alignment rate"
         @LN_FILES@
     #elif str($repeat.software_cond.software) == "busco"
         ## Searches for files "short_summary_[samplename].txt"
@@ -250,7 +250,7 @@ mkdir multiqc_WDir &&
                 #set $pattern = "picard.analysis.InsertSizeMetrics"
                 @LN_2_FILES@
             #elif str($repeat2.type) == "markdups"
-                #set $pattern = "picard.sam.DuplicationMetrics"
+                #set $pattern = "# MarkDuplicates"
                 @LN_2_FILES@
             #elif str($repeat2.type) == "oxogmetrics"
                 #set $pattern = "picard.analysis.CollectOxoGMetrics"

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1301,7 +1301,9 @@ MultiQC takes software output summaries/logs and creates a single report from th
 
 ----
 
-The first integration of this tool was made by Cyril Monjeaud and Yvan Le Bras (`Enancio <http://enancio.fr/>`_ and Rennes GenOuest Bio-informatics Core Facility). It is now maintained by the `Intergalactic Utilities Commission <https://galaxyproject.org/iuc>`_.
+The first integration of this tool was made by
+`@cmonjeau <https://github.com/cmonjeau>`_ and `@yvanlebras <https://github.com/yvanlebras>`_.
+It is now maintained by the `Intergalactic Utilities Commission <https://galaxyproject.org/iuc>`_.
     ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btw354</citation>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)


The specific cases fixed here are:
- bowtie2 mapping stats generated from an empty fastq
- picard MarkDuplicates stats generated from empty bams

In both cases, the MultiQC wrapper failed because it was looking for missing text patterns, while MultiQC itself is perfectly
capable of dealing with these inputs (and will simply produce empty output).
The issue is fixed here by scanning for parts of text that are constant under all conditions.