### PR TITLE
Use $GALAXY_SLOTS in kc-align instead of threads as a tool param

### DIFF
--- a/tools/kc-align/kc-align.xml
+++ b/tools/kc-align/kc-align.xml
@@ -1,4 +1,4 @@
-<tool id="kc-align" name="Kc-Align" version="1.0" python_template_version="3.5">
+<tool id="kc-align" name="Kc-Align" version="1.0.2" python_template_version="3.5">
     <requirements>
         <requirement type="package" version="1.0.2">kcalign</requirement>
     </requirements>
@@ -17,7 +17,7 @@
                 -d '$position.dist'
             #end if
             $compress
-            -th '$threads'
+            -th '\${GALAXY_SLOTS:-1}'
 
     ]]></command>
     <inputs>
@@ -51,7 +51,6 @@
             </when>
         </conditional>
         <param name="compress" type="boolean" truevalue="--compress" falsevalue="" label="Compress" help="Compress identical sequences" />
-        <param name="threads" type="integer" argument="-th" value="1" label="Cores" />
     </inputs>
     <outputs>
         <data name="fasta" format="fasta" from_work_dir="codon_align.fasta" label="${tool.name}: fasta output" />
@@ -64,7 +63,6 @@
         <param name="mode" value="genome" />
         <param name="start" value="21563" />
         <param name="end" value="25384" />
-        <param name="threads" value="15" />
         <output name="fasta" ftype="fasta" compare="contains" value="kc-align.fasta" />
         <output name="clustal" ftype="txt" compare="contains" value="kc-align.clustal" />
     </test>

--- a/tools/kc-align/kc-align.xml
+++ b/tools/kc-align/kc-align.xml
@@ -17,7 +17,7 @@
                 -d '$position.dist'
             #end if
             $compress
-            -th '\${GALAXY_SLOTS:-1}'
+            -th \${GALAXY_SLOTS:-1}
 
     ]]></command>
     <inputs>


### PR DESCRIPTION
Also set the version to the full tool version.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
