### PR TITLE
adapt PR workflow to new way of setting env vars

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,9 +31,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)
+      run: echo "GALAXY_HEAD_SHA=$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)" >> $GITHUB_ENV
     - name: Save latest galaxy commit to artifact file
-      run: echo ${{ env.GALAXY_HEAD_SHA }} > galaxy.sha
+      run: echo $GALAXY_HEAD_SHA > galaxy.sha
     - uses: actions/upload-artifact@v2
       with:
         name: Workflow artifacts
@@ -43,13 +43,13 @@ jobs:
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Cache .planemo
       uses: actions/cache@v2
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     # Install the `wheel` package so that when installing other packages which
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
@@ -75,15 +75,15 @@ jobs:
       if: github.ref != 'refs/heads/master' && github.event_name == 'push'
       run: |
         git fetch origin master
-        echo ::set-env name=COMMIT_RANGE::"origin/master..."
+        echo "COMMIT_RANGE=origin/master..." >> $GITHUB_ENV
     - name: Set commit range (push to the master branch, e.g. merge)
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: echo ::set-env name=COMMIT_RANGE::${{ github.event.before }}..""
+      run: echo "COMMIT_RANGE=${{ github.event.before }}.." >> $GITHUB_ENV
     - name: Set commit range (pull request)
       if: github.event_name == 'pull_request'
-      run: echo ::set-env name=COMMIT_RANGE::"HEAD~.."
+      run: echo "COMMIT_RANGE=HEAD~.." >> $GITHUB_ENV
     - name: Planemo ci_find_repos
-      run: planemo ci_find_repos --changed_in_commit_range ${{ env.COMMIT_RANGE }} --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
+      run: planemo ci_find_repos --changed_in_commit_range $COMMIT_RANGE --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
     - name: Show repo list
       run: cat changed_repositories.list
     - uses: actions/upload-artifact@v2.0.1
@@ -114,13 +114,13 @@ jobs:
         name: Workflow artifacts
         path: ../workflow_artifacts/
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat ../workflow_artifacts/galaxy.sha)
+      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo lint
@@ -153,13 +153,13 @@ jobs:
         name: Workflow artifacts
         path: ../workflow_artifacts/
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat ../workflow_artifacts/galaxy.sha)
+      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_$gxy_$GALAXY_HEAD_SHA
     - name: Install flake8
       run: pip install flake8 flake8-import-order
     - name: Flake8
@@ -258,19 +258,19 @@ jobs:
         name: Workflow artifacts
         path: ../workflow_artifacts/
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat ../workflow_artifacts/galaxy.sha)
+      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Cache .planemo
       uses: actions/cache@v2
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo ci_find_tools
@@ -346,13 +346,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat "artifacts/Workflow artifacts/galaxy.sha")
+      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
@@ -397,13 +397,13 @@ jobs:
         name: Workflow artifacts
         path: ../workflow_artifacts/
     - name: Determine latest galaxy commit
-      run: echo ::set-env name=GALAXY_HEAD_SHA::$(cat ../workflow_artifacts/galaxy.sha)
+      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ env.GALAXY_HEAD_SHA }}
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
     - name: Install Planemo
       run: pip install planemo
     - name: Deploy on testtoolshed


### PR DESCRIPTION
currently we see:

```
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
