### PR TITLE
fail PR workflow if no test was executed

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -371,7 +371,10 @@ jobs:
         path: upload
     - name: Check status of combined status
       run: |
-        if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
+        if [[ $(jq '.["tests"]' upload/tool_test_output.json) == "[]" ]]; then
+            echo "No tests were executed inspect the output of the chunks"
+            exit 1
+        else if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
             echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."
             exit 1
         fi


### PR DESCRIPTION
e.g. in case planemo itself fails as here https://github.com/galaxyproject/tools-iuc/pull/3232/checks?check_run_id=1246607831

- not sure why the linked example does not fail at linting stage as well (it fails, but for a different reason).
- also not entirely sure if its the right thing to do

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
