### PR TITLE
Remove filter from MAF data table references.

### DIFF
--- a/tools/genebed_maf_to_fasta/genebed_maf_to_fasta.xml
+++ b/tools/genebed_maf_to_fasta/genebed_maf_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="GeneBed_Maf_Fasta2" name="Stitch Gene blocks" version="1.0.1">
+<tool id="GeneBed_Maf_Fasta2" name="Stitch Gene blocks" version="1.0.1+galaxy0">
     <description>given a set of coding exon intervals</description>
     <macros>
           <import>macros.xml</import>

--- a/tools/genebed_maf_to_fasta/macros.xml
+++ b/tools/genebed_maf_to_fasta/macros.xml
@@ -35,11 +35,9 @@
                         <column name="indexed_for" index="2"/>
                         <column name="exists_in_maf" index="3" />
                         <column name="path" index="4" />
-                        <filter type="data_meta" ref="input1" key="dbkey" column="2" multiple="True" separator=","/>
-                        <validator type="no_options" message="No alignments are available for the build associated with the selected interval file"/>
                     </options>
                 </param>
-                <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment">
+                <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment. Results may not be easily predictable if the input species does not exist in the cached multi-alignment">
                     <options from_data_table="maf_indexes">
                         <column name="value" index="3"/>
                         <filter type="multiple_splitter" column="3" separator=","/>

--- a/tools/interval2maf/interval2maf.xml
+++ b/tools/interval2maf/interval2maf.xml
@@ -1,4 +1,4 @@
-<tool id="Interval2Maf1" name="Extract MAF blocks" version="1.0.1">
+<tool id="Interval2Maf1" name="Extract MAF blocks" version="1.0.1+galaxy0">
     <description>given a set of genomic intervals</description>
     <macros>
             <import>macros.xml</import>

--- a/tools/interval2maf/macros.xml
+++ b/tools/interval2maf/macros.xml
@@ -11,10 +11,7 @@
     <xml name="maf_source">
         <when value="cached">
             <param name="mafType" type="select" label="Choose alignments">
-                <options from_data_table="maf_indexes">
-                    <filter type="data_meta" ref="input1" key="dbkey" column="2" multiple="True" separator=","/>
-                    <validator type="no_options" message="No alignments are available for the build associated with the selected interval file"/>
-                </options>
+                <options from_data_table="maf_indexes" />
             </param>
             <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment">
                 <options from_data_table="maf_indexes">

--- a/tools/maf_stats/maf_stats.xml
+++ b/tools/maf_stats/maf_stats.xml
@@ -1,4 +1,4 @@
-<tool id="maf_stats1" name="MAF Coverage Stats" version="1.0.1">
+<tool id="maf_stats1" name="MAF Coverage Stats" version="1.0.1+galaxy0">
     <description>Alignment coverage information</description>
     <command>
         <![CDATA[

--- a/tools/maf_stats/maf_stats.xml
+++ b/tools/maf_stats/maf_stats.xml
@@ -48,8 +48,6 @@
                         <column name="indexed_for" index="2"/>
                         <column name="exists_in_maf" index="3" />
                         <column name="path" index="4" />
-                        <filter type="data_meta" ref="input1" key="dbkey" column="2" multiple="True" separator=","/>
-                        <validator type="no_options" message="No alignments are available for the build associated with the selected interval file"/>
                     </options>
                 </param>
                 <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR removes the input dataset dbkey filter from the maf_indexes reference in the tools that use this table. This allows a user to select any MultiZ alignment that they believe includes the appropriate species, instead of potentially needing to guess which dbkey to use. 