### PR TITLE
fix idr test diff sizes

### DIFF
--- a/tools/idr/idr.xml
+++ b/tools/idr/idr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="idr" name="IDR" version="@VERSION@">
+<tool id="idr" name="IDR" version="@VERSION@+galaxy1">
     <description>compare ranked list of identifications</description>
     <macros>
         <token name="@VERSION@">2.0.3</token>
@@ -95,7 +95,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out1.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out1.png" ftype="png" compare="sim_size" delta="1000"/>
+            <output name="idr_plot" file="idr_out1.png" ftype="png" compare="sim_size" delta="5000"/>
         </test>
         <test>
             <param name="primus" value="idr_input2.1.bed" ftype="bed" />
@@ -103,7 +103,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out2.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out2.png" ftype="png" compare="sim_size" delta="1000"/>
+            <output name="idr_plot" file="idr_out2.png" ftype="png" compare="sim_size" delta="5000"/>
         </test>
         <test>
             <param name="primus" value="idr_input3.1.bed" ftype="bed" />
@@ -112,7 +112,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out3.bed" ftype="bed" />
-            <output name="idr_plot" file="idr_out3.png" ftype="png" compare="sim_size" delta="1000"/>
+            <output name="idr_plot" file="idr_out3.png" ftype="png" compare="sim_size" delta="5000"/>
         </test>
         <test>
             <param name="primus" value="idr_input4.1.gff" ftype="gff" />
@@ -121,7 +121,7 @@
             <param name="rank" value="default" />
             <param name="plot" value="True" />
             <output name="idr_values" file="idr_out4.gff" ftype="gff" />
-            <output name="idr_plot" file="idr_out4.png" ftype="png" compare="sim_size" delta="1000"/>
+            <output name="idr_plot" file="idr_out4.png" ftype="png" compare="sim_size" delta="7500"/>
         </test>
      </tests>
     <help>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Fix original tests to properly diff against output files