### PR TITLE
hisat2 sorted output for cloud instances

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -934,7 +934,7 @@ simultaneously to achieve greater alignment speed. HISAT outputs
 alignments in `SAM <http://samtools.sourceforge.net/SAM1.pdf>`__ format,
 enabling interoperation with a large number of other tools (e.g.
 `SAMtools <http://samtools.sourceforge.net>`__,
-`GATK <http://www.broadinstitute.org/gsa/wiki/index.php/The_Genome_Analysis_Toolkit>`__)
+`GATK <https://gatk.broadinstitute.org/hc/en-us>`__)
 that use SAM. HISAT is distributed under the `GPLv3
 license <http://www.gnu.org/licenses/gpl-3.0.html>`__, and it runs on
 the command line under Linux, Mac OS X and Windows.

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -787,7 +787,7 @@ hisat2
             <param name="unaligned_file" value="true" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fasta" value="test_unaligned_reads.fasta" />
-            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
+            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" sort="true"/>
         </test>
         <!-- Ensure paired unaligned/aligned output works -->
         <test expect_num_outputs="5">
@@ -799,8 +799,8 @@ hisat2
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fasta" value="test_unaligned_reads.fasta" />
             <param name="input_2" ftype="fasta" value="test_unaligned_reads.fasta" />
-            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" />
-            <output name="output_unaligned_reads_r" file="test_unaligned_reads.fasta" />
+            <output name="output_unaligned_reads_l" file="test_unaligned_reads.fasta" sort="true"/>
+            <output name="output_unaligned_reads_r" file="test_unaligned_reads.fasta" sort="true"/>
         </test>
         <!-- Ensure fastqsanger.gz works -->
         <test expect_num_outputs="1">

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -932,10 +932,8 @@ addition to spliced alignment, HISAT handles reads involving indels and
 supports a paired-end alignment mode. Multiple processors can be used
 simultaneously to achieve greater alignment speed. HISAT outputs
 alignments in `SAM <http://samtools.sourceforge.net/SAM1.pdf>`__ format,
-enabling interoperation with a large number of other tools (e.g.
-`SAMtools <http://samtools.sourceforge.net>`__,
-`GATK <https://gatk.broadinstitute.org/hc/en-us>`__)
-that use SAM. HISAT is distributed under the `GPLv3
+enabling interoperation with a large number of other tools that use SAM.
+HISAT is distributed under the `GPLv3
 license <http://www.gnu.org/licenses/gpl-3.0.html>`__, and it runs on
 the command line under Linux, Mac OS X and Windows.
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
On cloud instances, some of this tool's tests returns fasta files with mostly identical outputs, but sorted differently, ie
```
read1
aaaaaaa
read2
ttttttttt
read3
gggggg
```

vs

```
read3
gggggg
read2
ttttttttt
read1
aaaaaaa
```

This just sorts the outputs to make sure they match in those tests