### PR TITLE
hyphy (relax) fixes

### DIFF
--- a/tools/hyphy/hyphy_relax.xml
+++ b/tools/hyphy/hyphy_relax.xml
@@ -9,10 +9,13 @@
     <command detect_errors="exit_code"><![CDATA[
         ln -s '$input_file' relax_input.fa &&
         ln -s '$input_nhx' relax_input.nhx &&
+
+        export OMP_NUM_THREADS="\${GALAXY_SLOTS:-1}" &&
         hyphy relax
             --alignment ./relax_input.fa
             --tree ./relax_input.nhx
             --models '$analysisType'
+            --code '$gencodeid'
             #if $treeAnnotations == "2":
                 --test TEST
                 --reference REFERENCE
@@ -51,7 +54,7 @@ RELAX: a test for selection differences
 What question does this method answer?
 --------------------------------------
 
-Is there ev- idence the strength of selection has been relaxed (or conversely intensified) on a specified group of lineages (TEST)
+Is there evidence the strength of selection has been relaxed (or conversely intensified) on a specified group of lineages (TEST)
 relative to a set of reference lineages (RELAX)? Importantly, RELAX is not designed to detect diversifying selection specifically.
 We note that the RELAX framework can perform both this specific hypothesis test as well as fit a suite of descriptive models which address,
 or example, overall rate differences between test and reference branches or lineage-specific inferences of selection relaxation.


### PR DESCRIPTION
Tool is failing CI. So I had a look and found a few problems:

- add missing `--code` parameter
- add OMP_NUM_THREADS to avoid CPU overutilization

other tools also should use OMP_NUM_THREADS. Some even use MPI variant. I would suggest to remove this / add an MPI version of the tools.



FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
