### PR TITLE
Fix for whitespace error on cloud instance

### DIFF
--- a/tools/column_order_header_sort/column_order_header_sort.xml
+++ b/tools/column_order_header_sort/column_order_header_sort.xml
@@ -25,7 +25,7 @@
         <test>
             <param name="input_tabular" value="in_1.tabular" ftype="tabular"/>
             <param name="key_column" value="1"/>
-            <output name="output_tabular" file="out_1.tabular" ftype="tabular"/>
+            <output name="output_tabular" file="out_1.tabular" ftype="tabular" compare="sim_size" delta="1"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
On cloud instance, there's a single whitespace removed from end of second line which throws the test off. This just allows for that.