### PR TITLE
remove ci_skip note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ These repositories are maintained and developed by the [Intergalactic Utilities 
 
 Pull Requests with dependencies specified as conda-package will be automatically tested and verified using [planemo](https://github.com/galaxyproject/planemo). If the tests pass and the pull request is merged, the tool will be automatically uploaded to the [Test](http://testtoolshed.g2.bx.psu.edu/)- and [Main Tool Shed](http://toolshed.g2.bx.psu.edu/).
 
-Please note, if you don’t want to run the tests or the automatic upload, add `[ci skip]` to the git commit message.
-Commits that have [ci skip] anywhere in the commit messages are ignored by Travis CI.
-
-
 Other repositories with Galaxy tools:
  * [Björn Grüning repo](https://github.com/bgruening/galaxytools)
  * [Galaxy devteam repo](https://github.com/galaxyproject/tools-devteam)


### PR DESCRIPTION

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Note is out of date. Alternatively we could add a note regarding `.tt_skip`
