### PR TITLE
make number of chunks dynamic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,10 @@ jobs:
       id: get-chunks
       run: |
         nchunks=$(find tools/ tool_collections/ data_managers/ -iname '*xml' | grep -v macro | wc -l)
-        if [[ $nchunks -gt $MAX_CHUNKS ]]; then
+        if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         fi
-        chunk_list=$(echo "["$(seq -s ", " 1 $nchunks)"]")
+        chunk_list='['$(seq -s ", " 0 $(($nchunks - 1)))']'
         echo "::set-output name=chunks::$chunk_list"
   test:
     name: Test tools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
     types: [run-all-tool-tests-command]
 env:
   GALAXY_RELEASE: release_20.09
+  MAX_CHUNKS: 40
 jobs:
   setup:
     name: Setup cache
@@ -51,13 +52,11 @@ jobs:
     - name: Get approximate number of tools and compute number of chunks
       id: get-chunks
       run: |
-        ntools=$(find tools/ tool_collections/ data_managers/ -iname '*xml' | grep -v macro | wc -l)
-        log=$(printf "%.0f" $(echo "l($ntools+1)/l(2)" | bc -l))
-        nchunks=$(echo "4 * $log" | bc)
-        if [[ $nchunks -gt 39 ]]; then
-            nchunks="39"
+        nchunks=$(find tools/ tool_collections/ data_managers/ -iname '*xml' | grep -v macro | wc -l)
+        if [[ $nchunks -gt $MAX_CHUNKS ]]; then
+            nchunks=$MAX_CHUNKS
         fi
-        chunk_list=$(echo "["$(seq -s ", " 0 $nchunks)"]")
+        chunk_list=$(echo "["$(seq -s ", " 1 $nchunks)"]")
         echo "::set-output name=chunks::$chunk_list"
   test:
     name: Test tools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     name: Setup cache
     if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
+    outputs:
+      chunks: ${{ steps.get-chunks.outputs.chunks }}
     strategy:
       matrix:
         python-version: [3.7]
@@ -43,6 +45,20 @@ jobs:
       run: |
         touch tool.xml
         PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_branch $GALAXY_RELEASE
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Get approximate number of tools and compute number of chunks
+      id: get-chunks
+      run: |
+        ntools=$(find tools tool_collections data_managers -iname "*xml" | grep -v macro | wc -l)
+        log=$(printf "%.0f" $(echo "l($ntools+1)/l(2)" | bc -l))
+        nchunks=$(echo "4 * $log" | bc)
+        if [[ $nchunks -gt 39 ]]; then
+            nchunks="39"
+        fi
+        chunk_list=$(echo "["$(seq -s ", " 0 $nchunks)"]")
+        echo "::set-output name=chunks::$chunk_list"
   test:
     name: Test tools
     # This job runs on Linux
@@ -51,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chunk: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39]
+        chunk: ${{ fromJson(needs.setup.outputs.chunks) }}
         python-version: [3.7]
     services:
       postgres:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Get approximate number of tools and compute number of chunks
       id: get-chunks
       run: |
-        ntools=$(find tools tool_collections data_managers -iname "*xml" | grep -v macro | wc -l)
+        ntools=$(find tools/ tool_collections/ data_managers/ -iname '*xml' | grep -v macro | wc -l)
         log=$(printf "%.0f" $(echo "l($ntools+1)/l(2)" | bc -l))
         nchunks=$(echo "4 * $log" | bc)
         if [[ $nchunks -gt 39 ]]; then

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,10 +98,10 @@ jobs:
       run: |
         planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
         nchunks=$(wc -l changed_tools.list)
-        if [[ $nchunks -gt $MAX_CHUNKS ]]; then
+        if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         fi
-        chunk_list=$(echo "["$(seq -s ", " 1 $nchunks)"]")
+        chunk_list='['$(seq -s ", " 0 $(($nchunks - 1)))']'
         echo "::set-output name=chunks::$chunk_list"
 
   # Planemo lint the changed repositories

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
       id: get-chunks
       run: |
         planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
-        nchunks=$(wc -l changed_tools.list)
+        nchunks=$(wc -l < changed_tools.list)
         if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   GALAXY_REPO: https://github.com/galaxyproject/galaxy
   GALAXY_RELEASE: release_20.09
+  MAX_CHUNKS: 4
 jobs:
   # the setup job does two things:
   # 1. cache the pip cache and .planemo
@@ -96,13 +97,11 @@ jobs:
       id: get-chunks
       run: |
         planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
-        ntools=$(wc -l changed_tools.list)
-        log=$(printf "%.0f" $(echo "l($ntools+1)/l(2)" | bc -l))
-        nchunks=$(echo "4 * $log" | bc)
-        if [[ $nchunks -gt 39 ]]; then
-            nchunks="39"
+        nchunks=$(wc -l changed_tools.list)
+        if [[ $nchunks -gt $MAX_CHUNKS ]]; then
+            nchunks=$MAX_CHUNKS
         fi
-        chunk_list=$(echo "["$(seq -s ", " 0 $nchunks)"]")
+        chunk_list=$(echo "["$(seq -s ", " 1 $nchunks)"]")
         echo "::set-output name=chunks::$chunk_list"
 
   # Planemo lint the changed repositories

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,8 @@ jobs:
   setup:
     name: Setup cache and determine changed repositories
     runs-on: ubuntu-latest
+    outputs:
+      chunks: ${{ steps.get-chunks.outputs.chunks }}
     strategy:
       matrix:
         python-version: [3.7]
@@ -90,6 +92,18 @@ jobs:
       with:
         name: Workflow artifacts
         path: changed_repositories.list
+    - name: Get number of changed tools and compute number of chunks
+      id: get-chunks
+      run: |
+        planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
+        ntools=$(wc -l changed_tools.list)
+        log=$(printf "%.0f" $(echo "l($ntools+1)/l(2)" | bc -l))
+        nchunks=$(echo "4 * $log" | bc)
+        if [[ $nchunks -gt 39 ]]; then
+            nchunks="39"
+        fi
+        chunk_list=$(echo "["$(seq -s ", " 0 $nchunks)"]")
+        echo "::set-output name=chunks::$chunk_list"
 
   # Planemo lint the changed repositories
   lint:
@@ -233,7 +247,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chunk: [0, 1, 2, 3]
+        chunk: ${{ fromJson(needs.setup.outputs.chunks) }}
         python-version: [3.7]
     services:
       postgres:


### PR DESCRIPTION
Computed as ~max~min(40, 4*log_2(ntools+1)) where ntools is the number of XML files in `tools/`, `tool_collections/`, and `data_managers` that do not contain `"macro"`.

Note that the formula gives 40 for the current number of tools

Fixes https://github.com/galaxyproject/tools-iuc/issues/3272

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
