### PR TITLE
Fix PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -103,7 +103,10 @@ jobs:
             nchunks=$MAX_CHUNKS
         fi
         echo "::set-output name=nchunks::$nchunks"
-        echo "::set-output name=chunk_list::'['$(seq -s ", " 0 $(($nchunks - 1)))']'"
+        echo "::set-output name=chunk_list::[$(seq -s ", " 0 $(($nchunks - 1)))]"
+    - name: Show chunks
+      run: |
+        echo 'Using ${{ steps.get-chunks.outputs.nchunks }} chunks (${{ steps.get-chunks.outputs.chunk_list }})'
 
   # Planemo lint the changed repositories
   lint:

--- a/tools/maxbin2/maxbin2.xml
+++ b/tools/maxbin2/maxbin2.xml
@@ -295,7 +295,7 @@ This is an experimental feature of MaxBin. It calls for each read bin IDBA_UD wi
 
 ** More information **
 
-https://downloads.jbei.org/data/microbial_communities/MaxBin/MaxBin.html
+https://web.archive.org/web/20190417100740/https://downloads.jbei.org/data/microbial_communities/MaxBin/MaxBin.html
 
 ]]></help>
     <citations>


### PR DESCRIPTION
Apparently there were to many quotes. 

The random tool that I used for testing contained a linting problem. I "fixed" the URL via archive org. Not sure if this is acceptable (I will be away from github today. Feel free to drop that commit and merge)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
