### PR TITLE
meme, vg_convert: fix openmpi/xg error by setting TMPDIR

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -11,4 +11,3 @@ tools/sarscov2formatter/sarscov2formatter.xml
 tools/trinotate
 tools/unicycler
 tools/valet
-tools/vg/convert.xml

--- a/.tt_skip
+++ b/.tt_skip
@@ -6,7 +6,6 @@ tools/jbrowse/
 tools/meme/meme.xml
 tools/migmap/
 tools/ncbi_entrez_eutils/einfo.xml
-tools/raven/
 tools/sarscov2formatter/sarscov2formatter.xml
 tools/trinotate
 tools/unicycler

--- a/tools/meme/meme.xml
+++ b/tools/meme/meme.xml
@@ -8,6 +8,7 @@
 export TMPDIR=/tmp;
 
 meme '$input1'
+-p \${GALAXY_SLOTS:-1}
 -o '${html_outfile.files_path}'
 -nostatus
 -maxsize 1000000

--- a/tools/meme/meme.xml
+++ b/tools/meme/meme.xml
@@ -5,6 +5,8 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+export TMPDIR=/tmp;
+
 meme '$input1'
 -o '${html_outfile.files_path}'
 -nostatus

--- a/tools/raven/raven.xml
+++ b/tools/raven/raven.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="raven" name="Raven" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="raven" name="Raven" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>De novo assembly of Oxford Nanopore Technologies data</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/vg/convert.xml
+++ b/tools/vg/convert.xml
@@ -5,6 +5,7 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
+export TMPDIR=\${TMPDIR:-.};
 ln -s '$infile' ./infile.${infile.ext} &&
 
 vg convert


### PR DESCRIPTION
fixes this problem:

```
A call to mkdir was unable to create the desired directory:

  Directory: /ompi.530361e930c3.1001
  Error:     Permission denied

Please check to ensure you have adequate permissions to perform
the desired operation.
```

Not sure if we should also add `-p \${GALAXY_SLOTS:-1}`, how does MPI play on out Galaxy instances?


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
