### PR TITLE
Topic/fix raven test

### DIFF
--- a/tools/raven/.shed.yml
+++ b/tools/raven/.shed.yml
@@ -1,0 +1,7 @@
+categories:
+- Assembly
+description: Raven is a de novo genome assembler for long uncorrected reads.
+homepage_url: https://github.com/lbcb-sci/raven
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/raven
+owner: iuc
+type: unrestricted

--- a/tools/raven/raven.xml
+++ b/tools/raven/raven.xml
@@ -57,7 +57,7 @@ $graphical_fragment_assembly
             <param name="input_reads" ftype="fastq.gz" value="ERA476754.fastq.gz"/>
             <output name="out_gfa" file="raven_gfa_assembly.txt">
                 <assert_contents>
-                    <has_n_lines n="1"/>
+                    <has_n_lines n="2"/>
                 </assert_contents>
             </output>
             <output name="out_fasta" file="raven_assembly.fasta">


### PR DESCRIPTION
seems that in https://github.com/galaxyproject/tools-iuc/pull/3271 and https://github.com/galaxyproject/tools-iuc/pull/3282
tests did not run because shed.yml was missing (note this will be covered with https://github.com/galaxyproject/tools-iuc/pull/3254). 

also makes kind of sense that the gfa file contains not less lines than the fasta

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
