### PR TITLE
change names of fastx tools

### DIFF
--- a/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
+++ b/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_clipping_histogram" name="fastx: Length Distribution" version="1.0.1">
+<tool id="cshl_fasta_clipping_histogram" name="FASTX-Toolkit: Length Distribution" version="1.0.1">
     <description>chart</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
+++ b/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_clipping_histogram" name="Length Distribution" version="1.0.1">
+<tool id="cshl_fasta_clipping_histogram" name="fastx: Length Distribution" version="1.0.1">
     <description>chart</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
+++ b/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_formatter" version="1.0.1" name="FASTA Width">
+<tool id="cshl_fasta_formatter" version="1.0.1" name="fastx: FASTA Width">
     <description>formatter</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
+++ b/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_formatter" version="1.0.1" name="fastx: FASTA Width">
+<tool id="cshl_fasta_formatter" version="1.0.1" name="FASTX-Toolkit: FASTA Width">
     <description>formatter</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="RNA/DNA" >
+<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="fastx: RNA/DNA" >
     <description>converter</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="fastx: RNA/DNA converter" >
+<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="FASTX-Toolkit: RNA/DNA converter" >
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -1,5 +1,5 @@
-<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="fastx: RNA/DNA" >
-    <description>converter</description>
+<tool id="cshl_fasta_nucleotides_changer" version="1.0.2" name="fastx: RNA/DNA converter" >
+    <description></description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_boxplot" name="fastx: Quality score boxplot" version="1.0.1">
+<tool id="cshl_fastq_quality_boxplot" name="FASTX-Toolkit: Quality score boxplot" version="1.0.1">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_boxplot" name="Draw quality score boxplot" version="1.0.1">
+<tool id="cshl_fastq_quality_boxplot" name="fastx: Draw quality score boxplot" version="1.0.1">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_boxplot" name="fastx: Draw quality score boxplot" version="1.0.1">
+<tool id="cshl_fastq_quality_boxplot" name="fastx: Quality score boxplot" version="1.0.1">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_converter" name="Quality format converter" version="1.0.1">
+<tool id="cshl_fastq_quality_converter" name="fastx: Quality format converter" version="1.0.1">
     <description>(ASCII-Numeric)</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_converter" name="fastx: Quality format converter" version="1.0.1">
+<tool id="cshl_fastq_quality_converter" name="FASTX-Toolkit: Quality format converter" version="1.0.1">
     <description>(ASCII-Numeric)</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_filter" version="1.0.2+galaxy0" name="Filter by quality">
+<tool id="cshl_fastq_quality_filter" version="1.0.2+galaxy0" name="fastx: Filter by quality">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_quality_filter" version="1.0.2+galaxy0" name="fastx: Filter by quality">
+<tool id="cshl_fastq_quality_filter" version="1.0.2+galaxy0" name="FASTX-Toolkit: Filter by quality">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_to_fasta" name="fastx: FASTQ to FASTA converter" version="1.0.2">
+<tool id="cshl_fastq_to_fasta" name="FASTX-Toolkit: FASTQ to FASTA converter" version="1.0.2">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -1,5 +1,5 @@
-<tool id="cshl_fastq_to_fasta" name="fastx: FASTQ to FASTA" version="1.0.2">
-    <description>converter from FASTX-toolkit</description>
+<tool id="cshl_fastq_to_fasta" name="fastx: FASTQ to FASTA converter" version="1.0.2">
+    <description></description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastq_to_fasta" name="FASTQ to FASTA" version="1.0.2">
+<tool id="cshl_fastq_to_fasta" name="fastx: FASTQ to FASTA" version="1.0.2">
     <description>converter from FASTX-toolkit</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_artifacts_filter" version="1.0.1+galaxy0" name="fastx: Remove sequencing artifacts">
+<tool id="cshl_fastx_artifacts_filter" version="1.0.1+galaxy0" name="FASTX-Toolkit: Remove sequencing artifacts">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_artifacts_filter" version="1.0.1+galaxy0" name="Remove sequencing artifacts">
+<tool id="cshl_fastx_artifacts_filter" version="1.0.1+galaxy0" name="fastx: Remove sequencing artifacts">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
+++ b/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_barcode_splitter" version="1.0.1" name="fastx: Barcode Splitter">
+<tool id="cshl_fastx_barcode_splitter" version="1.0.1" name="FASTX-Toolkit: Barcode Splitter">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
+++ b/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_barcode_splitter" version="1.0.1" name="Barcode Splitter">
+<tool id="cshl_fastx_barcode_splitter" version="1.0.1" name="fastx: Barcode Splitter">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_clipper" name="Clip" version="1.0.3+galaxy0">
+<tool id="cshl_fastx_clipper" name="fastx: Clip" version="1.0.3+galaxy0">
     <description>adapter sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_clipper" name="fastx: Clip" version="1.0.3+galaxy0">
+<tool id="cshl_fastx_clipper" name="FASTX-Toolkit: Clip" version="1.0.3+galaxy0">
     <description>adapter sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
+++ b/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_collapser" version="1.0.1" name="Collapse">
+<tool id="cshl_fastx_collapser" version="1.0.1" name="fastx: Collapse">
     <description>sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
+++ b/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_collapser" version="1.0.1" name="fastx: Collapse">
+<tool id="cshl_fastx_collapser" version="1.0.1" name="FASTX-Toolkit: Collapse">
     <description>sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
+++ b/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_nucleotides_distribution" version="1.0.1" name="Draw nucleotides distribution chart">
+<tool id="cshl_fastx_nucleotides_distribution" version="1.0.1" name="fastx: Draw nucleotides distribution chart">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
+++ b/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_nucleotides_distribution" version="1.0.1" name="fastx: Draw nucleotides distribution chart">
+<tool id="cshl_fastx_nucleotides_distribution" version="1.0.1" name="FASTX-Toolkit: Draw nucleotides distribution chart">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
+++ b/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_quality_statistics" version="1.0.1" name="fastx: Compute quality statistics">
+<tool id="cshl_fastx_quality_statistics" version="1.0.1" name="FASTX-Toolkit: Compute quality statistics">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
+++ b/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_quality_statistics" version="1.0.1" name="Compute quality statistics">
+<tool id="cshl_fastx_quality_statistics" version="1.0.1" name="fastx: Compute quality statistics">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_renamer" name="Rename sequences" version="@VERSION@+galaxy1" >
+<tool id="cshl_fastx_renamer" name="fastx: Rename sequences" version="@VERSION@+galaxy1" >
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_renamer" name="fastx: Rename sequences" version="@VERSION@+galaxy1" >
+<tool id="cshl_fastx_renamer" name="FASTX-Toolkit: Rename sequences" version="@VERSION@+galaxy1" >
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_reverse_complement" version="1.0.2+galaxy0" name="fastx: Reverse-Complement">
+<tool id="cshl_fastx_reverse_complement" version="1.0.2+galaxy0" name="FASTX-Toolkit: Reverse-Complement">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_reverse_complement" version="1.0.2+galaxy0" name="Reverse-Complement">
+<tool id="cshl_fastx_reverse_complement" version="1.0.2+galaxy0" name="fastx: Reverse-Complement">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
+++ b/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_trimmer" version="1.0.2+galaxy0" name="Trim sequences">
+<tool id="cshl_fastx_trimmer" version="1.0.2+galaxy0" name="fastx: Trim sequences">
     <description></description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
+++ b/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
@@ -1,4 +1,4 @@
-<tool id="cshl_fastx_trimmer" version="1.0.2+galaxy0" name="fastx: Trim sequences">
+<tool id="cshl_fastx_trimmer" version="1.0.2+galaxy0" name="FASTX-Toolkit: Trim sequences">
     <description></description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
`find . -type f -name "*xml" -exec sed -i 's/\(<tool.*name="\)/\1fastx: /' {} \;`

fixes: https://github.com/galaxyproject/tools-iuc/issues/2169

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
