### PR TITLE
Update busco to 4.1.4

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -82,7 +82,11 @@ ${adv.long}
             <param name="mode" value="geno"/>
             <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="4"/>
             <output name="busco_table" file="genome_results/full_table" compare="diff" lines_diff="4"/>
-            <output name="busco_missing" file="genome_results/missing_buscos_list" compare="diff" lines_diff="4"/>
+            <output name="busco_missing" file="genome_results/missing_buscos_list" compare="diff" lines_diff="4">
+                <assert_contents>
+                    <has_text text="# BUSCO version is: @TOOL_VERSION@" />
+                </assert_contents>
+            </output>
         </test>
         <test>
             <param name="input" value="proteome.fa"/>

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">4.1.2</token>
+    <token name="@TOOL_VERSION@">4.1.4</token>
 
     <xml name="citations">
         <citations>

--- a/tools/busco/test-data/genome_results/full_table
+++ b/tools/busco/test-data/genome_results/full_table
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id	Status	Sequence	Gene Start	Gene End	Score	Length	OrthoDB url	Description
 774at6656	Missing
 980at6656	Missing

--- a/tools/busco/test-data/genome_results/missing_buscos_list
+++ b/tools/busco/test-data/genome_results/missing_buscos_list
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id
 100070at6656
 100136at6656

--- a/tools/busco/test-data/genome_results/short_summary
+++ b/tools/busco/test-data/genome_results/short_summary
@@ -1,6 +1,6 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
-# Summarized benchmarking in BUSCO notation for file /tmp/tmpsafr8yho/files/4/1/7/dataset_417da650-712e-4081-86f4-3edaae2d6232.dat
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
+# Summarized benchmarking in BUSCO notation for file /tmp/tmp0yshlkbl/files/d/c/0/dataset_dc06dd53-8ed0-477c-b8bd-dd9fe68fd7e0.dat
 # BUSCO was run in mode: genome
 
 	***** Results: *****

--- a/tools/busco/test-data/proteome_results/full_table
+++ b/tools/busco/test-data/proteome_results/full_table
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id	Status	Sequence	Score	Length	OrthoDB url	Description
 774at6656	Missing
 980at6656	Missing

--- a/tools/busco/test-data/proteome_results/missing_buscos_list
+++ b/tools/busco/test-data/proteome_results/missing_buscos_list
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id
 100070at6656
 100136at6656

--- a/tools/busco/test-data/proteome_results/short_summary
+++ b/tools/busco/test-data/proteome_results/short_summary
@@ -1,6 +1,6 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
-# Summarized benchmarking in BUSCO notation for file /tmp/tmpsafr8yho/files/5/e/9/dataset_5e95c1d5-37e1-4fca-8e9b-3058fa860695.dat
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
+# Summarized benchmarking in BUSCO notation for file /tmp/tmp0yshlkbl/files/0/9/0/dataset_090e32f3-7f4a-47b2-b1c3-c80bb88da90f.dat
 # BUSCO was run in mode: proteins
 
 	***** Results: *****

--- a/tools/busco/test-data/transcriptome_results/full_table
+++ b/tools/busco/test-data/transcriptome_results/full_table
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id	Status	Sequence	Score	Length	OrthoDB url	Description
 774at6656	Missing
 980at6656	Missing

--- a/tools/busco/test-data/transcriptome_results/missing_buscos_list
+++ b/tools/busco/test-data/transcriptome_results/missing_buscos_list
@@ -1,5 +1,5 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
 # Busco id
 100070at6656
 100136at6656

--- a/tools/busco/test-data/transcriptome_results/short_summary
+++ b/tools/busco/test-data/transcriptome_results/short_summary
@@ -1,6 +1,6 @@
-# BUSCO version is: 4.1.2 
-# The lineage dataset is: arthropoda_odb10 (Creation date: 2019-11-20, number of species: 90, number of BUSCOs: 1013)
-# Summarized benchmarking in BUSCO notation for file /tmp/tmpsafr8yho/files/9/9/2/dataset_9922e6bd-50c2-4b64-8e36-70b9b9c3f8ed.dat
+# BUSCO version is: 4.1.4 
+# The lineage dataset is: arthropoda_odb10 (Creation date: 2020-09-10, number of species: 90, number of BUSCOs: 1013)
+# Summarized benchmarking in BUSCO notation for file /tmp/tmp0yshlkbl/files/c/d/5/dataset_cd590461-e7d2-4927-8b96-f3282e2da236.dat
 # BUSCO was run in mode: transcriptome
 
 	***** Results: *****


### PR DESCRIPTION
Busco uses biopython.BioAlphabet which has been removed in biopython 1.78, but installing busco currently installs the new biopython version in the environment, and busco jobs fail.  This is a patch for 4.1.2 only: busco versions >= 4.1.4 do not use BioAlphabet.

Is it OK to add a dependency without a version bump?  The tool is not changing at all.