### PR TITLE
Rename secrets to uppercase

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -425,7 +425,7 @@ jobs:
       run: pip install planemo
     - name: Deploy on testtoolshed
       env:
-        SHED_KEY: ${{ secrets.tts_api_key }}
+        SHED_KEY: ${{ secrets.TTS_API_KEY }}
       run: |
         while read -r DIR; do
             planemo shed_update --shed_target testtoolshed --shed_key "${{ env.SHED_KEY }}" --force_repository_creation "$DIR" || exit 1;
@@ -433,7 +433,7 @@ jobs:
       continue-on-error: true
     - name: Deploy on toolshed
       env:
-        SHED_KEY: ${{ secrets.ts_api_key }}
+        SHED_KEY: ${{ secrets.TS_API_KEY }}
       run: |
         while read -r DIR; do
             planemo shed_update --shed_target toolshed --shed_key "${{ env.SHED_KEY }}" --force_repository_creation "$DIR" || exit 1;


### PR DESCRIPTION
When a secret is added (Settings -> Secrets -> New repository secret) on GitHub, the secret name is changed to uppercase in the secrets list, even if it is actually lower/mixed case. I find this confusing.

N.B.: THIS CHANGE REQUIRES REMOVING AND RE-ADDING THE 2 SECRETS USING THE NEW UPPERCASE NAME! (I can do that)

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
