### PR TITLE
data manager mitos: fixed refseq39 reference data

### DIFF
--- a/data_managers/data_manager_mitos/data_manager/data_manager.py
+++ b/data_managers/data_manager_mitos/data_manager/data_manager.py
@@ -12,7 +12,7 @@ except ImportError:
 
 ZENODO = {
     "mitos": "2683856",
-    "mitos2": "3685310"
+    "mitos2": "4284483"
 }
 NAMES = {
     "mitos1-refdata": "RefSeq39 + MiTFi tRNA models",

--- a/data_managers/data_manager_mitos/data_manager/data_manager_mitos.xml
+++ b/data_managers/data_manager_mitos/data_manager/data_manager_mitos.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="data_manager_mitos" name="MITOS" tool_type="manage_data" version="0.0.1">
+<tool id="data_manager_mitos" name="MITOS" tool_type="manage_data" version="0.0.2">
     <description>reference data downloader</description>
     <requirements>
         <requirement type="package" version="3.7">python</requirement>
@@ -25,13 +25,13 @@
             </when>
             <when value="mitos2">
                 <param name="database" type="select" label="Reference data version">
-                    <option value="refseq39">RefSeq39 (equivalent to MITOS1 data)</option>
                     <option value="refseq63m">RefSeq63 Metazoa</option>
                     <option value="refseq63f">RefSeq63 Fungi</option>
                     <option value="refseq63o">RefSeq63 Opisthokonta</option>
                     <option value="refseq89m">RefSeq89 Metazoa</option>
                     <option value="refseq89f">RefSeq89 Fungi</option>
                     <option value="refseq89o">RefSeq89 Opisthokonta</option>
+                    <option value="refseq39">RefSeq39 (equivalent to MITOS1 data)</option>
                 </param>
             </when>
         </conditional>
@@ -46,6 +46,13 @@
                 <param name="database" value="mitos1-refdata"/>
             </conditional>
             <output name="out_file" file="mitos_refseq39.json"/>
+        </test>
+        <test>
+            <conditional name="type_cond">
+                <param name="type_select" value="mitos2"/>
+                <param name="database" value="refseq63m"/>
+            </conditional>
+            <output name="out_file" file="mitos2_refseq63.json"/>
         </test>
     </tests>
     <help>
@@ -74,7 +81,7 @@ The reference data sets contain:
 - covariance models computed for the data in the RefSeq releas based on the MITOS1 models 
 - in addition for Metazoa Release 63 also hidden markov models are available as described in Al Arab et al. 2017
 
-Data is downloaded from https://zenodo.org/record/3685310.
+Data is downloaded from https://zenodo.org/record/4284483.
     </help>
     <citations>
         <citation type="doi">10.1016/j.ympev.2012.08.023</citation>

--- a/data_managers/data_manager_mitos/test-data/mitos2_refseq63.json
+++ b/data_managers/data_manager_mitos/test-data/mitos2_refseq63.json
@@ -1,0 +1,1 @@
+{"data_tables": {"mitos": {"name": "RefSeq63 Metazoa", "path": "refseq63m", "type": "mitos2", "value": "refseq63m"}}}


### PR DESCRIPTION
refseq39 reference data for MITOS2 was broken and never worked.
in the new version of the zenodo record only this data set has
been replaced. So an unversioned change of the data should be OK.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
