### PR TITLE
Missing comma in make.contigs.xml

### DIFF
--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -54,7 +54,7 @@ echo 'make.contigs(
     mismatch=$mismatch,
     gapopen=$gapopen,
     gapextend=$gapextend,
-    rename=$rename
+    rename=$rename,
     processors='\${GALAXY_SLOTS:-8}'
 )'
 | sed 's/ //g'  ## mothur trips over whitespace

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -169,9 +169,21 @@ echo 'make.contigs(
             <param name="mismatch" value="-2"/>
             <param name="gapopen" value="-3"/>
             <param name="gapextend" value="-2"/>
-            <output name="fasta" md5="48e32c65bd9f064c5c0b4ea7695cabe9" ftype="fasta"/>
-            <output name="qual" md5="1e7778cee0d86bfa2759a07bb4356165" ftype="qual"/>
-            <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt"/>
+            <output name="fasta" md5="48e32c65bd9f064c5c0b4ea7695cabe9" ftype="fasta">
+                <assert_contents>
+    	    	    <has_text text=">M00967_43_000000000-A3JHG_1_1101_19936_3208" />
+                </assert_contents>
+            </output>
+            <output name="qual" md5="1e7778cee0d86bfa2759a07bb4356165" ftype="qual">
+                <assert_contents>
+    	    	    <has_text text=">M00967_43_000000000-A3JHG_1_1101_19936_3208" />
+                </assert_contents>
+            </output>
+            <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt">
+                <assert_contents>
+    	    	    <has_line line="M00967_43_000000000-A3JHG_1_1101_19936_3208	253	249	2	251	0	0" />
+                </assert_contents>
+            </output>
             <param name="savelog" value="true"/>
             <param name="rename" value="false"/>
             <expand macro="logfile-test"/>
@@ -187,9 +199,21 @@ echo 'make.contigs(
                     </collection>
                 </param>
             </conditional>
-            <output name="fasta" md5="addcc2f4233df75ab9e5feacadb6850f" ftype="fasta"/>
-            <output name="qual" md5="476932c0236a672c0c99cada2b114fe7" ftype="qual"/>
-            <output name="report" md5="7634bcab8db8907f80087da03259012a" ftype="txt"/>
+            <output name="fasta" md5="addcc2f4233df75ab9e5feacadb6850f" ftype="fasta">
+                <assert_contents>
+    	    	    <has_text text=">1" />
+                </assert_contents>
+            </output>
+            <output name="qual" md5="476932c0236a672c0c99cada2b114fe7" ftype="qual">
+                <assert_contents>
+    	    	    <has_text text=">1" />
+                </assert_contents>
+            </output>
+            <output name="report" md5="7634bcab8db8907f80087da03259012a" ftype="txt">
+                <assert_contents>
+    	    	    <has_line line="1	253	249	2	251	0	0" />
+                </assert_contents>
+            </output>
             <param name="savelog" value="true"/>
             <param name="rename" value="true"/>
             <expand macro="logfile-test"/>

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -181,7 +181,7 @@ echo 'make.contigs(
             </output>
             <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt">
                 <assert_contents>
-    	    	    <has_line line="M00967_43_000000000-A3JHG_1_1101_19936_3208	253	249	2	251	0	0" />
+    	    	    <has_line line="M00967_43_000000000-A3JHG_1_1101_19936_3208chr7&#009;253chr7&#009;249chr7&#009;2chr7&#009;251chr7&#009;0chr7&#009;0" />
                 </assert_contents>
             </output>
             <param name="savelog" value="true"/>
@@ -211,7 +211,7 @@ echo 'make.contigs(
             </output>
             <output name="report" md5="7634bcab8db8907f80087da03259012a" ftype="txt">
                 <assert_contents>
-    	    	    <has_line line="1	253	249	2	251	0	0" />
+    	    	    <has_line line="1chr7&#009;253chr7&#009;249chr7&#009;2chr7&#009;251chr7&#009;0chr7&#009;0" />
                 </assert_contents>
             </output>
             <param name="savelog" value="true"/>

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -181,7 +181,7 @@ echo 'make.contigs(
             </output>
             <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt">
                 <assert_contents>
-    	    	    <has_line line="M00967_43_000000000-A3JHG_1_1101_19936_3208chr7&#009;253chr7&#009;249chr7&#009;2chr7&#009;251chr7&#009;0chr7&#009;0" />
+    	    	    <has_line line="M00967_43_000000000-A3JHG_1_1101_19936_3208&#009;253&#009;249&#009;2&#009;251&#009;0&#009;0" />
                 </assert_contents>
             </output>
             <param name="savelog" value="true"/>
@@ -211,7 +211,7 @@ echo 'make.contigs(
             </output>
             <output name="report" md5="7634bcab8db8907f80087da03259012a" ftype="txt">
                 <assert_contents>
-    	    	    <has_line line="1chr7&#009;253chr7&#009;249chr7&#009;2chr7&#009;251chr7&#009;0chr7&#009;0" />
+    	    	    <has_line line="1&#009;253&#009;249&#009;2&#009;251&#009;0&#009;0" />
                 </assert_contents>
             </output>
             <param name="savelog" value="true"/>

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -1,4 +1,4 @@
-<tool profile="16.07" id="mothur_make_contigs" name="Make.contigs" version="@WRAPPER_VERSION@.0">
+<tool profile="16.07" id="mothur_make_contigs" name="Make.contigs" version="@WRAPPER_VERSION@.1">
     <description>Aligns paired forward and reverse fastq files to contigs as fasta and quality</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/mothur/make.contigs.xml
+++ b/tools/mothur/make.contigs.xml
@@ -132,6 +132,7 @@ echo 'make.contigs(
             <output name="qual" file="Mock_S280_L001_R1_001_small.trim.contigs.qual" ftype="qual"/>
             <output name="report" file="Mock_S280_L001_R1_001_small.contigs.report" ftype="txt"/>
             <param name="savelog" value="true"/>
+            <param name="rename" value="false"/>
             <expand macro="logfile-test"/>
         </test>
         <!-- Test with a simple paired collection as input -->
@@ -149,6 +150,7 @@ echo 'make.contigs(
             <output name="qual" file="Mock_S280_L001_R1_001_small.trim.contigs.qual" ftype="qual"/>
             <output name="report" file="Mock_S280_L001_R1_001_small.contigs.report" ftype="txt"/>
             <param name="savelog" value="true"/>
+            <param name="rename" value="false"/>
             <expand macro="logfile-test"/>
         </test>
         <!-- Test with a simple paired collection as input + extra parameters specified -->
@@ -171,6 +173,25 @@ echo 'make.contigs(
             <output name="qual" md5="1e7778cee0d86bfa2759a07bb4356165" ftype="qual"/>
             <output name="report" md5="5274725ef45890fd6da4650d5d536173" ftype="txt"/>
             <param name="savelog" value="true"/>
+            <param name="rename" value="false"/>
+            <expand macro="logfile-test"/>
+        </test>
+        <!-- Test with a simple paired collection as input + rename sequences -->
+        <test>
+            <conditional name="input_type">
+                <param name="type" value="simple_collection"/>
+                <param name="paired_collection">
+                    <collection type="paired">
+                        <element name="forward" value="Mock_S280_L001_R1_001_small.fastq" />
+                        <element name="reverse" value="Mock_S280_L001_R2_001_small.fastq" />
+                    </collection>
+                </param>
+            </conditional>
+            <output name="fasta" md5="addcc2f4233df75ab9e5feacadb6850f" ftype="fasta"/>
+            <output name="qual" md5="476932c0236a672c0c99cada2b114fe7" ftype="qual"/>
+            <output name="report" md5="7634bcab8db8907f80087da03259012a" ftype="txt"/>
+            <param name="savelog" value="true"/>
+            <param name="rename" value="true"/>
             <expand macro="logfile-test"/>
         </test>
         <!-- Test with a list:paired collection as input -->
@@ -199,6 +220,7 @@ echo 'make.contigs(
             <output name="report" md5="96a07f664105e4ddcb645c7cd9f5d692" ftype="txt"/>
             <output name="group" md5="ef83b393be4103f0b61a021234905210" ftype="mothur.groups"/>
             <param name="savelog" value="true"/>
+            <param name="rename" value="false"/>
             <expand macro="logfile-test"/>
         </test>
     </tests>


### PR DESCRIPTION

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [X] - This PR does something else (explain below)

Bugfix. Actual excerpt from make.contigs logfile:
mothur > 
<-1,gapopen=-2,gapextend=-1,rename=Trueprocessors=4)

Using 1 processors.

After correcting missing comma in "rename" parameter:
mothur > 
<1,gapopen=-2,gapextend=-1,rename=True,processors=4)

Using 4 processors.

Now the tool is able to use multiple cores. No impact in the result itself so much as I could see.
