### PR TITLE
 Correct the description in .shed.yml for IDR

### DIFF
--- a/tools/idr/.shed.yml
+++ b/tools/idr/.shed.yml
@@ -2,11 +2,11 @@ categories:
 - Sequence Analysis
 homepage_url: https://github.com/nboley/idr
 long_description: |
-    idr is a program for quantifying abundances of transcripts from RNA-Seq
-    data, or more generally of target sequences using high-throughput sequencing
-    reads. It is based on the novel idea of pseudoalignment for rapidly
-    determining the compatibility of reads with targets, without the need for
-    alignment.
+    The IDR (Irreproducible Discovery Rate) framework is a uniﬁed approach to measure
+    the reproducibility of ﬁndings identiﬁed from replicate experiments and provide
+    highly stable thresholds based on reproducibility. Unlike the usual scalar measures
+    of reproducibility, the IDR approach creates a curve, which quantitatively assesses
+    when the ﬁndings are no longer consistent across replicates.
 owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/idr/
 type: unrestricted

--- a/tools/idr/.shed.yml
+++ b/tools/idr/.shed.yml
@@ -2,11 +2,11 @@ categories:
 - Sequence Analysis
 homepage_url: https://github.com/nboley/idr
 long_description: |
-    The IDR (Irreproducible Discovery Rate) framework is a uniﬁed approach to measure
-    the reproducibility of ﬁndings identiﬁed from replicate experiments and provide
+    The IDR (Irreproducible Discovery Rate) framework is a unified approach to measure
+    the reproducibility of findings identified from replicate experiments and provide
     highly stable thresholds based on reproducibility. Unlike the usual scalar measures
     of reproducibility, the IDR approach creates a curve, which quantitatively assesses
-    when the ﬁndings are no longer consistent across replicates.
+    when the findings are no longer consistent across replicates.
 owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/idr/
 type: unrestricted

--- a/tools/idr/idr.xml
+++ b/tools/idr/idr.xml
@@ -126,7 +126,7 @@
      </tests>
     <help>
 <![CDATA[
-The `IDR <https://github.com/nboley/idr/blob/master/README.md>`__ (Irreproducible Discovery Rate) framework is a uniﬁed approach to measure the reproducibility of ﬁndings identiﬁed from replicate experiments and provide highly stable thresholds based on reproducibility. Unlike the usual scalar measures of reproducibility, the IDR approach creates a curve, which quantitatively assesses when the findings are no longer consistent across replicates.
+The `IDR <https://github.com/nboley/idr/blob/master/README.md>`__ (Irreproducible Discovery Rate) framework is a unified approach to measure the reproducibility of findings identified from replicate experiments and provide highly stable thresholds based on reproducibility. Unlike the usual scalar measures of reproducibility, the IDR approach creates a curve, which quantitatively assesses when the findings are no longer consistent across replicates.
 ]]>
     </help>
     <citations>

--- a/tools/idr/idr.xml
+++ b/tools/idr/idr.xml
@@ -126,7 +126,7 @@
      </tests>
     <help>
 <![CDATA[
-The `IDR <https://github.com/nboley/idr/blob/master/README.md>`__ (Irreproducible Discovery Rate) framework is a uniﬁed approach to measure the reproducibility of ﬁndings identiﬁed from replicate experiments and provide highly stable thresholds based on reproducibility. Unlike the usual scalar measures of reproducibility, the IDR approach creates a curve, which quantitatively assesses when the ﬁndings are no longer consistent across replicates.
+The `IDR <https://github.com/nboley/idr/blob/master/README.md>`__ (Irreproducible Discovery Rate) framework is a uniﬁed approach to measure the reproducibility of ﬁndings identiﬁed from replicate experiments and provide highly stable thresholds based on reproducibility. Unlike the usual scalar measures of reproducibility, the IDR approach creates a curve, which quantitatively assesses when the findings are no longer consistent across replicates.
 ]]>
     </help>
     <citations>


### PR DESCRIPTION
The IDR long description was not correct and made discovery in the toolshed more difficult.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
