### PR TITLE
Fix `with` statement in snpEff data manager

### DIFF
--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
@@ -129,7 +129,7 @@ def main():
         download_database(data_manager_dict, target_directory, genome_version, organism)
 
     # save info to json file
-    with open(filename, 'w'):
+    with open(filename, 'w') as fh:
         json.dump(data_manager_dict, fh, sort_keys=True)
 
 


### PR DESCRIPTION
Broken in commit 02d2967f77e3fa5a18aea63dc84aa9ab418dc165

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
