### PR TITLE
Run `planemo ci_find_tools` on changed repos to calculate chunks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Get approximate number of tools and compute number of chunks
       id: get-chunks
       run: |
-        nchunks=$(find tools/ tool_collections/ data_managers/ -iname '*xml' | grep -v macro | wc -l)
+        nchunks=$(find data_managers/ tools/ tool_collections/ -iname '*.xml' | grep -v 'data_manager_conf.xml\|macro\|repository_dependencies.xml\|test-data/\|tool_dependencies.xml' | wc -l)
         if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         elif [ "$nchunks" -eq 0 ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,8 @@ jobs:
       run: pip install wheel
     - name: Install Planemo
       run: pip install planemo
-    - name: Fake a planemo run to update cache
+    - name: Fake a Planemo run to update cache
+      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         touch tool.xml
         PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_branch $GALAXY_RELEASE
@@ -61,6 +62,10 @@ jobs:
         fi
         echo "::set-output name=nchunks::$nchunks"
         echo "::set-output name=chunk_list::[$(seq -s ", " 0 $(($nchunks - 1)))]"
+    - name: Show chunks
+      run: |
+        echo 'Using ${{ steps.get-chunks.outputs.nchunks }} chunks (${{ steps.get-chunks.outputs.chunk_list }})'
+
   test:
     name: Test tools
     # This job runs on Linux
@@ -97,23 +102,23 @@ jobs:
         key: pip_cache_${{ matrix.python-version }}_${{ env.GALAXY_RELEASE }}
     - name: Install Planemo
       run: pip install planemo
-    - name: Planemo ci_find_tools
+    - name: Planemo ci_find_tools, chunked
       run: planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk  }} --exclude test_repositories --exclude packages --exclude deprecated --exclude_from .tt_skip --exclude_from .tt_biocontainer_skip --group_tools --output tool.list
-    - name: Show repo list
+    - name: Show tools chunk list
       run: cat tool.list
     - name: Planemo test tools
       run: |
-           mkdir json_output/
-           while read -r TOOLS; do
-               if grep -qf .tt_biocontainer_skip <(echo $TOOLS); then
-                   PLANEMO_OPTIONS=""
-               else
-                   PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
-               fi
-               json=$(mktemp -u -p json_output --suff .json)
-               PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_branch $GALAXY_RELEASE  --galaxy_python_version ${{ matrix.python-version }} --test_output_json $json $TOOLS || true
-               docker system prune --all --force --volumes || true
-           done < tool.list
+        mkdir json_output
+        while read -r TOOL; do
+            if grep -q "$TOOL" .tt_biocontainer_skip; then
+                PLANEMO_OPTIONS=""
+            else
+                PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
+            fi
+            json=$(mktemp -u -p json_output --suff .json)
+            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" "$TOOL" || true
+            docker system prune --all --force --volumes || true
+        done < tool.list
     - name: Merge tool_test_output.json files
       run: planemo merge_test_reports json_output/*.json tool_test_output.json
     - name: Create tool_test_output.html
@@ -122,7 +127,7 @@ jobs:
       run: |
         mkdir upload
         mv tool_test_output.json tool_test_output.html upload/
-    - uses: actions/upload-artifact@v2.0.1
+    - uses: actions/upload-artifact@v2
       with:
         name: 'Tool test output ${{ matrix.chunk  }}'
         path: upload
@@ -142,19 +147,25 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_${{ matrix.python-version }}_${{ env.GALAXY_RELEASE }}
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
       run: sudo apt-get install jq
     - name: Combine outputs
-      run: find artifacts -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
+      run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
     - name: Create tool_test_output.html
       run: planemo test_reports tool_test_output.json --test_output tool_test_output.html
     - name: Copy artifacts into place
       run: |
         mkdir upload
         mv tool_test_output.json tool_test_output.html upload/
-    - uses: actions/upload-artifact@v2.0.1
+    - uses: actions/upload-artifact@v2
       with:
         name: 'All tool test results'
         path: upload

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -324,14 +324,14 @@ jobs:
       run: |
         mkdir json_output
         while read -r TOOL; do
-           if grep -q "$TOOL" .tt_biocontainer_skip; then
-               PLANEMO_OPTIONS=""
-           else
-               PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
-           fi
-           json=$(mktemp -u -p json_output --suff .json)
-           PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" "$TOOL" || true
-           docker system prune --all --force --volumes || true
+            if grep -q "$TOOL" .tt_biocontainer_skip; then
+                PLANEMO_OPTIONS=""
+            else
+                PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
+            fi
+            json=$(mktemp -u -p json_output --suff .json)
+            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" "$TOOL" || true
+            docker system prune --all --force --volumes || true
         done < changed_tools_chunk.list
         if [ ! -s changed_tools_chunk.list ]; then
             echo '{"tests":[]}' > "$(mktemp -u -p json_output --suff .json)"
@@ -391,7 +391,7 @@ jobs:
       with:
         name: 'All tool test results'
         path: upload
-    - name: Check status of combined status
+    - name: Check status of combined outputs
       run: |
         if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
             echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,7 @@ jobs:
     name: Setup cache and determine changed repositories
     runs-on: ubuntu-latest
     outputs:
+      galaxy_head_sha: ${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
       nchunks: ${{ steps.get-chunks.outputs.nchunks }}
       chunk_list: ${{ steps.get-chunks.outputs.chunk_list }}
     strategy:
@@ -34,26 +35,21 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)" >> $GITHUB_ENV
-    - name: Save latest galaxy commit to artifact file
-      run: echo $GALAXY_HEAD_SHA > galaxy.sha
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Workflow artifacts
-        path: galaxy.sha
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "::set-output name=galaxy_head_sha::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)"
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
     - name: Cache .planemo
       uses: actions/cache@v2
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
     # Install the `wheel` package so that when installing other packages which
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
@@ -137,14 +133,12 @@ jobs:
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo lint
@@ -194,14 +188,12 @@ jobs:
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install flake8
       run: pip install flake8 flake8-import-order
     - name: Flake8
@@ -299,20 +291,18 @@ jobs:
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Cache .planemo
       uses: actions/cache@v2
       id: cache-planemo
       with:
         path: ~/.planemo
-        key: planemo_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo ci_find_tools
@@ -359,7 +349,7 @@ jobs:
   #   and fail this step if this is the case
   combine_outputs:
     name: Combine chunked test results
-    needs: test
+    needs: [setup, test]
     strategy:
       matrix:
         python-version: [3.7]
@@ -372,14 +362,12 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
@@ -406,7 +394,7 @@ jobs:
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
-    needs: [lint,flake8,lintr,combine_outputs]
+    needs: [setup, lint, flake8, lintr, combine_outputs]
     strategy:
       matrix:
         python-version: [3.7]
@@ -423,14 +411,12 @@ jobs:
       with:
         name: Workflow artifacts
         path: ../workflow_artifacts/
-    - name: Determine latest galaxy commit
-      run: echo "GALAXY_HEAD_SHA=$(cat ../workflow_artifacts/galaxy.sha)" >> $GITHUB_ENV
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip
       with:
         path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}_gxy_$GALAXY_HEAD_SHA
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install Planemo
       run: pip install planemo
     - name: Deploy on testtoolshed

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       galaxy_head_sha: ${{ steps.get-galaxy-sha.outputs.galaxy_head_sha }}
+      commit_range: ${{ steps.get-commit-range.outputs.commit_range }}
       nchunks: ${{ steps.get-chunks.outputs.nchunks }}
       chunk_list: ${{ steps.get-chunks.outputs.chunk_list }}
     strategy:
@@ -82,21 +83,25 @@ jobs:
     - name: Set commit range (pull request)
       if: github.event_name == 'pull_request'
       run: echo "COMMIT_RANGE=HEAD~.." >> $GITHUB_ENV
+    - id: get-commit-range
+      run: echo "::set-output name=commit_range::$COMMIT_RANGE"
     - name: Planemo ci_find_repos
       run: planemo ci_find_repos --changed_in_commit_range $COMMIT_RANGE --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
     - name: Show repo list
       run: cat changed_repositories.list
-    - name: Planemo ci_find_tools
-      run: planemo ci_find_tools --changed_in_commit_range $COMMIT_RANGE --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_tools.list
-    - name: Show tool list
-      run: cat changed_tools.list
     - uses: actions/upload-artifact@v2
       with:
         name: Workflow artifacts
-        path: |
-          changed_repositories.list
-          changed_tools.list
-    - name: Get number of changed tools and compute number of chunks
+        path: changed_repositories.list
+    - name: Planemo ci_find_tools for the changed repos
+      run: |
+        touch changed_tools.list
+        if [ -s changed_repositories.list ]; then
+            planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
+        fi
+    - name: Show tool list
+      run: cat changed_tools.list
+    - name: Compute chunks
       id: get-chunks
       run: |
         nchunks=$(wc -l < changed_tools.list)
@@ -125,7 +130,7 @@ jobs:
     # and use it as the current working directory
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        fetch-depth: 0
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
@@ -147,6 +152,8 @@ jobs:
         while read -r DIR; do
             planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR";
         done < ../workflow_artifacts/changed_repositories.list
+    - name: Planemo ci_find_tools for the commit range
+      run: planemo ci_find_tools --changed_in_commit_range ${{ needs.setup.outputs.commit_range }} --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_tools.list
     - name: Check if each changed tool is in the list of changed repositories
       run: |
         set -e
@@ -164,7 +171,7 @@ jobs:
                 echo "Tool $TOOL not in changed repositories list: .shed.yml file missing" >&2
                 exit 1
             fi
-        done < ../workflow_artifacts/changed_tools.list
+        done < changed_tools.list
 
   # flake8 of Python scripts in the changed repositories
   flake8:
@@ -305,11 +312,11 @@ jobs:
         key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy_head_sha }}
     - name: Install Planemo
       run: pip install planemo
-    - name: Planemo ci_find_tools
+    - name: Planemo ci_find_tools for the change repos, chunked
       run: |
         touch changed_tools_chunk.list
         if [ -s ../workflow_artifacts/changed_repositories.list ]; then
-          planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_tools_chunk.list $(cat ../workflow_artifacts/changed_repositories.list)
+          planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --output changed_tools_chunk.list $(cat ../workflow_artifacts/changed_repositories.list)
         fi
     - name: Show changed tools chunk list
       run: cat changed_tools_chunk.list


### PR DESCRIPTION
Otherwise the number of chunks won't take into account tools for which the XML was not modified but other files in the repo were.
Noticed in https://github.com/galaxyproject/tools-iuc/pull/3343/checks?check_run_id=1445440585 , where "Show tool list" returns no tools.

Also:
- Save Galaxy HEAD sha as job output instead of as an artifact.
- Sync ci and pr workflows.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
