### PR TITLE
hisat2: Fix for issue #3312, an update to square root symbol in function arguments

### DIFF
--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,8 +439,8 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-		      <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
-		      <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+                      <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
+                      <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
@@ -467,8 +467,8 @@ hisat2
                     <param argument="--rdg" name="read_extend_penalty" type="integer" value="3" min="0" label="Read gap extend penalty" help="A read gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
-		    <expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
-		  </when>
+                    <expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
+                  </when>
             </conditional>
 
             <conditional name="spliced_options">
@@ -480,11 +480,11 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-		      <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-		      <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+                      <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+                      <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-		      <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-		      <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+                      <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+                      <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />
                     <param name="max_intron" type="integer" value="500000" min="0" label="Maximum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,4 +1,4 @@
-<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy5" profile="17.01">
+<tool id="hisat2" name="HISAT2" version="2.1.0+galaxy6" profile="17.01">
     <description>A fast and sensitive alignment program</description>
     <macros>
         <import>hisat2_macros.xml</import>
@@ -280,11 +280,11 @@ hisat2
     --min-intronlen ${adv.spliced_options.min_intron}
     --max-intronlen ${adv.spliced_options.max_intron}
     ${adv.spliced_options.tma}
-	
+
     #if str($adv.spliced_options.novel_splicesite_outfile) == "true":
        --novel-splicesite-outfile '$novel_splicesite_output'
     #end if
-	
+
     #if str($adv.spliced_options.notmplen):
         ${adv.spliced_options.notmplen}
     #end if
@@ -439,13 +439,13 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-		    <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>                    
-		    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+		                <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
+		                <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
                     <param argument="--norc" name="skip_reverse" type="boolean" truevalue="--norc" falsevalue="" label="Skip reverse strand of reference" help="If --norc is specified, HISAT2 will not attempt to align unpaired reads against the reverse-complement (Crick) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --norc causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the forward-complement (Watson) strand" />
-               </when>
+                </when>
             </conditional>
 
             <conditional name="scoring_options">
@@ -1177,7 +1177,7 @@ Note that if your reads are from a stranded library, you need to choose the appr
 
     --no-templatelen-adjustment
             Disables template length adjustment for RNA-seq reads.
-    
+
     --novel-splicesite-outfile
 			In this mode, HISAT2 reports a list of splice sites in the file :
 				chromosome name <tab> genomic position of the flanking base on the left side of an intron <tab> genomic position of the flanking base on the right <tab> strand (+, -, and .) '.' indicates an unknown strand for non-canonical splice sites.

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -442,7 +442,7 @@ hisat2
                     <param name="function_type" argument="--n-ceil" type="select" display="radio" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730;x]
                         <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,8 +439,8 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-		    <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
-		    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+		      <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
+		      <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
@@ -468,7 +468,7 @@ hisat2
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
 		    <expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
-		</when>
+		  </when>
             </conditional>
 
             <conditional name="spliced_options">

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -480,7 +480,7 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-                    <expand macro="nc_function" varname="nc_function_type" argument="--pen-noncanintronlen" value="G" />          
+                    <expand macro="nc_function" varname="function_type" argument="--pen-noncanintronlen" value="G" />          
                     <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <expand macro="nc_function" varname="nc_function_type" argument="--pen-noncanintronlen" value="G" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,13 +439,13 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-		<expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>                    
+		    <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>                    
 		    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
                     <param argument="--norc" name="skip_reverse" type="boolean" truevalue="--norc" falsevalue="" label="Skip reverse strand of reference" help="If --norc is specified, HISAT2 will not attempt to align unpaired reads against the reverse-complement (Crick) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --norc causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the forward-complement (Watson) strand" />
-                </when>
+               </when>
             </conditional>
 
             <conditional name="scoring_options">
@@ -467,8 +467,8 @@ hisat2
                     <param argument="--rdg" name="read_extend_penalty" type="integer" value="3" min="0" label="Read gap extend penalty" help="A read gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
-		<expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
-		    </when>
+		    <expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
+		</when>
             </conditional>
 
             <conditional name="spliced_options">
@@ -480,10 +480,10 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-		<expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		    <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
 		    <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-		<expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		    <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
 		    <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -442,7 +442,7 @@ hisat2
                     <param name="function_type" argument="--n-ceil" type="select" display="radio" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
                         <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
@@ -475,7 +475,7 @@ hisat2
                     <param name="function_type" argument="--score-min" type="select" display="radio" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
                         <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                 </when>
@@ -493,7 +493,7 @@ hisat2
                     <param name="function_type" argument="--pen-canintronlen" type="select" display="radio" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
                         <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
@@ -501,7 +501,7 @@ hisat2
                     <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
                         <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,8 +439,8 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-                      <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
-                      <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+                    <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
+                    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
@@ -468,7 +468,7 @@ hisat2
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
-                  </when>
+                </when>
             </conditional>
 
             <conditional name="spliced_options">
@@ -480,11 +480,11 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-                      <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-                      <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+                    <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+                    <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-                      <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-                      <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+                    <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+                    <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />
                     <param name="max_intron" type="integer" value="500000" min="0" label="Maximum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -480,11 +480,11 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-		    <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-		    <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+		      <expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		      <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-		    <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
-		    <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+		      <expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		      <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />
                     <param name="max_intron" type="integer" value="500000" min="0" label="Maximum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,8 +439,8 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-                    <expand macro="nc_function" varname="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" value="L" />
-                    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+		<expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>                    
+		    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />
@@ -467,8 +467,8 @@ hisat2
                     <param argument="--rdg" name="read_extend_penalty" type="integer" value="3" min="0" label="Read gap extend penalty" help="A read gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
-                    <expand macro="nc_function" varname="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" value="L" />
-                </when>
+		<expand macro="nc_function" name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" lselected="true"/>
+		    </when>
             </conditional>
 
             <conditional name="spliced_options">
@@ -480,11 +480,11 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-                    <expand macro="nc_function" varname="function_type" argument="--pen-noncanintronlen" value="G" />          
-                    <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+		<expand macro="nc_function" name="function_type" argument="--pen-canintronlen" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		    <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-                    <expand macro="nc_function" varname="nc_function_type" argument="--pen-noncanintronlen" value="G" />
-                    <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
+		<expand macro="nc_function" name="nc_function_type" argument="--pen-noncanintronlen" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones" gselected="true"/>
+		    <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />
                     <param name="max_intron" type="integer" value="500000" min="0" label="Maximum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -475,7 +475,7 @@ hisat2
                     <param name="function_type" argument="--score-min" type="select" display="radio" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
                         <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                 </when>
@@ -493,7 +493,7 @@ hisat2
                     <param name="function_type" argument="--pen-canintronlen" type="select" display="radio" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
                         <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
@@ -501,7 +501,7 @@ hisat2
                     <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730x;]</option>
+                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
                         <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,8 +439,8 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-		                <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
-		                <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
+		    <expand macro="nc_function" name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" lselected="true"/>
+		    <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
                     <param argument="--nofw" name="skip_forward" type="boolean" truevalue="--nofw" falsevalue="" label="Skip forward strand of reference" help="If --nofw is specified, HISAT2 will not attempt to align unpaired reads to the forward (Watson) reference strand. In paired-end mode, --nofw and --norc pertain to the fragments; i.e. specifying --nofw causes HISAT2 to explore only those paired-end configurations corresponding to fragments from the reverse-complement (Crick) strand" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,7 +439,7 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-                    <param name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" value="L"></param>
+                    <expand macro="nc_function" varname="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" value="L" />
                     <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
@@ -467,7 +467,7 @@ hisat2
                     <param argument="--rdg" name="read_extend_penalty" type="integer" value="3" min="0" label="Read gap extend penalty" help="A read gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
-                    <param name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" value="L"></param>
+                    <expand macro="nc_function" varname="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" value="L" />
                 </when>
             </conditional>
 
@@ -480,15 +480,10 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-                    <param name="nc_function_type" argument="--pen-noncanintronlen" value="G"></param>            
+                    <expand macro="nc_function" varname="nc_function_type" argument="--pen-noncanintronlen" value="G" />          
                     <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
-                    <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
-                        <option value="C">Constant [f(x) = B]</option>
-                        <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
-                        <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
-                    </param>
+                    <expand macro="nc_function" varname="nc_function_type" argument="--pen-noncanintronlen" value="G" />
                     <param name="nc_constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="nc_coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="min_intron" type="integer" value="20" min="0" label="Minimum intron length" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -442,7 +442,7 @@ hisat2
                     <param name="function_type" argument="--n-ceil" type="select" display="radio" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out">
                         <option value="C">Constant [f(x) = B]</option>
                         <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730;x]
+                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
                         <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
                     </param>
                     <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -439,12 +439,7 @@ hisat2
                 </param>
                 <when value="defaults" />
                 <when value="advanced">
-                    <param name="function_type" argument="--n-ceil" type="select" display="radio" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out">
-                        <option value="C">Constant [f(x) = B]</option>
-                        <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
-                        <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
-                    </param>
+                    <param name="function_type" argument="--n-ceil" label="Function governing the maximum number of ambiguous characters (usually Ns and/or .s) allowed in a read as a function of read length" help="Reads exceeding this ceiling are filtered out" value="L"></param>
                     <param name="constant_term" type="float" value="0" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="0.15" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param argument="--ignore-quals" name="ignore_quals" type="boolean" truevalue="--ignore-quals" falsevalue="" label="Ignore quality values" help="When calculating a mismatch penalty, always consider the quality value at the mismatched position to be the highest possible, regardless of the actual value. I.e. input is treated as though all quality values are high. This is also the default behavior when the input doesn't specify quality values" />
@@ -472,12 +467,7 @@ hisat2
                     <param argument="--rdg" name="read_extend_penalty" type="integer" value="3" min="0" label="Read gap extend penalty" help="A read gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_open_penalty" type="integer" value="5" min="0" label="Reference gap open penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
                     <param argument="--rfg" name="ref_extend_penalty" type="integer" value="3" min="0" label="Reference gap extend penalty" help="A reference gap of length N gets a penalty of [open_penalty] + N * [extend_penalty]" />
-                    <param name="function_type" argument="--score-min" type="select" display="radio" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length">
-                        <option value="C">Constant [f(x) = B]</option>
-                        <option value="L" selected="true">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
-                        <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
-                    </param>
+                    <param name="function_type" argument="--score-min" label="Function governing the minimum alignment score needed for an alignment to be considered &quot;valid&quot; (i.e. good enough to report)" help="This is a function of read length" value="L"></param>
                 </when>
             </conditional>
 
@@ -490,12 +480,7 @@ hisat2
                 <when value="advanced">
                     <param name="canonical_penalty" argument="--pen-cansplice" type="integer" value="0" min="0" label="Penalty for canonical splice sites" />
                     <param name="noncanonical_penalty" argument="--pen-noncansplice" type="integer" value="12" min="0" label="Penalty for non-canonical splice sites" />
-                    <param name="function_type" argument="--pen-canintronlen" type="select" display="radio" label="Penalty function for long introns with canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
-                        <option value="C">Constant [f(x) = B]</option>
-                        <option value="L">Linear [f(x) = B + A * x]</option>
-                        <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
-                        <option value="G" selected="true">Natural logarithm [f(x) = B + A * log(x)]</option>
-                    </param>
+                    <param name="nc_function_type" argument="--pen-noncanintronlen" value="G"></param>            
                     <param name="constant_term" type="float" value="-8" label="Constant term (B)" help="Constant term for the above function" />
                     <param name="coefficient" type="float" value="1" label="Coefficient (A)" help="Coefficient for the above function" />
                     <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -45,11 +45,11 @@
         </conditional>
     </xml>
     
-    <xml name= "nc_function" token_varname="nc_function_type" token_default_argument="--pen-noncanintronlen" token_type="select" token_display="radio" token_label="Penalty function for long introns with non-canonical splice sites" token_help="Alignments with shorter introns are preferred to those with longer ones">
-        <param name="@VARNAME@" argument="@DEFAULT_ARGUMENT@" type="@TYPE@" display="@DISPLAY@" label="@LABEL@" help="@HELP@">
+    <xml name= "nc_function" token_varname="nc_function_type" token_default_argument="--pen-noncanintronlen" token_label="Penalty function for long introns with non-canonical splice sites" token_help="Alignments with shorter introns are preferred to those with longer ones">
+        <param name="@VARNAME@" argument="@DEFAULT_ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
             <option value="C">Constant [f(x) = B]</option>
             <option value="L">Linear [f(x) = B + A * x]</option>
-            <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+            <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
             <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
         </param>
    </xml>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -46,7 +46,7 @@
     </xml>
     
     <xml name= "nc_function" token_name="NO NAME GIVEN" token_argument="NO ATGUMENT GIVEN" token_label="NO LABEL GIVEN" token_help="" token_cselected="false" token_lselected="false" token_sselected="false" token_gselected="false">
-        <param name="@VARNAME@" argument="@DEFAULT_ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
+        <param name="@NAME@" argument="@DEFAULT_ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
             <option value="C" selected="@CSELECTED@">Constant [f(x) = B]</option>
             <option value="L" selected="@LSELECTED@">Linear [f(x) = B + A * x]</option>
             <option value="S" selected="@SSELECTED@">Square root [f(x) = B + A * &#8730;x]</option>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -45,8 +45,8 @@
         </conditional>
     </xml>
     
-    <xml name= "nc_function">
-        <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
+    <xml name= "nc_function" token_varname="nc_function_type" token_default_argument="--pen-noncanintronlen" token_type="select" token_display="radio" token_label="Penalty function for long introns with non-canonical splice sites" token_help="Alignments with shorter introns are preferred to those with longer ones">
+        <param name="@VARNAME@" argument="@DEFAULT_ARGUMENT@" type="@TYPE@" display="@DISPLAY@" label="@LABEL@" help="@HELP@">
             <option value="C">Constant [f(x) = B]</option>
             <option value="L">Linear [f(x) = B + A * x]</option>
             <option value="S">Square root [f(x) = B + A * x&#178;]</option>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -45,8 +45,8 @@
         </conditional>
     </xml>
     
-    <xml name= "nc_function" token_name="NO NAME GIVEN" token_argument="NO ATGUMENT GIVEN" token_label="NO LABEL GIVEN" token_help="" token_cselected="false" token_lselected="false" token_sselected="false" token_gselected="false">
-        <param name="@NAME@" argument="@DEFAULT_ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
+    <xml name= "nc_function" token_name="NO NAME GIVEN" token_argument="NO ARGUMENT GIVEN" token_label="NO LABEL GIVEN" token_help="" token_cselected="false" token_lselected="false" token_sselected="false" token_gselected="false">
+        <param name="@NAME@" argument="@ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
             <option value="C" selected="@CSELECTED@">Constant [f(x) = B]</option>
             <option value="L" selected="@LSELECTED@">Linear [f(x) = B + A * x]</option>
             <option value="S" selected="@SSELECTED@">Square root [f(x) = B + A * &#8730;x]</option>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -44,5 +44,14 @@
               </when>
         </conditional>
     </xml>
+    
+    <xml name= "nc_function">
+        <param name="nc_function_type" argument="--pen-noncanintronlen" type="select" display="radio" label="Penalty function for long introns with non-canonical splice sites" help="Alignments with shorter introns are preferred to those with longer ones">
+            <option value="C">Constant [f(x) = B]</option>
+            <option value="L">Linear [f(x) = B + A * x]</option>
+            <option value="S">Square root [f(x) = B + A * x&#178;]</option>
+            <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
+        </param>
+   </xml>
 
 </macros>

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -45,12 +45,12 @@
         </conditional>
     </xml>
     
-    <xml name= "nc_function" token_varname="nc_function_type" token_default_argument="--pen-noncanintronlen" token_label="Penalty function for long introns with non-canonical splice sites" token_help="Alignments with shorter introns are preferred to those with longer ones">
+    <xml name= "nc_function" token_name="NO NAME GIVEN" token_argument="NO ATGUMENT GIVEN" token_label="NO LABEL GIVEN" token_help="" token_cselected="false" token_lselected="false" token_sselected="false" token_gselected="false">
         <param name="@VARNAME@" argument="@DEFAULT_ARGUMENT@" type="select" display="radio" label="@LABEL@" help="@HELP@">
-            <option value="C">Constant [f(x) = B]</option>
-            <option value="L">Linear [f(x) = B + A * x]</option>
-            <option value="S">Square root [f(x) = B + A * &#8730;x]</option>
-            <option value="G">Natural logarithm [f(x) = B + A * log(x)]</option>
+            <option value="C" selected="@CSELECTED@">Constant [f(x) = B]</option>
+            <option value="L" selected="@LSELECTED@">Linear [f(x) = B + A * x]</option>
+            <option value="S" selected="@SSELECTED@">Square root [f(x) = B + A * &#8730;x]</option>
+            <option value="G" selected="@GSELECTED@">Natural logarithm [f(x) = B + A * log(x)]</option>
         </param>
    </xml>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR is a fix for issue #3312, an update to the square root symbol in function arguments by replacing `x&#178` to `&#8730x`.
I'm not familiar with creating macros in XML but I can give it a try if you prefer it that way.
