### PR TITLE
data_manager_manual: fix DetachedInstanceError with >20.05

### DIFF
--- a/data_managers/data_manager_manual/data_manager/data_manager_manual.py
+++ b/data_managers/data_manager_manual/data_manager/data_manager_manual.py
@@ -58,7 +58,7 @@ def exec_before_job(app, inp_data, out_data, param_dict, tool=None, **kwd):
                     if tdtm is None:
                         from tool_shed.tools import data_table_manager
                         tdtm = data_table_manager.ToolDataTableManager(app)
-                        target_dir, tool_path, relative_target_dir = tdtm.get_target_install_dir(tool_shed_repository)
+                        target_dir = tool_shed_repository.repo_path(app)
                     # Dynamically add this data table
                     log.debug("Attempting to dynamically create a missing Tool Data Table named %s." % data_table_name)
                     repo_info = tdtm.generate_repository_info_elem_from_repository(tool_shed_repository, parent_elem=None)


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Since 20.05 I get errors DetachedInstanceError when using data_manager_manual (#3302 and https://github.com/galaxyproject/galaxy/issues/10023).
This tiny patch makes the DM use another simpler method which seems to work better, and without these DetachedInstanceError
Tested by running biomaj2galaxy on a patched docker galaxy instance.

I haven't changed the version as I see it more like bugfix..