### PR TITLE
fix CI & PR: unquote TOOL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,15 +123,15 @@ jobs:
     - name: Planemo test tools
       run: |
         mkdir json_output
-        while read -r TOOL; do
+        while read -r TOOL_GROUP; do
             # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL
-            if echo $TOOL | grep -qf .tt_biocontainer_skip; then
+            if echo $TOOL_GROUP | grep -qf .tt_biocontainer_skip; then
                 PLANEMO_OPTIONS=""
             else
                 PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
             fi
             json=$(mktemp -u -p json_output --suff .json)
-            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source "https://github.com/${{ needs.setup.outputs.fork }}/galaxy" --galaxy_branch "${{ needs.setup.outputs.branch }}" --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" "$TOOL" || true
+            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source "https://github.com/${{ needs.setup.outputs.fork }}/galaxy" --galaxy_branch "${{ needs.setup.outputs.branch }}" --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" $TOOL_GROUP || true
             docker system prune --all --force --volumes || true
         done < tool.list
     - name: Merge tool_test_output.json files

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -308,22 +308,22 @@ jobs:
       run: |
         touch changed_tools_chunk.list
         if [ -s ../workflow_artifacts/changed_repositories.list ]; then
-          planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --output changed_tools_chunk.list $(cat ../workflow_artifacts/changed_repositories.list)
+          planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk }} --group_tools --output changed_tools_chunk.list $(cat ../workflow_artifacts/changed_repositories.list)
         fi
     - name: Show changed tools chunk list
       run: cat changed_tools_chunk.list
     - name: Planemo test tools
       run: |
         mkdir json_output
-        while read -r TOOL; do
-            # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL
-            if echo $TOOL | grep -qf .tt_biocontainer_skip; then
+        while read -r TOOL_GROUP; do
+            # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
+            if echo $TOOL_GROUP | grep -qf .tt_biocontainer_skip; then
                 PLANEMO_OPTIONS=""
             else
                 PLANEMO_OPTIONS="--biocontainers --no_dependency_resolution --no_conda_auto_init"
             fi
             json=$(mktemp -u -p json_output --suff .json)
-            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" "$TOOL" || true
+            PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" $TOOL_GROUP || true
             docker system prune --all --force --volumes || true
         done < changed_tools_chunk.list
         if [ ! -s changed_tools_chunk.list ]; then


### PR DESCRIPTION
- unquote `$TOOL` (which is renamed to `TOOL_GROUP`) because its a space separated list of tools
- restore `--group_tools` argument for ci_find_tools

essentially restoring:

https://github.com/galaxyproject/tools-iuc/pull/3239
https://github.com/galaxyproject/tools-iuc/pull/3254

which have been lost somewhere ... :( I have the feeling that some of the lines are to long and diffs are easy to miss.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
