### PR TITLE
dada2: Bugs in macros.xml

### DIFF
--- a/tools/dada2/macros.xml
+++ b/tools/dada2/macros.xml
@@ -38,17 +38,17 @@ echo $(R --version | grep version | grep -v GNU)", dada2 version" $(R --vanilla 
          - uniques is a named integer vector (columns=ASVs, only one rows)-->
     <token name="@READ_FOO@"><![CDATA[
     read.uniques <- function ( fname ) {
-         p <- read.table(fname, header=F, sep="\t")
+         x <- read.table(fname, header=F, sep="\t")
          n <-x[,2]
          names(n)<-x[,1]
     }
     #def read_data($dataset)
         #if $dataset.is_of_type('dada2_sequencetable')
-            t(as.matrix( read.table('$dataset', header=T, sep="\t", row.names=1) ))
+            t(as.matrix( read.table('$dataset', header=T, sep="\t", row.names=1, check.names=FALSE) ))
         #else if $dataset.is_of_type('dada2_uniques')
             read.uniques('$dataset')
         #else if $dataset.is_of_type('tabular')
-            read.table('$dataset', header=T, sep="\t", row.names=1)
+            read.table('$dataset', header=T, sep="\t", row.names=1, check.names=FALSE)
         #else
             readRDS('$dataset')
         #end if

--- a/tools/dada2/macros.xml
+++ b/tools/dada2/macros.xml
@@ -41,7 +41,7 @@ echo $(R --version | grep version | grep -v GNU)", dada2 version" $(R --vanilla 
          x <- read.table(fname, header=F, sep="\t")
          n <-x[,2]
          names(n)<-x[,1]
-         return n
+         return(n)
     }
     #def read_data($dataset)
         #if $dataset.is_of_type('dada2_sequencetable')

--- a/tools/dada2/macros.xml
+++ b/tools/dada2/macros.xml
@@ -41,6 +41,7 @@ echo $(R --version | grep version | grep -v GNU)", dada2 version" $(R --vanilla 
          x <- read.table(fname, header=F, sep="\t")
          n <-x[,2]
          names(n)<-x[,1]
+         return n
     }
     #def read_data($dataset)
         #if $dataset.is_of_type('dada2_sequencetable')

--- a/tools/dada2/macros.xml
+++ b/tools/dada2/macros.xml
@@ -93,7 +93,7 @@ write.data <- function( data, fname, type ){
 
     <!-- for filterAndTrim -->
     <xml name="trimmers">
-        <section name="trim" title="Trimming parameters">
+        <section name="trim" title="Trimming parameters" expanded="true">
             <param argument="truncQ" type="integer" value="2" min="0" label="Truncate reads at quality threshold" help="Truncate reads at the first instance of a quality score less than or equal to this threshold"/>
             <param argument="trimLeft" type="integer" value="0" min="0" label="Trim start of each read" help="The number of nucleotides to remove from the start of each read."/>
             <param argument="trimRight" type="integer" value="0" min="0" label="Trim end of each read" help="The number of nucleotides to remove from the end of each read"/>
@@ -101,7 +101,7 @@ write.data <- function( data, fname, type ){
         </section>
     </xml>
     <xml name="filters">
-        <section name="filter" title="Filtering parameters">
+        <section name="filter" title="Filtering parameters" expanded="true">
             <param argument="maxLen" type="integer" value="" optional="true" min="0" label="Remove long reads" help="Remove reads with length greater than this value. Default: no length threshold"/>
             <param argument="minLen" type="integer" value="20" min="0" label="Remove short reads" help="Remove reads with length less than this value. Default: 20"/>
             <param argument="maxN" type="integer" value="0" min="0" label="Remove reads with more Ns" help="Note that some of the subsequent dada pipeline steps do not allow Ns"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [X] - This PR does something else (explain below)

Bug squashing.

read.table was correcting names to turn them into syntactically valid variable names. As a result samples names could be altered. in my use case, sample names start with a number, which I assume is quite common, so, for example, sample 31i was renamed X31i. This affects at least removeBimeraDenovo and sequence counts. The result is a scrambled sequence count table.

I also found a typo in the read.uniques function. I can't see what it might affect, but it looks rather dire.