### PR TITLE
More precise estimate of number of tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
     - name: Get approximate number of tools and compute number of chunks
       id: get-chunks
       run: |
-        nchunks=$(find data_managers/ tools/ tool_collections/ -iname '*.xml' | grep -v 'data_manager_conf.xml\|macro\|repository_dependencies.xml\|test-data/\|tool_dependencies.xml' | wc -l)
+        nchunks=$(find data_managers/ tools/ tool_collections/ -iname '*.xml' | grep -v 'data_manager_conf.xml\|datatypes_conf.xml\|macro\|repository_dependencies.xml\|test-data/\|tool_dependencies.xml' | xargs grep -l '<tool ' | wc -l)
         if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         elif [ "$nchunks" -eq 0 ]; then


### PR DESCRIPTION
Exclude `datatypes_conf.xml` files and check for `tool` XML element.

Estimating too many tools creates a problem for small repos like earlham-galaxytools

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
