### PR TITLE
Update samtools_view.xml - use GALAXY_MEMORY_MB_PER_SLOT as samtools_…

### DIFF
--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -43,6 +43,7 @@
     <expand macro="version_command"/>
     <command><![CDATA[
         @ADDTHREADS@
+	@ADDMEMORY@
         ## prepare reference data
         @PREPARE_FASTA_IDX@
         @PREPARE_IDX@

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -43,7 +43,7 @@
     <expand macro="version_command"/>
     <command><![CDATA[
         @ADDTHREADS@
-	@ADDMEMORY@
+        @ADDMEMORY@
         ## prepare reference data
         @PREPARE_FASTA_IDX@
         @PREPARE_IDX@

--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_view" name="Samtools view" version="@TOOL_VERSION@+galaxy2">
+<tool id="samtools_view" name="Samtools view" version="@TOOL_VERSION@+galaxy3">
     <description>- reformat, filter, or subsample SAM, BAM or CRAM</description>
     <macros>
         <import>macros.xml</import>
@@ -224,14 +224,14 @@
                 ## then sort the output by coordinate,
                 #if not $input.is_of_type('bam') and str($mode.output_options.output_format.oformat) == 'bam':
                     && samtools sort
-                        -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
+                        -@ \$addthreads -m \$addmemory"M" -T "\${TMPDIR:-.}"
                         -O bam
                         -o tmpsam
                         outfile
                         && mv tmpsam outfile
                     #if $with_non_selected_reads_output:
                         && samtools sort
-                            -@ \$addthreads -m \${GALAXY_MEMORY_MB:-768}M -T "\${TMPDIR:-.}"
+                            -@ \$addthreads -m \$addmemory"M" -T "\${TMPDIR:-.}"
                             -O bam
                             -o tmpsam
                             inv_outfile


### PR DESCRIPTION
Implement in `samtools view` which also launch `samtools sort` the usage of `GALAXY_MEMORY_MB_PER_SLOT` as  [samtools_sort.xml](https://github.com/galaxyproject/tools-iuc/blob/master/tool_collections/samtools/samtools_sort/samtools_sort.xml#L14)


FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
