### PR TITLE
Update to include newest SILVA reference files

### DIFF
--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.1.5" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.1.6" tool_type="manage_data" profile="19.05">
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
         <requirement type="package" version="2.7">python</requirement>
@@ -37,6 +37,8 @@
                     <option value="RDP_v9">RDP reference files (training set version 9)</option>
                     <option value="RDP_v7">RDP reference files (training set version 7)</option>
                     <option value="RDP_v6">RDP reference files (training set version 6)</option>
+                    <option value="silva_release_138">SILVA reference files (release 138)</option>
+                    <option value="silva_release_132">SILVA reference files (release 132)</option>
                     <option value="silva_release_128">SILVA reference files (release 128)</option>
                     <option value="silva_release_123">SILVA reference files (release 123)</option>
                     <option value="silva_release_119">SILVA reference files (release 119)</option>

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -76,6 +76,16 @@ MOTHUR_REFERENCE_DATA = {
     },
     # Silva reference files
     # http://www.mothur.org/wiki/Silva_reference_files
+    "silva_release_138": {
+        "SILVA release 138":
+        ["https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.nr_v138.tgz",
+         "https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.seed_v138.tgz", ],
+    },
+    "silva_release_132": {
+        "SILVA release 132":
+        ["https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.nr_v132.tgz",
+         "https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.seed_v132.tgz", ],
+    },
     "silva_release_128": {
         "SILVA release 128":
         ["https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.nr_v128.tgz",


### PR DESCRIPTION
Update includes SILVA reference files versions 132 and 138.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
