### PR TITLE
Update Jbrowse to 1.16.10

### DIFF
--- a/tools/jbrowse/macros.xml
+++ b/tools/jbrowse/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.16.9</token>
+  <token name="@TOOL_VERSION@">1.16.10</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="@TOOL_VERSION@">jbrowse</requirement>

--- a/tools/jbrowse/readme.rst
+++ b/tools/jbrowse/readme.rst
@@ -25,6 +25,15 @@ likely to change at any time! Beware. ;)
 History
 =======
 
+- 1.16.10+galaxy0
+
+    - UPDATED to JBrowse 1.16.10
+    - ADDED GALAXY_JBROWSE_SYMLINKS environment variable: if set, the tool will make symlinks to bam/bigwig files instead of copying them
+
+- 1.16.9+galaxy0
+
+    - UPDATED to JBrowse 1.16.9
+
 - 1.16.8+galaxy0
 
     - UPDATED to JBrowse 1.16.8


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

A little update of the jbrowse tool to 1.16.10
Also added a new GALAXY_JBROWSE_SYMLINKS env var:
- if unset bam/bigwig files will be copied to the jbrowse dataset dir
- otherwise it will be symlinked

Symlinks are fine to save space, but won't work if datasets are deleted or with pulsar. With GALAXY_JBROWSE_SYMLINKS the admin has the choice