### PR TITLE
Maker: fix mpi activation logic

### DIFF
--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -39,9 +39,9 @@
             export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
         #end if
 
-        MPI_CMD="mpiexec -n \${GALAXY_SLOTS:-4}" &&
-        if [ "\$MAKER_NO_MPI" != "1" ]; then
-            MPI_CMD="";
+        MPI_CMD="" &&
+        if [ "\$MAKER_MPI" == "1" ]; then
+            MPI_CMD="mpiexec -n \${GALAXY_SLOTS:-4}";
         fi &&
 
         \${MPI_CMD} maker --ignore_nfs_tmp maker_opts.ctl maker_bopts.ctl maker_exe.ctl < /dev/null

--- a/tools/maker/readme.rst
+++ b/tools/maker/readme.rst
@@ -1,0 +1,6 @@
+Running with MPI
+================
+
+By default, Maker will only run on 1 cpu. If you want to parallelize on any number
+of cpus and nodes, you can enable MPI by setting the ``MAKER_MPI`` variable to 1
+in the job destination.

--- a/tools/maker/readme.rst
+++ b/tools/maker/readme.rst
@@ -3,4 +3,5 @@ Running with MPI
 
 By default, Maker will only run on 1 cpu. If you want to parallelize on any number
 of cpus and nodes, you can enable MPI by setting the ``MAKER_MPI`` variable to 1
-in the job destination.
+in the job destination, and setting ``GALAXY_SLOTS`` to the desired number of cores
+(see https://galaxyproject.org/admin/config/galaxy_slots/#galaxy_slots-for-server-admins).


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

A fix for the broken logic of mpi activation for Maker.
Also disabled it by default as it seems like mpich>=3.3 node list parsing is not super reliable, making it fail when node names are not in the expected format (I had this problem on my cluster, heard of someone else having it too some time ago). I'll try to fix it in mpich :crossed_fingers: 
(also tried to pin mpich to 3.2.1, but getting conda package conflicts)