### PR TITLE
Revert changes in pr.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,7 @@ jobs:
             planemo shed_lint --tools --ensure_metadata --urls --report_level warn --fail_level error --recursive "$DIR";
         done < ../workflow_artifacts/changed_repositories.list
     - name: Planemo ci_find_tools for the commit range
-      run: planemo ci_find_tools --changed_in_commit_range ${{ needs.setup.outputs.commit_range }} --exclude .github --exclude packages --exclude deprecated --exclude .tt_skip --exclude .tt_biocontainer_skip --exclude_from .tt_skip --output changed_tools.list
+      run: planemo ci_find_tools --changed_in_commit_range ${{ needs.setup.outputs.commit_range }} --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_tools.list
     - name: Check if each changed tool is in the list of changed repositories
       run: |
         set -e


### PR DESCRIPTION
added in https://github.com/galaxyproject/tools-iuc/pull/3403 . The Planemo issue should be fixed in 0.74.1

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
