### PR TITLE
Ensure that secondary DESeq2 R script is in <command> for Pulsar

### DIFF
--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -41,6 +41,7 @@ echo $(R --version | grep version | grep -v GNU)", DESeq2 version" $(R --vanilla
     #end if
 #end if
 
+## This is needed for Pulsar to transfer the file
 cat '$__tool_directory__/get_deseq_dataset.R' > /dev/null &&
 
 #import json

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -41,6 +41,8 @@ echo $(R --version | grep version | grep -v GNU)", DESeq2 version" $(R --vanilla
     #end if
 #end if
 
+cat '$__tool_directory__/get_deseq_dataset.R' > /dev/null &&
+
 #import json
 #import os
 Rscript '${__tool_directory__}/deseq2.R'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Per @wm75 this is a trick (from @Slugger70) already used in some [other tools](https://github.com/galaxyproject/tools-iuc/blob/master/tools/snpfreqplot/snpfreqplot.xml) for getting Pulsar to transfer required files from the tool directory that don't appear directly in the command line. In this case, `get_deseq_dataset.R` is an include in `deseq2.R`.

From some discussion with @jmchilton on the admins gitter channel we'd like a way to annotate these sorts of things rather than a hack, but it's not on the list of priorities currently.