### PR TITLE
use planemo ci_find_repos+ci_find_tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,21 +66,17 @@ jobs:
       with:
         fetch-depth: 1
     - name: Planemo ci_find_repos
-      run: planemo ci_find_repos --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
-    - name: Show repo list
-      run: cat changed_repositories.list
-    - name: Planemo ci_find_tools for the changed repos
-      run: |
-        touch changed_tools.list
-        if [ -s changed_repositories.list ]; then
-            planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
-        fi
+      run: planemo ci_find_repos --exclude packages --exclude deprecated --exclude_from .tt_skip --output repository_list.txt
+    - name: Show repository list
+      run: cat repository_list.txt
+    - name: Planemo ci_find_tools for the repository list
+      run: planemo ci_find_tools --output tool_list.txt $(cat repository_list.txt)
     - name: Show tool list
-      run: cat changed_tools.list
+      run: cat tool_list.txt
     - name: Compute chunks
       id: get-chunks
       run: |
-        nchunks=$(wc -l < changed_tools.list)
+        nchunks=$(wc -l < tool_list.txt)
         if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         elif [ "$nchunks" -eq 0 ]; then
@@ -129,9 +125,9 @@ jobs:
     - name: Install Planemo
       run: pip install planemo
     - name: Planemo ci_find_tools, chunked
-      run: planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk  }} --exclude test_repositories --exclude packages --exclude deprecated --exclude_from .tt_skip --group_tools --output tool.list
-    - name: Show tools chunk list
-      run: cat tool.list
+      run: planemo ci_find_tools --chunk_count ${{ needs.setup.outputs.nchunks }} --chunk ${{ matrix.chunk  }} --exclude test_repositories --exclude packages --exclude deprecated --exclude_from .tt_skip --group_tools --output tool_list_chunk.txt
+    - name: Show tool list chunk
+      run: cat tool_list_chunk.txt
     - name: Planemo test tools
       run: |
         mkdir json_output
@@ -145,7 +141,10 @@ jobs:
             json=$(mktemp -u -p json_output --suff .json)
             PIP_QUIET=1 planemo test --database_connection postgresql://postgres:postgres@localhost:5432/galaxy $PLANEMO_OPTIONS --galaxy_source "https://github.com/${{ needs.setup.outputs.fork }}/galaxy" --galaxy_branch "${{ needs.setup.outputs.branch }}" --galaxy_python_version ${{ matrix.python-version }} --test_output_json "$json" $TOOL_GROUP || true
             docker system prune --all --force --volumes || true
-        done < tool.list
+        done < tool_list_chunk.txt
+        if [ ! -s tool_list_chunk.txt ]; then
+            echo '{"tests":[]}' > "$(mktemp -u -p json_output --suff .json)"
+        fi
     - name: Merge tool_test_output.json files
       run: planemo merge_test_reports json_output/*.json tool_test_output.json
     - name: Create tool_test_output.html

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,22 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Get approximate number of tools and compute number of chunks
+    - name: Planemo ci_find_repos
+      run: planemo ci_find_repos --exclude packages --exclude deprecated --exclude_from .tt_skip --output changed_repositories.list
+    - name: Show repo list
+      run: cat changed_repositories.list
+    - name: Planemo ci_find_tools for the changed repos
+      run: |
+        touch changed_tools.list
+        if [ -s changed_repositories.list ]; then
+            planemo ci_find_tools --output changed_tools.list $(cat changed_repositories.list)
+        fi
+    - name: Show tool list
+      run: cat changed_tools.list
+    - name: Compute chunks
       id: get-chunks
       run: |
-        nchunks=$(find data_managers/ tools/ tool_collections/ -iname '*.xml' | grep -v 'data_manager_conf.xml\|datatypes_conf.xml\|macro\|repository_dependencies.xml\|test-data/\|tool_dependencies.xml' | xargs grep -l '<tool ' | wc -l)
+        nchunks=$(wc -l < changed_tools.list)
         if [ "$nchunks" -gt "$MAX_CHUNKS" ]; then
             nchunks=$MAX_CHUNKS
         elif [ "$nchunks" -eq 0 ]; then


### PR DESCRIPTION
for counting tools and computing chunks.

- [ ] we should think about removing `-exclude packages --exclude deprecated` in favor of including these directories in `.tt_skip` (here and in the PR workflow). Advantage would be that the workflow would also run if those dirs do not exist in other repos. So all exclusions would be controlled in `.tt_skip`


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
