### PR TITLE
hmmer: fix number of CPUs

### DIFF
--- a/tools/hmmer3/hmmbuild.xml
+++ b/tools/hmmer3/hmmbuild.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmbuild" name="hmmbuild" version="@TOOL_VERSION@">
+<tool id="hmmer_hmmbuild" name="hmmbuild" version="@TOOL_VERSION@+galaxy1">
   <description>Build a profile HMM from an input multiple alignment</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 hmmbuild
 
 #if $hmmname:

--- a/tools/hmmer3/hmmscan.xml
+++ b/tools/hmmer3/hmmscan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmscan" name="hmmscan" version="@TOOL_VERSION@">
+<tool id="hmmer_hmmscan" name="hmmscan" version="@TOOL_VERSION@+galaxy1">
   <description>search protein sequence(s) against a protein profile database</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 @INPUTHMMCHOICE@
 hmmscan
 

--- a/tools/hmmer3/hmmsearch.xml
+++ b/tools/hmmer3/hmmsearch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_hmmsearch" name="hmmsearch" version="@TOOL_VERSION@">
+<tool id="hmmer_hmmsearch" name="hmmsearch" version="@TOOL_VERSION@+galaxy1">
   <description>search profile(s) against a sequence database</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 hmmsearch
 
 @OFORMAT_WITH_OPTS@

--- a/tools/hmmer3/jackhmmer.xml
+++ b/tools/hmmer3/jackhmmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_jackhmmer" name="jackhmmer" version="@TOOL_VERSION@">
+<tool id="hmmer_jackhmmer" name="jackhmmer" version="@TOOL_VERSION@+galaxy1">
   <description>iteratively search a protein sequence against a protein database (PSIBLAST-like)</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 jackhmmer
 -N $N
 @OFORMAT_WITH_OPTS@

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -226,8 +226,12 @@ $acc $noali $notextw
       <!-- -mxfile <f>  : read substitution score matrix from file <f> (with -singlemx)-->
     </conditional>
   </xml>
+  <token name="@ADDTHREADS@"><![CDATA[
+        ##compute the number of ADDITIONAL threads to be used (--cpu)
+        addthreads=\${GALAXY_SLOTS:-1} && (( addthreads-- )) &&
+    ]]></token>
   <token name="@CPU@">
-      --cpu \${GALAXY_SLOTS:-2}
+      --cpu \$addthreads
   </token>
   <token name="@SEED@">
       --seed $seed

--- a/tools/hmmer3/macros.xml
+++ b/tools/hmmer3/macros.xml
@@ -566,10 +566,9 @@ it off if you know you will have no problem with biased composition hits.
 **Advanced Documentation**
 
 A more detailed look at the internals of the various filter pipelines was
-posted on the `developer's blog <https://cryptogenomicon.org/2011/09/19/hmmer3-is-stubborn/>`__.
+posted on the `developer's blog <http://cryptogenomicon.org/hmmer3-is-stubborn.html>`__.
 The information posted there may be useful to those who are struggling with
 poor-scoring sequences.
-
 ]]></token>
   <token name="@ADV_OPTS_HELP@"><![CDATA[
 Advanced Options

--- a/tools/hmmer3/nhmmer.xml
+++ b/tools/hmmer3/nhmmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_nhmmer" name="nhmmer" version="@TOOL_VERSION@">
+<tool id="hmmer_nhmmer" name="nhmmer" version="@TOOL_VERSION@+galaxy1">
   <description>search a DNA model or alignment against a DNA database (BLASTN-like)</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 nhmmer
 
 @OFORMAT_WITH_OPTS@

--- a/tools/hmmer3/nhmmscan.xml
+++ b/tools/hmmer3/nhmmscan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_nhmmscan" name="nhmmscan" version="@TOOL_VERSION@">
+<tool id="hmmer_nhmmscan" name="nhmmscan" version="@TOOL_VERSION@+galaxy1">
   <description>search DNA sequence(s) against a DNA profile database</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 @INPUTHMMCHOICE@
 nhmmscan
 

--- a/tools/hmmer3/phmmer.xml
+++ b/tools/hmmer3/phmmer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hmmer_phmmer" name="phmmer" version="@TOOL_VERSION@">
+<tool id="hmmer_phmmer" name="phmmer" version="@TOOL_VERSION@+galaxy1">
   <description>search a protein sequence against a protein database (BLASTP-like)</description>
   <macros>
     <import>macros.xml</import>
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <command><![CDATA[
+@ADDTHREADS@
 phmmer
 
 @OFORMAT_WITH_OPTS@


### PR DESCRIPTION
from the man page:

```
--cpu <n>
    Set the number of parallel worker threads to <n>. On multicore machines, the default is 2. You can also control this number by setting an environment variable, HMMER_NCPU. There is also a master thread, so the actual number of threads that HMMER spawns is <n>+1.
```

I guess the test will run with GALAXY_SLOTS=1, i.e. we will know if
`--cpu 0` will work

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
