### PR TITLE
update chromeister to 1.5.a fixes memory error and reduces stdout prints

### DIFF
--- a/tools/chromeister/chromeister.xml
+++ b/tools/chromeister/chromeister.xml
@@ -1,7 +1,7 @@
 <tool id="chromeister" name="Chromeister" version="@TOOL_VERSION@">
     <description>ultra-fast pairwise genome comparisons</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.3.c</token>
+        <token name="@TOOL_VERSION@">1.5.a</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">chromeister</requirement>
@@ -121,6 +121,24 @@
                 <has_text text="-kmer 16"/>
                 <has_text text="-diffuse 3"/>
                 <has_text text="compute_score-nogrid.R"/>
+            </assert_command>
+        </test>
+        <!-- test to check grid -->
+        <test expect_num_outputs="5">
+            <param name="query" value="mycoplasma-232.fasta"/>
+            <param name="db" value="mycoplasma-7422.fasta"/>
+            <param name="dimension" value="500"/>
+            <param name="grid" value="true"/>
+            <output name="output" file="mycoplasma-232.fasta-mycoplasma-7422.fasta.mat"/>
+            <output name="output_imagen" file="mycoplasma-232.fasta-mycoplasma-7422.fasta.mat.filt.png" compare="sim_size"/>
+            <output name="output_csv" file="mycoplasma-232.fasta-mycoplasma-7422.fasta.mat.csv"/>
+            <output name="output_events" file="mycoplasma-232.fasta-mycoplasma-7422.fasta.mat.events.txt"/>
+            <output name="output_score" file="mycoplasma-232.fasta-mycoplasma-7422.fasta.scr.txt"/>
+            <assert_command>
+                <has_text text="-dimension 500"/>
+                <has_text text="-kmer 32"/>
+                <has_text text="-diffuse 4"/>
+                <has_text text="compute_score.R"/>
             </assert_command>
         </test>
         <test expect_num_outputs="6">


### PR DESCRIPTION
This update fixes one new bug and a potential one. 
It also reduces the number of inline prints so that it does not clog up the stdout interface in galaxy

An additional test has been included to test the memory error

Sorry for the many updates lately!

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
