### PR TITLE
humann2: add MemoryError stdio to all tools

### DIFF
--- a/tools/humann2/humann2.xml
+++ b/tools/humann2/humann2.xml
@@ -1,12 +1,10 @@
-<tool id="humann2" name="HUMAnN2" version="@WRAPPER_VERSION@.1">
+<tool id="humann2" name="HUMAnN2" version="@WRAPPER_VERSION@.2">
     <description>to profile presence/absence and abundance of microbial pathways and gene families</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
-    <stdio>
-        <regex match="Failed to allocate sufficient memory." source="stderr" level="fatal_oom" description="Out of memory error occurred" />
-    </stdio>
-    <expand macro="requirements">        
+    <expand macro="stdio"/>
+    <expand macro="requirements">
         <requirement type="package" version="2.3.0">bowtie2</requirement>
         <requirement type="package" version="2.6.0">metaphlan2</requirement>
         <requirement type="package" version="0.8.24">diamond</requirement>

--- a/tools/humann2/humann2_associate.xml
+++ b/tools/humann2/humann2_associate.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_associate" name="Associate" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_associate" name="Associate" version="@WRAPPER_VERSION@.1">
     <description>HUMAnN2 functions with metadata</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_barplot.xml
+++ b/tools/humann2/humann2_barplot.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_barplot" name="Barplot" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_barplot" name="Barplot" version="@WRAPPER_VERSION@.1">
     <description>stratified HUMAnN2 features</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements">
         <requirement type="package" version="2.0.2">matplotlib</requirement>
         <requirement type="package" version="1.13.1">numpy</requirement>

--- a/tools/humann2/humann2_genefamilies_genus_level.xml
+++ b/tools/humann2/humann2_genefamilies_genus_level.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_genefamilies_genus_level" name="Create a genus level gene families file" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_genefamilies_genus_level" name="Create a genus level gene families file" version="@WRAPPER_VERSION@.1">
     <description></description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_join_tables.xml
+++ b/tools/humann2/humann2_join_tables.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_join_tables" name="Join" version="@WRAPPER_VERSION@.1">
+<tool id="humann2_join_tables" name="Join" version="@WRAPPER_VERSION@.2">
     <description>HUMAnN2 generated tables</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_macros.xml
+++ b/tools/humann2/humann2_macros.xml
@@ -7,6 +7,13 @@
             <yield/>
         </requirements>
     </xml>
+    
+    <xml name="stdio">
+        <stdio>
+            <regex match="Failed to allocate sufficient memory." source="stderr" level="fatal_oom" description="Out of memory error occurred" />
+            <regex match="MemoryError" source="stderr" level="fatal_oom" description="Out of memory error occurred" />
+        </stdio>
+    </xml>
     <xml name="version">
         <version_command>humann2 --version</version_command>
     </xml>

--- a/tools/humann2/humann2_reduce_table.xml
+++ b/tools/humann2/humann2_reduce_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_reduce_table" name="Reduce" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_reduce_table" name="Reduce" version="@WRAPPER_VERSION@.1">
     <description>a HUMAnN2 generated table</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_regroup_table.xml
+++ b/tools/humann2/humann2_regroup_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_regroup_table" name="Regroup" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_regroup_table" name="Regroup" version="@WRAPPER_VERSION@.1">
     <description>a HUMAnN2 generated table by features</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_rename_table.xml
+++ b/tools/humann2/humann2_rename_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_rename_table" name="Rename" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_rename_table" name="Rename" version="@WRAPPER_VERSION@.1">
     <description>features of a HUMAnN2 generated table</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_renorm_table.xml
+++ b/tools/humann2/humann2_renorm_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_renorm_table" name="Renormalize" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_renorm_table" name="Renormalize" version="@WRAPPER_VERSION@.1">
     <description>a HUMAnN2 generated table</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_rna_dna_norm.xml
+++ b/tools/humann2/humann2_rna_dna_norm.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_rna_dna_norm" name="Normalize" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_rna_dna_norm" name="Normalize" version="@WRAPPER_VERSION@.1">
     <description> combined meta'omic sequencing data</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_split_stratified_table.xml
+++ b/tools/humann2/humann2_split_stratified_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_split_stratified_table" name="Split stratified table" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_split_stratified_table" name="Split stratified table" version="@WRAPPER_VERSION@.1">
     <description></description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_split_table.xml
+++ b/tools/humann2/humann2_split_table.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_split_table" name="Split" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_split_table" name="Split" version="@WRAPPER_VERSION@.1">
     <description> a HUMAnN2 generated table</description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_strain_profiler.xml
+++ b/tools/humann2/humann2_strain_profiler.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_strain_profiler" name="Make strain profiles" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_strain_profiler" name="Make strain profiles" version="@WRAPPER_VERSION@.1">
     <description></description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/humann2/humann2_unpack_pathways.xml
+++ b/tools/humann2/humann2_unpack_pathways.xml
@@ -1,8 +1,9 @@
-<tool id="humann2_unpack_pathways" name="Unpack pathway abundances to show genes included" version="@WRAPPER_VERSION@.0">
+<tool id="humann2_unpack_pathways" name="Unpack pathway abundances to show genes included" version="@WRAPPER_VERSION@.1">
     <description></description>
     <macros>
         <import>humann2_macros.xml</import>
     </macros>
+    <expand macro="stdio"/>
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Alternative: switch to aggressive error detection.

Just realized how outdated this tool is. It is 0.11.1 from 2017 and currently its 2.8.1 ... with 3.0 comming :(

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
