### PR TITLE
skip qiime in tool tests

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -5,3 +5,4 @@ tools/enasearch
 tools/ncbi_entrez_eutils/einfo.xml
 tools/trinotate
 tools/valet
+tools/qiime


### PR DESCRIPTION
The qiime tools time out and many of them fail tool tests. 

In most of the cases this is because of the missing `uclust` binary which is not in conda. My best guess is that in the past qiime downloaded `uclust ` at setup (https://github.com/biocore/qiime/blob/76d633c0389671e93febbe1338b5ded658eba31f/setup.py#L186) and this broke at some point. 

In some instances it would even be insufficient to not use uclust from the CLI (e.g. align_seqs) since uclust is used anyway.

Alternatively one could check if there are older containers that contain uclust and remove newer ones, but since the tools use different requirement combinations this seems to be quite some effort. 

Concluding two days of analyzing this I would say that qiime(1) is a dead end and maybe it would be the best to deprecate it .. in the end its just wrappers to other tools... if I'm not wrong.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
