### PR TITLE
fix efetch test

### DIFF
--- a/tools/ncbi_entrez_eutils/efetch.xml
+++ b/tools/ncbi_entrez_eutils/efetch.xml
@@ -44,7 +44,12 @@
       <param name="qss" value="id_file"/>
       <param name="id_file" value="efetchin.tabular"/>
       <output_collection name="output1" type="list" count="1">
-        <element name="EFetch-fasta-text-chunk1" ftype="xml" file="efetch.tabin.fasta" />
+        <element name="EFetch-fasta-text-chunk1" ftype="fasta">
+          <assert_contents>
+            <has_text text="XM_036034467"/>
+            <has_text text="NC_040910"/>
+          </assert_contents>
+        </element>
       </output_collection>
     </test>
   </tests>


### PR DESCRIPTION
test for collection was ignored until 21.01 (https://github.com/galaxyproject/galaxy/pull/11313)

test file was (and is) absent anyway.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
