### PR TITLE
Fix bug in gfa_to_fa converter.

### DIFF
--- a/tools/gfa_to_fa/gfa_to_fa.xml
+++ b/tools/gfa_to_fa/gfa_to_fa.xml
@@ -1,4 +1,4 @@
-<tool id="gfa_to_fa" name="GFA to FASTA" version="0.1.1">
+<tool id="gfa_to_fa" name="GFA to FASTA" version="0.1.2">
     <description>Convert Graphical Fragment Assembly files to FASTA format </description>
     <command detect_errors="exit_code"><![CDATA[
 cat '$in_gfa' | python '$convert' > '$out_fa'
@@ -9,13 +9,13 @@ from __future__ import print_function
 import sys
 for line in sys.stdin:
     if line.startswith("S"):
-        l,h,s,x = line.strip().split()
+        l,h,s = line.strip().split('\t')[:3]
         print(">" + h)
         print(s)
         ]]></configfile>
     </configfiles>
     <inputs>
-        <param name="in_gfa" type="data" format="tabular" label="Input GFA file" />
+        <param name="in_gfa" type="data" format="tabular,gfa1" label="Input GFA file" />
     </inputs>
     <outputs>
         <data name="out_fa" format="fasta" label="${tool.name} on ${on_string}: Fasta file" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

This converter would previously fail on gfa1 files with only three fields in an S line.
