### PR TITLE
CI: Provide linter outputs as artifacts

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -112,7 +112,7 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
     - uses: actions/upload-artifact@v2
-      if: always()
+      if: ${{ failure() }}
       with:
         name: 'Tool linting output'
         path: lint_report.txt
@@ -145,7 +145,7 @@ jobs:
     - name: Flake8
       run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
     - uses: actions/upload-artifact@v2
-      if: always()
+      if: ${{ failure() }}
       with:
         name: 'Python linting output'
         path: pylint_report.txt
@@ -204,7 +204,7 @@ jobs:
         quit(status = status)
       shell: Rscript {0}
     - uses: actions/upload-artifact@v2
-      if: always()
+      if: ${{ failure() }}
       with:
         name: 'R linting output'
         path: rlint_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -197,7 +197,7 @@ jobs:
             for (l in lnt) {
               rel_path <- paste(repo, l$filename, sep="/")
               write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), stderr())
-              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), "rlint_report.txt")
+              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), "rlint_report.txt", append=TRUE)
             }
           }
         }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -196,12 +196,13 @@ jobs:
             status <- 1
             for (l in lnt) {
               rel_path <- paste(repo, l$filename, sep="/")
-              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), stdout())
+              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), stderr())
+              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), "rlint_report.txt")
             }
           }
         }
         quit(status = status)
-      shell: Rscript {0} | tee rlint_report.txt
+      shell: Rscript {0}
     - uses: actions/upload-artifact@v2
       if: always()
       with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -142,7 +142,7 @@ jobs:
     - name: Install flake8
       run: pip install flake8 flake8-import-order
     - name: Flake8
-      run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file y --tee
+      run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
     - uses: actions/upload-artifact@v2
       with:
         name: 'Python linting output'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -112,6 +112,7 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
     - uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: 'Tool linting output'
         path: lint_report.txt
@@ -144,6 +145,7 @@ jobs:
     - name: Flake8
       run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
     - uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: 'Python linting output'
         path: pylint_report.txt
@@ -201,6 +203,7 @@ jobs:
         quit(status = status)
       shell: Rscript {0} | tee rlint_report.txt
     - uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: 'R linting output'
         path: rlint_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -111,6 +111,10 @@ jobs:
         mode: lint
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'Tool linting output'
+        path: lint_report.txt
 
   # flake8 of Python scripts in the changed repositories
   flake8:
@@ -138,7 +142,11 @@ jobs:
     - name: Install flake8
       run: pip install flake8 flake8-import-order
     - name: Flake8
-      run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8
+      run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file y --tee
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'Python linting output'
+        path: pylint_report.txt
 
   lintr:
     name: Lint R scripts
@@ -186,12 +194,16 @@ jobs:
             status <- 1
             for (l in lnt) {
               rel_path <- paste(repo, l$filename, sep="/")
-              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), stderr())
+              write(paste(paste(rel_path, l$line_number, l$column_number, sep=":"), l$message), stdout())
             }
           }
         }
         quit(status = status)
-      shell: Rscript {0}
+      shell: Rscript {0} | tee rlint_report.txt
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'R linting output'
+        path: rlint_report.txt
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests


### PR DESCRIPTION
Then users do not need to check the detailed job outputs. Might be more convenient.


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
