### PR TITLE
HiCExplorer Validation fix for Python 3.6 version

### DIFF
--- a/tools/hicexplorer/hicFindRestrictionSites.xml
+++ b/tools/hicexplorer/hicFindRestrictionSites.xml
@@ -19,7 +19,7 @@
                     is a regexp and can contain regexp specif syntax
                     (see https://docs.python.org/2/library/re.html). For example the pattern
                     CG..GC will find all occurrence of CG followed by any two bases and then GC.'>
-            <validator type="expression" message="Only ASCII characters are allowed.">value.isascii()</validator>
+            <validator type="expression" message="Only ASCII characters are allowed."><![CDATA[all(ord(c) < 128 for c in value)]]></validator>
         </param>
     </inputs>
     <outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [] - This PR does something else (explain below)

Python 3.6 does not support the `isascii()` validation of a string, only > Python 3.7 does.