### PR TITLE
'fix' paired output for cutadapt

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -1,4 +1,4 @@
-<tool id="cutadapt" name="Cutadapt" version="1.16.8" profile="17.09">
+<tool id="cutadapt" name="Cutadapt" version="1.16.9" profile="17.09">
     <description>Remove adapter sequences from Fastq/Fasta</description>
     <macros>
         <import>macros.xml</import>
@@ -93,8 +93,13 @@ cutadapt
 #else:
     @read1_options@
     @read2_options@
-    --output='$out1'
-    --paired-output='$out2'
+    #if $library.type == "paired"
+        --output='$out1'
+        --paired-output='$out2'
+    #else
+        --output='$out_pairs.forward'
+        --paired-output='$out_pairs.reverse'
+    #end if
 #end if
 
 --error-rate=$adapter_options.error_rate
@@ -240,13 +245,17 @@ $read_mod_options.trim_n
 
     <outputs>
         <data name="out1" format="fastqsanger" metadata_source="input_1" from_work_dir="out1*" label="${tool.name} on ${on_string}: Read 1 Output">
-            <filter>(output_options['multiple_output'] is False)</filter>
+            <filter>(output_options['multiple_output'] is False and library['type'] != 'paired_collection')</filter>
             <expand macro="inherit_format_1" />
         </data>
         <data name="out2" format="fastqsanger" metadata_source="input_2" from_work_dir="out2*" label="${tool.name} on ${on_string}: Read 2 Output" >
-            <filter>(library['type'] == 'paired' or library['type'] == 'paired_collection')</filter>
+            <filter>(output_options['multiple_output'] is False and library['type'] == 'paired')</filter>
             <expand macro="inherit_format_2" />
         </data>
+
+        <collection name="out_pairs" type="paired" format_source="input_1" label="${tool.name} on ${on_string}: Reads">
+            <filter>(output_options['multiple_output'] is False and library['type'] == 'paired_collection')</filter>
+        </collection>
 
         <data name="report" format="txt" from_work_dir="report.txt" label="${tool.name} on ${on_string}: Report">
             <filter>(output_options['report'] is True)</filter>
@@ -304,7 +313,7 @@ $read_mod_options.trim_n
 
     <tests>
         <!-- Ensure fastq works -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
@@ -312,7 +321,7 @@ $read_mod_options.trim_n
             <output name="out1" file="cutadapt_small.out" ftype="fastq"/>
         </test>
         <!-- Ensure single end fastq.gz works -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="adapter_source_list" value="user"/>
@@ -320,7 +329,7 @@ $read_mod_options.trim_n
             <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
         </test>
         <!-- Ensure paired end fastq.gz works -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
@@ -340,7 +349,7 @@ $read_mod_options.trim_n
             </assert_command>
         </test>
         <!-- Ensure paired collection works -->
-        <test>
+        <test expect_num_outputs="3">
             <param name="type" value="paired_collection" />
             <param name="input_1">
                 <collection type="paired">
@@ -352,11 +361,13 @@ $read_mod_options.trim_n
             <param name="adapter" value="AGATCGGAAGAGC"/>
             <param name="adapter_source_list2" value="user"/>
             <param name="adapter2" value="AGATCGGAAGAGC"/>
-            <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
-            <output name="out2" decompress="True" file="cutadapt_out2.fq.gz" ftype="fastq.gz"/>
+            <output_collection name="out_pairs" type="paired">
+                <element name="forward" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz" />
+                <element name="reverse" decompress="True" file="cutadapt_out2.fq.gz" ftype="fastq.gz" />
+            </output_collection>
         </test>
         <!-- Ensure built-in adapters work -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="builtin"/>
@@ -364,7 +375,7 @@ $read_mod_options.trim_n
             <output name="out1" file="cutadapt_builtin.out" ftype="fastq"/>
         </test>
         <!-- Ensure discard file output works -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
             <param name="adapter" value="TTAGACATATCTCCGTCG"/>
@@ -380,7 +391,7 @@ $read_mod_options.trim_n
             </assert_command>
         </test>
         <!-- Ensure rest file output works -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="input_1" ftype="fasta" value="cutadapt_rest.fa" />
             <param name="adapter_source_list" value="user"/>
             <param name="adapter" value="AAAGATG"/>
@@ -392,7 +403,7 @@ $read_mod_options.trim_n
             <output name="rest_output" file="cutadapt_rest2.out" ftype="fasta"/>
         </test>
         <!-- Ensure nextseq-trim option works -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="adapter_source_list" value="user"/>
@@ -402,7 +413,7 @@ $read_mod_options.trim_n
             <output name="out1" decompress="True" file="cutadapt_nextseq_out.fq.gz" ftype="fastq.gz"/>
         </test>
         <!-- Ensure Report and Info file output work -->
-        <test>
+        <test expect_num_outputs="3">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
@@ -419,7 +430,7 @@ $read_mod_options.trim_n
         </test>
 
 
-        <test>
+        <test expect_num_outputs="1">
             <conditional name="library">
                 <param name="type" value="single" />
                 <param name="input_1" ftype="fastq" value="cutadapt_in_split.fastq" />
@@ -453,7 +464,7 @@ $read_mod_options.trim_n
              </output_collection>
         </test>
 
-        <test>
+        <test expect_num_outputs="1">
             <conditional name="library">
                 <param name="type" value="single" />
                 <param name="input_1" ftype="fastq.gz" value="cutadapt_in_split.fastq.gz" />
@@ -480,7 +491,7 @@ $read_mod_options.trim_n
         </test>
 
         <!-- Ensure untrimmed file output works -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
@@ -490,7 +501,7 @@ $read_mod_options.trim_n
             <output name="untrimmed_output" file="cutadapt_untrimmed.out" ftype="fastq"/>
         </test>
         <!-- Ensure untrimmed gzip file output works -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="adapter_source_list" value="user"/>
@@ -506,7 +517,7 @@ $read_mod_options.trim_n
             <output name="untrimmed_output" file="cutadapt_untrimmed.out.gz" compare="sim_size" delta="4000" ftype="fastq.gz"/>
         </test>
         <!-- same as 1st test with paired data + filter options (because of discard_untrimmed no comparison is done) -->
-        <test>
+        <test expect_num_outputs="2">
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -338,11 +338,6 @@
                             <option type="from_param" name="library.input_1" param_attribute="ext" />
                         </action>
                     </when>
-                    <when value="paired_collection">
-                        <action type="format">
-                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
-                        </action>
-                    </when>
                 </conditional>
             </actions>
         </xml>
@@ -353,11 +348,6 @@
                     <when value="paired">
                         <action type="format">
                             <option type="from_param" name="library.input_2" param_attribute="ext" />
-                        </action>
-                    </when>
-                    <when value="paired_collection">
-                        <action type="format">
-                            <option type="from_param" name="library.input_1" param_attribute="reverse.ext" />
                         </action>
                     </when>
                 </conditional>


### PR DESCRIPTION
I thought it would be better to create a pair if the input is a pair.

Maybe one should also use `format_source` for `out1` and `out2` instead of the `inherit_format_...` macros?

Just have seen that there is now cutadapt 3.x .. I think this will be a good target for argparse2tool. I was searching for a playground for this for a while :) .. 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
