### PR TITLE
fix stacks2 populations test

### DIFF
--- a/tools/stacks2/stacks_populations.xml
+++ b/tools/stacks2/stacks_populations.xml
@@ -405,7 +405,7 @@ $advanced_options.log_fst_comp
             <output ftype="tabular" name="out_structure" value="populations/populations.structure" compare="sim_size" delta="50"/><!-- " -->
             <output ftype="tabular" name="out_radpainter" value="populations/populations.haps.radpainter" compare="sim_size" delta="50"/><!-- " -->
             <output ftype="tabular" name="out_treemix" value="populations/populations.treemix" compare="sim_size" delta="50"/><!-- " -->
-            <output ftype="gtf" name="out_gtf" value="populations/populations.gtf"/><!-- " -->
+            <output ftype="gtf" name="out_gtf" value="populations/populations.gtf" lines_diff="2"/><!-- " -->
         </test>
         <!-- test w vcf input and default options, just checking if finished -->
         <test expect_num_outputs="6">


### PR DESCRIPTION
gtf file contains a line with a date

is currently failing CI

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
