### PR TITLE
add calculate_numeric_param tool

### DIFF
--- a/tools/calculate_numeric_param/.shed.yml
+++ b/tools/calculate_numeric_param/.shed.yml
@@ -1,0 +1,11 @@
+categories:
+- Text Manipulation
+description: Calculate a numeric parameter value using integer and float values.
+homepage_url: 
+long_description: |
+  This tool can be used in workflows to calculate a numeric parameter from multiple individual
+  parameters together with simple arithmetic operations.
+name: calculate_numeric_param
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/calculate_numeric_param
+type: unrestricted

--- a/tools/calculate_numeric_param/calculate_numeric_param.xml
+++ b/tools/calculate_numeric_param/calculate_numeric_param.xml
@@ -49,10 +49,10 @@
         </param>
     </inputs>
     <outputs>
-        <output type="float" name="out1" from="output">
+        <output type="float" name="float_param" from="output">
             <filter>output_type == 'float'</filter>
         </output>
-        <output type="integer" name="out2" from="output">
+        <output type="integer" name="integer_param" from="output">
             <filter>output_type == 'integer'</filter>
         </output>
     </outputs>

--- a/tools/calculate_numeric_param/calculate_numeric_param.xml
+++ b/tools/calculate_numeric_param/calculate_numeric_param.xml
@@ -1,0 +1,134 @@
+<tool name="Calculate numeric parameter value" id="calculate_numeric_param" version="0.1.0" profile="19.05" tool_type="expression">
+    <description>from parameters</description>
+    <expression type="ecma5.1">
+{
+    let s = "";
+    for (const repeat of $job.components) {
+        s += repeat.param_type.component_value
+        s += repeat.arith
+        if (repeat.arith == "") {
+            break;
+        }
+    };
+    let e;
+    if ($job.output_type == "integer") {
+        e = parseInt(eval(s));
+    } else {
+        e = eval(s);
+    }
+    return {'output': e};
+}
+    </expression>
+    <inputs>
+        <repeat name="components" min="2">
+            <conditional name="param_type">
+                <param name="select_param_type" type="select" label="Choose the type of parameter for this field">
+                    <option value="integer">Integer Parameter</option>
+                    <option value="float">Float Parameter</option>
+                </param>
+                 <when value="integer">
+                    <param name="component_value" value="" type="integer" label="Enter integer for calculating the parameter"/>
+                </when>
+                 <when value="float">
+                    <param name="component_value" value="" type="float" label="Enter float for calculating the parameter"/>
+                </when>
+            </conditional>
+            <param name='arith' type='select' label='Choose the arithmetic operator to apply'>
+                <option value="+">Addition (+)</option>
+                <option value="-">Subtraction (-)</option>
+                <option value="*">Multiplication (*)</option>
+                <option value="/">Division (/)</option>
+                <option value="**">Exponentiation (**)</option>
+                <option value="%">Modulus (%)</option>
+                <option value="">None (expression should end here)</option>
+            </param>
+        </repeat>
+        <param name='output_type' type='select' label='Choose whether the output should be an integer or a float.'>
+            <option value="integer">Integer</option>
+            <option value="float">Float</option>
+        </param>
+    </inputs>
+    <outputs>
+        <output type="float" name="out1" from="output">
+            <filter>output_type == 'float'</filter>
+        </output>
+        <output type="integer" name="out2" from="output">
+            <filter>output_type == 'integer'</filter>
+        </output>
+    </outputs>
+    <tests>
+        <test>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="integer"/>
+                    <param name="component_value" value="1"/>
+                </conditional>
+                <param name="arith" value="+"/>
+            </repeat>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="integer"/>
+                    <param name="component_value" value="1"/>
+                </conditional>
+                <param name="arith" value=""/>
+            </repeat>
+            <param name="output_type" value="integer"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="2"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="float"/>
+                    <param name="component_value" value="1.5"/>
+                </conditional>
+                <param name="arith" value="*"/>
+            </repeat>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="float"/>
+                    <param name="component_value" value="1.5"/>
+                </conditional>
+                <param name="arith" value=""/>
+            </repeat>
+            <param name="output_type" value="float"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="2.25"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="float"/>
+                    <param name="component_value" value="1.5"/>
+                </conditional>
+                <param name="arith" value="*"/>
+            </repeat>
+            <repeat name="components">
+                <conditional name="param_type">
+                    <param name="select_param_type" value="float"/>
+                    <param name="component_value" value="1.5"/>
+                </conditional>
+                <param name="arith" value=""/>
+            </repeat>
+            <param name="output_type" value="integer"/>
+            <output name="output">
+                <assert_contents>
+                    <not_has_text text="2.25"/>
+                    <has_line line="2"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+This tool calculates an output (integer or float) parameter
+from integer and float input parameters and specified simple
+arithmetic operations (addition, subtraction, multiplication,
+division, exponentiation, and modulus).
+    ]]></help>
+</tool>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

An equivalent to https://github.com/galaxyproject/tools-iuc/blob/master/tools/compose_text_param/compose_text_param.xml, but allowing arithmetic operations on a workflow parameter. The use-case would be if I want to provide input `x` to one tool but e.g. `x+1` to another.