### PR TITLE
Updating tools/ont_fast5_api tool version(s)

### DIFF
--- a/tools/ont_fast5_api/fast5_subset.xml
+++ b/tools/ont_fast5_api/fast5_subset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="ont_fast5_api_fast5_subset" name="@TOOL_NAME@ Subset" version="@TOOL_VERSION@+galaxy1" profile="18.01">
+<tool id="ont_fast5_api_fast5_subset" name="@TOOL_NAME@ Subset" version="@TOOL_VERSION@+galaxy0" profile="18.01">
     <description>of multi read file(s)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ont_fast5_api/macros.xml
+++ b/tools/ont_fast5_api/macros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">3.1.3</token>
+    <token name="@TOOL_VERSION@">3.3.0</token>
     <token name="@TOOL_NAME@">ont_fast5_api:</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">ont-fast5-api</requirement>
-            <requirement type="package" version="1.10.5">hdf5</requirement>
+            <requirement type="package" version="1.12.0">hdf5</requirement>
         </requirements>
     </xml>
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ont_fast5_api**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.