### PR TITLE
Add header with samtools view for alignments produced via minimap2

### DIFF
--- a/tools/minimap2/macros.xml
+++ b/tools/minimap2/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.20</token>
-    <token name="@GALAXY_TOOL_VERSION@">galaxy0</token>
+    <token name="@GALAXY_TOOL_VERSION@">galaxy1</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0102</edam_topic>

--- a/tools/minimap2/macros.xml
+++ b/tools/minimap2/macros.xml
@@ -24,17 +24,15 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citations>
-                <citation type="doi">10.1093/bioinformatics/btp324</citation>
-                <citation type="doi">10.1093/bioinformatics/btp698</citation>
-                <citation type="bibtex">@misc{1303.3997,
-                    Author = {Heng Li},
-                    Title = {Minimap2: fast pairwise alignment for long nucleotide sequences},
-                    Year = {2017},
-                    Eprint = {arXiv:1708.01492},
-                    url = {https://arxiv.org/abs/1708.01492},
-                    }</citation>
-            </citations>
+            <citation type="doi">10.1093/bioinformatics/btp324</citation>
+            <citation type="doi">10.1093/bioinformatics/btp698</citation>
+            <citation type="bibtex">@misc{1303.3997,
+                Author = {Heng Li},
+                Title = {Minimap2: fast pairwise alignment for long nucleotide sequences},
+                Year = {2017},
+                Eprint = {arXiv:1708.01492},
+                url = {https://arxiv.org/abs/1708.01492},
+                }</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -398,7 +398,7 @@
             <param name="fastq_input_selector" value="single"/>
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fasta1.fa"/>
             <param name="analysis_type_selector" value="sr"/>
-            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test cram output -->
@@ -417,7 +417,7 @@
             <param name="fastq_input_selector" value="paired"/>
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fastq1.fq"/>
             <param name="fastq_input2" ftype="fastqsanger" value="bwa-mem-fastq2.fq"/>
-            <output name="alignment_output" ftype="bam" file="minimap2-test1.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test1.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test paired input with one pair compressed -->
@@ -426,7 +426,7 @@
             <param name="fastq_input_selector" value="paired"/>
             <param name="fastq_input1" ftype="fastqsanger.gz" value="bwa-mem-fastq1.fq.gz"/>
             <param name="fastq_input2" ftype="fastqsanger" value="bwa-mem-fastq2.fq"/>
-            <output name="alignment_output" ftype="bam" file="minimap2-test1.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test1.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test collection input -->
@@ -439,7 +439,7 @@
                     <element name="reverse" value="bwa-mem-fastq2.fq" />
                 </collection>
             </param>
-            <output name="alignment_output" ftype="bam" file="minimap2-test2.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test2.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test data table reference -->
@@ -448,7 +448,7 @@
             <param name="fastq_input_selector" value="single"/>
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fasta1.fa"/>
             <param name="analysis_type_selector" value="sr"/>
-            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test alignment options -->
@@ -471,7 +471,7 @@
                 <param name="z" value="400" />
                 <param name="s" value="40" />
             </section>
-            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="4" />
         </test>        
         <test>
             <!-- test paf output -->
@@ -490,7 +490,7 @@
             <param name="fastq_input_selector" value="single" />
             <param name="fastq_input1" ftype="fasta" value="minimap2-self-homology.fasta" />
             <param name="analysis_type_selector" value="self-homology" />
-            <output name="alignment_output" ftype="bam" file="minimap2-self-homology.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-self-homology.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test mask-len option -->
@@ -502,7 +502,7 @@
             <section name="mapping_options">
                 <param name="mask_len" value="100"/>
             </section>
-            <output name="alignment_output" ftype="bam" file="minimap2-test-mask_len.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test-mask_len.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test map-hifi -->
@@ -511,7 +511,7 @@
             <param name="fastq_input_selector" value="single"/>
             <param name="fastq_input1" ftype="fastqsanger" value="pacbio_hifi_reads.fasta.gz"/>
             <param name="analysis_type_selector" value="map-hifi"/>
-            <output name="alignment_output" ftype="bam" file="minimap2-test_hifi-fasta.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test_hifi-fasta.bam" lines_diff="4" />
         </test>
         <test>
             <!-- test kmer ocurrence interval option -->
@@ -525,7 +525,7 @@
                 <param name="lower_limit" value="10"/>
                 <param name="upper_limit" value="30"/>
             </conditional>
-            <output name="alignment_output" ftype="bam" file="minimap2-test-kmer_ocurrence.bam" lines_diff="2" />
+            <output name="alignment_output" ftype="bam" file="minimap2-test-kmer_ocurrence.bam" lines_diff="4" />
         </test>
     </tests>
     <help>

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -147,15 +147,16 @@
     #else if $fastq_input.fastq_input_selector == 'paired_collection':
          '$fastq_input.fastq_input1.forward' '$fastq_input.fastq_input1.reverse'
     #end if
+    #if str($io_options.output_format) in ('BAM', 'CRAM'):
+        -a | samtools view --no-PG -hT reference.fa
+    #end if
     #if $io_options.output_format == 'BAM':
-        -a
         | samtools sort
         -@\${GALAXY_SLOTS:-2}
         -T "\${TMPDIR:-.}"
         -O $io_options.output_format
         -o '$alignment_output'
     #else if $io_options.output_format == 'CRAM':
-        -a
         | samtools sort
         -T "\${TMPDIR:-.}"
         -@\${GALAXY_SLOTS:-2}

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -6,7 +6,6 @@
     </macros>
     <expand macro="edam_ontology"/>
     <expand macro="requirements"/>
-    <expand macro="pe_anaylsis_fixed_selector"/>
     <stdio>
         <exit_code range="1:" level="fatal" />
         <regex match="\[ERROR\]" source="stderr" level="fatal" />


### PR DESCRIPTION
Fixes #3734. The
problem is that minimap2 splits indexes above a certain basecount
(4GB by default, configurable with the -I parameter). If that
happens the SQ header lines won't be written, so we add them here.

Not sure about the performance impact of the additional samtools view
step ... it's probably minimal since it's sam in, sam out ?

Otherwise we could do something like
`(samtools view -H new_header.sam; minimap <options>) | samtool
sort` but getting a SAM header out of a fasta file would require
a custom script, it seems.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
