### PR TITLE
escape backslash

### DIFF
--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -136,7 +136,7 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                 For example: '%CHROM\_%POS\_%REF\_%FIRST_ALT'
                 </help>
                 <sanitizer sanitize="False"/>
-                <validator type="regex" message="">^([+]?(%[A-Z]+)(\_%[A-Z]+)*)?$</validator>
+                <validator type="regex" message="">^([+]?(%[A-Z]+)(\\_%[A-Z]+)*)?$</validator>
             </param>
         </section>
         <section name="sec_annotate" expanded="false" title="Change Annotations">


### PR DESCRIPTION
In its current form the regex for "set ID" did not actually allow input like "%CHROM\_%POS" because the backslash is not allowed. With the change the "set ID" option works as expected.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
