### PR TITLE
biom: convert: use biom1 and biom2 data types

### DIFF
--- a/tools/biom_format/biom_convert.xml
+++ b/tools/biom_format/biom_convert.xml
@@ -1,4 +1,4 @@
-<tool id="biom_convert" name="Convert" version="@VERSION@.3">
+<tool id="biom_convert" name="Convert" version="@VERSION@.4">
     <description>between BIOM table formats</description>
     <macros>
         <import>macros.xml</import>
@@ -113,7 +113,8 @@
         <data format="biom1" name="output_fp">
             <change_format>
                 <when input="output.type_selector" value="tsv" format="tabular" />
-                <when input="output.biom_type" value="hdf5" format="h5" />
+                <when input="output.biom_type" value="json" format="biom1" />
+                <when input="output.biom_type" value="hdf5" format="biom2" />
             </change_format>
         </data>
     </outputs>


### PR DESCRIPTION
- set biom1 output type explicitly
- use biom2 type instead of h5

A bit unsure about the 2nd change .. are there downstream tools that use biom2 files as h5? 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
