### PR TITLE
Update mothur fetcher

### DIFF
--- a/data_managers/data_manager_mothur_toolsuite/.shed.yml
+++ b/data_managers/data_manager_mothur_toolsuite/.shed.yml
@@ -5,6 +5,6 @@ homepage_url: https://github.com/galaxyproject/tools-iuc/
 long_description: |
     Download reference data for Mothur tools
 name: data_manager_mothur_toolsuite
-owner: rhpvorderman
+owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/data_managers/data_manager_mothur_toolsuite/
 type: unrestricted

--- a/data_managers/data_manager_mothur_toolsuite/.shed.yml
+++ b/data_managers/data_manager_mothur_toolsuite/.shed.yml
@@ -5,6 +5,6 @@ homepage_url: https://github.com/galaxyproject/tools-iuc/
 long_description: |
     Download reference data for Mothur tools
 name: data_manager_mothur_toolsuite
-owner: iuc
+owner: rhpvorderman
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/data_managers/data_manager_mothur_toolsuite/
 type: unrestricted

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -2,7 +2,7 @@
 <tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.1.5" tool_type="manage_data" profile="19.05">
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
-        <requirement type="package" version="2.7">python</requirement>
+        <requirement type="package" version="3.7">python</requirement>
     </requirements>
     <command><![CDATA[
         python '$__tool_directory__/fetch_mothur_reference_data.py'

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.2.0" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.2.1" tool_type="manage_data" profile="19.05">
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
         <requirement type="package" version="3.8">python</requirement>

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -2,7 +2,7 @@
 <tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.1.5" tool_type="manage_data" profile="19.05">
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
-        <requirement type="package" version="3.7">python</requirement>
+        <requirement type="package" version="3.8">python</requirement>
     </requirements>
     <command><![CDATA[
         python '$__tool_directory__/fetch_mothur_reference_data.py'

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -35,12 +35,14 @@
                     <option value="lookup_titanium">GS FLX Titanium lookup files</option>
                     <option value="lookup_gsflx">GSFLX lookup files</option>
                     <option value="lookup_gs20">GS20 lookup files</option>
+                    <option value="RDP_v18">RDP reference files (training set version 18)</option>
                     <option value="RDP_v16">RDP reference files (training set version 16)</option>
                     <option value="RDP_v14">RDP reference files (training set version 14)</option>
                     <option value="RDP_v10">RDP reference files (training set version 10)</option>
                     <option value="RDP_v9">RDP reference files (training set version 9)</option>
                     <option value="RDP_v7">RDP reference files (training set version 7)</option>
                     <option value="RDP_v6">RDP reference files (training set version 6)</option>
+                    <option value="silva_release_138.1">SILVA reference files (release 138.1)</option>
                     <option value="silva_release_128">SILVA reference files (release 128)</option>
                     <option value="silva_release_123">SILVA reference files (release 123)</option>
                     <option value="silva_release_119">SILVA reference files (release 119)</option>

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -3,6 +3,10 @@
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
         <requirement type="package" version="3.8">python</requirement>
+        <!--Since we are downloading data it is more important to have an
+         up-to-date container with the latest CA certificates than a bit-by-bit
+         reproducible image.-->
+        <container type="docker">python:3.8-slim</container>
     </requirements>
     <command><![CDATA[
         python '$__tool_directory__/fetch_mothur_reference_data.py'

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -3,10 +3,6 @@
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
         <requirement type="package" version="3.8">python</requirement>
-        <!--Since we are downloading data it is more important to have an
-         up-to-date container with the latest CA certificates than a bit-by-bit
-         reproducible image.-->
-        <container type="docker">python:3.8-slim</container>
     </requirements>
     <command><![CDATA[
         python '$__tool_directory__/fetch_mothur_reference_data.py'

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.1.5" tool_type="manage_data" profile="19.05">
+<tool id="data_manager_fetch_mothur_reference_data" name="Fetch Mothur toolsuite reference data" version="0.2.0" tool_type="manage_data" profile="19.05">
     <description>Fetch and install reference data for Mothur</description>
     <requirements>
         <requirement type="package" version="3.8">python</requirement>

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/data_manager_fetch_mothur_reference_data.xml
@@ -99,6 +99,18 @@
             </output>
         </test>
         <test>
+            <param name="data_source|ref_data" value="RDP_v18"/>
+            <output name="out_file">
+                <assert_contents>
+                    <has_text text="16S rRNA RDP training set 18" />
+                    <has_text text="trainset18_062020.rdp.fasta" />
+                    <has_text text="trainset18_062020.rdp.tax" />
+                    <has_text text="trainset18_062020.pds.fasta" />
+                    <has_text text="trainset18_062020.pds.tax" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
             <param name="data_source|ref_data" value="RDP_v16"/>
             <output name="out_file">
                 <assert_contents>

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -38,6 +38,14 @@ MOTHUR_REFERENCE_DATA = {
     },
     # RDP reference files
     # http://www.mothur.org/wiki/RDP_reference_files
+    "RDP_v18": {
+        "16S rRNA RDP training set 18":
+            [
+                "https://mothur.s3.us-east-2.amazonaws.com/wiki/trainset18_062020.rdp.tgz", ],
+        "16S rRNA PDS training set 18":
+            [
+                "https://mothur.s3.us-east-2.amazonaws.com/wiki/trainset18_062020.pds.tgz", ],
+    },
     "RDP_v16": {
         "16S rRNA RDP training set 16":
         ["https://mothur.s3.us-east-2.amazonaws.com/wiki/trainset16_022016.rdp.tgz", ],
@@ -76,6 +84,12 @@ MOTHUR_REFERENCE_DATA = {
     },
     # Silva reference files
     # http://www.mothur.org/wiki/Silva_reference_files
+    "silva_release_138.1": {
+        "SILVA release 138.1":
+            [
+                "https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.nr_v138_1.tgz",
+                "https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.seed_v138_1.tgz", ],
+    },
     "silva_release_128": {
         "SILVA release 128":
         ["https://mothur.s3.us-east-2.amazonaws.com/wiki/silva.nr_v128.tgz",

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -449,7 +449,7 @@ def fetch_from_mothur_website(data_tables, target_dir, datasets):
             for f in fetch_files(MOTHUR_REFERENCE_DATA[dataset][name], wd=wd):
                 type_ = identify_type(f)
                 name_from_file = os.path.splitext(os.path.basename(f))[0]
-                entry_name = f"{name_from_file} {name}"
+                entry_name = f"{name_from_file} ({name})"
                 print(f"{type_}\t\'{entry_name}'\t.../{os.path.basename(f)}")
                 if type_ is not None:
                     # Move to target dir

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import zipfile
 from functools import reduce
 
@@ -230,14 +230,14 @@ def download_file(url, target=None, wd=None):
     Returns the name that the file is saved with.
 
     """
-    print("Downloading %s" % url)
+    print(("Downloading %s" % url))
     if not target:
         target = os.path.basename(url)
     if wd:
         target = os.path.join(wd, target)
-    print("Saving to %s" % target)
+    print(("Saving to %s" % target))
     with open(target, 'wb') as fh:
-        fh.write(urllib2.urlopen(url).read())
+        fh.write(urllib.request.urlopen(url).read())
     return target
 
 
@@ -263,7 +263,7 @@ def unpack_zip_archive(filen, wd=None):
     with zipfile.ZipFile(filen) as z:
         for name in z.namelist():
             if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-                print("Ignoring %s" % name)
+                print(("Ignoring %s" % name))
                 continue
             if wd:
                 target = os.path.join(wd, name)
@@ -271,14 +271,14 @@ def unpack_zip_archive(filen, wd=None):
                 target = name
             if name.endswith('/'):
                 # Make directory
-                print("Creating dir %s" % target)
+                print(("Creating dir %s" % target))
                 try:
                     os.makedirs(target)
                 except OSError:
                     pass
             else:
                 # Extract file
-                print("Extracting %s" % name)
+                print(("Extracting %s" % name))
                 try:
                     os.makedirs(os.path.dirname(target))
                 except OSError:
@@ -286,7 +286,7 @@ def unpack_zip_archive(filen, wd=None):
                 with open(target, 'wb') as fh:
                     fh.write(z.read(name))
                 file_list.append(target)
-    print("Removing %s" % filen)
+    print(("Removing %s" % filen))
     os.remove(filen)
     return file_list
 
@@ -315,17 +315,17 @@ def unpack_tar_archive(filen, wd=None):
         for name in t.getnames():
             # Check for unwanted files
             if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-                print("Ignoring %s" % name)
+                print(("Ignoring %s" % name))
                 continue
             # Extract file
-            print("Extracting %s" % name)
+            print(("Extracting %s" % name))
             t.extract(name, wd)
             if wd:
                 target = os.path.join(wd, name)
             else:
                 target = name
             file_list.append(target)
-    print("Removing %s" % filen)
+    print(("Removing %s" % filen))
     os.remove(filen)
     return file_list
 
@@ -343,9 +343,9 @@ def unpack_archive(filen, wd=None):
     current working directory.
 
     """
-    print("Unpack %s" % filen)
+    print(("Unpack %s" % filen))
     ext = os.path.splitext(filen)[1]
-    print("Extension: %s" % ext)
+    print(("Extension: %s" % ext))
     if ext == ".zip":
         return unpack_zip_archive(filen, wd=wd)
     elif ext == ".tgz":
@@ -386,7 +386,7 @@ def identify_type(filen):
     try:
         return MOTHUR_FILE_TYPES[ext]
     except KeyError:
-        print("WARNING: unknown file type for " + filen + ", skipping")
+        print(("WARNING: unknown file type for " + filen + ", skipping"))
         return None
 
 
@@ -419,26 +419,26 @@ def fetch_from_mothur_website(data_tables, target_dir, datasets):
     """
     # Make working dir
     wd = tempfile.mkdtemp(suffix=".mothur", dir=os.getcwd())
-    print("Working dir %s" % wd)
+    print(("Working dir %s" % wd))
     # Iterate over all requested reference data URLs
     for dataset in datasets:
-        print("Handling dataset '%s'" % dataset)
+        print(("Handling dataset '%s'" % dataset))
         for name in MOTHUR_REFERENCE_DATA[dataset]:
             for f in fetch_files(MOTHUR_REFERENCE_DATA[dataset][name], wd=wd):
                 type_ = identify_type(f)
                 entry_name = "%s (%s)" % (os.path.splitext(os.path.basename(f))[0], name)
-                print("%s\t\'%s'\t.../%s" % (type_, entry_name, os.path.basename(f)))
+                print(("%s\t\'%s'\t.../%s" % (type_, entry_name, os.path.basename(f))))
                 if type_ is not None:
                     # Move to target dir
                     ref_data_file = os.path.basename(f)
                     f1 = os.path.join(target_dir, ref_data_file)
-                    print("Moving %s to %s" % (f, f1))
+                    print(("Moving %s to %s" % (f, f1)))
                     os.rename(f, f1)
                     # Add entry to data table
                     table_name = "mothur_%s" % type_
                     add_data_table_entry(data_tables, table_name, dict(name=entry_name, value=ref_data_file))
     # Remove working dir
-    print("Removing %s" % wd)
+    print(("Removing %s" % wd))
     shutil.rmtree(wd)
 
 
@@ -454,7 +454,7 @@ def files_from_filesystem_paths(paths):
     files = []
     for path in paths:
         path = os.path.abspath(path)
-        print("Examining '%s'..." % path)
+        print(("Examining '%s'..." % path))
         if os.path.isfile(path):
             # Store full path for file
             files.append(path)
@@ -493,14 +493,14 @@ def import_from_server(data_tables, target_dir, paths, description, link_to_data
     for f in files:
         type_ = identify_type(f)
         if type_ is None:
-            print("%s: unrecognised type, skipped" % f)
+            print(("%s: unrecognised type, skipped" % f))
             continue
         ref_data_file = os.path.basename(f)
         target_file = os.path.join(target_dir, ref_data_file)
         entry_name = "%s" % os.path.splitext(ref_data_file)[0]
         if description:
             entry_name += " (%s)" % description
-        print("%s\t\'%s'\t.../%s" % (type_, entry_name, ref_data_file))
+        print(("%s\t\'%s'\t.../%s" % (type_, entry_name, ref_data_file)))
         # Link to or copy the data
         if link_to_data:
             os.symlink(f, target_file)
@@ -522,8 +522,8 @@ if __name__ == "__main__":
     parser.add_option('--description', action='store', dest='description', default='')
     parser.add_option('--link', action='store_true', dest='link_to_data')
     options, args = parser.parse_args()
-    print("options: %s" % options)
-    print("args   : %s" % args)
+    print(("options: %s" % options))
+    print(("args   : %s" % args))
 
     # Check for JSON file
     if len(args) != 1:
@@ -536,7 +536,7 @@ if __name__ == "__main__":
     params, target_dir = read_input_json(jsonfile)
 
     # Make the target directory
-    print("Making %s" % target_dir)
+    print(("Making %s" % target_dir))
     os.mkdir(target_dir)
 
     # Set up data tables dictionary

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Data manager for reference data for the 'mothur_toolsuite' Galaxy tools
 import json

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -247,12 +247,12 @@ def download_file(url, target=None, wd=None):
     Returns the name that the file is saved with.
 
     """
-    print(("Downloading %s" % url))
+    print(f"Downloading {url}")
     if not target:
         target = os.path.basename(url)
     if wd:
         target = os.path.join(wd, target)
-    print(("Saving to %s" % target))
+    print(f"Saving to {target}")
     with open(target, 'wb') as fh:
         url_h = urllib.request.urlopen(url)
         while True:
@@ -279,13 +279,13 @@ def unpack_zip_archive(filen, wd=None):
 
     """
     if not zipfile.is_zipfile(filen):
-        print("%s: not ZIP formatted file")
+        print(f"{filen}: not ZIP formatted file")
         return [filen]
     file_list = []
     with zipfile.ZipFile(filen) as z:
         for name in z.namelist():
             if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-                print(("Ignoring %s" % name))
+                print(f"Ignoring {name}")
                 continue
             if wd:
                 target = os.path.join(wd, name)
@@ -293,14 +293,14 @@ def unpack_zip_archive(filen, wd=None):
                 target = name
             if name.endswith('/'):
                 # Make directory
-                print(("Creating dir %s" % target))
+                print(f"Creating dir {target}")
                 try:
                     os.makedirs(target)
                 except OSError:
                     pass
             else:
                 # Extract file
-                print(("Extracting %s" % name))
+                print("Extracting {target}")
                 try:
                     os.makedirs(os.path.dirname(target))
                 except OSError:
@@ -308,7 +308,7 @@ def unpack_zip_archive(filen, wd=None):
                 with open(target, 'wb') as fh:
                     fh.write(z.read(name))
                 file_list.append(target)
-    print(("Removing %s" % filen))
+    print(f"Removing {filen}")
     os.remove(filen)
     return file_list
 
@@ -331,23 +331,23 @@ def unpack_tar_archive(filen, wd=None):
     """
     file_list = []
     if not tarfile.is_tarfile(filen):
-        print("%s: not TAR file")
+        print(f"{filen}: not TAR file")
         return [filen]
     with tarfile.open(filen) as t:
         for name in t.getnames():
             # Check for unwanted files
             if reduce(lambda x, y: x or name.startswith(y), IGNORE_PATHS, False):
-                print(("Ignoring %s" % name))
+                print(f"Ignoring {name}")
                 continue
             # Extract file
-            print(("Extracting %s" % name))
+            print(f"Extracting {name}")
             t.extract(name, wd)
             if wd:
                 target = os.path.join(wd, name)
             else:
                 target = name
             file_list.append(target)
-    print(("Removing %s" % filen))
+    print(f"Removing {filen}")
     os.remove(filen)
     return file_list
 
@@ -365,9 +365,9 @@ def unpack_archive(filen, wd=None):
     current working directory.
 
     """
-    print(("Unpack %s" % filen))
+    print(f"Unpack {filen}")
     ext = os.path.splitext(filen)[1]
-    print(("Extension: %s" % ext))
+    print(f"Extension: {ext}")
     if ext == ".zip":
         return unpack_zip_archive(filen, wd=wd)
     elif ext == ".tgz":
@@ -408,7 +408,7 @@ def identify_type(filen):
     try:
         return MOTHUR_FILE_TYPES[ext]
     except KeyError:
-        print(("WARNING: unknown file type for " + filen + ", skipping"))
+        print(f"WARNING: unknown file type for {filen}, skipping")
         return None
 
 
@@ -441,26 +441,27 @@ def fetch_from_mothur_website(data_tables, target_dir, datasets):
     """
     # Make working dir
     wd = tempfile.mkdtemp(suffix=".mothur", dir=os.getcwd())
-    print(("Working dir %s" % wd))
+    print(f"Working dir {wd}")
     # Iterate over all requested reference data URLs
     for dataset in datasets:
-        print(("Handling dataset '%s'" % dataset))
+        print(f"Handling dataset '{dataset}'")
         for name in MOTHUR_REFERENCE_DATA[dataset]:
             for f in fetch_files(MOTHUR_REFERENCE_DATA[dataset][name], wd=wd):
                 type_ = identify_type(f)
-                entry_name = "%s (%s)" % (os.path.splitext(os.path.basename(f))[0], name)
-                print(("%s\t\'%s'\t.../%s" % (type_, entry_name, os.path.basename(f))))
+                name_from_file = os.path.splitext(os.path.basename(f))[0]
+                entry_name = f"{name_from_file} {name}"
+                print(f"{type_}\t\'{entry_name}'\t.../{os.path.basename(f)}")
                 if type_ is not None:
                     # Move to target dir
                     ref_data_file = os.path.basename(f)
                     f1 = os.path.join(target_dir, ref_data_file)
-                    print(("Moving %s to %s" % (f, f1)))
+                    print(f"Moving {f} to {f1}")
                     shutil.move(f, f1)
                     # Add entry to data table
-                    table_name = "mothur_%s" % type_
+                    table_name = f"mothur_{type_}"
                     add_data_table_entry(data_tables, table_name, dict(name=entry_name, value=ref_data_file))
     # Remove working dir
-    print(("Removing %s" % wd))
+    print(f"Removing {wd}")
     shutil.rmtree(wd)
 
 
@@ -476,7 +477,7 @@ def files_from_filesystem_paths(paths):
     files = []
     for path in paths:
         path = os.path.abspath(path)
-        print(("Examining '%s'..." % path))
+        print(f"Examining '{path}'...")
         if os.path.isfile(path):
             # Store full path for file
             files.append(path)
@@ -515,21 +516,21 @@ def import_from_server(data_tables, target_dir, paths, description, link_to_data
     for f in files:
         type_ = identify_type(f)
         if type_ is None:
-            print(("%s: unrecognised type, skipped" % f))
+            print(f"{f}: unrecognised type, skipped")
             continue
         ref_data_file = os.path.basename(f)
         target_file = os.path.join(target_dir, ref_data_file)
         entry_name = "%s" % os.path.splitext(ref_data_file)[0]
         if description:
             entry_name += " (%s)" % description
-        print(("%s\t\'%s'\t.../%s" % (type_, entry_name, ref_data_file)))
+        print(f"{type_}\t\'{entry_name}'\t.../{ref_data_file}")
         # Link to or copy the data
         if link_to_data:
             os.symlink(f, target_file)
         else:
             shutil.copyfile(f, target_file)
         # Add entry to data table
-        table_name = "mothur_%s" % type_
+        table_name = f"mothur_{type_}"
         add_data_table_entry(data_tables, table_name, dict(name=entry_name, value=ref_data_file))
 
 
@@ -544,8 +545,8 @@ if __name__ == "__main__":
     parser.add_option('--description', action='store', dest='description', default='')
     parser.add_option('--link', action='store_true', dest='link_to_data')
     options, args = parser.parse_args()
-    print(("options: %s" % options))
-    print(("args   : %s" % args))
+    print(f"options: {options}")
+    print(f"args   : {args}")
 
     # Check for JSON file
     if len(args) != 1:
@@ -558,7 +559,7 @@ if __name__ == "__main__":
     params, target_dir = read_input_json(jsonfile)
 
     # Make the target directory
-    print(("Making %s" % target_dir))
+    print(f"Making {target_dir}")
     os.mkdir(target_dir)
 
     # Set up data tables dictionary

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -8,7 +8,9 @@ import shutil
 import sys
 import tarfile
 import tempfile
-import urllib.request, urllib.error, urllib.parse
+import urllib.error
+import urllib.parse
+import urllib.request
 import zipfile
 from functools import reduce
 

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -447,7 +447,7 @@ def fetch_from_mothur_website(data_tables, target_dir, datasets):
                     ref_data_file = os.path.basename(f)
                     f1 = os.path.join(target_dir, ref_data_file)
                     print(("Moving %s to %s" % (f, f1)))
-                    os.rename(f, f1)
+                    shutil.move(f, f1)
                     # Add entry to data table
                     table_name = "mothur_%s" % type_
                     add_data_table_entry(data_tables, table_name, dict(name=entry_name, value=ref_data_file))

--- a/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
+++ b/data_managers/data_manager_mothur_toolsuite/data_manager/fetch_mothur_reference_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Data manager for reference data for the 'mothur_toolsuite' Galaxy tools
+import io
 import json
 import optparse
 import os
@@ -253,7 +254,12 @@ def download_file(url, target=None, wd=None):
         target = os.path.join(wd, target)
     print(("Saving to %s" % target))
     with open(target, 'wb') as fh:
-        fh.write(urllib.request.urlopen(url).read())
+        url_h = urllib.request.urlopen(url)
+        while True:
+            buffer = url_h.read(io.DEFAULT_BUFFER_SIZE)
+            if buffer == b"":
+                break
+            fh.write(buffer)
     return target
 
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This updates the data manager that fetches mothur reference datasets.

- Updated the tool to python3 with `2to3`.  Move to python 3.8. According to the python documentation moving files has had some optimizations in 3.8.
- ~Added a container requirement to circumvent any issues that arise from biocontainers base-container shennannigans (like: https://github.com/galaxyproject/galaxy/issues/12184)~
- Add the latest mothur references from the website
- Fix a bug where `os.rename` was used to move a file. `os.rename` only works for files on the same physical disk, and this is not necessarily the case on cluster filesystems. Use `shutil.move` instead, which always works.
- Fix an issue where the entire file would be read into memory during the download. This is now done in chunks.

A test has been added for one of the new reference. The SILVA reference was too big, but it has been tested on our testgalaxy instance and confirmed to be working.