### PR TITLE
Cutadapt: remove duplicated cut option

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -699,9 +699,9 @@ $read_mod_options.zero_cap
                     <conditional name="adapter_source">
                         <param name="adapter_source_list" value="user"/>
                         <param name="adapter" value="AGATCGGAAGAGC"/>
-                        <param name="cut" value="5"/>
                     </conditional>
                 </repeat>
+                <param name="cut" value="5"/>
             </section>
             <output name="out1" file="cutadapt_small_cut.out" ftype="fastq"/>
         </test>
@@ -714,9 +714,9 @@ $read_mod_options.zero_cap
                     <conditional name="adapter_source">
                         <param name="adapter_source_list" value="user"/>
                         <param name="adapter" value="AGATCGGAAGAGC"/>
-                        <param name="cut" value="5"/>
                     </conditional>
                 </repeat>
+                <param name="cut" value="5"/>
             </section>
             <section name="read_mod_options">
                 <param name="rename" value="{id} barcode={cut_prefix}"/>

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -603,10 +603,12 @@ $read_mod_options.zero_cap
         <!-- Test cut option -->
         <test expect_num_outputs="1">
             <param name="type" value="single" />
-            <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="cut" value="5"/>
+            <section name="r1">
+                <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <param name="cut" value="5"/>
+            </section>
             <output name="out1" file="cutadapt_small_cut.out" ftype="fastq"/>
         </test>
         <!-- Test rename options -->

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -149,9 +149,6 @@ $read_mod_options.trim_n
 #if str($read_mod_options.length_tag) != '':
     --length-tag='$read_mod_options.length_tag'
 #end if
-#if str($read_mod_options.cut) != '0':
-    --cut=$read_mod_options.cut
-#end if
 #if str($read_mod_options.rename) != '':
     --rename='$read_mod_options.rename'
 #end if
@@ -300,7 +297,6 @@ $read_mod_options.zero_cap
                 </sanitizer>
                 <validator type="regex">[A-Za-z0-9 {}=_]+</validator>
             </param>
-            <param argument="--cut" label="Remove a fixed number of bases" type="integer" value="0" help="This option allows to unconditionally remove bases from the beginning or end of each read. If the given length is positive, the bases are removed from the beginning of each read. If it is negative, the bases are removed from the end." />
             <param argument="--zero-cap" type="boolean" truevalue="--zero-cap" falsevalue="" checked="False" label="Change negative quality values to zero" />
         </section>
 
@@ -610,9 +606,7 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
             <param name="adapter" value="AGATCGGAAGAGC"/>
-             <section name="read_mod_options">
-                <param name="cut" value="5"/>
-            </section>
+            <param name="cut" value="5"/>
             <output name="out1" file="cutadapt_small_cut.out" ftype="fastq"/>
         </test>
         <!-- Test rename options -->
@@ -621,8 +615,8 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <param name="adapter_source_list" value="user"/>
             <param name="adapter" value="AGATCGGAAGAGC"/>
-            <section name="read_mod_options">
-                <param name="cut" value="5"/>
+            <param name="cut" value="5"/>
+            <section name="read_mod_options">       
                 <param name="rename" value="{id} barcode={cut_prefix}"/>
             </section>
             <output name="out1" file="cutadapt_small_rename.out" ftype="fastq">

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -234,7 +234,7 @@ $read_mod_options.zero_cap
                 </when>
                 <when value="False">
                 </when>
-            </conditional>   
+            </conditional>
             <param argument="--max-n" type="float" min="0" optional="True" label="Max N" help="Discard reads with more than this number of 'N' bases. A number between 0 and 1 is interpreted as a fraction of the read length." />
             <param argument="--pair-filter" type="select" optional="True" label="Pair filter" help="Which of the reads in a paired-end read have to match the filtering criterion in order for the pair to be filtered. Default: any">
                 <option value="any" selected="True">Any: a read pair is discarded (or redirected) if one of the reads (R1 or R2) fulfills the filtering criterion. </option>
@@ -384,16 +384,20 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
             <output name="out1" file="cutadapt_small.out" ftype="fastq"/>
         </test>
         <!-- Ensure single end fastq.gz works -->
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
             <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
         </test>
         <!-- Ensure paired end fastq.gz works -->
@@ -401,10 +405,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
             <output name="out2" decompress="True" file="cutadapt_out2.fq.gz" ftype="fastq.gz"/>
             <assert_command>
@@ -425,10 +433,14 @@ $read_mod_options.zero_cap
                     <element name="reverse" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
                 </collection>
             </param>
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <output_collection name="out_pairs" type="paired">
                 <element name="forward" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz" />
                 <element name="reverse" decompress="True" file="cutadapt_out2.fq.gz" ftype="fastq.gz" />
@@ -438,15 +450,19 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="builtin"/>
-            <param name="adapter" value="TGTAGGCC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="builtin"/>
+                <param name="adapter" value="TGTAGGCC"/>
+            </section>
             <output name="out1" file="cutadapt_builtin.out" ftype="fastq"/>
         </test>
         <!-- Ensure discard file output works -->
         <test expect_num_outputs="1">
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="TTAGACATATCTCCGTCG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="TTAGACATATCTCCGTCG"/>
+            </section>
             <param name="output_filtering" value="filter"/>
             <section name="filter_options">
                 <param name="discard_trimmed" value="True"/>
@@ -460,8 +476,10 @@ $read_mod_options.zero_cap
         <!-- Ensure rest file output works -->
         <test expect_num_outputs="2">
             <param name="input_1" ftype="fasta" value="cutadapt_rest.fa" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AAAGATG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AAAGATG"/>
+            </section>
             <param name="output_filtering" value="default"/>
             <param name="read_modification" value="none"/>
             <param name="output_selector" value="rest_file"/>
@@ -472,8 +490,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
             <param name="read_modification" value="modify"/>
             <param name="nextseq_trim" value="20" />
             <output name="out1" decompress="True" file="cutadapt_nextseq_out.fq.gz" ftype="fastq.gz"/>
@@ -482,8 +502,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="3">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
             <param name="output_selector" value="report,info_file" />
             <output name="out1" value="cutadapt_small.out" ftype="fastq"/>
             <output name="report">
@@ -555,8 +577,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AAAT"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AAAT"/>
+            </section>
             <param name="output_selector" value="untrimmed_file" />
             <output name="out1" file="cutadapt_trimmed.out" ftype="fastq"/>
             <output name="untrimmed_output" file="cutadapt_untrimmed.out" ftype="fastq"/>
@@ -565,11 +589,13 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="2">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
             <param name="output_selector" value="untrimmed_file" />
             <output name="out1" decompress="True" file="cutadapt_trimmed.out.gz" ftype="fastq.gz"/>
-            <!-- 
+            <!--
                 Do not use the decompress option for this assertion, since it does NOT test that the file is compressed
                 See discussion at https://github.com/galaxyproject/galaxy/issues/7671
                 `delta="4000" is more than the difference between gzip level 1 and gzip level 9, but much less than the
@@ -582,10 +608,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <section name="filter_options">
                 <param name="discard_untrimmed" value="true"/>
                 <param name="minimun_length" value="1"/>
@@ -603,8 +633,8 @@ $read_mod_options.zero_cap
         <!-- Test cut option -->
         <test expect_num_outputs="1">
             <param name="type" value="single" />
+            <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
                 <param name="adapter_source_list" value="user"/>
                 <param name="adapter" value="AGATCGGAAGAGC"/>
                 <param name="cut" value="5"/>
@@ -615,10 +645,12 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="cut" value="5"/>
-            <section name="read_mod_options">       
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <param name="cut" value="5"/>
+            </section>
+            <section name="read_mod_options">
                 <param name="rename" value="{id} barcode={cut_prefix}"/>
             </section>
             <output name="out1" file="cutadapt_small_rename.out" ftype="fastq">
@@ -631,8 +663,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="CGTCCGAANTAG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="CGTCCGAANTAG"/>
+            </section>
             <section name="adapter_options">
                 <param name="action" value="retain"/>
             </section>
@@ -641,8 +675,10 @@ $read_mod_options.zero_cap
            <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="CGTCCGAANTAG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="CGTCCGAANTAG"/>
+            </section>
             <section name="adapter_options">
                 <param name="action" value="mask"/>
             </section>
@@ -651,8 +687,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="CGTCCGAANTAG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="CGTCCGAANTAG"/>
+            </section>
             <section name="adapter_options">
                 <param name="action" value="lowercase"/>
             </section>
@@ -661,8 +699,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="CGTCCGAANTAG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="CGTCCGAANTAG"/>
+            </section>
             <section name="adapter_options">
                 <param name="action" value="none"/>
             </section>
@@ -672,8 +712,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="TAAACAGATTAGT"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="TAAACAGATTAGT"/>
+            </section>
             <section name="adapter_options">
                 <param name="revcomp" value="true"/>
             </section>
@@ -684,10 +726,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="ATCTGGTTCC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="CTACAAG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="ATCTGGTTCC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="CTACAAG"/>
+            </section>
             <section name="filter_options">
                 <param name="minimum_length" value="30"/>
                 <param name="pair_filter" value="both"/>
@@ -708,10 +754,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
                 <param name="maximum_length" value="50"/>
@@ -732,10 +782,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
                 <param name="minimum_length" value="10"/>
@@ -757,10 +811,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
                 <param name="minimum_length" value="10"/>
@@ -782,8 +840,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGCCGCTANGACG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGCCGCTANGACG"/>
+            </section>
             <section name="read_mod_options">
                 <conditional name="shorten_options">
                     <param name="shorten_values" value="True"/>
@@ -796,8 +856,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGCCGCTANGACG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGCCGCTANGACG"/>
+            </section>
             <section name="read_mod_options">
                 <conditional name="shorten_options">
                     <param name="shorten_values" value="True"/>
@@ -811,8 +873,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGCGGCTTAGACG"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGCGGCTTAGACG"/>
+            </section>
             <section name="filter_options">
                 <param name="max_expected_errors" value="10"/>
             </section>
@@ -822,8 +886,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="GAANTAGCTACCAC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="GAANTAGCTACCAC"/>
+            </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>
             </section>
@@ -836,10 +902,14 @@ $read_mod_options.zero_cap
             <param name="type" value="paired" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
-            <param name="adapter_source_list" value="user"/>
-            <param name="adapter" value="AGATCGGAAGAGC"/>
-            <param name="adapter_source_list2" value="user"/>
-            <param name="adapter2" value="AGATCGGAAGAGC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="user"/>
+                <param name="adapter" value="AGATCGGAAGAGC"/>
+            </section>
+            <section name="r2">
+                <param name="adapter_source_list2" value="user"/>
+                <param name="adapter2" value="AGATCGGAAGAGC"/>
+            </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>
             </section>
@@ -852,8 +922,10 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
-            <param name="adapter_source_list" value="builtin"/>
-            <param name="adapter" value="TGTAGGCC"/>
+            <section name="r1">
+                <param name="adapter_source_list" value="builtin"/>
+                <param name="adapter" value="TGTAGGCC"/>
+            </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>
             </section>

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -385,8 +385,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <output name="out1" file="cutadapt_small.out" ftype="fastq"/>
         </test>
@@ -395,8 +399,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
         </test>
@@ -406,12 +414,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <output name="out1" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz"/>
             <output name="out2" decompress="True" file="cutadapt_out2.fq.gz" ftype="fastq.gz"/>
@@ -434,12 +450,20 @@ $read_mod_options.zero_cap
                 </collection>
             </param>
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <output_collection name="out_pairs" type="paired">
                 <element name="forward" decompress="True" file="cutadapt_out1.fq.gz" ftype="fastq.gz" />
@@ -451,8 +475,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="builtin"/>
-                <param name="adapter" value="TGTAGGCC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="builtin"/>
+                        <param name="adapter" value="TGTAGGCC"/>
+                    </conditional>
+                </repeat>
             </section>
             <output name="out1" file="cutadapt_builtin.out" ftype="fastq"/>
         </test>
@@ -460,8 +488,12 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="1">
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="TTAGACATATCTCCGTCG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="TTAGACATATCTCCGTCG"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="output_filtering" value="filter"/>
             <section name="filter_options">
@@ -477,8 +509,12 @@ $read_mod_options.zero_cap
         <test expect_num_outputs="2">
             <param name="input_1" ftype="fasta" value="cutadapt_rest.fa" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AAAGATG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AAAGATG"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="output_filtering" value="default"/>
             <param name="read_modification" value="none"/>
@@ -491,8 +527,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="read_modification" value="modify"/>
             <param name="nextseq_trim" value="20" />
@@ -503,8 +543,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="output_selector" value="report,info_file" />
             <output name="out1" value="cutadapt_small.out" ftype="fastq"/>
@@ -578,8 +622,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AAAT"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AAAT"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="output_selector" value="untrimmed_file" />
             <output name="out1" file="cutadapt_trimmed.out" ftype="fastq"/>
@@ -590,8 +638,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <param name="output_selector" value="untrimmed_file" />
             <output name="out1" decompress="True" file="cutadapt_trimmed.out.gz" ftype="fastq.gz"/>
@@ -609,12 +661,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="discard_untrimmed" value="true"/>
@@ -635,9 +695,13 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
-                <param name="cut" value="5"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                        <param name="cut" value="5"/>
+                    </conditional>
+                </repeat>
             </section>
             <output name="out1" file="cutadapt_small_cut.out" ftype="fastq"/>
         </test>
@@ -646,9 +710,13 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
-                <param name="cut" value="5"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                        <param name="cut" value="5"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="read_mod_options">
                 <param name="rename" value="{id} barcode={cut_prefix}"/>
@@ -664,8 +732,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="CGTCCGAANTAG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="CGTCCGAANTAG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="action" value="retain"/>
@@ -676,8 +748,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="CGTCCGAANTAG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="CGTCCGAANTAG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="action" value="mask"/>
@@ -688,8 +764,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="CGTCCGAANTAG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="CGTCCGAANTAG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="action" value="lowercase"/>
@@ -700,8 +780,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="CGTCCGAANTAG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="CGTCCGAANTAG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="action" value="none"/>
@@ -713,8 +797,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="TAAACAGATTAGT"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="TAAACAGATTAGT"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="revcomp" value="true"/>
@@ -727,12 +815,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="ATCTGGTTCC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="ATCTGGTTCC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="CTACAAG"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="CTACAAG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="minimum_length" value="30"/>
@@ -755,12 +851,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
@@ -783,12 +887,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
@@ -812,12 +924,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="pair_filter" value="both"/>
@@ -841,8 +961,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGCCGCTANGACG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGCCGCTANGACG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="read_mod_options">
                 <conditional name="shorten_options">
@@ -857,8 +981,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGCCGCTANGACG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGCCGCTANGACG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="read_mod_options">
                 <conditional name="shorten_options">
@@ -874,8 +1002,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGCGGCTTAGACG"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGCGGCTTAGACG"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="filter_options">
                 <param name="max_expected_errors" value="10"/>
@@ -887,8 +1019,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="GAANTAGCTACCAC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="GAANTAGCTACCAC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>
@@ -903,12 +1039,20 @@ $read_mod_options.zero_cap
             <param name="input_1" ftype="fastq.gz" value="bwa-mem-fastq1_assimetric.fq.gz" />
             <param name="input_2" ftype="fastq.gz" value="bwa-mem-fastq2_assimetric.fq.gz" />
             <section name="r1">
-                <param name="adapter_source_list" value="user"/>
-                <param name="adapter" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="user"/>
+                        <param name="adapter" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="r2">
-                <param name="adapter_source_list2" value="user"/>
-                <param name="adapter2" value="AGATCGGAAGAGC"/>
+                <repeat name="adapters2">
+                    <conditional name="adapter_source2">
+                        <param name="adapter_source_list2" value="user"/>
+                        <param name="adapter2" value="AGATCGGAAGAGC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>
@@ -923,8 +1067,12 @@ $read_mod_options.zero_cap
             <param name="type" value="single" />
             <param name="input_1" ftype="fastq" value="cutadapt_small.fastq" />
             <section name="r1">
-                <param name="adapter_source_list" value="builtin"/>
-                <param name="adapter" value="TGTAGGCC"/>
+                <repeat name="adapters">
+                    <conditional name="adapter_source">
+                        <param name="adapter_source_list" value="builtin"/>
+                        <param name="adapter" value="TGTAGGCC"/>
+                    </conditional>
+                </repeat>
             </section>
             <section name="adapter_options">
                 <param name="internal" value="X"/>

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.4</token>
-    <token name="@GALAXY_TOOL_VERSION@">galaxy</token>
+    <token name="@GALAXY_TOOL_VERSION@">galaxy0</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0632</edam_topic>

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -265,7 +265,7 @@
                     </conditional>
                 </repeat>
 
-                <param name="cut" argument="-u" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming. (--cut)" />
+                <param name="cut" argument="-u/--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming. (--cut)" />
 
             </section>
 

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.4</token>
-    <token name="@GALAXY_TOOL_VERSION@">galaxy0</token>
+    <token name="@GALAXY_TOOL_VERSION@">galaxy</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0632</edam_topic>
@@ -265,7 +265,7 @@
                     </conditional>
                 </repeat>
 
-                <param name="cut" argument="-u" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
+                <param name="cut" argument="-u" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming. (--cut)" />
 
             </section>
 

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.4</token>
-    <token name="@GALAXY_TOOL_VERSION@">galaxy0</token>
+    <token name="@GALAXY_TOOL_VERSION@">galaxy1</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0632</edam_topic>

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -265,7 +265,7 @@
                     </conditional>
                 </repeat>
 
-                <param name="cut" argument="-u/--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
+                <param name="cut" argument="--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
 
             </section>
 

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -265,7 +265,7 @@
                     </conditional>
                 </repeat>
 
-                <param name="cut" argument="-u/--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming. (--cut)" />
+                <param name="cut" argument="-u/--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
 
             </section>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

An eagle-eyed user noticed that the cut option is present twice. It was in the tool form listed as the short form -u (as -U is the option for Read 2) and it was recently added again as --cut. This PR removes the --cut option and adds `(--cut)` to the help for the -u option to clarify it is the --cut option.
