### PR TITLE
Fix --cs option of minimap2

### DIFF
--- a/tools/minimap2/macros.xml
+++ b/tools/minimap2/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.20</token>
-    <token name="@GALAXY_TOOL_VERSION@">galaxy1</token>
+    <token name="@GALAXY_TOOL_VERSION@">galaxy2</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0102</edam_topic>

--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -131,7 +131,7 @@
     $io_options.L
     $io_options.c
     #if $io_options.cs:
-        --cs $io_options.cs
+        --cs=$io_options.cs
     #end if
     $io_options.Y
     #if $io_options.K:
@@ -469,6 +469,11 @@
                 <param name="E2" value="1" />
                 <param name="z" value="400" />
                 <param name="s" value="40" />
+            </section>
+            <section name="io_options">
+                <!-- the next setting is a noop for bam output, but tests that
+                a valid command line is formed for the cs option -->
+                <param name="cs" value="none" />
             </section>
             <output name="alignment_output" ftype="bam" file="minimap2-test1-fasta.bam" lines_diff="4" />
         </test>        


### PR DESCRIPTION
This option needs to be specified with --cs=[string], --cs string is not
acceptable.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
