### PR TITLE
Fix missed pRESTO version macro update

### DIFF
--- a/tools/presto/presto_alignsets.xml
+++ b/tools/presto/presto_alignsets.xml
@@ -1,4 +1,4 @@
-<tool id="presto_alignsets" name="pRESTO AlignSets" version="@PRESTO_VERSION@">
+<tool id="presto_alignsets" name="pRESTO AlignSets" version="@TOOL_VERSION@">
     <description>Multiple-align sequences with the same barcodes.</description>
     
     <macros>

--- a/tools/presto/presto_assemblepairs.xml
+++ b/tools/presto/presto_assemblepairs.xml
@@ -1,4 +1,4 @@
-<tool id="presto_assemblepairs" name="pRESTO AssemblePairs" version="@PRESTO_VERSION@">
+<tool id="presto_assemblepairs" name="pRESTO AssemblePairs" version="@TOOL_VERSION@">
     <description>Assembles paired-end reads into a single sequence.</description>
     
     <macros>

--- a/tools/presto/presto_buildconsensus.xml
+++ b/tools/presto/presto_buildconsensus.xml
@@ -1,4 +1,4 @@
-<tool id="presto_buildconsensus" name="pRESTO BuildConsensus" version="@PRESTO_VERSION@">
+<tool id="presto_buildconsensus" name="pRESTO BuildConsensus" version="@TOOL_VERSION@">
     <description>Builds a consensus sequence for each set of input sequences</description>
     
     <macros>

--- a/tools/presto/presto_collapseseq.xml
+++ b/tools/presto/presto_collapseseq.xml
@@ -1,4 +1,4 @@
-<tool id="presto_collapseseq" name="pRESTO CollapseSeq" version="@PRESTO_VERSION@">
+<tool id="presto_collapseseq" name="pRESTO CollapseSeq" version="@TOOL_VERSION@">
     <description>Remove/collapse duplicate sequences</description>
     
     <macros>

--- a/tools/presto/presto_filterseq.xml
+++ b/tools/presto/presto_filterseq.xml
@@ -1,4 +1,4 @@
-<tool id="presto_filterseq" name="pRESTO FilterSeq" version="@PRESTO_VERSION@">
+<tool id="presto_filterseq" name="pRESTO FilterSeq" version="@TOOL_VERSION@">
     <description>Filters and/or masks reads based on length, quality, missing bases and repeats.</description>
     
     <macros>

--- a/tools/presto/presto_macros.xml
+++ b/tools/presto/presto_macros.xml
@@ -39,7 +39,7 @@
     <token name="@PRESTO_URL_BASE@">https://presto.readthedocs.io</token>
     
     <!-- When modifying this file ensure that the version here matches the version above in requirements. -->
-    <token name="@PRESTO_VERSION@">0.5.4</token>
+    <token name="@PRESTO_VERSION@">0.6.2</token>
     
     <token name="@HELP_NOTE@"><![CDATA[
 

--- a/tools/presto/presto_macros.xml
+++ b/tools/presto/presto_macros.xml
@@ -6,11 +6,11 @@
         </citations>
     </xml>
 
-    <token name="@PRESTO_VERSION@">0.6.2</token>
+    <token name="@TOOL_VERSION@">0.6.2</token>
     
     <xml name="requirements">
         <requirements>
-              <requirement type="package" version="@PRESTO_VERSION@">presto</requirement>
+              <requirement type="package" version="@TOOL_VERSION@">presto</requirement>
         </requirements>
     </xml>
     

--- a/tools/presto/presto_macros.xml
+++ b/tools/presto/presto_macros.xml
@@ -5,10 +5,12 @@
             <yield />
         </citations>
     </xml>
+
+    <token name="@PRESTO_VERSION@">0.6.2</token>
     
     <xml name="requirements">
         <requirements>
-              <requirement type="package" version="0.6.2">presto</requirement>
+              <requirement type="package" version="@PRESTO_VERSION@">presto</requirement>
         </requirements>
     </xml>
     
@@ -37,9 +39,6 @@
     </xml>
 
     <token name="@PRESTO_URL_BASE@">https://presto.readthedocs.io</token>
-    
-    <!-- When modifying this file ensure that the version here matches the version above in requirements. -->
-    <token name="@PRESTO_VERSION@">0.6.2</token>
     
     <token name="@HELP_NOTE@"><![CDATA[
 

--- a/tools/presto/presto_maskprimers.xml
+++ b/tools/presto/presto_maskprimers.xml
@@ -1,4 +1,4 @@
-<tool id="presto_maskprimers" name="pRESTO MaskPrimers" version="@PRESTO_VERSION@">
+<tool id="presto_maskprimers" name="pRESTO MaskPrimers" version="@TOOL_VERSION@">
     <description>Removes primers and annotates sequences with primer and barcode identifiers.</description>
     
     <macros>

--- a/tools/presto/presto_pairseq.xml
+++ b/tools/presto/presto_pairseq.xml
@@ -1,4 +1,4 @@
-<tool id="presto_pairseq" name="pRESTO PairSeq" version="@PRESTO_VERSION@">
+<tool id="presto_pairseq" name="pRESTO PairSeq" version="@TOOL_VERSION@">
     <description>Sorts and matches sequence records with matching coordinates across files</description>
     
     <macros>

--- a/tools/presto/presto_parseheaders.xml
+++ b/tools/presto/presto_parseheaders.xml
@@ -1,4 +1,4 @@
-<tool id="presto_parseheaders" name="pRESTO ParseHeaders" version="@PRESTO_VERSION@">
+<tool id="presto_parseheaders" name="pRESTO ParseHeaders" version="@TOOL_VERSION@">
     <description>Manage annotations in FASTQ headers.</description>
     
     <macros>

--- a/tools/presto/presto_parselog.xml
+++ b/tools/presto/presto_parselog.xml
@@ -1,4 +1,4 @@
-<tool id="presto_parselog" name="pRESTO ParseLog" version="@PRESTO_VERSION@">
+<tool id="presto_parselog" name="pRESTO ParseLog" version="@TOOL_VERSION@">
     <description>Create tabular report from pRESTO log file</description>
     
     <macros>

--- a/tools/presto/presto_partition.xml
+++ b/tools/presto/presto_partition.xml
@@ -1,4 +1,4 @@
-<tool id="presto_partition" name="pRESTO Partition" version="@PRESTO_VERSION@">
+<tool id="presto_partition" name="pRESTO Partition" version="@TOOL_VERSION@">
     <description>Partition a file in two</description>
     
     <macros>

--- a/tools/presto/prestor_abseq3.xml
+++ b/tools/presto/prestor_abseq3.xml
@@ -1,4 +1,4 @@
-<tool id="prestor_abseq3" name="pRESTOr AbSeq3 Report" version="@PRESTO_VERSION@+galaxy1">
+<tool id="prestor_abseq3" name="pRESTOr AbSeq3 Report" version="@TOOL_VERSION@+galaxy1">
     <description>Create HTML QC report from pRESTO outputs</description>
     
     <macros>


### PR DESCRIPTION
The tools were actually updated in #3747, but because this version macro wasn't updated, they do not appear as new versions in the Tool Shed.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
