### PR TITLE
Update Snippy v4.6

### DIFF
--- a/tools/snippy/macros.xml
+++ b/tools/snippy/macros.xml
@@ -8,7 +8,7 @@
     </xml>
 
     <token name="@WRAPPER_VERSION@">4.6.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="version_command">
         <version_command><![CDATA[snippy --version]]></version_command>

--- a/tools/snippy/macros.xml
+++ b/tools/snippy/macros.xml
@@ -7,7 +7,7 @@
         </requirements>
     </xml>
 
-    <token name="@WRAPPER_VERSION@">4.5.0</token>
+    <token name="@WRAPPER_VERSION@">4.6.0</token>
     <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="version_command">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This PR updates the Snippy tool up to version 4.6. According to the developers, it includes the following improvements:
- Now runs 2 to 3 times faster due to new threading support in markdup and fixmate
- All required Linux binaries are now bundled to simplify container building
- Reinstated TRAVIS testing
- Improved CPU spreading logic for main alignment pipeline stages
- Variants near contig ends will be less likely to be missed due to improved samclip
- Bundled tools now fully python3 compatible