### PR TITLE
annotatemyids: Drop from_work_dir attribute from outputs

### DIFF
--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -1,4 +1,4 @@
-<tool id="annotatemyids" name="annotateMyIDs" version="3.12.0">
+<tool id="annotatemyids" name="annotateMyIDs" version="3.12.0+galaxy1">
     <description>annotate a generic set of identifiers</description>
     <requirements>
         <requirement type="package" version="3.12.0">bioconductor-org.hs.eg.db</requirement>

--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -102,8 +102,8 @@ write.table(result, file='$out_tab', sep="\t", row.names=FALSE, quote=FALSE)
         <param name="rscriptOpt" type="boolean" truevalue="TRUE" falsevalue="FALSE" checked="False" label="Output Rscript?" help="If this option is set to Yes, the Rscript used to annotate the IDs will be provided as a text file in the output. Default: No" />
     </inputs>
     <outputs>
-        <data name="out_tab" format="tabular" from_work_dir="*.tab" label="${tool.name} on ${on_string}: Annotated IDs" />
-        <data name="out_rscript" format="txt" from_work_dir="*.txt" label="${tool.name} on ${on_string}: Rscript">
+        <data name="out_tab" format="tabular" label="${tool.name} on ${on_string}: Annotated IDs" />
+        <data name="out_rscript" format="txt" label="${tool.name} on ${on_string}: Rscript">
             <filter>rscriptOpt is True</filter>
         </data>
     </outputs>


### PR DESCRIPTION
...since the tool writes to the output dataset paths directly.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
