### PR TITLE
Updating tools/nanocompore tool version(s)

### DIFF
--- a/tools/nanocompore/macros.xml
+++ b/tools/nanocompore/macros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.0.0rc3.post2</token>
+    <token name="@TOOL_VERSION@">1.0.4</token>
     <token name="@DESCRIPTION@"></token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">nanocompore</requirement>
-            <requirement type="package" version="1.32">tar</requirement>
+            <requirement type="package" version="1.34">tar</requirement>
         </requirements>
     </xml>
     <xml name="citations">

--- a/tools/nanocompore/nanocompore_db.xml
+++ b/tools/nanocompore/nanocompore_db.xml
@@ -1,4 +1,4 @@
-<tool id="nanocompore_db" name="NanoComporeDB" version="@TOOL_VERSION@+galaxy2">
+<tool id="nanocompore_db" name="NanoComporeDB" version="@TOOL_VERSION@+galaxy0">
     <description>Process SampComp results database</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nanocompore**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.