### PR TITLE
Updating tools/odgi tool to 0.6.3 0.7.0
0.8.2

### DIFF
--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.8.0</token>
+    <token name="@TOOL_VERSION@">0.8.1</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.6.2</token>
+    <token name="@TOOL_VERSION@">0.6.3</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.3</token>
+    <token name="@TOOL_VERSION@">0.6</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.7.1</token>
+    <token name="@TOOL_VERSION@">0.7.2</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.7.2</token>
+    <token name="@TOOL_VERSION@">0.7.3</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.7.3</token>
+    <token name="@TOOL_VERSION@">0.8.0</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.7.0</token>
+    <token name="@TOOL_VERSION@">0.7.1</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.6.3</token>
+    <token name="@TOOL_VERSION@">0.7.0</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.8.1</token>
+    <token name="@TOOL_VERSION@">0.8.2</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.6</token>
+    <token name="@TOOL_VERSION@">0.6.1</token>
     <xml name="citations">
         <citations>
             <yield />

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -5,7 +5,7 @@
             <requirement type="package" version="@TOOL_VERSION@">odgi</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.6.1</token>
+    <token name="@TOOL_VERSION@">0.6.2</token>
     <xml name="citations">
         <citations>
             <yield />


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/odgi**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.