### PR TITLE
tb_variant_filter: fix invalid xml

### DIFF
--- a/tools/tb_variant_filter/tb_variant_filter.xml
+++ b/tools/tb_variant_filter/tb_variant_filter.xml
@@ -1,4 +1,4 @@
-<tool id="tb_variant_filter" name="TB Variant Filter" version="@TOOL_VERSION@+galaxy0" profile="21.01">
+<tool id="tb_variant_filter" name="TB Variant Filter" version="@TOOL_VERSION@+galaxy1" profile="21.01">
     <description>M. tuberculosis H37Rv VCF filter</description>
     <macros>
         <token name="@TOOL_VERSION@">0.3.5</token>
@@ -135,7 +135,7 @@
             </conditional>
             <assert_stderr>
                 <has_text text="masked: 2" />
-            </assert_stdout>
+            </assert_stderr>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
this should have never passed linting?

CI error reported at https://github.com/galaxyproject/tools-iuc/issues/3831