### PR TITLE
Updating tools/busco tool version(s)

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -5,7 +5,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">busco</requirement>
-        <requirement type="package" version="1.32">tar</requirement>
+        <requirement type="package" version="1.34">tar</requirement>
         <requirement type="package" version="1">fonts-conda-ecosystem</requirement>
     </requirements>
     <version_command>busco --version</version_command>

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.2.1</token>
+    <token name="@TOOL_VERSION@">5.2.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/busco**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.