### PR TITLE
updated wrapper so busco auto-detect lineage works

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -29,10 +29,10 @@ busco
 --evalue ${adv.evalue}
 --limit ${adv.limit}
 
-#if $adv.auto_lineage:
-    $adv.auto_lineage
-#else:
-    --lineage_dataset '${lineage_dataset}'
+#if $lineage.lineage_mode == "auto_detect":
+    $lineage.auto_lineage
+#else if $lineage.lineage_mode == "select_lineage":
+    --lineage_dataset '${lineage.lineage_dataset}'
 #end if
 #if $busco_mode.mode == 'geno' and $busco_mode.use_augustus.use_augustus_selector == 'yes':
 
@@ -96,19 +96,28 @@ busco
             <when value="tran" />
             <when value="prot" />
         </conditional>
-
-        <param argument="--lineage_dataset" type="select" label="Lineage">
-            <expand macro="lineages" />
-        </param>
-
+        <conditional name="lineage">
+            <param name="lineage_mode" type="select" label="Auto-detect or select lineage?" help="">
+                <option value="nothing_selected">Nothing selected</option>
+                <option value="auto_detect">Auto-detect</option>
+                <option value="select_lineage">Select lineage</option>
+            </param>
+            <when value="auto_detect">
+                <param name="auto_lineage" type="select" label="Run auto-lineage to find optimal lineage path">
+                    <option value="--auto-lineage">Run auto-lineage to find optimum lineage path</option>
+                    <option value="--auto-lineage-prok">Run auto-lineage just on non-eukaryote trees to find optimum lineage path</option>
+                    <option value="--auto-lineage-euk">Run auto-placement just on eukaryote tree to find optimum lineage path</option>
+                </param>
+            </when>
+            <when value="select_lineage">
+                <param argument="--lineage_dataset" type="select" label="Lineage">
+                    <expand macro="lineages" />
+                </param>
+            </when>
+        </conditional>
         <section name="adv" title="Advanced Options" expanded="False">
             <param argument="--evalue" type="float" value="0.001" min="0" max="1" label="E-value cutoff for BLAST searches." />
             <param argument="--limit" type="integer" value="3" label="How many candidate regions to consider" />
-            <param name="auto_lineage" type="select" optional="true" label="Run auto-lineage to find optimal lineage path">
-                <option value="--auto-lineage">Run auto-lineage to find optimum lineage path</option>
-                <option value="--auto-lineage-prok">Run auto-lineage just on non-eukaryote trees to find optimum lineage path</option>
-                <option value="--auto-lineage-euk">Run auto-placement just on eukaryote tree to find optimum lineage path</option>
-            </param>
             <param name="outputs" type="select" optional="true" multiple="true" label="Which outputs should be generated">
                 <option value="short_summary">short summary text</option>
                 <option value="missing">list with missing IDs</option>
@@ -131,7 +140,10 @@ busco
     <tests>
         <test expect_num_outputs="3">
             <param name="input" value="genome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="select_lineage" />
+                <param name="lineage_dataset" value="arthropoda_odb10" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="geno" />
                 <conditional name="use_augustus">
@@ -151,7 +163,10 @@ busco
         </test>
         <test expect_num_outputs="4">
             <param name="input" value="proteome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="select_lineage" />
+                <param name="lineage_dataset" value="arthropoda_odb10" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="prot" />
             </conditional>
@@ -165,12 +180,14 @@ busco
         </test>
         <test expect_num_outputs="4">
             <param name="input" value="transcriptome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="auto_detect" />
+                <param name="auto_lineage" value="--auto-lineage" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="tran" />
             </conditional>
             <section name="adv">
-                <param name="auto_lineage" value="--auto-lineage" />
                 <param name="outputs" value="short_summary,missing,image" />
             </section>
             <output name="busco_sum" file="transcriptome_results/short_summary" compare="diff" lines_diff="4" />
@@ -180,7 +197,10 @@ busco
         </test>
         <test expect_num_outputs="2">
             <param name="input" value="genome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="select_lineage" />
+                <param name="lineage_dataset" value="arthropoda_odb10" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="geno" />
                 <conditional name="use_augustus">
@@ -199,7 +219,10 @@ busco
         </test>
         <test expect_num_outputs="3">
             <param name="input" value="genome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="select_lineage" />
+                <param name="lineage_dataset" value="arthropoda_odb10" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="geno" />
                 <conditional name="use_augustus">
@@ -219,7 +242,10 @@ busco
         </test>
         <test expect_num_outputs="4">
             <param name="input" value="genome.fa" />
-            <param name="lineage_dataset" value="arthropoda_odb10" />
+            <conditional name="lineage">
+                <param name="lineage_mode" value="select_lineage" />
+                <param name="lineage_dataset" value="arthropoda_odb10" />
+            </conditional>
             <conditional name="busco_mode">
                 <param name="mode" value="geno" />
                 <conditional name="use_augustus">

--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -98,7 +98,6 @@ busco
         </conditional>
         <conditional name="lineage">
             <param name="lineage_mode" type="select" label="Auto-detect or select lineage?" help="">
-                <option value="nothing_selected">Nothing selected</option>
                 <option value="auto_detect">Auto-detect</option>
                 <option value="select_lineage">Select lineage</option>
             </param>

--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -22,7 +22,6 @@ export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
 
 busco
 --in '${input}'
---lineage_dataset '${lineage_dataset}'
 --update-data
 --mode '${busco_mode.mode}'
 --out busco_galaxy
@@ -32,6 +31,8 @@ busco
 
 #if $adv.auto_lineage:
     $adv.auto_lineage
+#else:
+    --lineage_dataset '${lineage_dataset}'
 #end if
 #if $busco_mode.mode == 'geno' and $busco_mode.use_augustus.use_augustus_selector == 'yes':
 

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.2.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@TOOL_VERSION@">5.2.2</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="citations">
         <citations>
@@ -109,7 +109,6 @@
     </xml>
 
     <xml name="lineages">
-        <option value="none" selected="true">None</option>
         <option value="acidobacteria_odb10">Acidobacteria</option>
         <option value="aconoidasida_odb10">Aconoidasida</option>
         <option value="actinobacteria_class_odb10">Actinobacteria class</option>

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.2.2</token>
+    <token name="@TOOL_VERSION@">5.2.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -109,6 +109,7 @@
     </xml>
 
     <xml name="lineages">
+        <option value="none" selected="true">None</option>
         <option value="acidobacteria_odb10">Acidobacteria</option>
         <option value="aconoidasida_odb10">Aconoidasida</option>
         <option value="actinobacteria_class_odb10">Actinobacteria class</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ YES ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ YES ] - License permits unrestricted use (educational + commercial)
* [ NO ] - This PR adds a new tool or tool collection
* [ YES ] - This PR updates an existing tool or tool collection
* [ NO ] - This PR does something else (explain below)

This pull fixes an issue with the busco 5.2.2 wrapper. 

When running busco, either a specific lineage should be given with --lineage_dataset, or the lineage can be auto-detected by providing --auto-lineage.  It is not allowed to pass both at the same time.   The current wrapper passes them both at the same time, disabling any use of the --auto-lineage feature as --lineage_dataset has priority.  

This pull provides a sample fix.   The command section of the tool xml should now have proper behaviour, and a 'None' option (default) has been added to the lineages. The 'None' lineage option isn't needed, but I believe will help people feel more at ease when using the tool as it is more intuitive. 