### PR TITLE
cuffmerge: fix broken generation of -s command line option in cuffmerge_wrapper.xml

### DIFF
--- a/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
+++ b/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="cuffmerge" name="Cuffmerge" version="@VERSION@.2">
+<tool id="cuffmerge" name="Cuffmerge" version="@VERSION@.3">
     <description>merge together several Cufflinks assemblies</description>
     <macros>
       <import>cuff_macros.xml</import>

--- a/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
+++ b/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
@@ -20,9 +20,9 @@
             #if $seq_data.use_seq_data == "Yes":
                 -s
                 #if $seq_data.seq_source.index_source == "history":
-                    --ref_file '${seq_data.seq_source.ref_file}'
+                    '${seq_data.seq_source.ref_file}'
                 #else:
-                    --index '${seq_data.seq_source.index.fields.path}'
+                    '${seq_data.seq_source.index.fields.path}'
                 #end if
             #end if
 


### PR DESCRIPTION
PR which fixes a bug in the generation of the command line in the tool wrapper, specifically: erroneous extra arguments were being were inserted after `-s` option when specifying sequence data (`--ref_file` or `--index`, depending on the options chosen by the user - neither of which appear in the `cuffmerge` documentation http://cole-trapnell-lab.github.io/cufflinks/cuffmerge/ - the presence of the additional argument appeared to make `cuffmerge` incorrectly use the sequence file as the assembly GTF list).

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
