### PR TITLE
Python 3.x compatibility for selection data manager.

### DIFF
--- a/data_managers/data_manager_selection_background/data_manager/data_manager_selection_background.py
+++ b/data_managers/data_manager_selection_background/data_manager/data_manager_selection_background.py
@@ -8,7 +8,6 @@ import shutil
 import sys
 import uuid
 import zipfile
-
 from urllib.request import urlretrieve
 
 # Nice solution to opening compressed files (zip/bz2/gz) transparently

--- a/data_managers/data_manager_selection_background/data_manager/data_manager_selection_background.py
+++ b/data_managers/data_manager_selection_background/data_manager/data_manager_selection_background.py
@@ -9,7 +9,7 @@ import sys
 import uuid
 import zipfile
 
-from six.moves.urllib.request import urlretrieve
+from urllib.request import urlretrieve
 
 # Nice solution to opening compressed files (zip/bz2/gz) transparently
 # https://stackoverflow.com/a/13045892/638445


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

```
Traceback (most recent call last):
  File "/cvmfs/test.galaxyproject.org/shed_tools/toolshed.g2.bx.psu.edu/repos/iuc/data_manager_selection_background/bb5794942b5e/data_manager_selection_background/data_manager/data_manager_selection_background.py", line 12, in <module>
    from six.moves.urllib.request import urlretrieve
ModuleNotFoundError: No module named 'six'
```