### PR TITLE
Fix mykrobe_predict to display sample identifiers instead of the word…

### DIFF
--- a/tools/mykrobe/macro.xml
+++ b/tools/mykrobe/macro.xml
@@ -1,121 +1,102 @@
-<?xml version="1.1"?>
 <macros>
-  <token name="@TOOL_VERSION@">0.10.0</token>
-  <xml name="requirements">
-    <requirements>
-      <requirement type="package" version="@TOOL_VERSION@">mykrobe</requirement>
-    </requirements>    
-  </xml>
-  <token name="@select_inputs@">
-    <![CDATA[
-         #set $name='sample'
-    ]]>
-  </token>
+    <token name="@TOOL_VERSION@">0.10.0</token>
+    <token name="@PROFILE@">20.09</token>
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="@TOOL_VERSION@">mykrobe</requirement>
+      </requirements>
+    </xml>
 
-  <token name="@shared_options@">
-    <![CDATA[
-        #if $kmer:
-          --kmer '${kmer}'
-        #end if
-        #if $expected_depth:
-          --expected_depth '${expected_depth}'
-        #end if
+    <token name="@shared_options@">
+        <![CDATA[
+            #if $kmer:
+                --kmer ${kmer}
+            #end if
+            #if $expected_depth:
+                --expected_depth ${expected_depth}
+            #end if
+            $ont
+            $report_all_calls
+            #if $expected_error_rate:
+                --expected_error_rate ${expected_error_rate}
+            #end if
+            #if $min_variant_conf:
+                --min_variant_conf ${min_variant_conf}
+            #end if
+            #if $min_gene_conf:
+                --min_gene_conf ${min_gene_conf}
+            #end if
+            #if $min_proportion_expected_depth:
+                --min_proportion_expected_depth ${min_proportion_expected_depth}
+            #end if
+            #if $min_gene_percent_covg_threshold:
+                --min_gene_percent_covg_threshold  ${min_gene_percent_covg_threshold}
+            #end if
+            $guess_sequence_method
+            $ignore_minor_calls
+            #if $ignore_filtered:
+                --ignore_filtered '${ignore_filtered}'
+            #end if
+            #if $model:
+                --model '${model}'
+            #end if
+            #if $ploidy:
+                --ploidy '${ploidy}'
+            #end if
+        ]]>
+    </token>
 
-        $ont
+    <xml name="inputs">
+        <conditional name="data_type">
+            <param name="type" type="select" label="Specify the read type.">
+                <option value="single">Single-end Data</option>
+                <option value="paired">Paired-end Data</option>
+                <option value="collection">Collection Paired-end Data</option>
+            </param>
+            <when value="single">
+                <param name="seq1" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz,fasta,fasta.gz,bam" label="Single end read file(s)"/>
+            </when>
+            <when value="paired">
+                <param name="seq1" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" label="Forward paired-end read file"/>
+                <param name="seq2" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" label="Reverse paired-end read file"/>
+            </when>
+            <when value="collection">
+                <param name="collection1" type="data_collection" label="Paired-end reads collection" optional="false" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" collection_type="paired" />
+            </when>
+        </conditional>
+    </xml>
 
-        $report_all_calls
+    <xml name="options">
+        <param argument="--kmer" optional="True" type="integer" min="0" label="Kmer length" value="21" help="default = 21"/>
+        <param argument="--expected_error_rate" optional="True" type="float" label="Expected error rate"  help="Expected sequencing error rate. Set to 0.15 for ONT genotyping"/>
+        <param argument="--expected_depth" optional="True" type="integer" min="0" label="Expected depth"  help=""/>
+        <param argument="--ont" type="boolean" truevalue="--ont" falsevalue="" label="Set default for ONT data"  help=""/>
+        <param argument="--min_variant_conf" optional="True" type="integer" min="0" label="Minimum genotype confidence for variant genotyping"  help=""/>
+        <param argument="--min_gene_conf" optional="True" type="integer" min="0" label="Minimum genotype confidence for gene genotyping"  help=""/>
+        <param argument="--min_gene_percent_covg_threshold" optional="True" type="integer" min="0" label="Minimum gene predict coverage"  help="all genes alleles found above this percent coverage will be reported (default 100 (only best alleles reported))"/>
+        <param argument="--min_proportion_expected_depth" optional="True" type="float" label="Minimum depth required on the sum of both alleles" help="Default 0.3 (30%)"/>
+        <param argument="--model" optional="True" type="data" format="txt" label="Genotype model used" help="default kmer_count. Options kmer_count, median_depth"/>
+        <param argument="--ploidy" optional="True" type="select" label="Diploid or Haploid" help="Use a diploid (includes 0/1 calls) or haploid genotyping model">
+            <option value="diploid">diploid</option>
+            <option value="haploid">haploid</option>
+        </param>
+        <param argument="--report_all_calls" type="boolean" truevalue="--report_all_calls" falsevalue="" label="Report all calls"  help=""/>
+        <param argument="--ignore_minor_calls" type="boolean" truevalue="--ignore_minor_calls" falsevalue="" label="Ignore minor calls"  help="Ignore minor calls when running resistance prediction"/>
+        <param argument="--ignore_filtered" type="data" format="txt" label="Ignore filtered" optional="True" help="Don't include filtered genotypes"/>
+        <param argument="--guess_sequence_method" type="boolean" truevalue="--guess_sequence_method" falsevalue="" label="Guess sequence method"  help="Guess if ONT or Illumia based on error rate. If error rate is > 10%, ploidy is set to haploid and a confidence threshold is used"/>
+    </xml>
 
-        #if $expected_error_rate:
-          --expected_error_rate '${expected_error_rate}'
-        #end if
+    <token name="@ATTRIBUTION@">
+        <![CDATA[
+            **MyKrobe predict - Antibiotic resistance predictions**
+            Rapid antibiotic-resistance predictions from genome sequence data for Staphylococcus aureus and Mycobacterium tuberculosis
+            using Bruijn graph.
+        ]]>
+    </token>
 
-        #if $min_variant_conf:
-          --min_variant_conf '${min_variant_conf}'
-        #end if
-
-        #if $min_gene_conf:
-          --min_gene_conf '${min_gene_conf}'
-        #end if
-
-        #if $min_proportion_expected_depth:
-          --min_proportion_expected_depth '${min_proportion_expected_depth}'
-        #end if
-
-        #if $min_gene_percent_covg_threshold:
-          --min_gene_percent_covg_threshold  '${min_gene_percent_covg_threshold}'
-        #end if
-
-        $guess_sequence_method
-
-        $ignore_minor_calls
-
-        #if $ignore_filtered:
-          --ignore_filtered '${ignore_filtered}'
-        #end if
-
-        #if $model:
-          --model '${model}'
-        #end if
-
-        #if $ploidy:
-          --ploidy '${ploidy}'
-        #end if
-    ]]>
-  </token>
-
-  <xml name="inputs">
-    <conditional name="data_type">
-      <param name="type" type="select" label="Specify the read type.">
-        <option value="single">Single-end Data</option>
-        <option value="paired">Paired-end Data</option>
-        <option value="collection">Collection Paired-end Data</option>
-      </param>
-      <when value="single">
-        <param name="seq1" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz,fasta,fasta.gz,bam" label="Single end read file(s)"/>
-      </when>
-      <when value="paired">
-        <param name="seq1" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" label="Forward paired-end read file"/>
-        <param name="seq2" type="data" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" label="Reverse paired-end read file"/>
-      </when>
-      <when value="collection">
-        <param name="collection1" type="data_collection" label="Paired-end reads collection" optional="false" format="fastqsanger,fastqsanger.gz,fastq,fastq.gz" collection_type="paired" />
-      </when>
-    </conditional>
-  </xml>
-
-  <xml name="options">
-    <param argument="--kmer" optional="True" type="integer" min="0" label="Kmer length" value="21" help="default = 21"/>
-    <param argument="--expected_error_rate" optional="True" type="float" label="Expected error rate"  help="Expected sequencing error rate. Set to 0.15 for ONT genotyping"/>
-    <param argument="--expected_depth" optional="True" type="integer" min="0" label="Expected depth"  help=""/>
-    <param argument="--ont" type="boolean" truevalue="--ont" falsevalue="" label="Set default for ONT data"  help=""/>
-    <param argument="--min_variant_conf" optional="True" type="integer" min="0" label="Minimum genotype confidence for variant genotyping"  help=""/>      
-    <param argument="--min_gene_conf" optional="True" type="integer" min="0" label="Minimum genotype confidence for gene genotyping"  help=""/>
-    <param argument="--min_gene_percent_covg_threshold" optional="True" type="integer" min="0" label="Minimum gene predict coverage"  help="all genes alleles found above this percent coverage will be reported (default 100 (only best alleles reported))"/>      
-    <param argument="--min_proportion_expected_depth" optional="True" type="float" label="Minimum depth required on the sum of both alleles" help="Default 0.3 (30%)"/>
-    <param argument="--model" optional="True" type="data" format="txt" label="Genotype model used" help="default kmer_count. Options kmer_count, median_depth"/>
-    <param argument="--ploidy" optional="True" type="select" label="Diploid or Haploid" help="Use a diploid (includes 0/1 calls) or haploid genotyping model">
-      <option value="diploid">diploid</option>
-      <option value="haploid">haploid</option>
-    </param>
-    <param argument="--report_all_calls" type="boolean" truevalue="--report_all_calls" falsevalue="" label="Report all calls"  help=""/>
-    <param argument="--ignore_minor_calls" type="boolean" truevalue="--ignore_minor_calls" falsevalue="" label="Ignore minor calls"  help="Ignore minor calls when running resistance prediction"/>
-    <param argument="--ignore_filtered" type="data" format="txt" label="Ignore filtered" optional="True" help="Don't include filtered genotypes"/>
-    <param argument="--guess_sequence_method" type="boolean" truevalue="--guess_sequence_method" falsevalue="" label="Guess sequence method"  help="Guess if ONT or Illumia based on error rate. If error rate is > 10%, ploidy is set to haploid and a confidence threshold is used"/>
-  </xml>
-
-  <token name="@ATTRIBUTION@">
-    <![CDATA[
-             
-             **MyKrobe predict - Antibiotic resistance predictions**
-             
-             Rapid antibiotic-resistance predictions from genome sequence data for Staphylococcus aureus and Mycobacterium tuberculosis
-             using Bruijn graph.
-    ]]>      
-  </token>
-
-  <xml name="citation">
-    <citations>
-      <citation type="doi">10.1038/ncomms10063</citation>
-    </citations>
-  </xml>
+    <xml name="citation">
+        <citations>
+            <citation type="doi">10.1038/ncomms10063</citation>
+        </citations>
+    </xml>
 </macros>

--- a/tools/mykrobe/mykrobe_predict.xml
+++ b/tools/mykrobe/mykrobe_predict.xml
@@ -1,129 +1,140 @@
-<tool id="mykrobe_predict" name="mkyrobe predict" version="@TOOL_VERSION@">
-  <description>Antibiotic resistance predictions</description>
-  <macros>
-    <import>macro.xml</import>
-  </macros>
-  <expand macro="requirements"/>
-  <command detect_errors="exit_code">
-<![CDATA[
-        @select_inputs@
+<tool id="mykrobe_predict" name="mkyrobe predict" version="@TOOL_VERSION@.1+galaxy0"  profile="@PROFILE@">
+    <description>Antibiotic resistance predictions</description>
+    <macros>
+        <import>macro.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command detect_errors="exit_code"><![CDATA[
+#import difflib
+#import re
 
-        mykrobe predict 
-        --sample '${name}'
-        --species ${select_species.species}
-        --panel '${select_species.panel}'
+mykrobe predict
+--species '${select_species.species}'
+--panel '${select_species.panel}'
 
-        #if $conf_percent_cutoff:
-          --conf_percent_cutoff '${conf_percent_cutoff}'
-        #end if
+#if $conf_percent_cutoff:
+    --conf_percent_cutoff '${conf_percent_cutoff}'
+#end if
 
-        #if $min_depth:
-          --min_depth '${min_depth}'
-        #end if
+#if $min_depth:
+    --min_depth ${min_depth}
+#end if
 
-        @shared_options@
+@shared_options@
 
-        -q
-        -t "\${GALAXY_SLOTS:-1}"
+-q
+-t "\${GALAXY_SLOTS:-1}"
 
-        --seq
-        #if $data_type.type == "single":
-          $data_type.seq1
-        #elif $data_type.type == "paired":
-	  $data_type.seq1 $data_type.seq2
-        #elif $data_type.type == "collection":
-          $data_type.collection1.forward $data_type.collection1.reverse
-	#end if
+#if $data_type.type in ["single", "paired"]:
+    #set read1 = $data_type.seq1
+    #set read1_identifier = re.sub('[^\s\w\-]', '_', str($read1.element_identifier))
+    #if $data_type.type == "single":
+        --sample '${read1_identifier}'
+    --seq '${read1}'
+    #else:
+        #set read2 = $data_type.seq2
+        #set read2_identifier = re.sub('[^\s\w\-]', '_', str($read2.element_identifier))
+        #set matches = difflib.SequenceMatcher(None, read1_identifier, read2_identifier).get_matching_blocks()
+        #set match = $matches[0]
+        #set identifier = re.sub('[^\s\w\-]', '_', str($read1_identifier[match.a:match.a + match.size]))
+    --sample '${identifier}'
+    --seq '${read1}' '${read2}'
+    #end if
+#elif $data_type.type == "collection":
+    #set identifier = re.sub('[^\s\w\-]', '_', str($data_type.collection1.element_identifier))
+    --sample '${identifier}'
+    --seq '${data_type.collection1.forward}' '${data_type.collection1.reverse}'
+#end if
 
-        --format '${format}'
+--format '${format}'
 
-        > '$output'
-]]>
-  </command>
-  <inputs>
-    <expand macro="inputs"/>
-    <conditional name="select_species">
-      <param name="species" type="select" label="Specify Species for AMR">
-        <option value="tb">Mycobacterium tuberculosis (tb)</option>
-        <option value="staph">Staphylococcus aureus (staph)</option>
-        <option value="sonnei">Shigella sonnei (sonnei)</option>
-      </param>
-      <when value="staph">
-        <param name="panel" type="select" label="Select panel for Staph only">
-          <option value="20170217">20170217</option>
+> '$output']]>
+    </command>
+    <inputs>
+        <expand macro="inputs"/>
+        <conditional name="select_species">
+            <param name="species" type="select" label="Specify Species for AMR">
+                <option value="tb">Mycobacterium tuberculosis (tb)</option>
+                <option value="staph">Staphylococcus aureus (staph)</option>
+                <option value="sonnei">Shigella sonnei (sonnei)</option>
+            </param>
+            <when value="staph">
+                <param name="panel" type="select" label="Select panel for Staph only">
+                    <option value="20170217">20170217</option>
+                </param>
+            </when>
+            <when value="tb">
+                <param name="panel" type="select" label="Select panel for TB only">
+                    <option value="202010">202010</option>
+                    <option value="201901">201901</option>
+                    <option value="bradley-2015">Bradely 2015</option>
+                </param>
+            </when>
+            <when value="sonnei">
+                <param name="panel" type="select" label="Select panel for sonnei only">
+                    <option value="20210201">20210201</option>
+                    <option value="20201012">20201012</option>
+                </param>
+            </when>
+        </conditional>
+        <param argument="--min_depth" optional="True" type="integer" min="0" label="Minimum depth"  help=""/>
+        <param argument="--conf_percent_cutoff" optional="True" type="integer" label="Confidence percent cutoff" help="Number between 0 and 100. Determines --min_variant_conf, by simulating variants and choosing the cutoff that would keep x% of the variants. Default is 90 if --ont, otherwise --min_variant_conf is used as the cutoff">
+            <validator type="in_range" min="0" max="100" message="Confidence percent cutoff should be between 0 and 100" />
         </param>
-      </when>
-      <when value="tb">
-	<param name="panel" type="select" label="Select panel for TB only">
-          <option value="202010">202010</option>
-          <option value="201901">201901</option>
-          <option value="bradley-2015">Bradely 2015</option>
+        <expand macro="options"/>
+        <param argument="--format" type="select" label="Select the prefered output format">
+            <option value="csv" >csv</option>
+            <option value="json">json</option>
         </param>
-      </when>
-      <when value="sonnei">
-        <param name="panel" type="select" label="Select panel for sonnei only">
-          <option value="20210201">20210201</option>
-          <option value="20201012">20201012</option>
-        </param>
-      </when>
-    </conditional>
-    <param argument="--min_depth" optional="True" type="integer" min="0" label="Minimum depth"  help=""/>
-    <param argument="--conf_percent_cutoff" optional="True" type="integer" label="Confidence percent cutoff" help="Number between 0 and 100. Determines --min_variant_conf, by simulating variants and choosing the cutoff that would keep x% of the variants. Default is 90 if --ont, otherwise --min_variant_conf is used as the cutoff">
-      <validator type="in_range" min="0" max="100" message="Confidence percent cutoff should be between 0 and 100" />
-    </param>
-    <expand macro="options"/>
-    <param argument="--format" type="select" label="Select the prefered output format">
-      <option value="csv" >csv</option>
-      <option value="json">json</option>
-    </param>
-  </inputs>
-  <outputs>
-    <data name="output" format="csv" label="prediction">
-      <change_format>
-        <when input="format" value="json" format="json"/>
-      </change_format>
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="type" value="single"/>
-      <param name="seq1" ftype="fastq" value="reads.fastq"/>
-      <param name="species" value="tb"/>
-      <param name="panel" value="bradley-2015"/>
-      <param name="format" value="json"/>
-      <output name="output">
-        <assert_contents>
-          <has_text_matching expression="susceptibility"/>
-        </assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="type" value="single"/>
-      <param name="seq1" ftype="fastq" value="reads.fastq"/>
-      <param name="species" value="sonnei"/>
-      <param name="panel" value="20201012"/>
-      <param name="format" value="json"/>
-      <output name="output">
-        <assert_contents>
-          <has_text_matching expression="susceptibility"/>
-        </assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="type" value="single"/>
-      <param name="seq1" ftype="fastq.gz" value="reads.fastq.gz"/>
-      <param name="species" value="sonnei"/>
-      <param name="panel" value="20201012"/>
-      <param name="format" value="json"/>
-      <output name="output">
-        <assert_contents>
-          <has_text_matching expression="susceptibility"/>
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-    @ATTRIBUTION@
-  </help>
-  <expand macro="citation" />
+    </inputs>
+    <outputs>
+        <data name="output" format="csv" label="prediction">
+            <change_format>
+                <when input="format" value="json" format="json"/>
+            </change_format>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="type" value="single"/>
+            <param name="seq1" ftype="fastq" value="reads.fastq"/>
+            <param name="species" value="tb"/>
+            <param name="panel" value="bradley-2015"/>
+            <param name="format" value="json"/>
+            <output name="output">
+                <assert_contents>
+                    <has_text_matching expression="susceptibility"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="type" value="single"/>
+            <param name="seq1" ftype="fastq" value="reads.fastq"/>
+            <param name="species" value="sonnei"/>
+            <param name="panel" value="20201012"/>
+            <param name="format" value="json"/>
+            <output name="output">
+                <assert_contents>
+                    <has_text_matching expression="susceptibility"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="type" value="single"/>
+            <param name="seq1" ftype="fastq.gz" value="reads.fastq.gz"/>
+            <param name="species" value="sonnei"/>
+            <param name="panel" value="20201012"/>
+            <param name="format" value="json"/>
+            <output name="output">
+                <assert_contents>
+                    <has_text_matching expression="susceptibility"/>
+              </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+        @ATTRIBUTION@
+    </help>
+    <expand macro="citation" />
 </tool>
+


### PR DESCRIPTION
… sample for all rows

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)


Additional fixes:
- text params single quoted
- integer and float params not quoted
- added profile
- proper indentation