### PR TITLE
Use `command -v` instead of `which` in augustus_training for compatibility

### DIFF
--- a/tools/augustus/augustus_training.xml
+++ b/tools/augustus/augustus_training.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="augustus_training" name="Train Augustus" profile="16.04" version="@VERSION@">
+<tool id="augustus_training" name="Train Augustus" profile="16.04" version="@VERSION@+galaxy@SUFFIX_VERSION@">
     <description>ab-initio gene predictor</description>
     <macros>
         <import>macros.xml</import>
@@ -8,7 +8,7 @@
         <requirement type="package" version="2.31.10">maker</requirement>
     </expand>
     <command><![CDATA[
-        cp -r `which augustus | xargs dirname`/../config/ augustus_dir/ &&
+        cp -r `command -v augustus | xargs dirname`/../config/ augustus_dir/ &&
 
         export AUGUSTUS_CONFIG_PATH=`pwd`/augustus_dir/ &&
 

--- a/tools/augustus/macros.xml
+++ b/tools/augustus/macros.xml
@@ -8,7 +8,7 @@
     </xml>
 
     <token name="@VERSION@">3.4.0</token>
-    <token name="@SUFFIX_VERSION@">0</token>
+    <token name="@SUFFIX_VERSION@">1</token>
 
 
     <xml name="citations">


### PR DESCRIPTION
`which` is not POSIX and not guaranteed to exist, e.g.:

```console
nate@weyerbacher% singularity run /cvmfs/singularity.galaxyproject.org/all/centos:8.3.2011 which yes
FATAL:   "which": executable file not found in $PATH
nate@weyerbacher% singularity run /cvmfs/singularity.galaxyproject.org/all/centos:8.3.2011 command -v yes
/usr/bin/yes
```

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
