### PR TITLE
fix pangolearn DM tag parsing

### DIFF
--- a/data_managers/data_manager_pangolearn/data_manager/pangolearn_dm.py
+++ b/data_managers/data_manager_pangolearn/data_manager/pangolearn_dm.py
@@ -15,6 +15,8 @@ import requests
 def extract_date(tag_str):
     parts = tag_str.split("_")
     assert len(parts) < 3, "expected maximum of two parts, got " + str(parts)
+    # there are tags like: 2021-07-07-2
+    parts[0] = "-".join(parts[0].split("-")[:3])
     tag_date = datetime.datetime.strptime(parts[0], "%Y-%m-%d")
     if len(parts) == 2:
         version = int(parts[1])

--- a/data_managers/data_manager_pangolearn/data_manager/pangolearn_dm.xml
+++ b/data_managers/data_manager_pangolearn/data_manager/pangolearn_dm.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_pangolearn" name="PANGOlearn data manager" version="0.0.2" tool_type="manage_data" profile="20.01">
+<tool id="data_manager_pangolearn" name="PANGOlearn data manager" version="0.0.3" tool_type="manage_data" profile="20.01">
     <requirements>
         <requirement type="package" version="3.8">python</requirement>
         <requirement type="package" version="2.24.0">requests</requirement>


### PR DESCRIPTION
there are tags like: 2021-07-07-2 which made the DM fail

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
