### PR TITLE
Update featureCounts: fix --fraction option labels

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -2,7 +2,7 @@
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <macros>
         <token name="@TOOL_VERSION@">2.0.1</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
 
     <requirements>
@@ -303,7 +303,7 @@
                             falsevalue=""
                             argument="--fraction"
                             label="Assign fractions to multi-overlapping features"
-                            help="If specified, a fractional count 1/y will be generated for each multi-overlapping features, where y is the number of features overlapping with the read."/>
+                            help="If specified, a fractional count 1/y will be generated for each multi-overlapping feature, where y is the number of features overlapping with the read."/>
                 </when>
                 <when value="-O -M">
                         <param name="fraction"

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -2,7 +2,7 @@
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files.</description>
     <macros>
         <token name="@TOOL_VERSION@">2.0.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
 
     <requirements>
@@ -281,8 +281,8 @@
 
             <conditional name = "multifeatures">
                 <param name="multifeat" type="select" label="Allow reads to map to multiple features" help="Setting -O, -M and --fraction">
-                    <option value="" selected="true">Disabled; reads that align to multiple features or overlapping features are excluded</option>
-                    <option value="-M">Enabled; multi-mapping reads are included (-M)</option>
+                    <option value="" selected="true">Disabled: reads that align to multiple features or overlapping features are excluded</option>
+                    <option value="-M">Enabled: multi-mapping reads are included (-M)</option>
                     <option value="-O">Enabled: multi-overlapping features are included (-O)</option>
                     <option value="-O -M">Enabled: both multi-mapping and multi-overlapping features are included (-M -O)</option>
                 </param>
@@ -293,8 +293,8 @@
                             truevalue="--fraction"
                             falsevalue=""
                             argument="--fraction"
-                            label="Assign fractions to multimapping reads"
-                            help="If specified, a fractional count 1/n will be generated for each multi-mapping read, where n is the number of alignments (indica- ted by 'NH' tag) reported for the read."/>
+                            label="Assign fractions to multi-mapping reads"
+                            help="If specified, a fractional count 1/x will be generated for each multi-mapping read, where x is the number of alignments (indicated by 'NH' tag) reported for the read."/>
                 </when>
                 <when value="-O">
                         <param name="fraction"
@@ -302,8 +302,8 @@
                             truevalue="--fraction"
                             falsevalue=""
                             argument="--fraction"
-                            label="Assign fractions to multimapping reads"
-                            help="If specified, a fractional count 1/n will be generated for each multi-overlapping read, where n is the number of alignments (indica- ted by 'NH' tag) reported for the read."/>
+                            label="Assign fractions to multi-overlapping features"
+                            help="If specified, a fractional count 1/y will be generated for each multi-overlapping features, where y is the number of features overlapping with the read."/>
                 </when>
                 <when value="-O -M">
                         <param name="fraction"
@@ -311,8 +311,8 @@
                             truevalue="--fraction"
                             falsevalue=""
                             argument="--fraction"
-                            label="Assign fractions to multimapping reads"
-                            help="If specified, a fractional count 1/n will be generated for each multi-mapping or multi-overlapping read, where n is the number of alignments (indica- ted by 'NH' tag) reported for the read."/>
+                            label="Assign fractions to both multi-mapping reads and multi-overlapping features"
+                            help="If specified, a fractional count 1/(x*y) will be generated, where x is the number of alignments (indicated by 'NH' tag) and y the number of overlapping features."/>
                 </when>
             </conditional>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR fixes the labels of the --fraction option. This small bug was reported by an user in [GHelp](https://help.galaxyproject.org/t/does-enabling-the-featurecounts-fractions-will-calculate-only-multimapping-nh-or-also-overlapping/6577).