### PR TITLE
Revert direct aws access workaround

### DIFF
--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -244,7 +244,7 @@ To keep all reads, and maybe do not have the same number of reads in forward and
 
 
 .. _fastq: https://en.wikipedia.org/wiki/FASTQ_format
-.. _fastq-dump: https://ncbi.github.io/sra-tools/fastq-dump.html
+.. _fastq-dump: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=toolkit_doc&f=fastq-dump
 .. _fasterq-dump: https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 .. _collection: https://galaxyproject.org/tutorials/collections/
 .. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -1,4 +1,4 @@
-<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy0" profile="18.01">
+<tool id="fasterq_dump" name="Faster Download and Extract Reads in FASTQ" version="@VERSION@+galaxy1" profile="18.01">
     <description>format from NCBI SRA</description>
     <expand macro="bio_tools"/>
     <macros>
@@ -15,11 +15,8 @@
         ln -s '${input.file}' "\$acc" &&
     #end if
     @CONFIGURE_RETRY@
-    ## fetch from public s3 bucket if we can
-    export acc_or_path="\$acc" &&
-    aws s3 cp --no-sign-request "s3://sra-pub-sars-cov2/run/\$acc/\$acc" "\$acc.sra" 2>&1 | tee '$log' && export acc_or_path="\$acc.sra"|| true &&
     while [ \$SRA_PREFETCH_ATTEMPT -le \$SRA_PREFETCH_RETRIES ] ; do
-        fasterq-dump "\$acc_or_path" -e \${GALAXY_SLOTS:-1}
+        fasterq-dump "\$acc" -e \${GALAXY_SLOTS:-1}
         $adv.split
         #if str( $adv.minlen ) != "":
             --min-read-len "$adv.minlen"
@@ -181,19 +178,6 @@
                     <element name="reverse" file="SRR11953971_2.fastq.gz" decompress="True"/>
                 </element>
             </output_collection>
-        </test>
-        <test expect_num_outputs="4">
-             <!-- test accession downloaded from public bucket -->
-            <param name="input_select" value="accession_number"/>
-            <param name="accession" value="SRR11859153"/>
-            <output_collection name="output_collection" type="list" count="1">
-                <element name="SRR11859153" file="SRR11859153.fastq.gz" decompress="True"/>
-            </output_collection>
-            <output name="log">
-                <assert_contents>
-                    <has_text text="download: s3://sra-pub-sars-cov2/"/>
-                </assert_contents>
-            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -336,7 +336,7 @@ Or a single *interleaved* dataset::
 
 
 .. _fastq: https://en.wikipedia.org/wiki/FASTQ_format
-.. _fastq-dump: https://ncbi.github.io/sra-tools/fastq-dump.html
+.. _fastq-dump: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=toolkit_doc&f=fastq-dump
 .. _collection: https://galaxyproject.org/tutorials/collections/
 .. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
 

--- a/tools/sra-tools/sam_dump.xml
+++ b/tools/sra-tools/sam_dump.xml
@@ -168,7 +168,7 @@ If a SRA dataset is present in the history, it can be converted into BAM dataset
 -----
 
 .. _BAM: https://samtools.github.io/hts-specs/SAMv1.pdf
-.. _sam-dump: https://ncbi.github.io/sra-tools/sam-dump.html
+.. _sam-dump: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=toolkit_doc&f=sam-dump
 .. _collection: https://galaxyproject.org/tutorials/collections/
 .. _link: https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies
 

--- a/tools/sra-tools/sra_macros.xml
+++ b/tools/sra-tools/sra_macros.xml
@@ -40,7 +40,6 @@
     <macro name="requirements">
         <requirements>
             <requirement type="package" version="@VERSION@">sra-tools</requirement>
-            <requirement type="package" version="1.18.222">awscli</requirement>
             <requirement type="package" version="2.5">pigz</requirement>
             <yield/>
         </requirements>


### PR DESCRIPTION
We don't need to use this anymore, the toolkit will download them from
S3 anyway.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
