### PR TITLE
FastQE was missing a meta header

### DIFF
--- a/tools/fastqe/fastqe.xml
+++ b/tools/fastqe/fastqe.xml
@@ -1,4 +1,4 @@
-<tool id="fastqe" name="FASTQE" version="0.2.6+galaxy1">
+<tool id="fastqe" name="FASTQE" version="0.2.6+galaxy2">
     <description>visualize fastq files with emoji's 🧬😎</description>
     <requirements>
         <requirement type="package" version="0.2.6">fastqe</requirement>
@@ -17,7 +17,7 @@
         ln -s $i inputs/$identifier &&
     #end for
 
-    echo "<html><head><title>FASTQE Report 🤔</title></head><body><h1>FASTQE Report 🤔</h1>" > '$output' &&
+    echo "<html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"><title>FASTQE Report 🤔</title></head><body><h1>FASTQE Report 🤔</h1>" > '$output' &&
 
     fastqe
         $bin

--- a/tools/fastqe/test-data/out.html
+++ b/tools/fastqe/test-data/out.html
@@ -1,4 +1,4 @@
-<html><head><title>FASTQE Report 🤔</title></head><body><h1>FASTQE Report 🤔</h1>
+<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"><title>FASTQE Report 🤔</title></head><body><h1>FASTQE Report 🤔</h1>
 <h2>test.fq: max</h2>
 😜 😛 😛 😛 😛 😉 😉 😉 😉 😉 😉 😉 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😎 😄 😄 😎 😎 😎 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😄 😁 😁 😁 😁 😁 😁 😁 😁 😄 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😁 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉 😉<br>
 <h2>test.fq: mean</h2>


### PR DESCRIPTION
This resulted in firefox rendering it poorly whenever viewed in a standalone page where the documents encoding was not set. 

xref https://github.com/usegalaxy-eu/issues/issues/304

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
