### PR TITLE
Add coreutils requirement to vcfsort

### DIFF
--- a/tool_collections/vcflib/vcfsort/vcfsort.xml
+++ b/tool_collections/vcflib/vcfsort/vcfsort.xml
@@ -3,6 +3,9 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <requirements>
+        <requirement type="package" version="8.31">coreutils</requirement>
+    </requirements>
     <command><![CDATA[
 (grep ^"#" "${input1}" && grep -v ^"#" "${input1}" | LC_ALL=C sort -k1,1 -k2,2n -V) > '${out_file1}'
     ]]></command>


### PR DESCRIPTION
When running with containers, you may end up in a container without coreutils `sort`. The busybox `sort`, for example, does not support `-V`.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
