### PR TITLE
fix twopass for cached index

### DIFF
--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -52,11 +52,15 @@
         #end for
         #if str($twopass.twopassMode) != 'None':
             #if str($refGenomeSource.GTFconditional.GTFselect) == 'with-gtf':
-                #if not $refGenomeSource.GTFconditional.sjdbGTFfile:
-                    ## case of cached index without built-in gene model,
-                    ## when user does not supply the optional gtf, but
-                    ## specifies the splice junction overhang
-                    --sjdbOverhang $refGenomeSource.GTFconditional.sjdbOverhang
+                ## need to check first if its a cached index or from history
+                ## if it's cached then the sjdbGTFfile and sjdbOverhang params are not provided
+                #if str($refGenomeSource.geneSource) == 'history':
+                    #if not $refGenomeSource.GTFconditional.sjdbGTFfile:
+                       ## case of cached index without built-in gene model,
+                       ## when user does not supply the optional gtf, but
+                       ## specifies the splice junction overhang
+                       --sjdbOverhang $refGenomeSource.GTFconditional.sjdbOverhang
+                    #end if
                 #end if
             #end if
         #end if

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -838,6 +838,42 @@ used: >=5 mappings => MAPQ=0; 3-4 mappings => MAPQ=1; 2 mappings => MAPQ=3. This
             <output name="splice_junctions" file="rnastar_test_splicejunctions_twopass.bed"/>
             <output name="mapped_reads" file="rnastar_test_mapped_reads_twopass.bam" compare="sim_size" delta="634" />
         </test>
+        <!-- test Basic twopass with a built-in gtf index option -->
+        <test expect_num_outputs="3">
+            <conditional name="singlePaired">
+                <param name="sPaired" value="single" />
+                <param name="input1" value="tophat_in2.fastqsanger" ftype="fastqsanger" />
+            </conditional>
+            <conditional name="refGenomeSource">
+                <param name="geneSource" value="indexed" />
+                <conditional name="GTFconditional">
+                    <param name="GTFselect" value="with-gtf" />
+                    <param name="genomeDir" value="001" />
+                </conditional>
+            </conditional>
+            <conditional name="twopass">
+                <param name="twopassMode" value="Basic" />
+            </conditional>
+            <section name="oformat">
+                <param name="outSAMattributes" value="NH,HI,AS,nM,NM,MD,jM,jI,MC,ch" />
+                <param name="outSAMmapqUnique" value="255" />
+            </section>
+            <section name="filter">
+                <param name="basic_filters" value="exclude_unmapped,--outFilterIntronMotifs RemoveNoncanonical" />
+                <conditional name="output_params2">
+                    <param name="output_select2" value="yes" />
+                </conditional>
+            </section>
+            <section name="algo">
+                <conditional name="params">
+                    <param name="settingsType" value="full" />
+                </conditional>
+            </section>
+
+            <output name="output_log" file="rnastar_test_twopass.log" compare="re_match_multiline" />
+            <output name="splice_junctions" file="rnastar_test_splicejunctions_twopass.bed"/>
+            <output name="mapped_reads" file="rnastar_test_mapped_reads_twopass.bam" compare="sim_size" delta="634" />
+        </test>
         <!-- test "multisample" twopass -->
         <test expect_num_outputs="3">
             <conditional name="singlePaired">


### PR DESCRIPTION
Just fixing the case when an index built with a GFF guide is used. The code was assuming that the index was created during tool execution and thus was checking for the refGenomeSource.GTFconditional.sjdbGTFfile parameter, which is not present in the case of cached indexes.


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
 [ ] - This PR does something else (explain below)
