### PR TITLE
IQtree: --mset parameter requires lowercase

### DIFF
--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -488,7 +488,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </conditional>
                 <param argument="--mset" type="text" optional="true" label="Specify the name of a program (raxml, phyml or mrbayes) to restrict to only those models supported by the specified program" help="Alternatively, one can specify a comma-separated list of base models. For example, -mset WAG,LG,JTT will restrict model selection to WAG, LG, and JTT instead of all 18 AA models to save computations.">
                     <expand macro="sanitize_query"
-                    validinitial="string.ascii_uppercase,string.punctuation" />
+                    validinitial="string.ascii_letters,string.punctuation" />
                 </param>
                 <param argument="--msub" type="select" label="Specify either nuclear, mitochondrial, chloroplast or viral to restrict to those AA models designed for specified source." help="">
                     <option value="nuclear">nuclear</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Default values are currently unable to be used on the --mset parameter. The ones that appear in the help text are "(raxml, phyml or mrbayes)". Lower case is required, and they are being sanitized away with the current version. Not bumping version, since this is a bug in the wrapper.