### PR TITLE
Update bedtools_nucbed and bectools_getfastabed to symlink fasta input to prevent writing to read-only input directory

### DIFF
--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -12,12 +12,13 @@
 #else
     #set $fasta_file = $fasta_source.fasta_id.fields.path
 #end if
+ln -s '$fasta_file' 'input.fasta' &&
 bedtools getfasta
 $name
 $tab
 $strand
 $split
--fi '$fasta_file'
+-fi 'input.fasta'
 -bed '$input'
 -fo '$output'
     ]]></command>

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -11,7 +11,7 @@
     #set $fasta_file = $fasta_source.fasta
 #else
     #set $fasta_file = $fasta_source.fasta_id.fields.path
-    [ ! -f '${fasta_file}.fai' ] || ln -s '${fasta_file}.fai' 'input.fasta.fai' &&
+    ln -s '${fasta_file}.fai' 'input.fasta.fai' &&
 #end if
 ln -s '$fasta_file' 'input.fasta' &&
 bedtools getfasta

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -11,6 +11,7 @@
     #set $fasta_file = $fasta_source.fasta
 #else
     #set $fasta_file = $fasta_source.fasta_id.fields.path
+    [ ! -f '${fasta_file}.fai' ] || ln -s '${fasta_file}.fai' 'input.fasta.fai' &&
 #end if
 ln -s '$fasta_file' 'input.fasta' &&
 bedtools getfasta

--- a/tools/bedtools/nucBed.xml
+++ b/tools/bedtools/nucBed.xml
@@ -7,6 +7,7 @@
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[
+ln -s '$fasta' 'input.fasta' &&
 bedtools nuc
 $s
 $seq
@@ -14,7 +15,7 @@ $seq
     -pattern '$pattern'
     $C
 #end if
--fi '$fasta'
+-fi 'input.fasta'
 -bed '$input'
 > '$output'
     ]]></command>


### PR DESCRIPTION
If the fasta input does not have a corresponding .fai, these tools automatically create one. This assumes that the directory containing the fasta input is writable, which it should not be (albeit in many deployments it often is):

```
index file /galaxy-repl/test/object_store_cache/8/7/1/dataset_8717543b-c220-4420-9185-56ecd77f61aa.dat.fai not found, generating...
could not open index file /galaxy-repl/test/object_store_cache/8/7/1/dataset_8717543b-c220-4420-9185-56ecd77f61aa.dat.fai for writing!
```

~~The conditional in bedtools_getfastabed might be the wrong idea, since it would quietly mask a configuration problem (an entry in fasta_indexes that is present but the file itself is missing). We could just take the conditional out and unconditionally symlink the fai, which should cause the tool to fail if it's not present.~~ went ahead and dropped that.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
