### PR TITLE
Update SnpSift Annotate to avoid writing to input directory

### DIFF
--- a/tool_collections/snpsift/snpsift/snpSift_annotate.xml
+++ b/tool_collections/snpsift/snpsift/snpSift_annotate.xml
@@ -10,12 +10,13 @@
     <expand macro="stdio" />
     <expand macro="version_command" />
     <command><![CDATA[
+ln -s '$dbSnp' 'dbSnp.vcf' &&
 SnpSift -Xmx8G annotate
 ${annotate.no_info}
 #if str($annotate.info_ids).strip():
     -info '$annotate.info_ids'
 #end if
--q '$dbSnp' '$input' > '$output'
+-q 'dbSnp.vcf' '$input' > '$output'
     ]]></command>
     <inputs>
         <param name="input" type="data" format="vcf" label="Variant input file in VCF format"/>


### PR DESCRIPTION
Otherwise it tries to create `${dbSnp}.sidx`. There may be other tools in the suite that would also encounter this - any ideas @wm75?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
