### PR TITLE
Symlink matrix input in trinity_contig_exn50_statistic to avoid writing to input dataset dir

### DIFF
--- a/tools/trinity/contig_exn50_statistic.xml
+++ b/tools/trinity/contig_exn50_statistic.xml
@@ -6,8 +6,9 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="aggressive"><![CDATA[
+    ln -s '$matrix' 'matrix.tabular' &&
     contig_ExN50_statistic.pl
-        '$matrix'
+        'matrix.tabular'
         '$transcripts'
         > '$output'
     ]]></command>


### PR DESCRIPTION
This script [writes to a file](https://github.com/trinityrnaseq/trinityrnaseq/blob/0c0e4a0a17192d48aec51ba43b41002aa8b5c2aa/util/misc/contig_ExN50_statistic.pl#L121) adjacent to the matrix input.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
