### PR TITLE
Fix nextclade coreutils dependency

### DIFF
--- a/tools/nextclade/nextalign.xml
+++ b/tools/nextclade/nextalign.xml
@@ -2,7 +2,7 @@
     <description>Viral genome sequence alignment</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nextalign</requirement>

--- a/tools/nextclade/nextclade.xml
+++ b/tools/nextclade/nextclade.xml
@@ -6,7 +6,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nextclade</requirement>
-        <requirement type="package">coreutils</requirement>
+        <requirement type="package" version="8.31">coreutils</requirement>
     </requirements>
     <version_command>nextclade --version-detailed</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Without a version we can't use the container.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
