### PR TITLE
Fix Roary which puts unquoted filenames into command lines

### DIFF
--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -5,7 +5,7 @@
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">3.13.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">roary</requirement>
@@ -14,8 +14,9 @@
     <command detect_errors="exit_code"><![CDATA[
         #set $filenames = list()
         #for $gff in $gff_input.gffs
-            cp '$gff' '${gff.element_identifier}.gff' &&
-            #set $filename = str($gff.element_identifier) + '.gff'
+            #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($gff.element_identifier))
+            cp '$gff' '${escaped_element_identifier}.gff' &&
+            #set $filename = str($escaped_element_identifier) + '.gff'
             $filenames.append(str($filename))
         #end for
 

--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -15,7 +15,7 @@
         #set $filenames = list()
         #for $gff in $gff_input.gffs
             #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($gff.element_identifier))
-            cp '$gff' '${escaped_element_identifier}.gff' &&
+            ln -s '$gff' '${escaped_element_identifier}.gff' &&
             #set $filename = str($escaped_element_identifier) + '.gff'
             $filenames.append(str($filename))
         #end for

--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -12,6 +12,7 @@
     </requirements>
 
     <command detect_errors="exit_code"><![CDATA[
+        #import re
         #set $filenames = list()
         #for $gff in $gff_input.gffs
             #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($gff.element_identifier))

--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -5,7 +5,7 @@
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">3.13.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">roary</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Honestly floored no one caught this before? It happens just during basic usage of roary if you pass in a prokka output (which of course is named `Prokka on data 28: gff` or so) it fails because that's written into a shell script, unquoted, which i'm assuming gets run. And that of course fails.

```
galaxy@sn06:/data/jwd/main/031/134/31134210$ cat tmp.20210923-121237/G7iTb3gxvu
extract_proteome_from_gff --translation_table 11 --apply_unknowns_filter 1 -d /data/jwd/main/031/134/31134210/working/out/cD0VOY4Fzb -o proteome.faa /data/jwd/main/031/134/31134210/working/Prokka on data 24: gff.gff
extract_proteome_from_gff --translation_table 11 --apply_unknowns_filter 1 -d /data/jwd/main/031/134/31134210/working/out/cD0VOY4Fzb -o proteome.faa /data/jwd/main/031/134/31134210/working/Prokka on data 26: gff.gff
extract_proteome_from_gff --translation_table 11 --apply_unknowns_filter 1 -d /data/jwd/main/031/134/31134210/working/out/cD0VOY4Fzb -o proteome.faa /data/jwd/main/031/134/31134210/working/Prokka on data 28: gff.gff
```

Note the unquoted spaces.

Maybe we need a `element_identifier_safe` or so? That can be used whenever filenames are present that sanitizes things for us.

@bazante1 this is for you