### PR TITLE
Fix Roary bug: remove whitespaces from filenames

### DIFF
--- a/tools/roary/roary.xml
+++ b/tools/roary/roary.xml
@@ -5,18 +5,19 @@
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">3.13.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">roary</requirement>
     </requirements>
 
     <command detect_errors="exit_code"><![CDATA[
+        #import re
         #set $filenames = list()
         #for $gff in $gff_input.gffs
-            cp '$gff' '${gff.element_identifier}.gff' &&
-            #set $filename = str($gff.element_identifier) + '.gff'
-            $filenames.append(str($filename))
+            #set $tmp_name = re.sub('[^\w\-_\.]','_',str($gff.element_identifier)) + '.gff'
+            cp '$gff' $tmp_name &&
+            $filenames.append(str($tmp_name))
         #end for
 
         roary


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR fixes a bug related to whitespaces (when used in a filename, it triggers an error).