### PR TITLE
Update iqtree2 wrapper to correctly invoke consensus tree parameters

### DIFF
--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -1,7 +1,7 @@
 <tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@+@VERSION_SUFFIX@" >
     <description>Phylogenomic / evolutionary tree construction from multiple sequences</description>
     <macros>
-        <token name="@VERSION_SUFFIX@">galaxy3</token>
+        <token name="@VERSION_SUFFIX@">galaxy2</token>
         <import>iqtree_macros.xml</import>
     </macros>
     <expand macro="requirements" />
@@ -44,9 +44,9 @@ iqtree
 
     ## file
     #if $tree_parameters.computing_robinson_foulds.tree_dist_all
-        $tree_dist_all
-        --tree-dist $tree_dist
-        --tree-dist2 $tree_dist2
+        $tree_parameters.computing_robinson_foulds.tree_dist_all
+        --tree-dist $tree_parameters.computing_robinson_foulds.tree_dist
+        --tree-dist2 $tree_parameters.computing_robinson_foulds.tree_dist2
     #end if
     $tree_parameters.ancestral_state.ancestral
     #if $tree_parameters.ancestral_state.asr_min:
@@ -686,7 +686,7 @@ IQ-TREE also works for codon, binary and morphogical data.
     <outputs>
         <data name="bionj" format="nhx" from_work_dir="*.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
         <data name="treefile" format="nhx" from_work_dir="*.treefile" label="${tool.name} on ${on_string}: MaxLikelihood Tree" />
-        <data name="contree" format="nhx" from_work_dir="*.contree" label="${tool.name} on ${on_string}: Consensus Tree">
+        <data name="consensus_tree" format="nhx" from_work_dir="*.contree" label="${tool.name} on ${on_string}: Consensus Tree">
             <filter>tree_parameters['constructing_consensus']['contree']</filter>
         </data>
         <data name="mldist" format="mldist" from_work_dir="*.mldist" label="${tool.name} on ${on_string}: MaxLikelihood Distance Matrix"/>

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -735,7 +735,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                     <has_line_matching expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*" />
                 </assert_contents>
             </output>
-            <output name="contree">
+            <output name="consensus_tree">
                 <assert_contents>
                     <has_line_matching
                         expression="\(LngfishAu:(\d|\..)+,\(LngfishSA:(\d.)+,.*\)\d+:(\d|\.)+,.*" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -703,7 +703,7 @@ IQ-TREE also works for codon, binary and morphogical data.
         </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <param name="seed" value="1257" />
             <param name="seqtype" value="AA" />
             <param name="s" value="example.phy" />
@@ -748,7 +748,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <!-- bootstrap sans model -->
             <param name="seed" value="1257" />
             <param name="seqtype" value="AA" />
@@ -782,7 +782,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <!-- model sans bootstrap -->
             <param name="seed" value="1257" />
             <param name="seqtype" value="AA" />
@@ -816,7 +816,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <param name="s" value="example.phy" />
             <output name="iqtree">
                 <assert_contents>
@@ -829,7 +829,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <param name="s" value="example.phy" />
             <param name="opt_custommodel" value="true" />
             <param name="m" value="GTR+G{0.9}" />
@@ -844,7 +844,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="5">
             <param name="s" value="short.fasta" />
             <param name="short_alignments" value="true" />
             <output name="treefile">
@@ -853,7 +853,7 @@ IQ-TREE also works for codon, binary and morphogical data.
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="8">
+        <test expect_num_outputs="7">
             <param name="s" value="dates.fa" />
             <param name="n" value="100" />
             <param name="seed" value="122125" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -1,7 +1,7 @@
 <tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@+@VERSION_SUFFIX@" >
     <description>Phylogenomic / evolutionary tree construction from multiple sequences</description>
     <macros>
-        <token name="@VERSION_SUFFIX@">galaxy1</token>
+        <token name="@VERSION_SUFFIX@">galaxy3</token>
         <import>iqtree_macros.xml</import>
     </macros>
     <expand macro="requirements" />
@@ -27,8 +27,8 @@ iqtree
 ## file
 #if $general_options.t
     -t '$general_options.t'
-    $tree_parameters.constructing_consensus.con_tree
-    $tree_parameters.constructing_consensus.con_net
+    $tree_parameters.constructing_consensus.contree
+    $tree_parameters.constructing_consensus.connet
     #if str($tree_parameters.constructing_consensus.burnin) != ''
         --burnin '$tree_parameters.constructing_consensus.burnin'
     #end if
@@ -43,10 +43,10 @@ iqtree
     #end if
 
     ## file
-    #if $tree_parameters.computing_robinson_foulds.rf
-        -rf '$tree_parameters.computing_robinson_foulds.rf'
-        $tree_parameters.computing_robinson_foulds.tree_dist_all
-        $tree_parameters.computing_robinson_foulds.rf_adj
+    #if $tree_parameters.computing_robinson_foulds.tree_dist_all
+        $tree_dist_all
+        --tree-dist $tree_dist
+        --tree-dist2 $tree_dist2
     #end if
     $tree_parameters.ancestral_state.ancestral
     #if $tree_parameters.ancestral_state.asr_min:
@@ -602,8 +602,8 @@ IQ-TREE also works for codon, binary and morphogical data.
                 <param argument="--test-au" type="boolean" truevalue="--test-au" falsevalue="" checked="false" label="Used together with --test to additionally perform the approximately unbiased (AU) test (Shimodaira, 2002)" help="Note that you have to specify the number of replicates for the AU test via -test."/>
             </section>
             <section name="constructing_consensus" expanded="False" title="Constructing consensus tree">
-                <param argument="--con-tree" type="boolean" truevalue="--con-tree" falsevalue="" checked="false" label="Compute consensus tree of the trees passed via -t" help="Resulting consensus tree is written to .contree file."/>
-                <param argument="--con-net" type="boolean" truevalue="--con-net" falsevalue="" checked="false" label="Compute consensus network of the trees passed via -t" help="Resulting consensus network is written to .nex file."/>
+                <param argument="--contree" type="boolean" truevalue="--contree" falsevalue="" checked="false" label="Compute consensus tree of the trees passed via -t" help="Resulting consensus tree is written to .contree file."/>
+                <param argument="--connet" type="boolean" truevalue="--connet" falsevalue="" checked="false" label="Compute consensus network of the trees passed via -t" help="Resulting consensus network is written to .nex file."/>
                 <param argument="--sup-min" type="float" value="0.0" optional="true" label="Specify a minimum threshold (between 0 and 1) to keep branches in the consensus tree"/>
                 <param argument="--burnin" type="integer" optional="true" label="Specify a burn-in, which is the number of beginning trees passed via -t to discard before consensus construction" help="This is useful e.g. when summarizing trees from MrBayes analysis."/>
                 <param argument="--support" type="data" format="nhx" optional="true" label="Specify an input “target” tree file" help="That means, support values are first extracted from the trees passed via -t, and then mapped onto the target tree. Resulting tree with assigned support values is written to .suptree file. This option is useful to map and compare support values from different approaches onto a single tree."/>
@@ -686,7 +686,9 @@ IQ-TREE also works for codon, binary and morphogical data.
     <outputs>
         <data name="bionj" format="nhx" from_work_dir="*.bionj" label="${tool.name} on ${on_string}: BIONJ Tree" />
         <data name="treefile" format="nhx" from_work_dir="*.treefile" label="${tool.name} on ${on_string}: MaxLikelihood Tree" />
-        <data name="contree" format="nhx" from_work_dir="*.contree" label="${tool.name} on ${on_string}: Consensus Tree" />
+        <data name="contree" format="nhx" from_work_dir="*.contree" label="${tool.name} on ${on_string}: Consensus Tree">
+            <filter>tree_parameters['constructing_consensus']['contree']</filter>
+        </data>
         <data name="mldist" format="mldist" from_work_dir="*.mldist" label="${tool.name} on ${on_string}: MaxLikelihood Distance Matrix"/>
         <data name="splits" format="nex" from_work_dir="*.splits.nex" label="${tool.name} on ${on_string}: Occurence Frequencies in Bootstrap Trees" />
         <data name="iqtree" format="iqtree" from_work_dir="*.iqtree" label="${tool.name} on ${on_string}: Report and Final Tree" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

The `--help` output lists `--con-tree` and `--con-net` as parameters, but the code that parses the command line, as seen in the snippet below, defines them as `--contree` and `--connet`

```C++
if (strcmp(argv[cnt], "-con") == 0 || strcmp(argv[cnt], "--contree") == 0) {
    params.consensus_type = CT_CONSENSUS_TREE;
    continue;
}
if (strcmp(argv[cnt], "-net") == 0 || strcmp(argv[cnt], "--connet") == 0) {
    params.consensus_type = CT_CONSENSUS_NETWORK;
    continue;
}

```