### PR TITLE
Updating tools/optitype from version 1.3.5 to 2015.10.20

### DIFF
--- a/tools/optitype/optitype.xml
+++ b/tools/optitype/optitype.xml
@@ -1,7 +1,7 @@
 <tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>HLA genotyping predictions from NGS data</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.3.5</token>
+        <token name="@TOOL_VERSION@">2015.10.20</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/optitype**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/optitype from version 1.3.5 to 2015.10.20.

**Project home page:** https://github.com/FRED-2/OptiType/releases