### PR TITLE
Let PR workflow check file sizes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -244,7 +244,18 @@ jobs:
       with:
         name: 'File size report'
         path: file_size_report.txt
-
+    - name: PR Comment
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.PAT }}
+        script: |
+          github.issues.createComment({
+            issue_number: ${{ github.event.number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
+          })
+  
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -244,6 +244,14 @@ jobs:
       with:
         name: 'File size report'
         path: file_size_report.txt
+    - name: Comment PR
+      if: ${{ failure() }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.PAT }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -219,7 +219,7 @@ jobs:
   file_sizes:
     name: Check file sizes
     needs: setup
-    if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && needs.setup.outputs.repository-list != '' }}
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.repository-list != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,7 @@ env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_21.09
   MAX_CHUNKS: 4
+  MAX_FILE_SIZE: 500k
 concurrency:
   # group runs by PR, but keep runs on master separate
   # because we do not want to cancel toolshed uploads
@@ -215,6 +216,35 @@ jobs:
         name: 'R linting output'
         path: rlint_report.txt
 
+  sizes:
+    name: Check file sizes
+    needs: setup
+    if: ${{ needs.setup.outputs.repository-list != '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Save repositories to file
+      run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
+    - name: lintr
+      run: |
+        while read repo; do
+          find "$repo" -size +${{ env.MAX_FILE_SIZE }}
+        done < repository_list.txt > file_size_report.txt
+        if [[ -s file_size_report.txt ]]; then
+          echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
+          cat file_size_report.txt
+          exit 1
+        fi
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: 'File size report'
+        path: file_size_report.txt
+
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests
   test:
@@ -354,7 +384,7 @@ jobs:
 
   determine-success:
     name: Check workflow success
-    needs: [setup, lint, flake8, lintr, combine_outputs]
+    needs: [setup, lint, flake8, lintr, sizes, combine_outputs]
     if: ${{ always() && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -366,6 +396,9 @@ jobs:
       run: exit 1
     - name: Indicate R script lint status
       if: ${{ needs.lintr.result != 'success' && needs.lintr.result != 'skipped' }}
+      run: exit 1
+    - name: Indicate file size status
+      if: ${{ needs.sizes.result != 'success' && needs.sizes.result != 'skipped' }}
       run: exit 1
     - name: Check tool test status
       if: ${{ needs.combine_outputs.result != 'success' && needs.combine_outputs.result != 'skipped' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -251,7 +251,7 @@ jobs:
         github-token: ${{ secrets.PAT }}
         script: |
           github.rest.issues.createComment({
-            issue_number: ${{ github.event.number }},
+            issue_number: github.event.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -246,10 +246,12 @@ jobs:
         path: file_size_report.txt
     - name: Comment PR
       if: ${{ failure() }}
-      uses: thollander/actions-comment-pull-request@v1
+      uses: peter-evans/create-or-update-comment@v1
       with:
-        message: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        token: ${{ secrets.PAT }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -244,14 +244,6 @@ jobs:
       with:
         name: 'File size report'
         path: file_size_report.txt
-    - name: Comment PR
-      if: ${{ failure() }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.PAT }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -244,18 +244,12 @@ jobs:
       with:
         name: 'File size report'
         path: file_size_report.txt
-    - name: PR Comment
+    - name: Comment PR
       if: ${{ failure() }}
-      uses: actions/github-script@v5
+      uses: thollander/actions-comment-pull-request@v1
       with:
-        github-token: ${{ secrets.PAT }}
-        script: |
-          github.rest.issues.createComment({
-            issue_number: github.event.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
-          })
+        message: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
+        GITHUB_TOKEN: ${{ secrets.PAT }}
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -229,7 +229,7 @@ jobs:
         fetch-depth: 1
     - name: Save repositories to file
       run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
-    - name: lintr
+    - name: Check file sizes
       run: |
         while read repo; do
           find "$repo" -size +${{ env.MAX_FILE_SIZE }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -245,17 +245,18 @@ jobs:
         name: 'File size report'
         path: file_size_report.txt
     - name: PR Comment
-      uses: actions/github-script@v2
+      if: ${{ failure() }}
+      uses: actions/github-script@v5
       with:
         github-token: ${{ secrets.PAT }}
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: ${{ github.event.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: ':warning: Some files in this PR are large. Try to reduce the size, e.g. by using content assertions.'
           })
-  
+
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -384,7 +384,7 @@ jobs:
 
   determine-success:
     name: Check workflow success
-    needs: [setup, lint, flake8, lintr, file_sizes, combine_outputs]
+    needs: [setup, lint, flake8, lintr, combine_outputs]
     if: ${{ always() && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -396,9 +396,6 @@ jobs:
       run: exit 1
     - name: Indicate R script lint status
       if: ${{ needs.lintr.result != 'success' && needs.lintr.result != 'skipped' }}
-      run: exit 1
-    - name: Indicate file size status
-      if: ${{ needs.file_sizes.result != 'success' && needs.file_sizes.result != 'skipped' }}
       run: exit 1
     - name: Check tool test status
       if: ${{ needs.combine_outputs.result != 'success' && needs.combine_outputs.result != 'skipped' }}

--- a/tools/artic/artic_guppyplex.xml
+++ b/tools/artic/artic_guppyplex.xml
@@ -1,4 +1,4 @@
-<tool id="artic_guppyplex" name="ARTIC guppyplex" version="@PACKAGE_VERSION@+galaxy0" profile="20.09">
+<tool id="artic_guppyplex" name="ARTIC guppyplex" version="@PACKAGE_VERSION@+galaxy1" profile="20.09">
     <description>Filter Nanopore reads by read length and (optionally) quality</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/gatk4/macros.xml
+++ b/tools/gatk4/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@VERSION@">4.1.7.0</token>
-    <token name="@WRAPPER_VERSION@">@VERSION@+galaxy0</token>
+    <token name="@WRAPPER_VERSION@">@VERSION@+galaxy1</token>
 
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Large test data should be avoided. So lets automatize this in the PR workflow. .. Sometimes it can even create problems: https://github.com/galaxyproject/galaxy/pull/12604

At the moment we have 410 files > 500k and 225 files > 1M

We can argue if we want to fail `determine-success` if large files are found.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
