### PR TITLE
fix aegan tests

### DIFF
--- a/tools/aegean/canongff3.xml
+++ b/tools/aegean/canongff3.xml
@@ -36,16 +36,16 @@
     </outputs>
     <tests>
         <test>
-            <param name='gff3file' value='TAIR10_GFF3_genes.gff'/>
+            <param name='gff3file' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <output name='output' file='canon-output_test1.gff3'/>
         </test>
         <test>
-            <param name='gff3file' value='TAIR10_GFF3_genes.gff'/>
+            <param name='gff3file' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='source' value='test_source'/>
             <output name='output' file='canon-output_test2.gff3'/>
         </test>
         <test>
-            <param name='gff3file' value='TAIR10_GFF3_genes.gff'/>
+            <param name='gff3file' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='infer' value='true'/>
             <output name='output' file='canon-output_test3.gff3'/>
         </test>

--- a/tools/aegean/gaeval.xml
+++ b/tools/aegean/gaeval.xml
@@ -63,13 +63,13 @@
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff'/>
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff' ftype="gff3"/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <output name='output' file='gaeval_output_test1.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff'/>
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff' ftype="gff3"/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='weights'>
                 <param name='alpha' value='0.5'/>
                 <param name='beta' value='0.4'/>
@@ -79,8 +79,8 @@
             <output name='output' file='gaeval_output_test2.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff'/>
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='alignmentgff3' value='TAIR10_GFF3_alignment.gff' ftype="gff3"/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='expected'>
                 <param name='expcds' value='20'/>
                 <param name='exp5putr' value='150'/>

--- a/tools/aegean/locuspocus.xml
+++ b/tools/aegean/locuspocus.xml
@@ -122,11 +122,11 @@
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <output name='output' file='locuspocus_output_test1.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='ilocus_parsing'>
                 <param name='delta' value='400'/>
                 <param name='mode' value='--skipends'/>
@@ -134,7 +134,7 @@
             <output name='output' file='locuspocus_output_test2.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='ilocus_parsing'>
                 <param name='skipiloci' value='true'/>
                 <param name='mode' value='--endsonly'/>
@@ -142,7 +142,7 @@
             <output name='output' file='locuspocus_output_test3.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='refine_options'>
                 <param name='refine_parameters|refine' value='--refine'/>
                 <param name='minoverlap' value='5'/>
@@ -150,7 +150,7 @@
             <output name='output' file='locuspocus_output_test4.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='input_options'>
                 <param name='filter' value='gene,intron'/>
                 <param name='parent' value='mRNA:gene'/>
@@ -158,7 +158,7 @@
             <output name='output' file='locuspocus_output_test5.txt'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='input_options'>
                 <param name='filter' value='gene,intron'/>
                 <param name='parent' value='mRNA:gene'/>
@@ -167,7 +167,7 @@
             <output name='output' file='locuspocus_output_test6.txt'/>
         </test>
         <test expect_num_outputs="4">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <section name='output_options'>
                 <param name='retainids' value='true'/>
                 <param name='namefmt' value='test%lu'/>
@@ -179,7 +179,7 @@
             <output name='output_transmap' file='locuspocus_transmap_test7.txt'/>
         </test>
         <test expect_num_outputs="4">
-            <param name='genesgff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='genesgff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
 	        <section name='refine_options'>
                 <param name='refine_parameters|refine' value='--refine'/>
                 <param name='refine_options|minoverlap' value='5'/>

--- a/tools/aegean/parseval.xml
+++ b/tools/aegean/parseval.xml
@@ -66,41 +66,41 @@
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='delta' value='5'/>
             <param name='maxtrans' value='20'/>
             <output name='output_txt' file='parseval_output_test1.txt' lines_diff='8'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <output name='output_txt' file='parseval_output_test2.txt' lines_diff='8'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='delta' value='10'/>
             <param name='maxtrans' value='10'/>
             <output name='output_txt' file='parseval_output_test3.txt' lines_diff='8'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='output_type' value='html'/>
             <output name='output_html' file='parseval_output_test4.html' lines_diff='8'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='output_type' value='html'/>
             <param name='delta' value='10'/>
             <param name='maxtrans' value='10'/>
             <output name='output_html' file='parseval_output_test5.html' lines_diff='8'/>
         </test>
         <test expect_num_outputs="1">
-            <param name='referencegff3' value='TAIR9_GFF3_genes.gff'/>
-            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff'/>
+            <param name='referencegff3' value='TAIR9_GFF3_genes.gff' ftype="gff3"/>
+            <param name='predictiongff3' value='TAIR10_GFF3_genes.gff' ftype="gff3"/>
             <param name='output_type' value='text'/>
             <param name='refrlabel' value='example_ref_label'/>
             <param name='predlabel' value='example_pred_label'/>


### PR DESCRIPTION
test data is sniffed as gff (because it really is gff2) and therefore can not be used as input which needs to be gff2

forcing gff3 by setting ftype since the aegan website insists that gff3 is
used (so allowing gff seems not an option)

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
