### PR TITLE
Extract genomic DNA fix tests

### DIFF
--- a/tools/extract_genomic_dna/extract_genomic_dna.xml
+++ b/tools/extract_genomic_dna/extract_genomic_dna.xml
@@ -1,4 +1,4 @@
-<tool id="extract_genomic_dna_1" name="Extract Genomic DNA" version="3.0.3+galaxy2">
+<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="3.0.3+galaxy2">
     <description>using coordinates from assembled/unassembled genomes</description>
     <requirements>
         <requirement type="package" version="0.7.1">bx-python</requirement>


### PR DESCRIPTION
dbkey needs to be set since the dynamic options filter otherwise
removes the dataset here

https://github.com/galaxyproject/galaxy/blob/5ea4d7e647d09dde957e824a083b1bd6acaa6f17/lib/galaxy/tools/parameters/basic.py#L1961
https://github.com/galaxyproject/galaxy/blob/5ea4d7e647d09dde957e824a083b1bd6acaa6f17/lib/galaxy/tools/parameters/dataset_matcher.py#L156

Currently this only leads to not considering the dataset for implicit conversion.

With https://github.com/galaxyproject/galaxy/pull/12073 this makes the
tool fail.

See also https://github.com/galaxyproject/galaxy/pull/12679 .. if this PR is changed such that it it checked if the refered dataset has set the dbkey then we could also remove the validator of `input` which would lead to the behaviour:

- if input has dbkey then the reference needs a matching reference
- if input has no dbkey then any reference can be chosen

Additionally: remove spaces from tool id and remove spaces

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
