### PR TITLE
multiqc: fix test dataset

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1218,7 +1218,7 @@ sp:
             <repeat name="results">
                 <conditional name="software_cond">
                     <param name="software" value="snpeff" />
-                    <param name="input" value="snpeff.csv" />
+                    <param name="input" value="snpeff.csv" ftype="csv" />
                 </conditional>
             </repeat>
             <repeat name="results">


### PR DESCRIPTION
snpeff is csv (even if its not proper csv)

could also make the input text (and the snpeff output as well)

xref: https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
