### PR TITLE
limma: contrasts file needs to be tabular

### DIFF
--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -728,7 +728,7 @@ cp '$outReport.files_path'/*tsv output_dir/
                 <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT" />
             </repeat>
             <param name="cfile" value="yes" />
-            <param name="cinfo" value="contrasts.txt" />
+            <param name="cinfo" value="contrasts.txt" ftype="tabular" />
             <param name="normalisationOption" value="TMM" />
             <param name="topgenes" value="6" />
             <output_collection name="outTables" count="3">


### PR DESCRIPTION
seems to be a single column file which is not sniffed as tabular

or we add txt to the allowed datatypes

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
