### PR TITLE
hicexplorer: set datatypes in tests

### DIFF
--- a/tools/hicexplorer/hicAverageRegions.xml
+++ b/tools/hicexplorer/hicAverageRegions.xml
@@ -51,7 +51,7 @@
     <tests>
         <test>
             <param name="matrix_h5_cooler" value="small_test_matrix.cool" />
-            <param name="regions" value="hicAverageRegions/regions.bed" />
+            <param name="regions" value="hicAverageRegions/regions.bed" ftype="bed"/>
             <conditional name="rangeFormat_conditional">
                 <param name="rangeFormat_selector" value='optionGenomicUnits' />
                 <param name="upstreamRange" value='100000' />
@@ -61,7 +61,7 @@
         </test>
         <test>
             <param name="matrix_h5_cooler" value="small_test_matrix.cool" />
-            <param name="regions" value="hicAverageRegions/regions.bed" />
+            <param name="regions" value="hicAverageRegions/regions.bed" ftype="bed" />
             <conditional name="rangeFormat_conditional">
                 <param name="rangeFormat_selector" value='optionBinUnits' />
                 <param name="upstreamRange" value='100' />

--- a/tools/hicexplorer/hicCompartmentalization.xml
+++ b/tools/hicexplorer/hicCompartmentalization.xml
@@ -58,18 +58,18 @@
     <tests>
         <test>
             <param name="matrix_h5_cooler_multiple" value="hicTransform/obs_exp_norm.h5" />
-            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" />
+            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" ftype="bedgraph" />
             <output name="outFileName" file="hicCompartmentsPolarization/compartmentsPolarizationRatio.png" ftype="png" compare="sim_size" />
         </test>
         <test>
             <param name="matrix_h5_cooler_multiple" value="hicTransform/obs_exp_norm.h5" />
-            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" />
+            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" ftype="bedgraph" />
             <param name="quantile" value='30' />
             <output name="outFileName" file="hicCompartmentsPolarization/compartmentsPolarizationRatio.png" ftype="png" compare="sim_size" />
         </test>
         <test>
             <param name="matrix_h5_cooler_multiple" value="hicTransform/obs_exp_norm.h5" />
-            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" />
+            <param name="pca" value="hicCompartmentsPolarization/pca1.bedgraph" ftype="bedgraph" />
             <param name="outliers" value='1.0' />
             <output name="outFileName" file="hicCompartmentsPolarization/compartmentsPolarizationRatio.png" ftype="png" compare="sim_size" />
         </test>

--- a/tools/hicexplorer/hicFindTADs.xml
+++ b/tools/hicexplorer/hicFindTADs.xml
@@ -148,7 +148,7 @@
             <param name="matrix_h5_cooler" value="small_test_matrix.h5" />
             <conditional name="precomputedZscore_conditional">
                 <param name="precomputedZscore_selector" value="precomputed" />
-                <param name="scoreFile" value="find_TADs/multiFDR_tad_score.bm" />
+                <param name="scoreFile" value="find_TADs/multiFDR_tad_score.bm" ftype="bedgraph" />
                 <param name="zscoreMatrix" value="find_TADs/multiFDR_zscore_matrix.h5" />
             </conditional>
             <param name="minBoundaryDistance" value="5000" />


### PR DESCRIPTION
- the bed files are 3 column bed which are not sniffed as bed
- bedgraph has no sniffer

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
