### PR TITLE
odgi viz: test set datatype explicitly

### DIFF
--- a/tools/odgi/vis.xml
+++ b/tools/odgi/vis.xml
@@ -41,7 +41,7 @@ $path_per_row
     </outputs>
     <tests>
         <test>
-            <param name="input" value="note5_out.og" />
+            <param name="input" value="note5_out.og" ftype="odgi" />
             <param name="width" value="4000" />
             <param name="height" value="500" />
             <output name="output" file="note5.png" ftype="png" />


### PR DESCRIPTION
since it is subclassed and has no sniffer

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
