### PR TITLE
progressive mauve: test ftype

### DIFF
--- a/tools/progressivemauve/progressivemauve.xml
+++ b/tools/progressivemauve/progressivemauve.xml
@@ -219,7 +219,7 @@ $disable_backbone
       </test>
       <test>
           <param name="sequences" value="merged.fa" />
-          <param name="match_input" value="1.mums" />
+          <param name="match_input" value="1.mums" ftype="tabular"/>
           <output name="output" file="2.xmfa" lines_diff="24"/>
       </test>
   </tests>


### PR DESCRIPTION
needs to be set manually to tabular (data is tab separated but header
lines make sniffing fail)

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
