### PR TITLE
schicexplorer misses scool datatype

### DIFF
--- a/tools/schicexplorer/macros.xml
+++ b/tools/schicexplorer/macros.xml
@@ -1,6 +1,7 @@
 <macros>
     <token name="@THREADS@">\${GALAXY_SLOTS:-4}</token>
     <token name="@WRAPPER_VERSION@">4</token>
+    <token name="@PROFILE@">22.01</token>
 
      <xml name="requirements">
         <requirements>

--- a/tools/schicexplorer/macros.xml
+++ b/tools/schicexplorer/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@THREADS@">\${GALAXY_SLOTS:-4}</token>
     <token name="@TOOL_VERSION@">4</token>
-    <token name="@PROFILE@">22.01</token>
+    <token name="@PROFILE@">22.05</token>
 
      <xml name="requirements">
         <requirements>

--- a/tools/schicexplorer/macros.xml
+++ b/tools/schicexplorer/macros.xml
@@ -1,11 +1,11 @@
 <macros>
     <token name="@THREADS@">\${GALAXY_SLOTS:-4}</token>
-    <token name="@WRAPPER_VERSION@">4</token>
+    <token name="@TOOL_VERSION@">4</token>
     <token name="@PROFILE@">22.01</token>
 
      <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@WRAPPER_VERSION@">schicexplorer</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">schicexplorer</requirement>
             <yield />
         </requirements>
         <version_command>@BINARY@ --version</version_command>

--- a/tools/schicexplorer/scHicAdjustMatrix.xml
+++ b/tools/schicexplorer/scHicAdjustMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicadjustmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicadjustmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices on the raw data</description>
     <macros>
         <token name="@BINARY@">scHicAdjustMatrix</token>

--- a/tools/schicexplorer/scHicAdjustMatrix.xml
+++ b/tools/schicexplorer/scHicAdjustMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicadjustmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicadjustmatrix" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices on the raw data</description>
     <macros>
         <token name="@BINARY@">scHicAdjustMatrix</token>

--- a/tools/schicexplorer/scHicAdjustMatrix.xml
+++ b/tools/schicexplorer/scHicAdjustMatrix.xml
@@ -8,10 +8,10 @@
     <command detect_errors="exit_code"><![CDATA[
         @BINARY@
 
-        --matrix '$matrix_scooler'
+        --matrix "$matrix_scooler"
         --action $action_selector
         #if $chromosomes:
-            #set $chromosome = ' '.join([ '\'%s\'' % $chrom for $chrom in str($chromosomes).split(' ') ])
+            #set $chromosome = " ".join([ "\"%s\"" % $chrom for $chrom in str($chromosomes).split(" ") ])
             --chromosomes $chromosome
         #end if
 
@@ -19,30 +19,27 @@
         --outFileName adjusted_matrix.scool
 
         --threads @THREADS@
-
-
-
     ]]></command>
     <inputs>
         
         <expand macro="matrix_scooler_macro"/>
         <param name="action_selector" type="select" label="Action to take apply on matrices:">
-                <option value="keep" selected="True">Keep the listed chromosomes</option>
+                <option value="keep" selected="true">Keep the listed chromosomes</option>
                 <option value="remove" >Remove the listed chromosomes</option>
         </param>
-        <param name='chromosomes' type='text' label='List of chromosomes to consider' help='Please separate the chromosomes by space'/>
+        <param name="chromosomes" type="text" label="List of chromosomes to consider" help="Please separate the chromosomes by space"/>
     </inputs>
     <outputs>
         <data name="outFileName" from_work_dir="adjusted_matrix.scool" format="scool" label="${tool.name} on ${on_string}: Adjusted matrix"/>
     </outputs>
     <tests>
         <test>
-            <param name='matrix_scooler' value='test_matrix.scool' />
-            <param name='clusterMethod_selector' value='keep' />
-            <param name='chromosomes' value='chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chrX' />
+            <param name="matrix_scooler" value="test_matrix.scool" />
+            <param name="action_selector" value="keep" />
+            <param name="chromosomes" value="chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chrX" />
             <output name="outFileName" ftype="scool">
                 <assert_contents>
-                    <has_h5_keys keys='Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins, 
+                    <has_h5_keys keys="Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins, 
                     Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/chrom, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/end, 
                     Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/bins/start, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms, 
                     Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms/length, Diploid_1_CGTACTAG_AAGGAGTA_R1fastqgz/chroms/name, 
@@ -190,7 +187,7 @@
                     Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes/bin1_offset,
                     Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/indexes/chrom_offset, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels, 
                     Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/bin1_id, Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/bin2_id, 
-                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/count'/>
+                    Diploid_2_AGGCAGAA_AAGGAGTA_R1fastqgz/pixels/count"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/schicexplorer/scHicCluster.xml
+++ b/tools/schicexplorer/scHicCluster.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccluster" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schiccluster" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices on the raw data</description>
     <macros>
         <token name="@BINARY@">scHicCluster</token>

--- a/tools/schicexplorer/scHicCluster.xml
+++ b/tools/schicexplorer/scHicCluster.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccluster" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schiccluster" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices on the raw data</description>
     <macros>
         <token name="@BINARY@">scHicCluster</token>

--- a/tools/schicexplorer/scHicClusterCompartments.xml
+++ b/tools/schicexplorer/scHicClusterCompartments.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclustercompartments" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicclustercompartments" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with A/B compartments dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterCompartments</token>

--- a/tools/schicexplorer/scHicClusterCompartments.xml
+++ b/tools/schicexplorer/scHicClusterCompartments.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclustercompartments" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicclustercompartments" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with A/B compartments dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterCompartments</token>

--- a/tools/schicexplorer/scHicClusterMinHash.xml
+++ b/tools/schicexplorer/scHicClusterMinHash.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclusterminhash" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicclusterminhash" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with MinHash dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterMinHash</token>

--- a/tools/schicexplorer/scHicClusterMinHash.xml
+++ b/tools/schicexplorer/scHicClusterMinHash.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclusterminhash" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicclusterminhash" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with MinHash dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterMinHash</token>

--- a/tools/schicexplorer/scHicClusterSVL.xml
+++ b/tools/schicexplorer/scHicClusterSVL.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclustersvl" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicclustersvl" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with svl dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterSVL</token>

--- a/tools/schicexplorer/scHicClusterSVL.xml
+++ b/tools/schicexplorer/scHicClusterSVL.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicclustersvl" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicclustersvl" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>clusters single-cell Hi-C interaction matrices with svl dimension reduction</description>
     <macros>
         <token name="@BINARY@">scHicClusterSVL</token>

--- a/tools/schicexplorer/scHicConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicConsensusMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>creates per cluster one average matrix</description>
     <macros>
         <token name="@BINARY@">scHicConsensusMatrices</token>

--- a/tools/schicexplorer/scHicConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicConsensusMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>creates per cluster one average matrix</description>
     <macros>
         <token name="@BINARY@">scHicConsensusMatrices</token>

--- a/tools/schicexplorer/scHicConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicConsensusMatrices.xml
@@ -23,7 +23,6 @@
         <expand macro="matrix_scooler_macro"/>
         <param name='clusters' type='data' format='txt' label='Cluster file' help='Cluster file created by scHicCluster, scHicClusterCompartments, scHicClusterMinHash or scHicClusterSVL'/>
         
-        <param name='chromosomes' type='text' label='List of chromosomes to consider' help='Please separate the chromosomes by space'/>
     </inputs>
     <outputs>
         <data name="outFileName" from_work_dir="consensus_matrix.scool" format="scool" label="${tool.name} on ${on_string}: Consensus matrices"/>

--- a/tools/schicexplorer/scHicCorrectMatrices.xml
+++ b/tools/schicexplorer/scHicCorrectMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccorrectmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schiccorrectmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>correct with KR algorithm single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicCorrectMatrices</token>

--- a/tools/schicexplorer/scHicCorrectMatrices.xml
+++ b/tools/schicexplorer/scHicCorrectMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccorrectmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schiccorrectmatrices" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>correct with KR algorithm single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicCorrectMatrices</token>

--- a/tools/schicexplorer/scHicCreateBulkMatrix.xml
+++ b/tools/schicexplorer/scHicCreateBulkMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccreatebulkmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schiccreatebulkmatrix" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>creates the bulk matrix out of  single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicCreateBulkMatrix</token>

--- a/tools/schicexplorer/scHicCreateBulkMatrix.xml
+++ b/tools/schicexplorer/scHicCreateBulkMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schiccreatebulkmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schiccreatebulkmatrix" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>creates the bulk matrix out of  single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicCreateBulkMatrix</token>
@@ -20,12 +20,12 @@
         <expand macro="matrix_scooler_macro"/>
     </inputs>
     <outputs>
-        <data name="outFileName" from_work_dir="bulk_matrix.cool" format="cool" label="${tool.name} on ${on_string}: Bulk matrix"/>
+        <data name="outFileName" from_work_dir="bulk_matrix.cool" format="scool" label="${tool.name} on ${on_string}: Bulk matrix"/>
     </outputs>
     <tests>
         <test>
             <param name='matrix_scooler' value='test_matrix.scool' />
-            <output name="outFileName" file="scHicCreateBulkMatrix/bulk_matrix.cool" ftype="cool" compare="sim_size" delta="4000"/>
+            <output name="outFileName" file="scHicCreateBulkMatrix/bulk_matrix.cool" ftype="scool" compare="sim_size" delta="4000"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/schicexplorer/scHicDemultiplex.xml
+++ b/tools/schicexplorer/scHicDemultiplex.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicdemultiplex" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicdemultiplex" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>demultiplexes Nagano 2017 raw fastq files</description>
     <macros>
         <token name="@BINARY@">scHicDemultiplex</token>

--- a/tools/schicexplorer/scHicDemultiplex.xml
+++ b/tools/schicexplorer/scHicDemultiplex.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicdemultiplex" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicdemultiplex" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>demultiplexes Nagano 2017 raw fastq files</description>
     <macros>
         <token name="@BINARY@">scHicDemultiplex</token>

--- a/tools/schicexplorer/scHicInfo.xml
+++ b/tools/schicexplorer/scHicInfo.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicinfo" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicinfo" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>information about a single-cell scool matrix</description>
     <macros>
         <token name="@BINARY@">scHicInfo</token>

--- a/tools/schicexplorer/scHicInfo.xml
+++ b/tools/schicexplorer/scHicInfo.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicinfo" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicinfo" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>information about a single-cell scool matrix</description>
     <macros>
         <token name="@BINARY@">scHicInfo</token>

--- a/tools/schicexplorer/scHicMergeMatrixBins.xml
+++ b/tools/schicexplorer/scHicMergeMatrixBins.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicmergematrixbins" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicmergematrixbins" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>change the resolution of the scHi-C matrices</description>
     <macros>
         <token name="@BINARY@">scHicMergeMatrixBins</token>

--- a/tools/schicexplorer/scHicMergeMatrixBins.xml
+++ b/tools/schicexplorer/scHicMergeMatrixBins.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicmergematrixbins" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicmergematrixbins" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>change the resolution of the scHi-C matrices</description>
     <macros>
         <token name="@BINARY@">scHicMergeMatrixBins</token>

--- a/tools/schicexplorer/scHicMergeToSCool.xml
+++ b/tools/schicexplorer/scHicMergeToSCool.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicmergetoscool" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicmergetoscool" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>merge multiple cool files to one scool file</description>
     <macros>
         <token name="@BINARY@">scHicMergeToSCool</token>

--- a/tools/schicexplorer/scHicMergeToSCool.xml
+++ b/tools/schicexplorer/scHicMergeToSCool.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicmergetoscool" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicmergetoscool" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>merge multiple cool files to one scool file</description>
     <macros>
         <token name="@BINARY@">scHicMergeToSCool</token>

--- a/tools/schicexplorer/scHicNormalize.xml
+++ b/tools/schicexplorer/scHicNormalize.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicnormalize" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicnormalize" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>normalize single-cell Hi-C interaction matrices to the same read coverage</description>
     <macros>
         <token name="@BINARY@">scHicNormalize</token>

--- a/tools/schicexplorer/scHicNormalize.xml
+++ b/tools/schicexplorer/scHicNormalize.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicnormalize" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicnormalize" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>normalize single-cell Hi-C interaction matrices to the same read coverage</description>
     <macros>
         <token name="@BINARY@">scHicNormalize</token>

--- a/tools/schicexplorer/scHicPlotClusterProfiles.xml
+++ b/tools/schicexplorer/scHicPlotClusterProfiles.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>plot single-cell Hi-C interaction matrices cluster profiles</description>
     <macros>
         <token name="@BINARY@">scHicPlotClusterProfiles</token>

--- a/tools/schicexplorer/scHicPlotClusterProfiles.xml
+++ b/tools/schicexplorer/scHicPlotClusterProfiles.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>plot single-cell Hi-C interaction matrices cluster profiles</description>
     <macros>
         <token name="@BINARY@">scHicPlotClusterProfiles</token>

--- a/tools/schicexplorer/scHicPlotConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicPlotConsensusMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicplotconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicplotconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>plot single-cell Hi-C interaction matrices cluster consensus matrices</description>
     <macros>
         <token name="@BINARY@">scHicPlotConsensusMatrices</token>

--- a/tools/schicexplorer/scHicPlotConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicPlotConsensusMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicplotconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicplotconsensusmatrices" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>plot single-cell Hi-C interaction matrices cluster consensus matrices</description>
     <macros>
         <token name="@BINARY@">scHicPlotConsensusMatrices</token>

--- a/tools/schicexplorer/scHicQualityControl.xml
+++ b/tools/schicexplorer/scHicQualityControl.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
     <description>quality control for single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicQualityControl</token>

--- a/tools/schicexplorer/scHicQualityControl.xml
+++ b/tools/schicexplorer/scHicQualityControl.xml
@@ -6,9 +6,12 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+        ## https://github.com/open2c/cooler/issues/299
+        cp '$matrix_scooler' matrix.scooler &&
+
         @BINARY@
 
-        --matrix '$matrix_scooler'
+        --matrix matrix.scooler
         #if $chromosomes:
             #set $chromosome = ' '.join([ '\'%s\'' % $chrom for $chrom in str($chromosomes).split(' ') ])
             --chromosomes $chromosome

--- a/tools/schicexplorer/scHicQualityControl.xml
+++ b/tools/schicexplorer/scHicQualityControl.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@WRAPPER_VERSION@.1" profile="@PROFILE@">
+<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>quality control for single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicQualityControl</token>


### PR DESCRIPTION
there is no scool datatype in Galaxy. scool is currently sniffed as h5
which leads to an error with galaxyproject/galaxy#12073

possible solutions:

- replace scool by h5 and lower the profile
- add scool dataype to Galaxy and set the profile to the Galaxy version
  where it was added

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
