### PR TITLE
seacr: test set bedgraph datatype

### DIFF
--- a/tools/seacr/seacr.xml
+++ b/tools/seacr/seacr.xml
@@ -53,7 +53,7 @@
     <tests>
         <!-- #1 -->
         <test expect_num_outputs="1">
-            <param name="bedgraph" value="test.bedgraph"/>
+            <param name="bedgraph" value="test.bedgraph" ftype="bedgraph"/>
             <conditional name="control_cond">
                 <param name="control_sel" value="t"/>
                 <param name="t" value="0.2"/>
@@ -70,7 +70,7 @@
         </test>
         <!-- #2 -->
         <test expect_num_outputs="1">
-            <param name="bedgraph" value="test.bedgraph"/>
+            <param name="bedgraph" value="test.bedgraph" ftype="bedgraph"/>
             <conditional name="control_cond">
                 <param name="control_sel" value="t"/>
                 <param name="t" value="0.1"/>
@@ -87,10 +87,10 @@
         </test>
         <!-- #3 -->
         <test expect_num_outputs="1">
-            <param name="bedgraph" value="test.bedgraph"/>
+            <param name="bedgraph" value="test.bedgraph" ftype="bedgraph"/>
             <conditional name="control_cond">
                 <param name="control_sel" value="f"/>
-                <param name="f" value="control.bedgraph"/>
+                <param name="f" value="control.bedgraph" ftype="bedgraph"/>
             </conditional>
             <param name="normalize" value="norm"/>
             <param name="mode" value="relaxed"/>


### PR DESCRIPTION
because its not sniffed

xref: https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
