### PR TITLE
swift: datatype fixes

### DIFF
--- a/tools/swift/swift.xml
+++ b/tools/swift/swift.xml
@@ -3,7 +3,7 @@
     <macros>
         <token name="@VERSION@">1.0</token>
         <xml name="test_inputs" >
-            <param name="inp_ped" value="pedin.21" />
+            <param name="inp_ped" value="pedin.21" ftype="linkage_pedin"/>
             <param name="inp_dat" value="datain.21" />
             <param name="inp_map" value="map.21" />
         </xml>
@@ -51,7 +51,7 @@ swiftlink
 
     <inputs>
         <param name="inp_ped" type="data" format="linkage_pedin" label="Pedigree" />
-        <param name="inp_dat" type="data" format="linkage_recomb" label="Recombination Freqs." />
+        <param name="inp_dat" type="data" format="linkage_datain" label="Recombination Freqs." />
         <param name="inp_map" type="data" format="linkage_map" label="Marker Positions" />
 
         <conditional name="elod_opts" >


### PR DESCRIPTION
- linkage_recomb does not exists guess it needs to be linkage_datain
- linkage_pedin is not sniffable and needs to be set

does not work yet because linkage_pedin is not uploadable

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
