### PR TITLE
table_compute: skiplines.tsv is not tabular

### DIFF
--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -1204,7 +1204,7 @@ Data = {
             <!-- Test 36: Skip first 3 lines -->
             <conditional name="singtabop" >
                 <param name="use_type" value="single" />
-                <param name="input" value="skiplines.tsv" />
+                <param name="input" value="skiplines.tsv" ftype="tabular" />
                 <section name="adv" >
                     <param name="header" value="2" />
                     <param name="nrows" value="4" />
@@ -1227,7 +1227,7 @@ Data = {
             <!-- Test 37: Skip first 3 lines -->
             <conditional name="singtabop" >
                 <param name="use_type" value="single" />
-                <param name="input" value="skiplines.tsv" />
+                <param name="input" value="skiplines.tsv" ftype="tabular" />
                 <section name="adv" >
                     <param name="header" value="2" />
                     <param name="skipfooter" value="2" />


### PR DESCRIPTION
there is an empty line (containing only spaces) that makes Galaxy's
sniffer fail. so the ftype needs to be set

alternatively extend the sniffer or allow txt input

xref: https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
