### PR TITLE
transdecoder: domtbl input from hmmscan needs to be txt

### DIFF
--- a/tools/transdecoder/transdecoder.xml
+++ b/tools/transdecoder/transdecoder.xml
@@ -1,11 +1,11 @@
-<tool id="transdecoder" name="TransDecoder" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="transdecoder" name="TransDecoder" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05">
     <description>finds coding regions within transcripts</description>
     <xrefs>
         <xref type="bio.tools">TransDecoder</xref>
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">5.5.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">transdecoder</requirement>


### PR DESCRIPTION
- because it is a space separated table
- also the hmmscan output is txt

xref: https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
