### PR TITLE
vg view: use ftype for vg files

### DIFF
--- a/tools/vg/view.xml
+++ b/tools/vg/view.xml
@@ -63,7 +63,7 @@ $output_format
         <test>
             <conditional name="input_format">
                 <param name="input_format_selector" value="--vg-in" />
-                <param name="infile" value="x.vg" />
+                <param name="infile" value="x.vg" ftype="vg" />
             </conditional>
             <param name="output_format" value="--json" />
             <output name="output" file="x.json" ftype="json" />


### PR DESCRIPTION
which cant be sniffed

xref https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
