### PR TITLE
xpath: set xml ftype

### DIFF
--- a/tools/xpath/xpath.xml
+++ b/tools/xpath/xpath.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <tool id="xpath" name="XPath" version="@WRAPPER_VERSION@.0">
   <description>compute xpath expressions on XML data</description>
   <macros>
@@ -28,17 +27,17 @@
     <test>
       <param name="input" value="test.xml"/>
       <param name="expression" value="//b[@attr=&quot;value&quot;]" />
-      <output name="output" file="1.xml"/>
+      <output name="output" file="1.xml" ftype="xml"/>
     </test>
     <test>
       <param name="input" value="test.xml"/>
       <param name="expression" value="//b[@attr]" />
-      <output name="output" file="2.xml"/>
+      <output name="output" file="2.xml" ftype="xml"/>
     </test>
     <test>
       <param name="input" value="test.xml"/>
       <param name="expression" value="//b/text()" />
-      <output name="output" file="3.xml"/>
+      <output name="output" file="3.xml" ftype="xml"/>
     </test>
   </tests>
   <help><![CDATA[


### PR DESCRIPTION
since Galaxy's xml sniffer expects `<?xml `.

xref: https://github.com/galaxyproject/galaxy/pull/12073

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
