### PR TITLE
Check for potentially unused test data files and check file sizes only for changed files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,13 +234,32 @@ jobs:
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt
+        fi
+    - name: Check for unused files in test data
+      run: |
+        while read repo; do
+          for file in $(find $repo/test-data -type f)
+          do
+            b=$(echo $file | sed "s@$repo/test-data/@@");
+            if ! grep -q $b $repo/ -r ; then
+              echo "$file";
+            fi
+          done
+        done < repository_list.txt > file_unused_report.txt
+        if [[ -s file_unused_report.txt ]]; then
+          echo "Potentially unused files found"
+          cat file_unused_report.txt
+        fi
+    - name: Check success
+      run: |
+        if [[ -s file_size_report.txt ]] || [[ -s file_unused_report.txt ]]; then
           exit 1
         fi
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: 'File size report'
-        path: file_size_report.txt
+        name: 'File size and unused files report'
+        path: file_*_report.txt
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,7 +234,27 @@ jobs:
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt
+          exit 1
         fi
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: 'File size and unused files report'
+        path: file_size_report.txt
+
+  unused_test_data:
+    name: Check for unused test data files
+    needs: setup
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.repository-list != '' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Save repositories to file
+      run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
     - name: Check for unused files in test data
       run: |
         while read repo; do
@@ -249,17 +269,13 @@ jobs:
         if [[ -s file_unused_report.txt ]]; then
           echo "Potentially unused files found"
           cat file_unused_report.txt
-        fi
-    - name: Check success
-      run: |
-        if [[ -s file_size_report.txt ]] || [[ -s file_unused_report.txt ]]; then
           exit 1
         fi
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: 'File size and unused files report'
-        path: file_*_report.txt
+        name: 'Unused files report'
+        path: file_unused_report.txt
 
   # Planemo test the changed repositories, each chunk creates an artifact
   # containing HTML and JSON reports for the executed tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -119,6 +119,7 @@ jobs:
         mode: lint
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
+        fail_level: warn
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:

--- a/tools/aegean/parseval.xml
+++ b/tools/aegean/parseval.xml
@@ -1,4 +1,4 @@
-<tool id='aegean_parseval' name='AEGeAn ParsEval' version='@TOOL_VERSION@+galaxy1' profile='20.01'>
+<tool id='aegean_parseval' name='AEGeAn ParsEval' version='@TOOL_VERSION@' profile='20.01'>
     <description> compare two sets of gene annotations for the same sequence.</description>
     <macros>                                                                                           
         <import>macros.xml</import>

--- a/tools/aegean/parseval.xml
+++ b/tools/aegean/parseval.xml
@@ -1,4 +1,4 @@
-<tool id='aegean_parseval' name='AEGeAn ParsEval' version='@TOOL_VERSION@' profile='20.01'>
+<tool id='aegean_parseval' name='AEGeAn ParsEval' version='@TOOL_VERSION@+galaxy1' profile='20.01'>
     <description> compare two sets of gene annotations for the same sequence.</description>
     <macros>                                                                                           
         <import>macros.xml</import>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@VERSION@">0.7.5</token>
-    <token name="@GALAXY_VERSION@">galaxy0</token>
+    <token name="@GALAXY_VERSION@">galaxy1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@VERSION@">anndata</requirement>


### PR DESCRIPTION
Raise linter error-level to warn. This will require https://github.com/galaxyproject/planemo-ci-action/pull/23/ and a new release of the action.

The check for unused test data is clearly not fool proof, e.g. index files. But maybe it helps. 

The change in the file size job is to check only changed files. Seems to work, since `find tools/anndata -type f -size +500k` would return 

```
tools/anndata/test-data/tl.diffmap.h5ad
tools/anndata/test-data/tl.draw_graph.h5ad
tools/anndata/test-data/tl.umap.h5ad
tools/anndata/test-data/pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad
tools/anndata/test-data/tl.paga.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad
```

But since none of these files was changed they are not reported.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
