### PR TITLE
dexseq use rds datatype

### DIFF
--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -1,4 +1,4 @@
-<tool id="dexseq" name="DEXSeq" version="@VERSION@+galaxy1">
+<tool id="dexseq" name="DEXSeq" version="@VERSION@+galaxy2">
     <description>Determines differential exon usage from count tables</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>
@@ -102,11 +102,11 @@ echo $(R --version | grep version | grep -v GNU)", DEXSeq version" $(R --vanilla
         <param name="fdr_cutoff" type="float" min="0.0" max="1.0" value="0.05" label="All the genes under this FDR threshold will be shown in the html report"/>
     </inputs>
     <outputs>
-        <data name="dexseq_out" format="tabular" label="DEXSeq result file on ${on_string}" />
-        <data name="htmlreport" format="html" label="DEXSeq report on ${on_string}">
+        <data name="dexseq_out" format="tabular" label="${tool.name} on ${on_string}: result" />
+        <data name="htmlreport" format="html" label="${tool.name} on ${on_string}: report">
             <filter>report is True</filter>
         </data>
-        <data name="rds_out" format="rdata" from_work_dir="DEXSeqResults.rds" label="DEXSeq rds file on ${on_string}">
+        <data name="rds_out" format="rds" from_work_dir="DEXSeqResults.rds" label="${tool.name} on ${on_string}: rds file">
             <filter>rds is True</filter>
         </data>
     </outputs>
@@ -174,7 +174,7 @@ echo $(R --version | grep version | grep -v GNU)", DEXSeq version" $(R --vanilla
             <param name="rds" value="True"/>
             <param name="fdr_cutoff" value="0.05"/>
             <output name="dexseq_out" ftype="tabular" file="dexseq_result.tabular" compare="sim_size"/>
-            <output name="rds_out" ftype="rdata" file="dexseq.rds" compare="sim_size"/>
+            <output name="rds_out" ftype="rds" file="dexseq.rds" compare="sim_size"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -1,4 +1,4 @@
-<tool id="dexseq" name="DEXSeq" version="@VERSION@+galaxy2">
+<tool id="dexseq" name="DEXSeq" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>Determines differential exon usage from count tables</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>

--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -1,4 +1,4 @@
-<tool id="dexseq_count" name="DEXSeq-Count" version="@TOOL_VERSION@.0">
+<tool id="dexseq_count" name="DEXSeq-Count" version="@TOOL_VERSION@.1" profile="@PROFILE@">
     <description>Prepare and count exon abundancies from RNA-seq data</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>

--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -1,4 +1,4 @@
-<tool id="dexseq_count" name="DEXSeq-Count" version="@VERSION@.0">
+<tool id="dexseq_count" name="DEXSeq-Count" version="@TOOL_VERSION@.0">
     <description>Prepare and count exon abundancies from RNA-seq data</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -4,7 +4,7 @@
     <token name="@PROFILE@">21.05</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@VERSION@">bioconductor-dexseq</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">bioconductor-dexseq</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.28.1</token>
-    <token name="@PROFILE@">21.05</token>
+    <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-dexseq</requirement>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@VERSION@">1.28.1</token>
+    <token name="@TOOL_VERSION@">1.28.1</token>
+    <token name="@PROFILE@">21.05</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@VERSION@">bioconductor-dexseq</requirement>

--- a/tools/dexseq/plotdexseq.xml
+++ b/tools/dexseq/plotdexseq.xml
@@ -1,4 +1,4 @@
-<tool id="plotdexseq" name="plotDEXSeq" version="@VERSION@.0">
+<tool id="plotdexseq" name="plotDEXSeq" version="@VERSION@.1" profile="@PROFILE@">
     <description>Visualization of the per gene DEXSeq results</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/3695

but it will only work with https://github.com/galaxyproject/galaxy/pull/12712 .. which probably can not be included in 21.09 ..?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
