### PR TITLE
Funannotate: fix --protein_evidence option

### DIFF
--- a/tools/funannotate/funannotate_predict.xml
+++ b/tools/funannotate/funannotate_predict.xml
@@ -506,8 +506,8 @@ mv output/predict_results/*.stats.json out.stats.json
                 <has_text text="Aligning transcript evidence to genome with minimap2"/>
                 <has_text text="Found 16 alignments, wrote GFF3 and Augustus hints to file"/>
                 <has_text text="Extracting hints from RNA-seq BAM file using bam2hints"/>
-                <has_text text="Mapping 13 proteins to genome using diamond and exonerate"/>
-                <has_text text="Found 4 preliminary alignments --> aligning with exonerate"/>
+                <has_text text="Mapping 16 proteins to genome using diamond and exonerate"/>
+                <has_text text="Found 21 preliminary alignments --> aligning with exonerate"/>
             </assert_stderr>
             <assert_command>
                 <has_text text="--protein_evidence"/>
@@ -580,8 +580,8 @@ mv output/predict_results/*.stats.json out.stats.json
                 <not_has_text text="Aligning transcript evidence to genome with minimap2"/>
                 <not_has_text text="Found 16 alignments, wrote GFF3 and Augustus hints to file"/>
                 <not_has_text text="Extracting hints from RNA-seq BAM file using bam2hints"/>
-                <has_text text="Mapping 13 proteins to genome using diamond and exonerate"/>
-                <has_text text="Found 4 preliminary alignments --> aligning with exonerate"/>
+                <has_text text="Mapping 16 proteins to genome using diamond and exonerate"/>
+                <has_text text="Found 21 preliminary alignments --> aligning with exonerate"/>
             </assert_stderr>
             <assert_command>
                 <has_text text="--protein_evidence"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Just a small bug fix for the funannotate predict tool