### PR TITLE
Fix missing = in ggplot tool

### DIFF
--- a/tools/ggplot2/ggplot_point.xml
+++ b/tools/ggplot2/ggplot_point.xml
@@ -38,7 +38,7 @@ names(input)[$yplot] <- "ycol"
         gg_point = geom_point(size=1, alpha=1, gg_factor)
         gg_line = geom_line(size=1, alpha=1, gg_factor)
      #else
-        gg_point = geom_point(size$adv.points.size, alpha=$adv.points.alpha, colour='$adv.points.pointcolor')
+        gg_point = geom_point(size=$adv.points.size, alpha=$adv.points.alpha, colour='$adv.points.pointcolor')
         gg_line = geom_line(size=$adv.points.size, alpha=$adv.points.alpha, colour='$adv.points.pointcolor')
      #end if
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

I think this fixes it, but it is still unclear for me why alpha is quoted but size isn't. 
https://usegalaxy.org/datasets/bbd44e69cb8906b523334d86b2f9331c/details has the following in the tool log, but size and and alpha are treated identically (afaict) and are both floats, so that looks extremely odd to me

```

        gg_point = geom_point(size=2.0, alpha='1.0', gg_factor)
        gg_line = geom_line(size=2.0, alpha='1.0', gg_factor)

        color_scale = scale_color_brewer(palette='Set2', direction='1')
```

xref https://github.com/galaxyproject/training-material/issues/2886 where it was discovered