### PR TITLE
Updating tools/ncbi_acc_download from version 0.2.7 to 0.2.8

### DIFF
--- a/tools/ncbi_acc_download/macros.xml
+++ b/tools/ncbi_acc_download/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.2.7</token>
+    <token name="@TOOL_VERSION@">0.2.8</token>
 </macros>

--- a/tools/ncbi_acc_download/ncbi_acc_download.xml
+++ b/tools/ncbi_acc_download/ncbi_acc_download.xml
@@ -24,6 +24,9 @@
             #if $molecule.format != 'featuretable' and $molecule.format != 'gff3':
                 --extended-validation all
             #end if
+            #if $range != ""
+                --range $range
+            #end if
             \${accession};
         failure=\$?;
         if [ \$failure -ne 0 ]; then
@@ -73,6 +76,15 @@
                 </param>
             </when>
         </conditional>
+        <param argument="--range" type="text" label="Range" help="Region to subset accession. Start and end position separated by ':', '..', or '.'. Only for single accession">
+            <sanitizer invalid_char="">
+                <valid initial="string.digits">
+                    <add value=":" />
+                    <add value=".." />
+                    <add value="." />
+                </valid>
+            </sanitizer>
+        </param>
         <param name="ignore_failed" type="select" display="radio"
         label="How to handle download failures">
             <option value="0">Abort with error on first failure</option>
@@ -292,6 +304,25 @@
                 <element name="NP_003192" ftype="fasta">
                     <assert_contents>
                         <has_line line=">NP_003192.1 transcription factor A, mitochondrial isoform 1 precursor [Homo sapiens]" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+        <test>
+            <conditional name="molecule">
+                <param name="select" value="nucleotide"/>
+                <param name="format" value="genbank"/>
+            </conditional>
+            <conditional name="query_source">
+                <param name="select" value="accession_list" />
+                <param name="accession_list" value="NC_006666"/>
+            </conditional>
+            <param name="range" value="1697:2764"/>
+            <output_collection name="output" type="list">
+                <element name="NC_006666" ftype="genbank">
+                    <assert_contents>
+                        <has_text text="ND2" />
+                        <not_has_text text="tRNA-Ile" />
                     </assert_contents>
                 </element>
             </output_collection>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ncbi_acc_download**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ncbi_acc_download from version 0.2.7 to 0.2.8.

**Project home page:** https://github.com/kblin/ncbi-acc-download/releases