### PR TITLE
Updating tools/pangolin from version 3.1.14 to
3.1.16

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -5,10 +5,6 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>
-	<!-- the scorpio requirement is because pangolin got an update to use scorpio 0.3.13 (to detect AY.4.2 better) 
-             while still using the pangolin 3.1.14 code. when pangolin gets updated past 3.1.14 this requirement can
-             be removed -->
-	<requirement type="package" version="0.3.13">scorpio</requirement>
         <requirement type="package" version="0.23.0">csvtk</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,7 +1,7 @@
 <tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.15</token>
+        <token name="@TOOL_VERSION@">3.1.16</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>

--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,7 +1,7 @@
-<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy1" profile="20.01">
+<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.14</token>
+        <token name="@TOOL_VERSION@">3.1.15</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pangolin**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pangolin from version 3.1.14 to 3.1.15.

**Project home page:** https://github.com/cov-lineages/pangolin/releases