### PR TITLE
Version bump for earlier change on hyphy cfel

### DIFF
--- a/tools/hyphy/hyphy_cfel.xml
+++ b/tools/hyphy/hyphy_cfel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="hyphy_cfel" name="HyPhy-CFEL" version="@VERSION@+galaxy1" profile="19.09">
+<tool id="hyphy_cfel" name="HyPhy-CFEL" version="@VERSION@+galaxy2" profile="19.09">
     <description>Test for Differences in Selective Pressures at Individual Sites among Clades and Sets of Branches</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
Fix previous pr (https://github.com/galaxyproject/tools-iuc/pull/4007) that changed the tool but didn't version bump