### PR TITLE
Trinity: scratch folder has to be unique to each Trinity instance 

### DIFF
--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -3,8 +3,6 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@WRAPPER_VERSION@">trinity</requirement>
-            <requirement type="package" version="8.32">coreutils</requirement>
-            <requirement type="package" version="3.2.3">rsync</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/trinity/macros.xml
+++ b/tools/trinity/macros.xml
@@ -3,6 +3,8 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@WRAPPER_VERSION@">trinity</requirement>
+            <requirement type="package" version="8.32">coreutils</requirement>
+            <requirement type="package" version="3.2.3">rsync</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -1,4 +1,4 @@
-<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="trinity" name="Trinity" version="@WRAPPER_VERSION@+galaxy2">
     <description>de novo assembly of RNA-Seq data</description>
     <expand macro="bio_tools"/>
     <macros>
@@ -14,7 +14,8 @@
 
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             workdir=`pwd` ;
-            cd "\$TRINITY_SCRATCH_DIR" ;
+            scratchfolder=`mktemp -d -p \$TRINITY_SCRATCH_DIR` ;
+            cd "\$scratchfolder" ;
         fi ;
 
         #if $additional_params.guided.is_guided == "yes":
@@ -149,6 +150,10 @@
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             mkdir -p "\$workdir/trinity_out_dir";
             cp -p trinity_out_dir/Trinity* "\$workdir/trinity_out_dir";
+            mkdir -p "\$TRINITY_SCRATCH_DIR/empty_dir";
+            cd "\$TRINITY_SCRATCH_DIR";
+            rsync -a --delete "\$TRINITY_SCRATCH_DIR/empty_dir/ \$scratchfolder/";
+            rmdir "\$TRINITY_SCRATCH_DIR/empty_dir \$scratchfolder/";
             cd "\$workdir";
         fi ;
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -14,7 +14,7 @@
 
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             workdir=`pwd` ;
-            scratchfolder=`mktemp -d -p \$TRINITY_SCRATCH_DIR` ;
+            scratchfolder=\$(mktemp -d -p "\$TRINITY_SCRATCH_DIR");
             cd "\$scratchfolder" ;
         fi ;
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -18,6 +18,7 @@
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             workdir=`pwd` ;
             scratchfolder=\$(mktemp -d -p "\$TRINITY_SCRATCH_DIR");
+            emptyfolder=\$(mktemp -d -p "\$TRINITY_SCRATCH_DIR");
             cd "\$scratchfolder" ;
         fi ;
 
@@ -153,10 +154,9 @@
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             mkdir -p "\$workdir/trinity_out_dir";
             cp -p trinity_out_dir/Trinity* "\$workdir/trinity_out_dir";
-            mkdir -p "\$TRINITY_SCRATCH_DIR/empty_dir";
             cd "\$TRINITY_SCRATCH_DIR";
-            rsync -a --delete "\$TRINITY_SCRATCH_DIR/empty_dir/" "\$scratchfolder/";
-            rmdir "\$TRINITY_SCRATCH_DIR/empty_dir" "\$scratchfolder/";
+            rsync -a --delete "\$emptyfolder/" "\$scratchfolder/";
+            rmdir "\$emptyfolder" "\$scratchfolder/";
             cd "\$workdir";
         fi ;
 

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -151,6 +151,9 @@
 
         &&
 
+        ## Trinity can create millions of files in the same directory, so the cleaning task makes use of rsync
+        ## for ensuring better performances.
+        ## see: https://web.archive.org/web/20130929001850/http://linuxnote.net/jianingy/en/linux/a-fast-way-to-remove-huge-number-of-files.html
         if [ ! -z "\$TRINITY_SCRATCH_DIR" ] ; then
             mkdir -p "\$workdir/trinity_out_dir";
             cp -p trinity_out_dir/Trinity* "\$workdir/trinity_out_dir";

--- a/tools/trinity/trinity.xml
+++ b/tools/trinity/trinity.xml
@@ -4,7 +4,10 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements" />
+    <expand macro="requirements">
+        <requirement type="package" version="8.32">coreutils</requirement>
+        <requirement type="package" version="3.2.3">rsync</requirement>
+    </expand>
     <command detect_errors="aggressive"><![CDATA[
         if [ -z "\$GALAXY_MEMORY_MB" ] ; then
             GALAXY_MEMORY_GB=1 ;
@@ -152,8 +155,8 @@
             cp -p trinity_out_dir/Trinity* "\$workdir/trinity_out_dir";
             mkdir -p "\$TRINITY_SCRATCH_DIR/empty_dir";
             cd "\$TRINITY_SCRATCH_DIR";
-            rsync -a --delete "\$TRINITY_SCRATCH_DIR/empty_dir/ \$scratchfolder/";
-            rmdir "\$TRINITY_SCRATCH_DIR/empty_dir \$scratchfolder/";
+            rsync -a --delete "\$TRINITY_SCRATCH_DIR/empty_dir/" "\$scratchfolder/";
+            rmdir "\$TRINITY_SCRATCH_DIR/empty_dir" "\$scratchfolder/";
             cd "\$workdir";
         fi ;
 


### PR DESCRIPTION
Trinity wrapper can use a scratch directory defined by the variable $TRINITY_SCRATCH_DIR but, in the current implementation, could happen that multiple Trinity instance running at the same time can overwrite results in that common path.
I am using mktemp to enforce a directory creation with a unique name  to be used as scratch dir per each instance.

Trinity has also the bad attitude to create millions of files in the same directory (we have had a dir with 9M), so I added a cleaning task using rsync for ensuring better performances.

Added coreutils and rsync to the dependencies.

FOR CONTRIBUTOR:
* [X ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
