### PR TITLE
Improve remote check

### DIFF
--- a/tools/ena_upload/check_remote.py
+++ b/tools/ena_upload/check_remote.py
@@ -12,7 +12,7 @@ def check_remote_entry(entry_type, query_dict, out_format='json'):
     '''
     assert entry_type in ['study', 'sample', 'experiment', 'run']
     params_dict = {}
-    query_str = ' AND '.join(['%s=%s' % (key, value) for (key, value) in query_dict.items()])
+    query_str = ' AND '.join(['%s="%s"' % (key, value) for (key, value) in query_dict.items()])
     params_dict['query'] = query_str
     params_dict['result'] = 'read_' + entry_type
     params_dict['fields'] = entry_type + '_alias'

--- a/tools/ena_upload/ena_upload.xml
+++ b/tools/ena_upload/ena_upload.xml
@@ -1,6 +1,6 @@
 <tool id="ena_upload" name="ENA Upload tool" version="@VERSION@" profile="20.01" license="MIT">
     <macros>
-        <token name="@VERSION@">0.4.1</token>
+        <token name="@VERSION@">0.4.3</token>
         <import>samples_macros.xml</import>
     </macros>
     <requirements>

--- a/tools/ena_upload/ena_upload.xml
+++ b/tools/ena_upload/ena_upload.xml
@@ -374,7 +374,7 @@ $samples.append({'title':str($sample.sample_title),'description':str($sample.sam
                     <has_n_lines n="2"/>
                     <has_n_columns n="8"/>
                     <has_line_matching expression="alias\tstatus\taccession\ttitle\tstudy_type\tstudy_abstract\tpubmed_id\tsubmission_date"/>
-                    <has_line_matching expression="SARS-CoV-2_genomes_01\tmodify\tENA_accession\tWhole-genome sequencing of SARS-CoV-2 from Covid-19 patients\tWhole Genome Sequencing\tWhole-genome sequences of SARS-CoV-2 from oro-pharyngeal swabs obtained from Covid-19 patients(.*)"/>
+                    <has_line_matching expression="SARS-CoV-2_genomes_01\tadd\tENA_accession\tWhole-genome sequencing of SARS-CoV-2 from Covid-19 patients\tWhole Genome Sequencing\tWhole-genome sequences of SARS-CoV-2 from oro-pharyngeal swabs obtained from Covid-19 patients(.*)"/>
                 </assert_contents>
             </output>
             <output name="samples_table_out">
@@ -425,7 +425,7 @@ $samples.append({'title':str($sample.sample_title),'description':str($sample.sam
                     <has_n_lines n="2"/>
                     <has_n_columns n="8"/>
                     <has_line_matching expression="alias\tstatus\taccession\ttitle\tstudy_type\tstudy_abstract\tpubmed_id\tsubmission_date"/>
-                    <has_line_matching expression="SARS-CoV-2_genomes_01\tmodify\tENA_accession\tWhole-genome sequencing of SARS-CoV-2 from Covid-19 patients\tWhole Genome Sequencing\tWhole-genome sequences of SARS-CoV-2 from oro-pharyngeal swabs obtained from Covid-19 patients(.*)"/>
+                    <has_line_matching expression="SARS-CoV-2_genomes_01\tadd\tENA_accession\tWhole-genome sequencing of SARS-CoV-2 from Covid-19 patients\tWhole Genome Sequencing\tWhole-genome sequences of SARS-CoV-2 from oro-pharyngeal swabs obtained from Covid-19 patients(.*)"/>
                 </assert_contents>
             </output>
             <output name="samples_table_out">

--- a/tools/ena_upload/process_xlsx.py
+++ b/tools/ena_upload/process_xlsx.py
@@ -14,7 +14,7 @@ def identify_action(entry_type, alias):
     ''' define action ['add' | 'modify'] that needs to be perfomed for this entry '''
     query = {entry_type + '_alias': alias}
     remote_accessions = check_remote_entry(entry_type, query)
-    if len(remote_accessions) > 0:
+    if isinstance(remote_accessions,list) and len(remote_accessions) > 0:
         print(f'Found: {entry_type} entry with alias {alias}')
         return 'modify'
     else:

--- a/tools/ena_upload/process_xlsx.py
+++ b/tools/ena_upload/process_xlsx.py
@@ -14,7 +14,7 @@ def identify_action(entry_type, alias):
     ''' define action ['add' | 'modify'] that needs to be perfomed for this entry '''
     query = {entry_type + '_alias': alias}
     remote_accessions = check_remote_entry(entry_type, query)
-    if isinstance(remote_accessions,list) and len(remote_accessions) > 0:
+    if isinstance(remote_accessions, list) and len(remote_accessions) > 0:
         print(f'Found: {entry_type} entry with alias {alias}')
         return 'modify'
     else:


### PR DESCRIPTION
A small update to fix the request to the remote ENA server to check if there is an existing entry with the same alias. 

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)


