### PR TITLE
correct a bug in bamToBed -bedpe and add a test

### DIFF
--- a/tools/bedtools/annotateBed.xml
+++ b/tools/bedtools/annotateBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_annotatebed" name="bedtools AnnotateBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>annotate coverage of features from multiple files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_bamtobed" name="bedtools BAM to BED" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_bamtobed" name="bedtools BAM to BED" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>converter</description>
     <expand macro="bio_tools" />
     <macros>
@@ -10,7 +10,7 @@
     <expand macro="stdio" />
     <command><![CDATA[
 #if $input.extension in ['bam', 'unsorted.bam', 'qname_input_sorted.bam'] and $option == "-bedpe":
-    samtools sort -n -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:-.}" '${input}' ./input &&
+    samtools sort -n -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:-.}" '${input}' > ./input &&
 #else
     ln -s '${input}' ./input.bam &&
 #end if
@@ -53,6 +53,12 @@ $split
             <param name="option" value="" />
             <param name="tag" value="NM" />
             <output name="output" file="bamToBed_result2.bed" ftype="bed" />
+        </test>
+        <test>
+            <param name="input" value="bedpeToBam_result1.bam" ftype="bam" />
+            <param name="option" value="-bedpe" />
+            <param name="tag" value="" />
+            <output name="output" file="bamToBed_result3.bed" ftype="bed" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_bamtobed" name="bedtools BAM to BED" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>converter</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
     </expand>

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -10,7 +10,7 @@
     <expand macro="stdio" />
     <command><![CDATA[
 #if $input.extension in ['bam', 'unsorted.bam', 'qname_input_sorted.bam'] and $option == "-bedpe":
-    samtools sort -n -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:-.}" '${input}' > ./input &&
+    samtools sort -n -@ "\${GALAXY_SLOTS:-4}" -T "\${TMPDIR:-.}" '${input}' > ./input.bam &&
 #else
     ln -s '${input}' ./input.bam &&
 #end if

--- a/tools/bedtools/bed12ToBed6.xml
+++ b/tools/bedtools/bed12ToBed6.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_bed12tobed6" name="bedtools BED12 to BED6" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>converter</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bedToBam.xml
+++ b/tools/bedtools/bedToBam.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_bedtobam" name="bedtools BED to BAM" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>converter</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bedToIgv.xml
+++ b/tools/bedtools/bedToIgv.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_bedtoigv" name="bedtools BED to IGV" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>create batch script for taking IGV screenshots</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bedpeToBam.xml
+++ b/tools/bedtools/bedpeToBam.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_bedpetobam" name="bedtools BEDPE to BAM" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>converter</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <!-- bedtobam broken in 2.29.0 <expand macro="requirements" /> -->
     <requirements>
         <requirement type="package" version="2.27.1">bedtools</requirement>

--- a/tools/bedtools/closestBed.xml
+++ b/tools/bedtools/closestBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_closestbed" name="bedtools ClosestBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>find the closest, potentially non-overlapping interval</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/clusterBed.xml
+++ b/tools/bedtools/clusterBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_clusterbed" name="bedtools ClusterBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>cluster overlapping/nearby intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/complementBed.xml
+++ b/tools/bedtools/complementBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_complementbed" name="bedtools ComplementBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>Extract intervals not represented by an interval file</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_coveragebed" name="bedtools Compute both the depth and breadth of coverage" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>of features in file B on the features in file A (bedtools coverage)</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
     </expand>

--- a/tools/bedtools/expandBed.xml
+++ b/tools/bedtools/expandBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_expandbed" name="bedtools ExpandBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>replicate lines based on lists of values in columns</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/fisherBed.xml
+++ b/tools/bedtools/fisherBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_fisher" name="bedtools FisherBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>calculate Fisher statistic between two feature files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/flankBed.xml
+++ b/tools/bedtools/flankBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_flankbed" name="bedtools FlankBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>create new intervals from the flanks of existing intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/genomeCoverageBed.xml
+++ b/tools/bedtools/genomeCoverageBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_genomecoveragebed" name="bedtools Genome Coverage" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>compute the coverage over an entire genome</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_getfastabed" name="bedtools GetFastaBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>use intervals to extract sequences from a FASTA file</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/groupbyBed.xml
+++ b/tools/bedtools/groupbyBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_groupbybed" name="bedtools GroupByBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>group by common cols and summarize other cols</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/groupbyBed.xml
+++ b/tools/bedtools/groupbyBed.xml
@@ -25,7 +25,7 @@ bedtools groupby
             </sanitizer>
         </param>
         <param name="operation" argument="-o" type="select" label="Specify the operation">
-            <option value="sum" selected="true">Sum - numeric only</option>
+            <!-- <option value="sum" selected="true">Sum - numeric only</option> This is already in math-->
             <option value="stdev">Stdev - numeric only</option>
             <option value="sstdev">Sstdev - numeric only</option>
             <option value="freqasc">Freqasc - comma separated list of values observed and the number of times they were observed (ascending)</option>

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_intersectbed" name="bedtools Intersect intervals" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>find overlapping intervals in various ways</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
     </expand>

--- a/tools/bedtools/jaccardBed.xml
+++ b/tools/bedtools/jaccardBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_jaccard" name="bedtools JaccardBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>calculate the distribution of relative distances between two files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/linksBed.xml
+++ b/tools/bedtools/linksBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_links" name="bedtools LinksBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>create a HTML page of links to UCSC locations</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/makeWindowsBed.xml
+++ b/tools/bedtools/makeWindowsBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_makewindowsbed" name="bedtools MakeWindowsBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>make interval windows across a genome</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/mapBed.xml
+++ b/tools/bedtools/mapBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_map" name="bedtools MapBed" version="@TOOL_VERSION@.2" profile="@PROFILE@">
     <description>apply a function to a column for each overlapping interval</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/maskFastaBed.xml
+++ b/tools/bedtools/maskFastaBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_maskfastabed" name="bedtools MaskFastaBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>use intervals to mask sequences from a FASTA file</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/mergeBed.xml
+++ b/tools/bedtools/mergeBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_mergebed" name="bedtools MergeBED" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>combine overlapping/nearby intervals into a single interval</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/multiCov.xml
+++ b/tools/bedtools/multiCov.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_multicovtbed" name="bedtools MultiCovBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>counts coverage from multiple BAMs at specific intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/multiIntersectBed.xml
+++ b/tools/bedtools/multiIntersectBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_multiintersectbed" name="bedtools Multiple Intersect" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>identifies common intervals among multiple interval files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/nucBed.xml
+++ b/tools/bedtools/nucBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_nucbed" name="bedtools NucBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>profile the nucleotide content of intervals in a FASTA file</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/overlapBed.xml
+++ b/tools/bedtools/overlapBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_overlapbed" name="bedtools OverlapBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>computes the amount of overlap from two intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/randomBed.xml
+++ b/tools/bedtools/randomBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_randombed" name="bedtools RandomBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>generate random intervals in a genome</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/reldist.xml
+++ b/tools/bedtools/reldist.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_reldistbed" name="bedtools ReldistBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>calculate the distribution of relative distances</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/shuffleBed.xml
+++ b/tools/bedtools/shuffleBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_shufflebed" name="bedtools ShuffleBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>randomly redistrubute intervals in a genome</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/slopBed.xml
+++ b/tools/bedtools/slopBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_slopbed" name="bedtools SlopBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>adjust the size of intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/sortBed.xml
+++ b/tools/bedtools/sortBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_sortbed" name="bedtools SortBED" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>order the intervals</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/spacingBed.xml
+++ b/tools/bedtools/spacingBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_spacingbed" name="bedtools SpacingBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>reports the distances between features</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/subtractBed.xml
+++ b/tools/bedtools/subtractBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_subtractbed" name="bedtools SubtractBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>remove intervals based on overlaps</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/tagBed.xml
+++ b/tools/bedtools/tagBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_tagbed" name="bedtools TagBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>tag BAM alignments based on overlaps with interval files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/test-data/bamToBed_result3.bed
+++ b/tools/bedtools/test-data/bamToBed_result3.bed
@@ -1,0 +1,2 @@
+chr1	100	200	chr5	5000	5100	bedpe_example1	255	+	-
+chr9	1000	5000	chr9	3000	3800	bedpe_example2	255	+	-

--- a/tools/bedtools/unionBedGraphs.xml
+++ b/tools/bedtools/unionBedGraphs.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_unionbedgraph" name="bedtools Merge BedGraph files" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>combines coverage intervals from multiple BEDGRAPH files</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/windowBed.xml
+++ b/tools/bedtools/windowBed.xml
@@ -1,9 +1,9 @@
 <tool id="bedtools_windowbed" name="bedtools WindowBed" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description>find overlapping intervals within a window around an interval</description>
-    <expand macro="bio_tools" />
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="stdio" />
     <command><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

I don't know for how long there is a bug here but `samtools sort` requires either the `-o` option or send to standard output. In addition the output was `./input` instead of `./input.bam`.