### PR TITLE
Kraken2 Data Manager: Update URLs & Add Standard Pre-built DBs

### DIFF
--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -60,6 +60,14 @@ class StandardPrebuiltSizes(Enum):
         return self.value
 
 
+class PrebuiltDates(Enum):
+    date_2021_05_17 = '2021-05-17'
+    date_2020_12_02 = '2020-12-02'
+
+    def __str__(self):
+        return self.value
+
+
 def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_TABLE_NAME):
     now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
 
@@ -120,7 +128,7 @@ def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_
     return data_table_entry
 
 
-def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, data_table_name=DATA_TABLE_NAME):
+def kraken2_build_standard_prebuilt(standard_prebuilt_size, prebuilt_date, target_directory, data_table_name=DATA_TABLE_NAME):
 
     now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
 
@@ -145,7 +153,7 @@ def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, da
         '8': '_8gb',
     }
     # we may need to let the user choose the date when new DBs are posted.
-    date_url_str = '20210517'
+    date_url_str = prebuilt_date.replace('-', '')
     standard_prebuilt_size_url = size_to_url_str[standard_prebuilt_size]
     # download the pre-built database
     src = urlopen(
@@ -360,6 +368,7 @@ def main():
     parser.add_argument('--database-type', dest='database_type', type=KrakenDatabaseTypes, choices=list(KrakenDatabaseTypes), required=True, help='type of kraken database to build')
     parser.add_argument('--minikraken2-version', dest='minikraken2_version', type=Minikraken2Versions, choices=list(Minikraken2Versions), help='MiniKraken2 version (only applies to --database-type minikraken)')
     parser.add_argument('--standard-prebuilt-size', dest='standard_prebuilt_size', type=StandardPrebuiltSizes, choices=list(StandardPrebuiltSizes), help='Size of standard prebuilt database to download (only applies to --database-type standard_prebuilt. Options are: "8", "16", "full".)')
+    parser.add_argument('--prebuilt-date', dest='prebuilt_date', type=PrebuiltDates, choices=list(PrebuiltDates), help='Database build date (YYYY-MM-DD). Only applies to --database-type standard_prebuilt. Options are: "2021-05-17", "2020-12-02".)')
     parser.add_argument('--special-database-type', dest='special_database_type', type=SpecialDatabaseTypes, choices=list(SpecialDatabaseTypes), help='type of special database to build (only applies to --database-type special)')
     parser.add_argument('--custom-fasta', dest='custom_fasta', help='fasta file for custom database (only applies to --database-type custom)')
     parser.add_argument('--custom-database-name', dest='custom_database_name', help='Name for custom database (only applies to --database-type custom)')
@@ -398,6 +407,7 @@ def main():
     elif str(args.database_type) == 'standard_prebuilt':
         data_manager_output = kraken2_build_standard_prebuilt(
             str(args.standard_prebuilt_size),
+            str(args.prebuilt_date),
             target_directory
         )
     elif str(args.database_type) == 'minikraken':

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -119,6 +119,7 @@ def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_
 
     return data_table_entry
 
+
 def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, data_table_name=DATA_TABLE_NAME):
 
     now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
@@ -137,7 +138,7 @@ def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, da
     ])
 
     database_path = database_value
-    
+
     size_to_url_str = {
         'full': '',
         '16': '_16gb',

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -132,7 +132,7 @@ def kraken2_build_minikraken(minikraken2_version, target_directory, data_table_n
 
     # download the minikraken2 data
     src = urlopen(
-        'ftp://ftp.ccb.jhu.edu/pub/data/kraken2_dbs/minikraken2_%s_8GB_201904_UPDATE.tgz'
+        'https://genome-idx.s3.amazonaws.com/kraken/minikraken2_%s_8GB_201904.tgz'
         % minikraken2_version
     )
     with open('tmp_data.tar.gz', 'wb') as dst:

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -24,7 +24,8 @@ DATA_TABLE_NAME = "kraken2_databases"
 
 
 class KrakenDatabaseTypes(Enum):
-    standard = 'standard'
+    standard_local_build = 'standard_local_build'
+    standard_prebuilt = 'standard_prebuilt'
     minikraken = 'minikraken'
     special = 'special'
     custom = 'custom'
@@ -50,6 +51,15 @@ class Minikraken2Versions(Enum):
         return self.value
 
 
+class StandardPrebuiltSizes(Enum):
+    full = 'full'
+    gb_16 = '16'
+    gb_8 = '8'
+
+    def __str__(self):
+        return self.value
+
+
 def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_TABLE_NAME):
     now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
 
@@ -63,7 +73,7 @@ def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_
     ])
 
     database_name = " ".join([
-        "Standard",
+        "Standard (Local Build)",
         "(Created:",
         now + ",",
         "kmer-len=" + str(kraken2_args["kmer_len"]) + ",",
@@ -94,6 +104,60 @@ def kraken2_build_standard(kraken2_args, target_directory, data_table_name=DATA_
         ]
 
         subprocess.check_call(['kraken2-build'] + args, cwd=target_directory)
+
+    data_table_entry = {
+        'data_tables': {
+            data_table_name: [
+                {
+                    "value": database_value,
+                    "name": database_name,
+                    "path": database_path,
+                }
+            ]
+        }
+    }
+
+    return data_table_entry
+
+def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, data_table_name=DATA_TABLE_NAME):
+
+    now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
+
+    database_value = "_".join([
+        now,
+        "standard_prebuilt",
+        standard_prebuilt_size
+    ])
+
+    database_name = " ".join([
+        "Standard (Prebuilt)",
+        standard_prebuilt_size,
+        "(Downloaded:",
+        now + ")"
+    ])
+
+    database_path = database_value
+    
+    size_to_url_str = {
+        'full': '',
+        '16': '_16gb',
+        '8': '_8gb',
+    }
+    date_url_str = '20210517'
+    standard_prebuilt_size_url = size_to_url_str[standard_prebuilt_size]
+    # download the pre-built database
+    src = urlopen(
+        's3://genome-idx/kraken/k2_standard%s_%s.tar.gz'
+        % standard_prebuilt_size_url, date_url_str
+    )
+    with open('tmp_data.tar.gz', 'wb') as dst:
+        shutil.copyfileobj(src, dst)
+    # unpack the downloaded archive to the target directory
+    with tarfile.open('tmp_data.tar.gz', 'r:gz') as fh:
+        for member in fh.getmembers():
+            if member.isreg():
+                member.name = os.path.basename(member.name)
+                fh.extract(member, os.path.join(target_directory, database_path))
 
     data_table_entry = {
         'data_tables': {
@@ -293,6 +357,7 @@ def main():
     parser.add_argument('--threads', dest='threads', default=1, help='threads')
     parser.add_argument('--database-type', dest='database_type', type=KrakenDatabaseTypes, choices=list(KrakenDatabaseTypes), required=True, help='type of kraken database to build')
     parser.add_argument('--minikraken2-version', dest='minikraken2_version', type=Minikraken2Versions, choices=list(Minikraken2Versions), help='MiniKraken2 version (only applies to --database-type minikraken)')
+    parser.add_argument('--standard-prebuilt-size', dest='standard_prebuilt_size', type=StandardPrebuiltSizes, choices=list(StandardPrebuiltSizes), help='Size of standard prebuilt database to download (only applies to --database-type standard_prebuilt)')
     parser.add_argument('--special-database-type', dest='special_database_type', type=SpecialDatabaseTypes, choices=list(SpecialDatabaseTypes), help='type of special database to build (only applies to --database-type special)')
     parser.add_argument('--custom-fasta', dest='custom_fasta', help='fasta file for custom database (only applies to --database-type custom)')
     parser.add_argument('--custom-database-name', dest='custom_database_name', help='Name for custom database (only applies to --database-type custom)')

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -144,6 +144,7 @@ def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, da
         '16': '_16gb',
         '8': '_8gb',
     }
+    # we may need to let the user choose the date when new DBs are posted.
     date_url_str = '20210517'
     standard_prebuilt_size_url = size_to_url_str[standard_prebuilt_size]
     # download the pre-built database
@@ -358,7 +359,7 @@ def main():
     parser.add_argument('--threads', dest='threads', default=1, help='threads')
     parser.add_argument('--database-type', dest='database_type', type=KrakenDatabaseTypes, choices=list(KrakenDatabaseTypes), required=True, help='type of kraken database to build')
     parser.add_argument('--minikraken2-version', dest='minikraken2_version', type=Minikraken2Versions, choices=list(Minikraken2Versions), help='MiniKraken2 version (only applies to --database-type minikraken)')
-    parser.add_argument('--standard-prebuilt-size', dest='standard_prebuilt_size', type=StandardPrebuiltSizes, choices=list(StandardPrebuiltSizes), help='Size of standard prebuilt database to download (only applies to --database-type standard_prebuilt)')
+    parser.add_argument('--standard-prebuilt-size', dest='standard_prebuilt_size', type=StandardPrebuiltSizes, choices=list(StandardPrebuiltSizes), help='Size of standard prebuilt database to download (only applies to --database-type standard_prebuilt. Options are: "8", "16", "full".)')
     parser.add_argument('--special-database-type', dest='special_database_type', type=SpecialDatabaseTypes, choices=list(SpecialDatabaseTypes), help='type of special database to build (only applies to --database-type special)')
     parser.add_argument('--custom-fasta', dest='custom_fasta', help='fasta file for custom database (only applies to --database-type custom)')
     parser.add_argument('--custom-database-name', dest='custom_database_name', help='Name for custom database (only applies to --database-type custom)')

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.py
@@ -147,8 +147,8 @@ def kraken2_build_standard_prebuilt(standard_prebuilt_size, target_directory, da
     standard_prebuilt_size_url = size_to_url_str[standard_prebuilt_size]
     # download the pre-built database
     src = urlopen(
-        's3://genome-idx/kraken/k2_standard%s_%s.tar.gz'
-        % standard_prebuilt_size_url, date_url_str
+        'https://genome-idx.s3.amazonaws.com/kraken/k2_standard%s_%s.tar.gz'
+        % (standard_prebuilt_size_url, date_url_str)
     )
     with open('tmp_data.tar.gz', 'wb') as dst:
         shutil.copyfileobj(src, dst)
@@ -380,7 +380,7 @@ def main():
 
     data_manager_output = {}
 
-    if str(args.database_type) == 'standard':
+    if str(args.database_type) == 'standard_local_build':
         kraken2_args = {
             "kmer_len": args.kmer_len,
             "minimizer_len": args.minimizer_len,
@@ -392,6 +392,11 @@ def main():
         data_manager_output = kraken2_build_standard(
             kraken2_args,
             target_directory,
+        )
+    elif str(args.database_type) == 'standard_prebuilt':
+        data_manager_output = kraken2_build_standard_prebuilt(
+            str(args.standard_prebuilt_size),
+            target_directory
         )
     elif str(args.database_type) == 'minikraken':
         data_manager_output = kraken2_build_minikraken(

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -72,7 +72,7 @@
                     <option value="16">Standard-16 (~16 GB)</option>
                     <option value="8">Standard-8 (~8 GB)</option>
                 </param>
-		<param name="prebuilt_date" type="select" multiple="false" label="Select database build date">
+                <param name="prebuilt_date" type="select" multiple="false" label="Select database build date">
                     <option value="2021-05-17">May 17, 2021</option>
                     <option value="2020-12-02">December 2, 2020</option>
                 </param>

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -23,7 +23,9 @@
           --database-type ${database_type.database_type}
           #if $database_type.database_type == "minikraken"
             --minikraken2-version ${database_type.minikraken2_version}
-          #else if $database_type.database_type == "standard"
+          #else if $database_type.database_type == "standard_prebuilt"
+            --standard-prebuilt-size ${database_type.standard_prebuilt_size}
+          #else if $database_type.database_type == "standard_local_build"
             --threads \${GALAXY_SLOTS:-1}
             --kmer-len ${database_type.kmer_len}
             --minimizer-len ${database_type.minimizer_len}
@@ -54,13 +56,21 @@
     <inputs>
         <conditional name="database_type">
             <param name="database_type" type="select" multiple="false" label="Database Type">
-                <option value="standard">Standard</option>
+                <option value="standard_local_build">Standard, Local Build</option>
+                <option value="standard_prebuilt">Standard, Pre-Built</option>      
                 <option value="minikraken">MiniKraken</option>
                 <option value="special">Special</option>
                 <option value="custom">Custom</option>
             </param>
-            <when value="standard">
+            <when value="standard_local_build">
                 <expand macro="common_params" />
+            </when>
+	    <when value="standard_prebuilt">
+                <param name="standard_prebuilt_size" type="select" multiple="false" label="Select size of prebuilt database to download">
+                    <option value="full">Full (~50 GB)</option>
+                    <option value="16">Standard-16 (~16 GB)</option>
+		    <option value="8">Standard-8 (~8 GB)</option>
+                </param>
             </when>
             <when value="minikraken">
                 <param name="minikraken2_version" type="select" multiple="false" label="Select MiniKraken2 database version to download">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -76,11 +76,11 @@
                     <option value="16">Standard-16 (~16 GB)</option>
                     <option value="8">Standard-8 (~8 GB)</option>
                 </param>
-                <param name="prebuilt_date" type="select" multiple="false" label="Select database build date">
+                <param name="prebuilt_date" type="select" multiple="false" optional="true" label="Select database build date">
                     <option value="2021-05-17">May 17, 2021</option>
                     <option value="2020-12-02">December 2, 2020</option>
                 </param>
-                <param name="prebuilt_date_custom" type="text" label="Custom date (YYYY-MM-DD)" />
+                <param name="prebuilt_date_custom" type="text" label="Custom date (YYYY-MM-DD)" help="Any text here will overwrite the selected date above." />
             </when>
             <when value="minikraken">
                 <param name="minikraken2_version" type="select" multiple="false" label="Select MiniKraken2 database version to download">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -25,6 +25,7 @@
             --minikraken2-version ${database_type.minikraken2_version}
           #else if $database_type.database_type == "standard_prebuilt"
             --standard-prebuilt-size ${database_type.standard_prebuilt_size}
+            --prebuilt-date ${database_type.prebuilt_date}
           #else if $database_type.database_type == "standard_local_build"
             --threads \${GALAXY_SLOTS:-1}
             --kmer-len ${database_type.kmer_len}
@@ -70,6 +71,10 @@
                     <option value="full">Standard-Full (~50 GB)</option>
                     <option value="16">Standard-16 (~16 GB)</option>
                     <option value="8">Standard-8 (~8 GB)</option>
+                </param>
+		<param name="prebuilt_date" type="select" multiple="false" label="Select database build date">
+                    <option value="2021-05-17">May 17, 2021</option>
+                    <option value="2020-12-02">December 2, 2020</option>
                 </param>
             </when>
             <when value="minikraken">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -25,7 +25,11 @@
             --minikraken2-version ${database_type.minikraken2_version}
           #else if $database_type.database_type == "standard_prebuilt"
             --standard-prebuilt-size ${database_type.standard_prebuilt_size}
-            --prebuilt-date ${database_type.prebuilt_date}
+            #if $database_type.prebuilt_date_custom != ""
+              --prebuilt-date ${database_type.prebuilt_date_custom}
+            #else
+              --prebuilt-date ${database_type.prebuilt_date}
+            #end if
           #else if $database_type.database_type == "standard_local_build"
             --threads \${GALAXY_SLOTS:-1}
             --kmer-len ${database_type.kmer_len}
@@ -76,6 +80,7 @@
                     <option value="2021-05-17">May 17, 2021</option>
                     <option value="2020-12-02">December 2, 2020</option>
                 </param>
+                <param name="prebuilt_date_custom" type="text" label="Custom date (YYYY-MM-DD)" />
             </when>
             <when value="minikraken">
                 <param name="minikraken2_version" type="select" multiple="false" label="Select MiniKraken2 database version to download">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -65,11 +65,11 @@
             <when value="standard_local_build">
                 <expand macro="common_params" />
             </when>
-	    <when value="standard_prebuilt">
+            <when value="standard_prebuilt">
                 <param name="standard_prebuilt_size" type="select" multiple="false" label="Select size of prebuilt database to download">
                     <option value="full">Standard (~50 GB)</option>
                     <option value="16">Standard-16 (~16 GB)</option>
-		    <option value="8">Standard-8 (~8 GB)</option>
+                    <option value="8">Standard-8 (~8 GB)</option>
                 </param>
             </when>
             <when value="minikraken">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -67,7 +67,7 @@
             </when>
             <when value="standard_prebuilt">
                 <param name="standard_prebuilt_size" type="select" multiple="false" label="Select size of prebuilt database to download">
-                    <option value="full">Standard (~50 GB)</option>
+                    <option value="full">Standard-Full (~50 GB)</option>
                     <option value="16">Standard-16 (~16 GB)</option>
                     <option value="8">Standard-8 (~8 GB)</option>
                 </param>

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -67,7 +67,7 @@
             </when>
 	    <when value="standard_prebuilt">
                 <param name="standard_prebuilt_size" type="select" multiple="false" label="Select size of prebuilt database to download">
-                    <option value="full">Full (~50 GB)</option>
+                    <option value="full">Standard (~50 GB)</option>
                     <option value="16">Standard-16 (~16 GB)</option>
 		    <option value="8">Standard-8 (~8 GB)</option>
                 </param>

--- a/data_managers/data_manager_build_kraken2_database/data_manager_conf.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager_conf.xml
@@ -1,5 +1,5 @@
 <data_managers>
-    <data_manager tool_file="data_manager/kraken2_build_database.xml" id="kraken2_build_database" version="2.0.8_beta+galaxy1">
+    <data_manager tool_file="data_manager/kraken2_build_database.xml" id="kraken2_build_database" version="2.1.1+galaxy0">
         <data_table name="kraken2_databases">
             <output>
                 <column name="value"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

This pull-request addresses #4073 and also adds a bit of additional functionality to download the pre-built 'Standard' databases from Ben Langmead's [Index Zone](https://benlangmead.github.io/aws-indexes/k2) 