### PR TITLE
Updating tools/nextclade from version 1.4.1 to 1.4.5

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.4.1</token>
+    <token name="@TOOL_VERSION@">1.4.5</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/nextalign.xml
+++ b/tools/nextclade/nextalign.xml
@@ -2,7 +2,7 @@
     <description>Viral genome sequence alignment</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nextalign</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.4.1 to 1.4.5.

**Project home page:** https://github.com/nextstrain/nextclade/releases