### PR TITLE
Updating tools/scater from version 1.20.0 to 1.22.0

### DIFF
--- a/tools/scater/macros.xml
+++ b/tools/scater/macros.xml
@@ -1,12 +1,12 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.20.0</token>
+    <token name="@TOOL_VERSION@">1.22.0</token>
     <token name="@PROFILE@">20.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-scater</requirement>
-            <requirement type="package" version="1.6.6">r-optparse</requirement>
+            <requirement type="package" version="1.7.1">r-optparse</requirement>
             <requirement type="package" version="0.0.7">r-workflowscriptscommon</requirement>
-            <requirement type="package" version="1.10.1">bioconductor-loomexperiment</requirement>
+            <requirement type="package" version="1.12.0">bioconductor-loomexperiment</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/scater/scater-filter.xml
+++ b/tools/scater/scater-filter.xml
@@ -5,7 +5,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="0.93_8">r-robustbase</requirement>
+        <requirement type="package" version="0.93_9">r-robustbase</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 #if $filter_type.filter_type_selector == 'manual':


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/scater**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/scater from version 1.20.0 to 1.22.0.

**Project home page:** http://bioconductor.org/packages/scater