### PR TITLE
Updating tools/tximport from version 1.20.0 to 1.22.0

### DIFF
--- a/tools/tximport/tximport.xml
+++ b/tools/tximport/tximport.xml
@@ -1,6 +1,6 @@
 <tool id="tximport" name="tximport" version="@TOOL_VERSION@" profile="20.09">
     <macros>
-        <token name="@TOOL_VERSION@">1.20.0</token>
+        <token name="@TOOL_VERSION@">1.22.0</token>
     </macros>
     <description>Summarize transcript-level estimates for gene-level analysis</description>
     <xrefs>
@@ -8,7 +8,7 @@
     </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-tximport</requirement>
-        <requirement type="package" version="1.44.0">bioconductor-genomicfeatures</requirement>
+        <requirement type="package" version="1.46.1">bioconductor-genomicfeatures</requirement>
         <requirement type="package" version="1.20.3">r-getopt</requirement>
     </requirements>
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/tximport**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/tximport from version 1.20.0 to 1.22.0.

**Project home page:** http://bioconductor.org/packages/tximport