### PR TITLE
funannotate clean: add cpu option

### DIFF
--- a/tools/funannotate/funannotate_clean.xml
+++ b/tools/funannotate/funannotate_clean.xml
@@ -15,7 +15,7 @@ funannotate clean
 --cov ${cov}
 --minlen ${minlen}
 ${exhaustive}
---cpus \${GALAXY_SLOTS:-2}
+--cpus \${GALAXY_SLOTS:-1}
     ]]></command>
     <inputs>
         <param argument="--input" type="data" format="fasta" label="Assembly to clean" />

--- a/tools/funannotate/funannotate_clean.xml
+++ b/tools/funannotate/funannotate_clean.xml
@@ -15,6 +15,7 @@ funannotate clean
 --cov ${cov}
 --minlen ${minlen}
 ${exhaustive}
+--cpus \${GALAXY_SLOTS:-2}
     ]]></command>
     <inputs>
         <param argument="--input" type="data" format="fasta" label="Assembly to clean" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Just adding the --cpus option (it's not in the --help, but it works)