### PR TITLE
Correct output datatype for prokka.

### DIFF
--- a/tools/prokka/prokka.xml
+++ b/tools/prokka/prokka.xml
@@ -5,7 +5,7 @@
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">1.14.6</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">prokka</requirement>
@@ -151,7 +151,7 @@ $input
 
     </inputs>
     <outputs>
-        <data name="out_gff" format="gff" label="${tool.name} on ${on_string}: gff" from_work_dir="outdir/prokka.gff">
+        <data name="out_gff" format="gff3" label="${tool.name} on ${on_string}: gff" from_work_dir="outdir/prokka.gff">
             <filter>outputs and 'gff' in outputs</filter>
         </data>
         <data name="out_gbk" format="genbank" label="${tool.name} on ${on_string}: gbk" from_work_dir="outdir/prokka.gbk">

--- a/tools/prokka/prokka.xml
+++ b/tools/prokka/prokka.xml
@@ -190,27 +190,27 @@ $input
         <test>
             <param name="input" ftype="fasta" value="phiX174.fasta" />
             <param name="outputs" value="gff,gbk,fna,faa,ffn,sqn,fsa,tbl,tsv,err,txt" />
-            <output name="out_gff" file="out.gff" />
+            <output name="out_gff" file="out.gff" ftype="gff3" />
             <output name="out_gbk" >
                 <assert_contents>
                     <has_text_matching expression="LOCUS" />
                     <has_text_matching expression="//" />
                 </assert_contents>
             </output>
-            <output name="out_fna" file="out.fna" />
-            <output name="out_faa" file="out.faa" />
-            <output name="out_ffn" file="out.ffn" />
+            <output name="out_fna" file="out.fna" ftype="fasta" />
+            <output name="out_faa" file="out.faa" ftype="fasta" />
+            <output name="out_ffn" file="out.ffn" ftype="fasta" />
             <output name="out_sqn" >
                 <assert_contents>
                     <has_text_matching expression="Seq-entry" />
                     <has_text_matching expression="contig2" />
                 </assert_contents>
             </output>
-            <output name="out_fsa" file="out.fsa" />
-            <output name="out_tbl" file="out.tbl" />
-            <output name="out_tsv" file="out.tsv" />
-            <output name="out_err" file="out.err" lines_diff="14" />
-            <output name="out_txt" file="out.txt" />
+            <output name="out_fsa" file="out.fsa" ftype="fasta" />
+            <output name="out_tbl" file="out.tbl" ftype="txt" />
+            <output name="out_tsv" file="out.tsv" ftype="tabular" />
+            <output name="out_err" file="out.err" lines_diff="14" ftype="txt" />
+            <output name="out_txt" file="out.txt" ftype="txt" />
             <output name="out_log">
                 <assert_contents>
                     <has_text text="Type 'prokka --citation' for more details." />

--- a/tools/prokka/prokka.xml
+++ b/tools/prokka/prokka.xml
@@ -135,7 +135,7 @@ $input
         <param argument="--norrna" type="boolean" checked="false" label="Don't run rRNA search with Barrnap" />
         <param argument="--notrna" type="boolean" checked="false" label="Don't run tRNA search with Aragorn" />
 
-        <param name="outputs" type="select" multiple="true" display="checkboxes" label="Additional outputs">
+        <param name="outputs" type="select" multiple="true" label="Additional outputs">
             <option value="gff" selected="True">Annotation in GFF3 format, containing both sequences and annotations (.gff)</option>
             <option value="gbk" selected="True">Standard GenBank file. If the input was a multi-FASTA, then this will be a multi-GenBank, with one record for each sequence (.gbk)</option>
             <option value="fna" selected="True">Nucleotide FASTA file of the input contig sequences (.fna)</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [x] - This PR updates an existing tool or tool collection

Prokka actually outputs gff3, not gff, which can break or complicate downstream analyses.