### PR TITLE
Bugfix for interproscan data manager

### DIFF
--- a/data_managers/data_manager_interproscan/data_manager/interproscan.py
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.py
@@ -119,7 +119,7 @@ def main():
         shutil.move(os.path.join(output_directory, 'interproscan-%s' % tag, 'core/jms-implementation/support-mini-x86-32/data/'), os.path.join(output_directory, 'data'))
     else:
         print("Moving data files around...")
-        shutil.move(os.path.join(output_directory, 'interproscan-%s' % tag), os.path.join(output_directory, 'data'))
+        shutil.move(os.path.join(output_directory, 'interproscan-%s' % tag, 'data'), os.path.join(output_directory, 'data'))
 
     print("Done, removing tarball and unneeded files...")
     os.remove(dest_tar)

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.py
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.py
@@ -97,7 +97,15 @@ def main():
         download_file(DATA_URL.format(version=tag), dest_tar)
 
         print("Finished, now checking md5...")
-        md5_computed = hashlib.md5(open(dest_tar, 'rb').read()).hexdigest()
+        m = hashlib.md5()
+        blocksize = 2**20
+        with open(dest_tar, 'rb') as tarball:
+            while True:
+                buf = tarball.read(blocksize)
+                if not buf:
+                    break
+                m.update(buf)
+        md5_computed = m.hexdigest()
         if not md5.startswith(md5_computed):
             raise RuntimeError("MD5 check failed: computed '%s', expected '%s'" % (md5_computed, md5))
 

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.xml
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.xml
@@ -4,7 +4,7 @@
         <requirement type="package" version="2.26.0">requests</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-python '$__tool_directory__/interproscan.py'
+python -u '$__tool_directory__/interproscan.py'
 $partial_data
 --version '$version'
 'interproscan'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

3 tiny changes:
- fix the broken path in a `mv`
- lower memory usage why checking md5
- make debugging easier by writing logs immediately to stdout