### PR TITLE
UMI-tools: include additional symbols in the sanitizer

### DIFF
--- a/tools/umi_tools/macros.xml
+++ b/tools/umi_tools/macros.xml
@@ -82,7 +82,6 @@
         <param argument="--bc-pattern2" type="text" value="" label="Barcode pattern for second read"
             help="Use this option to specify the format of the UMI/barcode for
                 the second read pair if required" >
-            <validator type="empty_field" /> 
             <expand macro="barcode_sanitizer" />
         </param>
     </macro>

--- a/tools/umi_tools/macros.xml
+++ b/tools/umi_tools/macros.xml
@@ -4,7 +4,7 @@
     <!-- macros applying to all umi_tools -->
 
     <token name="@TOOL_VERSION@">1.1.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
@@ -56,6 +56,8 @@
                 <add value="&#123;"/><!-- left brace -->
                 <add value="&#125;"/><!-- right brace -->
                 <add value="&#94;"/> <!-- caret -->
+                <add value="&#36;"/> <!-- dollar sign-->
+                <add value="&#43;" /><!-- plus sign -->
                 <add value="-"/>
                 <add value="!"/>
             </valid>
@@ -80,6 +82,7 @@
         <param argument="--bc-pattern2" type="text" value="" label="Barcode pattern for second read"
             help="Use this option to specify the format of the UMI/barcode for
                 the second read pair if required" >
+            <validator type="empty_field" /> 
             <expand macro="barcode_sanitizer" />
         </param>
     </macro>

--- a/tools/umi_tools/macros.xml
+++ b/tools/umi_tools/macros.xml
@@ -4,7 +4,7 @@
     <!-- macros applying to all umi_tools -->
 
     <token name="@TOOL_VERSION@">1.1.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
@@ -56,6 +56,8 @@
                 <add value="&#123;"/><!-- left brace -->
                 <add value="&#125;"/><!-- right brace -->
                 <add value="&#94;"/> <!-- caret -->
+                <add value="&#36;"/> <!-- dollar sign-->
+                <add value="&#43;" /><!-- plus sign -->
                 <add value="-"/>
                 <add value="!"/>
             </valid>

--- a/tools/umi_tools/macros.xml
+++ b/tools/umi_tools/macros.xml
@@ -4,7 +4,7 @@
     <!-- macros applying to all umi_tools -->
 
     <token name="@TOOL_VERSION@">1.1.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
@@ -56,8 +56,6 @@
                 <add value="&#123;"/><!-- left brace -->
                 <add value="&#125;"/><!-- right brace -->
                 <add value="&#94;"/> <!-- caret -->
-                <add value="&#36;"/> <!-- dollar sign-->
-                <add value="&#43;" /><!-- plus sign -->
                 <add value="-"/>
                 <add value="!"/>
             </valid>
@@ -176,8 +174,8 @@
         <conditional name="extract_method_cond">
             <param argument="--extract-method" type="select" label="Barcode Extraction Method"
                    help="If bracketed expressions are used in the above barcode pattern, then set this to 'regex'. Otherwise leave as 'string'" >
-                <option value="string" selected="true" />
-                <option value="regex" />
+                <option value="string" selected="true">String</option>
+                <option value="regex">Regex</option>
             </param>
             <when value="string">
                 <param argument="--3prime" name="prime3" type="boolean" label="Is barcode on 3' end of the read?"

--- a/tools/umi_tools/umi-tools_whitelist.xml
+++ b/tools/umi_tools/umi-tools_whitelist.xml
@@ -67,8 +67,8 @@
 
         <param argument="--method" type="select" label="Count reads or UMIs"
                help="Many published protocols rank CBs by the number of reads the CBs appear in. However you could also use the number of unique UMIs a CB is associated with. Note that this is still and approximation to the number of transcripts captured because the same UMI could be associated with two different transcripts and be counted as independent" >
-            <option value="reads" selected="true">Reads</options>
-            <option value="umis">UMIs</options>
+            <option value="reads" selected="true">Reads</option>
+            <option value="umis">UMIs</option>
         </param>
         <!-- TODO Cannot use expect-cells with 'distance' knee method.-->
         <param argument="--knee-method" type="select" label="Method for detection of knee">
@@ -78,8 +78,8 @@
         <param argument="--subset-reads" type="integer" min="0" value="0" label="Use the first N reads to automatically identify the true cell barcodes" />
         <param argument="--allow-threshold-error" type="boolean" truevalue="--allow-threshold-error" falsevalue="" label="Don't select a threshold" help="Will still output the plots if requested"/> 
         <param argument="--ed-above-threshold" type="select" optional="true" label="Detect and correct CBs above the threshold" help="which may be sequence errors from another CB">
-            <option value="correct">correct</option>
-            <option value="discard">discard</option>
+            <option value="correct">Correct</option>
+            <option value="discard">Discard</option>
         </param>
         <conditional name="celloptions" >
             <param name="use_cell_opts" type="select" label="Cell parameters" >

--- a/tools/umi_tools/umi-tools_whitelist.xml
+++ b/tools/umi_tools/umi-tools_whitelist.xml
@@ -67,13 +67,13 @@
 
         <param argument="--method" type="select" label="Count reads or UMIs"
                help="Many published protocols rank CBs by the number of reads the CBs appear in. However you could also use the number of unique UMIs a CB is associated with. Note that this is still and approximation to the number of transcripts captured because the same UMI could be associated with two different transcripts and be counted as independent" >
-            <option value="reads" selected="true" />
-            <option value="umis" />
+            <option value="reads" selected="true">Reads</options>
+            <option value="umis">UMIs</options>
         </param>
         <!-- TODO Cannot use expect-cells with 'distance' knee method.-->
         <param argument="--knee-method" type="select" label="Method for detection of knee">
-            <option value="distance" selected="true" />
-            <option value="density"/>
+            <option value="distance" selected="true">Distance</option>
+            <option value="density">Density</option>
         </param>
         <param argument="--subset-reads" type="integer" min="0" value="0" label="Use the first N reads to automatically identify the true cell barcodes" />
         <param argument="--allow-threshold-error" type="boolean" truevalue="--allow-threshold-error" falsevalue="" label="Don't select a threshold" help="Will still output the plots if requested"/> 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This PR includes two additional signs ($ and +) in the sanitizer. It was requested by an user in [GHelp](https://help.galaxyproject.org/t/umi-tools-extract-help-with-complex-regex-on-galaxy/7042). 