### PR TITLE
Funannotate data manager: https certificate fix

### DIFF
--- a/data_managers/data_manager_funannotate/data_manager/funannotate.xml
+++ b/data_managers/data_manager_funannotate/data_manager/funannotate.xml
@@ -5,6 +5,12 @@
     </requirements>
     <version_command>funannotate check --show-versions</version_command>
     <command detect_errors="exit_code"><![CDATA[
+#if $wget:
+    ## Asked for wget, we assume there's a certificate problem on (at least) one
+    ## of the many requested servers, force disable of all checks
+    echo "check_certificate = off" > \$HOME/.wgetrc &&
+#end if
+
 python -u '$__tool_directory__/funannotate.py'
 $partial_data
 $wget


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

A tiny hacky fix: when using wget, disable all certificate checks while downloading.
I had to do it as I had different (minor) cert errors on different servers where funannotate downloads data...