### PR TITLE
stacks2: fix unused inputs

### DIFF
--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -10,7 +10,7 @@
     </xml>
 
     <token name="@STACKS_VERSION@">2.55</token>
-    <token name="@WRAPPER_VERSION@">1</token>
+    <token name="@WRAPPER_VERSION@">2</token>
     <token name="@PROFILE@">20.05</token>
 
     <xml name="citation">
@@ -222,17 +222,17 @@ Stacks was developed by Julian Catchen with contributions from Angel Amores, Pau
          - se_option: wording for "single end" option (for tsv2bam this is the
               reverse reads for the others its the forward reads)
          - help: help text -->
-    <xml name="fastq_input" token_fastq_optional="false" token_se_option="single end or forward reads" token_help="">
+    <xml name="fastq_input" token_fastq_optional="false" token_se_option="single end or forward reads" token_help="" token_multiple="false" token_listtype="paired">
         <conditional name="input_type">
             <param name="input_type_select" type="select" label="Short read data from individuals" help="@HELP@">
                 <option value="single" selected="true">@SE_OPTION@</option>
                 <option value="paired">(paired) dataset list</option>
             </param>
             <when value="single">
-                <param name="fqinputs" argument="-f" format="fastqsanger,fastqsanger.gz,fasta,fasta.gz" type="data" label="Reads" multiple="true" optional="@FASTQ_OPTIONAL@"/>
+                <param name="fqinputs" argument="-f" format="fastqsanger,fastqsanger.gz,fasta,fasta.gz" type="data" label="Reads" multiple="@MULTIPLE@" optional="@FASTQ_OPTIONAL@"/>
             </when>
             <when value="paired">
-                <param name="fqinputs" argument="-f" type="data_collection" collection_type="list:paired" format="fastqsanger,fastqsanger.gz,fasta,fasta.gz" label="List for forward reads or read pairs" optional="@FASTQ_OPTIONAL@"/>
+                <param name="fqinputs" argument="-f" type="data_collection" collection_type="@LISTTYPE@" format="fastqsanger,fastqsanger.gz,fasta,fasta.gz" label="List for forward reads or read pairs" optional="@FASTQ_OPTIONAL@"/>
             </when>
         </conditional>
     </xml>

--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -2,15 +2,15 @@
 <macros>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@STACKS_VERSION@">stacks</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">stacks</requirement>
             <requirement type="package" version="3.7">python</requirement>
             <requirement type="package" version="4.6.0">findutils</requirement>
             <yield/>
         </requirements>
     </xml>
 
-    <token name="@STACKS_VERSION@">2.55</token>
-    <token name="@WRAPPER_VERSION@">2</token>
+    <token name="@TOOL_VERSION@">2.55</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">20.05</token>
 
     <xml name="citation">

--- a/tools/stacks2/stacks_clonefilter.xml
+++ b/tools/stacks2/stacks_clonefilter.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_clonefilter" name="Stacks2: clone filter" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_clonefilter" name="Stacks2: clone filter" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 <description>Identify PCR clones</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_cstacks.xml
+++ b/tools/stacks2/stacks_cstacks.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_cstacks" name="Stacks2: cstacks" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_cstacks" name="Stacks2: cstacks" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Generate catalog of loci</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_denovomap.xml
+++ b/tools/stacks2/stacks_denovomap.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_denovomap" name="Stacks2: de novo map" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_denovomap" name="Stacks2: de novo map" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>the Stacks pipeline without a reference genome (denovo_map.pl)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_denovomap.xml
+++ b/tools/stacks2/stacks_denovomap.xml
@@ -42,7 +42,7 @@ $pe_options.rm_pcr_duplicates
     ]]></command>
 
     <inputs>
-        <expand macro="fastq_input"/>
+        <expand macro="fastq_input" multiple="true" listtype="list:paired"/>
         <param argument="--popmap" type="data" optional="true" format="tabular,txt" label="Population map"/>
         <section name="assembly_options" title="Assembly options" expanded="true">
             <param name="M" argument="-M" type="integer" value="2" label="Number of mismatches allowed between loci when processing a single individual" help="used in ustacks"/>

--- a/tools/stacks2/stacks_gstacks.xml
+++ b/tools/stacks2/stacks_gstacks.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_gstacks" name="Stacks2: gstacks" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_gstacks" name="Stacks2: gstacks" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Call variants, genotypes and haplotype</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_kmerfilter.xml
+++ b/tools/stacks2/stacks_kmerfilter.xml
@@ -81,7 +81,7 @@ $options_kmer_char.k_dist
 #end if
     ]]></command>
     <inputs>
-        <expand macro="fastq_input_bc"/>
+        <expand macro="fastq_input"/>
         <param name="capture" type="boolean" checked="false" truevalue="-D" falsevalue="" argument="-D" label="Capture discarded reads to a file"/>
         <section name="options_filtering" title="Filtering options" expanded="False">
             <param argument="--rare" type="boolean" checked="false" truevalue="--rare" falsevalue="" label="Turn on filtering based on rare k-mers"/>

--- a/tools/stacks2/stacks_kmerfilter.xml
+++ b/tools/stacks2/stacks_kmerfilter.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_kmerfilter" name="Stacks2: kmer filter" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_kmerfilter" name="Stacks2: kmer filter" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 <description>Identify PCR clones</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_populations.xml
+++ b/tools/stacks2/stacks_populations.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_populations" name="Stacks2: populations" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_populations" name="Stacks2: populations" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Calculate population-level summary statistics</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_populations.xml
+++ b/tools/stacks2/stacks_populations.xml
@@ -119,8 +119,6 @@ $populations_output.vcf
 $populations_output.genepop
 $populations_output.structure
 $populations_output.radpainter
-##$populations_output.phase
-##$populations_output.fastphase
 $populations_output.plink
 $populations_output.hzar
 $populations_output.phylip
@@ -235,8 +233,6 @@ $advanced_options.log_fst_comp
             <param argument="--genepop" truevalue="--genepop" falsevalue="" type="boolean" checked="false" label="Output results in GenePop Format"/>
             <param argument="--structure" truevalue="--structure" falsevalue="" type="boolean" checked="false" label="Output results in Structure Format"/>
             <param argument="--radpainter" truevalue="--radpainter" falsevalue="" type="boolean" checked="false" label="Output results in fineRADstructure/RADpainter format"/>
-            <!--<param argument="\-\-phase" truevalue="\-\-phase" falsevalue="" type="boolean" checked="false" label="Output genotypes in PHASE format"/>-->
-            <param argument="--fastphase" truevalue="--fastphase" falsevalue="" type="boolean" checked="false" label="Output genotypes in fastPHASE format"/>
             <param argument="--plink" truevalue="--plink" falsevalue="" type="boolean" checked="false" label="Output genotypes in PLINK format"/>
             <param argument="--hzar" truevalue="--hzar" falsevalue="" type="boolean" checked="false" label="Output genotypes in Hybrid Zone Analysis using R (HZAR) format."/>
             <param argument="--phylip" truevalue="--phylip" falsevalue="" type="boolean" checked="false" label="Output nucleotides that are fixed-within, and variant among populations in Phylip format for phylogenetic tree construction"/>
@@ -360,21 +356,21 @@ $advanced_options.log_fst_comp
             </param>
             <param name="popmap" ftype="tabular" value="denovo_map/popmap_cstacks.tsv"/>
             <param name="add_log" value="yes"/>
-            <param name="advanced_options|log_fst_comp" value="yes"/>
+            <param name="advanced_options|log_fst_comp" value="true"/>
             <param name="fstats_conditional|fstats" value="yes"/>
-            <param name="populations_output|fasta_loci" value="yes"/>
-            <param name="populations_output|fasta_samples" value="yes"/>
-            <param name="populations_output|fasta_samples_raw" value="yes"/>
-            <param name="populations_output|phylip" value="yes"/>
-            <param name="populations_output|phylip_var" value="yes"/>
-            <param name="populations_output|genepop" value="yes"/>
-            <param name="populations_output|vcf" value="yes"/>
-            <param name="populations_output|hzar" value="yes"/>
-            <param name="populations_output|plink" value="yes"/>
-            <param name="populations_output|structure" value="yes"/>
-            <param name="populations_output|radpainter" value="yes"/>
-            <param name="populations_output|treemix" value="yes"/>
-            <param name="populations_output|gtf" value="yes"/>
+            <param name="populations_output|fasta_loci" value="true"/>
+            <param name="populations_output|fasta_samples" value="true"/>
+            <param name="populations_output|fasta_samples_raw" value="true"/>
+            <param name="populations_output|phylip" value="true"/>
+            <param name="populations_output|phylip_var" value="true"/>
+            <param name="populations_output|genepop" value="true"/>
+            <param name="populations_output|vcf" value="true"/>
+            <param name="populations_output|hzar" value="true"/>
+            <param name="populations_output|plink" value="true"/>
+            <param name="populations_output|structure" value="true"/>
+            <param name="populations_output|radpainter" value="true"/>
+            <param name="populations_output|treemix" value="true"/>
+            <param name="populations_output|gtf" value="true"/>
             <assert_command>
                 <has_text text="--log-fst-comp"/>
             </assert_command>

--- a/tools/stacks2/stacks_procrad.xml
+++ b/tools/stacks2/stacks_procrad.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_procrad" name="Stacks2: process radtags" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_procrad" name="Stacks2: process radtags" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>the Stacks demultiplexing script</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_refmap.xml
+++ b/tools/stacks2/stacks_refmap.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_refmap" name="Stacks2: reference map" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_refmap" name="Stacks2: reference map" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>the Stacks pipeline with a reference genome (ref_map.pl)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_shortreads.xml
+++ b/tools/stacks2/stacks_shortreads.xml
@@ -46,6 +46,7 @@ $options_advanced.no_overhang
         </section>
         <expand macro="process_filter"/>
         <expand macro="process_output_types"/>
+        <expand macro="in_log"/>
     </inputs>
 
     <outputs>

--- a/tools/stacks2/stacks_shortreads.xml
+++ b/tools/stacks2/stacks_shortreads.xml
@@ -1,5 +1,5 @@
 <!-- this is essentially a copy of stacks_procrad minus the unsupported options -->
-<tool id="stacks2_shortreads" name="Stacks2: process shortreads" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_shortreads" name="Stacks2: process shortreads" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 <description>fast cleaning of randomly sheared genomic or transcriptomic data</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_sstacks.xml
+++ b/tools/stacks2/stacks_sstacks.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_sstacks" name="Stacks2: sstacks" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_sstacks" name="Stacks2: sstacks" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Match samples to the catalog</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_tsv2bam.xml
+++ b/tools/stacks2/stacks_tsv2bam.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_tsv2bam" name="Stacks2: tsv2bam" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_tsv2bam" name="Stacks2: tsv2bam" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Sort reads by RAD locus</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_tsv2bam.xml
+++ b/tools/stacks2/stacks_tsv2bam.xml
@@ -60,7 +60,7 @@ tsv2bam
         <expand macro="input_cat_macro"/>
         <expand macro="input_matches_macro"/>
         <!-- TODO add BAM? -->
-        <expand macro="fastq_input" fastq_optional="true" se_option="reverse reads" help="Paired end data or reverse reads. If a paired list is provided only the reverse reads are used in tsv2bam. Leave selection empty if you analyse single end data."/>
+        <expand macro="fastq_input" fastq_optional="true"  multiple="true" listtype="list:paired" se_option="reverse reads" help="Paired end data or reverse reads. If a paired list is provided only the reverse reads are used in tsv2bam. Leave selection empty if you analyse single end data."/>
         <param name="popmap" type="data" format="tabular,txt" label="Population map" help="If set, matching will be done only for samples listed in this file" optional="true" argument="-M"/>
         <expand macro="in_log"/>
     </inputs>

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -1,4 +1,4 @@
-<tool id="stacks2_ustacks" name="Stacks2: ustacks" profile="@PROFILE@" version="@STACKS_VERSION@+galaxy@WRAPPER_VERSION@">
+<tool id="stacks2_ustacks" name="Stacks2: ustacks" profile="@PROFILE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Identify unique stacks</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -70,7 +70,7 @@ true
     ]]></command>
 
     <inputs>
-        <expand macro="fastq_input" help="Single end data or forward reads. If a paired list is provided only the forward reads are used in ustacks"/>
+        <expand macro="fastq_input" multiple="true" listtype="list:paired" help="Single end data or forward reads. If a paired list is provided only the forward reads are used in ustacks"/>
 
         <param argument="-m" type="integer" value="3" label="Minimum depth of coverage required to create a stack"/>
         <param argument="-M" type="integer" value="2" label="Maximum distance (in nucleotides) allowed between stacks"/>


### PR DESCRIPTION
kmerfilter: barcode_encoding in inputs but unused
populations: fastphase present in inputs but unused
shortreads: add_log used in test but absent from inputs

xref https://github.com/galaxyproject/tools-iuc/issues/4095

TODO:

- [ ] Fix https://github.com/galaxyproject/tools-iuc/issues/4269

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
