### PR TITLE
cutadapt: add missing arguments and remove unsued test params

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -509,7 +509,6 @@ $read_mod_options.zero_cap
             <section name="filter_options">
                 <param name="discard_trimmed" value="True"/>
             </section>
-            <param name="read_modification" value="none"/>
             <output name="out1" file="cutadapt_discard.out" ftype="fastq"/>
             <assert_command>
                 <has_text text="--discard-trimmed"/>
@@ -527,7 +526,6 @@ $read_mod_options.zero_cap
                 </repeat>
             </section>
             <param name="output_filtering" value="default"/>
-            <param name="read_modification" value="none"/>
             <param name="output_selector" value="rest_file,json_stats"/>
             <output name="out1" file="cutadapt_rest.out" ftype="fasta"/>
             <output name="json_stats" file="cutadapt_rest.json" ftype="json"/>
@@ -545,7 +543,6 @@ $read_mod_options.zero_cap
                     </conditional>
                 </repeat>
             </section>
-            <param name="read_modification" value="modify"/>
             <param name="nextseq_trim" value="20" />
             <output name="out1" decompress="True" file="cutadapt_nextseq_out.fq.gz" ftype="fastq.gz"/>
         </test>

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -505,7 +505,6 @@ $read_mod_options.zero_cap
                     </conditional>
                 </repeat>
             </section>
-            <param name="output_filtering" value="filter"/>
             <section name="filter_options">
                 <param name="discard_trimmed" value="True"/>
             </section>
@@ -525,7 +524,6 @@ $read_mod_options.zero_cap
                     </conditional>
                 </repeat>
             </section>
-            <param name="output_filtering" value="default"/>
             <param name="output_selector" value="rest_file,json_stats"/>
             <output name="out1" file="cutadapt_rest.out" ftype="fasta"/>
             <output name="json_stats" file="cutadapt_rest.json" ftype="json"/>

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -134,7 +134,7 @@ $filter_options.discard_untrimmed
 #if str($filter_options.max_expected_errors):
     --max-expected-errors=$filter_options.max_expected_errors
 #end if
-
+$filter_options.discard_cassava
 
 #if str($read_mod_options.quality_cutoff) != '0':
    --quality-cutoff=$read_mod_options.quality_cutoff
@@ -143,6 +143,9 @@ $filter_options.discard_untrimmed
     --nextseq-trim=$read_mod_options.nextseq_trim
 #end if
 $read_mod_options.trim_n
+#if $read_mod_options.strip_suffix != ''
+    --strip-suffix $read_mod_options.strip_suffix
+#end if
 #if str($read_mod_options.shorten_options.shorten_values) == 'True':
     #if str($read_mod_options.shorten_options.shorten_end) == '3prime'
         --length=$read_mod_options.shorten_options.length

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@FASTQ_TYPES@">fastq.gz,fastq,fasta</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  


### PR DESCRIPTION
`--strip-suffix` and `--discard-cassava` were forgotten in the command block.

`read_modification` and `output_filtering` were once the selects of conditionals which were removed in ttps://github.com/galaxyproject/tools-iuc/commit
/9a3d1b1c3c2e2d1f6d06fa92e9a95580e8529291

xref https://github.com/galaxyproject/tools-iuc/issues/4095
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
