### PR TITLE
kraken: fix typo in test parameter

### DIFF
--- a/tool_collections/kraken/kraken-translate.xml
+++ b/tool_collections/kraken/kraken-translate.xml
@@ -28,7 +28,7 @@
     <tests>
         <test>
             <param name="input" value="kraken-translate/kraken_translate_test1.tab" ftype="tabular"/>
-            <param name="mpa-format" value="false"/>
+            <param name="mpa_format" value="false"/>
             <param name="kraken_database" value="new_style_test_entry"/>
             <output name="translated" file="kraken-translate/kraken_translate_test1_output.tab" ftype="tabular"/>
         </test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
