### PR TITLE
fastx clipper: remove unused test param

### DIFF
--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -65,7 +65,6 @@ $DISCARD_OPTIONS
     <tests>
         <test>
             <param name="input" value="fastx_clipper1.fastq" ftype="fastqsolexa"/>
-            <param name="maxmismatches" value="2" />
             <param name="minlength" value="15" />
             <param name="clip_source_list" value="user" />
             <param name="clip_sequence" value="CAATTGGTTAATCCCCCTATATA" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
