### PR TITLE
vcfsort: fix typo in test parameter name

### DIFF
--- a/tool_collections/vcflib/vcfcheck/vcfcheck.xml
+++ b/tool_collections/vcflib/vcfcheck/vcfcheck.xml
@@ -52,7 +52,7 @@
     <tests>
         <test>
             <param name="reference_source_selector" value="history" />
-            <param name="failure_selection" value="-x" />
+            <param name="failure_selector" value="-x" />
             <param name="input_vcf" value="vcflib-phix.vcf"/>
             <param name="ref_file" value="vcflib-test-genome-phix.fa" />
             <output name="out_file1" file="vcfcheck-test1.vcf"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
