### PR TITLE
cuffdiff: remove unused test param

### DIFF
--- a/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
+++ b/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
@@ -283,7 +283,6 @@
             <param name="fdr" value="0.05" />
             <param name="min_alignment_count" value="0" />
             <param name="do_bias_correction" value="No" />
-            <param name="do_normalization" value="No" />
             <param name="multiread_correct" value="No"/>
             <param name="sAdditional" value="No"/>
             <output name="output_cummerbund" ftype="sqlite" file="cuffdiff_out.sqlite" compare="sim_size" />
@@ -308,7 +307,6 @@
             <param name="fdr" value="0.05" />
             <param name="min_alignment_count" value="0" />
             <param name="do_bias_correction" value="No" />
-            <param name="do_normalization" value="No" />
             <param name="multiread_correct" value="No"/>
             <param name="sAdditional" value="No"/>
             <output name="output_cummerbund" ftype="sqlite" file="cuffdiff_out.sqlite" compare="sim_size" />
@@ -333,7 +331,6 @@
             <param name="fdr" value="0.05" />
             <param name="min_alignment_count" value="0" />
             <param name="do_bias_correction" value="No" />
-            <param name="do_normalization" value="No" />
             <param name="multiread_correct" value="No"/>
             <param name="sAdditional" value="No"/>
             <output name="splicing_diff" file="splicing.diff"/>


### PR DESCRIPTION
seems to be there since the beginning in dev-team tools.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
