### PR TITLE
merlin: fix typo in test param name

### DIFF
--- a/tools/merlin/merlin.xml
+++ b/tools/merlin/merlin.xml
@@ -337,7 +337,7 @@
             <param name="mname" value="basic2.map"/>
             <param name="dname" value="basic2.dat"/>
             <param name="allelefreq" value="individuals"/>
-            <param name="random" value="5" />
+            <param name="randomseed" value="5" />
             <output name="merlinoutput">
                 <assert_contents>
                     <has_text text= "Phenotype: some_disease [ALL] (1 family)" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
