### PR TITLE
bwamem2: remove unused test param

### DIFF
--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -306,7 +306,6 @@ bwa-mem2 mem
         <test>
             <param name="reference_source_selector" value="history" />
             <param name="ref_file" ftype="fasta" value="bwa-mem-mt-genome.fa"/>
-            <param name="index_a" value="is"/>
             <param name="fastq_input_selector" value="paired"/>
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fastq1.fq"/>
             <param name="fastq_input2" ftype="fastqsanger" value="bwa-mem-fastq2.fq"/>

--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -5,8 +5,8 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
-    <expand macro="stdio"/>
     <expand macro="xrefs"/>
+    <expand macro="stdio"/>
     <command><![CDATA[
 @pipefail@
 @set_reference_fasta_filename@


### PR DESCRIPTION
seems that this was only available in v1

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
