### PR TITLE
transit: remove unused burnin test parameter

### DIFF
--- a/tools/transit/macros.xml
+++ b/tools/transit/macros.xml
@@ -13,11 +13,12 @@
     </xml>
 	<xml name="requirements">
 		<requirements>
-			<requirement type="package" version="@VERSION@">transit</requirement>
+			<requirement type="package" version="@TOOL_VERSION@">transit</requirement>
 			<yield />
 		</requirements>
 	</xml>
-	<token name="@VERSION@">3.0.2</token>
+	<token name="@TOOL_VERSION@">3.0.2</token>
+	<token name="@VERSION_SUFFIX@">1</token>
 	<xml name="outputs">
         <yield />
         <data name="sites" from_work_dir="transit_out.txt" format="tabular" label="${tool.name} on ${on_string} Sites" />

--- a/tools/transit/transit_gumbel.xml
+++ b/tools/transit/transit_gumbel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="transit_gumbel" name="Gumbel" version="@VERSION@+galaxy0">
+<tool id="transit_gumbel" name="TRANSIT Gumbel" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>- determine essential genes</description>
     <expand macro="bio_tools"/>
     <macros>

--- a/tools/transit/transit_hmm.xml
+++ b/tools/transit/transit_hmm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="transit_hmm" name="HMM" version="@VERSION@+galaxy0">
+<tool id="transit_hmm" name="TRANSIT HMM" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>- determine essentiality of a genome</description>
     <expand macro="bio_tools"/>
     <macros>

--- a/tools/transit/transit_resampling.xml
+++ b/tools/transit/transit_resampling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="transit_resampling" name="Resampling" version="@VERSION@+galaxy0">
+<tool id="transit_resampling" name="TRANSIT Resampling" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>- determine per-gene p-values</description>
     <expand macro="bio_tools"/>
     <macros>
@@ -39,7 +39,6 @@
             <param name="controls" ftype="wig" value="transit-co1-rep1.wig,transit-co1-rep2.wig,transit-co1-rep3.wig" />
             <param name="annotation" ftype="tabular" value="transit-in1.prot" />
             <param name="samples" value="1000" />
-            <param name="burnin" value="100" />
             <param name="replicates" value="Replicates" />
             <output name="sites" file="resampling-sites1.txt" ftype="tabular" compare="sim_size" />
         </test>

--- a/tools/transit/transit_tn5gaps.xml
+++ b/tools/transit/transit_tn5gaps.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="transit_tn5gaps" name="Tn5Gaps" version="@VERSION@+galaxy0">
+<tool id="transit_tn5gaps" name="TRANSIT Tn5Gaps" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>- determine essential genes</description>
     <expand macro="bio_tools"/>
     <macros>


### PR DESCRIPTION
and

- switch to `TOOL_VERSION`
- prefix tool names with `TRANSIT`

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
