### PR TITLE
DESeq2 Update  - Add sample size factors output option

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -221,14 +221,14 @@ if (!is.null(opt$esf)) {
 
 # estimate size factors for each sample
 # - https://support.bioconductor.org/p/97676/
-if (!is.null(opt$sizefactorsfile)){
+if (!is.null(opt$sizefactorsfile)) {
     nm <- assays(dds)[["avgTxLength"]]
-    if (!is.null(nm)){
+    if (!is.null(nm)) {
         ## Recommended: takes into account tximport data
         size_factors <- estimateSizeFactorsForMatrix(counts(dds) / nm)
     } else {
         norm_factors <- normalizationFactors(dds)
-        if (!is.null(norm_factors)){
+        if (!is.null(norm_factors)) {
             ## In practice, gives same results as above.
             size_factors <- estimateSizeFactorsForMatrix(norm_factors)
         } else {

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -236,7 +236,6 @@ if (!is.null(opt$sizefactorsfile)){
             size_factors <- estimateSizeFactorsForMatrix(counts(dds))
         }
     }
-    saveRDS(size_factors, "/tmp/spice3.rds")
     write.table(size_factors, file = opt$sizefactorsfile, sep = "\t", col.names = F, quote = FALSE)
 }
 

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -52,6 +52,7 @@ spec <- matrix(c(
   "batch_factors", "w", 1, "character",
   "outfile", "o", 1, "character",
   "countsfile", "n", 1, "character",
+  "sizefactorsfile", "F", 1, "character",
   "rlogfile", "r", 1, "character",
   "vstfile", "v", 1, "character",
   "header", "H", 0, "logical",
@@ -217,6 +218,28 @@ dds <- get_deseq_dataset(sample_table, header = opt$header, design_formula = des
 if (!is.null(opt$esf)) {
     dds <- estimateSizeFactors(dds, type = opt$esf)
 }
+
+# estimate size factors for each sample
+# - https://support.bioconductor.org/p/97676/
+if (!is.null(opt$sizefactorsfile)){
+    nm <- assays(dds)[["avgTxLength"]]
+    if (!is.null(nm)){
+        ## Recommended: takes into account tximport data
+        size_factors <- estimateSizeFactorsForMatrix(counts(dds) / nm)
+    } else {
+        norm_factors <- normalizationFactors(dds)
+        if (!is.null(norm_factors)){
+            ## In practice, gives same results as above.
+            size_factors <- estimateSizeFactorsForMatrix(norm_factors)
+        } else {
+            ## If we have no other information, estimate from raw.
+            size_factors <- estimateSizeFactorsForMatrix(counts(dds))
+        }
+    }
+    saveRDS(size_factors, "/tmp/spice3.rds")
+    write.table(size_factors, file = opt$sizefactorsfile, sep = "\t", col.names = F, quote = FALSE)
+}
+
 apply_batch_factors <- function(dds, batch_factors) {
   rownames(batch_factors) <- batch_factors$identifier
   batch_factors <- subset(batch_factors, select = -c(identifier, condition))

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -225,14 +225,17 @@ if (!is.null(opt$sizefactorsfile)) {
     nm <- assays(dds)[["avgTxLength"]]
     if (!is.null(nm)) {
         ## Recommended: takes into account tximport data
+        cat("\nsize factors for samples: taking tximport data into account\n")
         size_factors <- estimateSizeFactorsForMatrix(counts(dds) / nm)
     } else {
         norm_factors <- normalizationFactors(dds)
         if (!is.null(norm_factors)) {
             ## In practice, gives same results as above.
+            cat("\nsize factors for samples: no tximport data, using derived normalization factors\n")
             size_factors <- estimateSizeFactorsForMatrix(norm_factors)
         } else {
             ## If we have no other information, estimate from raw.
+            cat("\nsize factors for samples: no tximport data, no normalization factors, estimating from raw data\n")
             size_factors <- estimateSizeFactorsForMatrix(counts(dds))
         }
     }

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -674,9 +674,9 @@ Column Description
        which controls false discovery rate (FDR)
 ====== ==========================================================
 
-By selecting ``Output sample size factors'' in the "Output options"
+By selecting ``Output sample size factors`` in the "Output options"
 selection box, the size factors used to normalize the samples can also
-be output as a tabluar file.
+be output as a tabular file.
 
 .. _DESeq2: http://master.bioconductor.org/packages/release/bioc/html/DESeq2.html
 .. _tximport: https://bioconductor.org/packages/devel/bioc/vignettes/tximport/inst/doc/tximport.html

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -198,7 +198,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         <section name="output_options" title="Output options">
             <param name="output_selector" type="select" multiple="True" optional="true" display="checkboxes" label="Output selector">
                 <option value="pdf" selected="True">Generate plots for visualizing the analysis results</option>
-                <option value="sizefactors" >Output size factors</option>
+                <option value="sizefactors" >Output sample size factors</option>
                 <option value="normCounts">Output normalised counts</option>
                 <option value="normVST">Output VST normalized table</option>
                 <option value="normRLog">Output rLog normalized table</option>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -47,6 +47,9 @@ Rscript '${__tool_directory__}/deseq2.R'
     #if 'normCounts' in $output_options.output_selector:
         -n '$counts_out'
     #end if
+    #if 'sizefactors' in $output_options.output_selector:
+        -F '$sizefactors_out'
+    #end if
     #if 'normRLog' in $output_options.output_selector:
         -r '$rlog_out'
     #end if
@@ -195,6 +198,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         <section name="output_options" title="Output options">
             <param name="output_selector" type="select" multiple="True" optional="true" display="checkboxes" label="Output selector">
                 <option value="pdf" selected="True">Generate plots for visualizing the analysis results</option>
+                <option value="sizefactors" >Output size factors</option>
                 <option value="normCounts">Output normalised counts</option>
                 <option value="normVST">Output VST normalized table</option>
                 <option value="normRLog">Output rLog normalized table</option>
@@ -216,6 +220,9 @@ Rscript '${__tool_directory__}/deseq2.R'
         </collection>
         <data name="plots" format="pdf" label="DESeq2 plots on ${on_string}">
             <filter>output_options['output_selector'] and 'pdf' in output_options['output_selector']</filter>
+        </data>
+        <data name="sizefactors_out" format="tabular" label="Size Factors on ${on_string}">
+            <filter>output_options['output_selector'] and 'sizefactors' in output_options['output_selector']</filter>
         </data>
         <data name="counts_out" format="tabular" label="Normalized counts file on ${on_string}">
             <filter>output_options['output_selector'] and 'normCounts' in output_options['output_selector']</filter>
@@ -510,6 +517,65 @@ Rscript '${__tool_directory__}/deseq2.R'
             <output name="deseq_out" >
                 <assert_contents>
                     <has_text_matching expression="ENSG00000168671\t1.8841.*\t-0.1180.*\t0.7429.*\t-0.1589.*\t0.8737.*\t0.9999.*" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Same as above alpha_ma test, but with size factors -->
+        <test expect_num_outputs="2">
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment"/>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf1.tab,sailfish_ensembl/sailfish_quant.sf2.tab,sailfish_ensembl/sailfish_quant.sf3.tab"/>
+                </repeat>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Untreated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf4.tab,sailfish_ensembl/sailfish_quant.sf5.tab,sailfish_ensembl/sailfish_quant.sf6.tab"/>
+                </repeat>
+            </repeat>
+            <section name="output_options">
+                <param name="output_selector" value="sizefactors"/>
+                <param name="alpha_ma" value="0.05"/>
+            </section>
+            <param name="tximport_selector" value="tximport"/>
+            <param name="txtype" value="sailfish"/>
+            <param name="mapping_format_selector" value="gtf"/>
+            <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
+            <output name="sizefactors_out">
+                <assert_contents>
+                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+" />
+                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Same as above alpha_ma size factor test, but with a non-default estimator-->
+        <test expect_num_outputs="2">
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment"/>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf1.tab,sailfish_ensembl/sailfish_quant.sf2.tab,sailfish_ensembl/sailfish_quant.sf3.tab"/>
+                </repeat>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Untreated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf4.tab,sailfish_ensembl/sailfish_quant.sf5.tab,sailfish_ensembl/sailfish_quant.sf6.tab"/>
+                </repeat>
+            </repeat>
+            <section name="advanced_options">
+                <param name="esf" value="poscounts" />
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="sizefactors"/>
+                <param name="alpha_ma" value="0.05"/>
+            </section>
+            <param name="tximport_selector" value="tximport"/>
+            <param name="txtype" value="sailfish"/>
+            <param name="mapping_format_selector" value="gtf"/>
+            <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
+            <output name="sizefactors_out" >
+                <assert_contents>
+                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+" />
+                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -674,6 +674,10 @@ Column Description
        which controls false discovery rate (FDR)
 ====== ==========================================================
 
+By selecting ``Output sample size factors'' in the "Output options"
+selection box, the size factors used to normalize the samples can also
+be output as a tabluar file.
+
 .. _DESeq2: http://master.bioconductor.org/packages/release/bioc/html/DESeq2.html
 .. _tximport: https://bioconductor.org/packages/devel/bioc/vignettes/tximport/inst/doc/tximport.html
     ]]></help>

--- a/tools/deseq2/deseq2_macros.xml
+++ b/tools/deseq2/deseq2_macros.xml
@@ -33,7 +33,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">2.11.40.7</token>
-    <token name="@SUFFIX_VERSION@">0</token>
+    <token name="@SUFFIX_VERSION@">1</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_3308</edam_topic>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)


Useful for scaling BAM files via the `bedtools genomecoverage` tool in order to better assess the Log2FC of a specific gene given in DESeq2 via manual inspection in IGV.

Sample size factor calculation was taken from this post:  https://support.bioconductor.org/p/97676/