### PR TITLE
varscan copynumber: remove sample_names parameter

### DIFF
--- a/tools/varscan/varscan.py
+++ b/tools/varscan/varscan.py
@@ -358,8 +358,7 @@ class VariantCallingError (RuntimeError):
                 self.call, self.error
             )
         else:
-            msg_header = '{0} failed.\n'
-            'No further information about this error is available.\n\n'.format(
+            msg_header = '{0} failed.\nNo further information about this error is available.\n\n'.format(
                 self.call
             )
         return msg_header + self.message
@@ -1045,8 +1044,8 @@ class VarScanCaller (object):
                         if mmqs_diff > max_mmqs_diff:
                             record.filter.add('MMQSdiff')
                         if (
-                            1 -
-                            alt_stats.avg_clipped_len
+                            1
+                            - alt_stats.avg_clipped_len
                             / ref_stats.avg_clipped_len
                         ) > max_relative_len_diff:
                             record.filter.add('ReadLenDiff')

--- a/tools/varscan/varscan_copynumber.xml
+++ b/tools/varscan/varscan_copynumber.xml
@@ -41,8 +41,6 @@
         <param argument="--data-ratio" name="data_ratio" type="float" value="1.0" min="0.0" max="1.0"
             label="The normal/tumor input data ratio for copynumber adjustment"/>
 
-        <param name="sample_names" type="text" value="" help="Separate sample names by comma; leave blank to use default sample names."/>
-
     </inputs>
     <outputs>
         <data name="output" from_work_dir="galaxy_out.copynumber" format="interval"/>


### PR DESCRIPTION
unused in the CLI and apparently there is no commandline parameter
that could take the information

guess this is a copy paste error (from the mpileup tool)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
