### PR TITLE
stringtie: add point features to command

### DIFF
--- a/tools/stringtie/macros.xml
+++ b/tools/stringtie/macros.xml
@@ -4,7 +4,7 @@
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">stringtie</requirement>
-        <requirement type="package" version="1.13">samtools</requirement>
+        <requirement type="package" version="1.14">samtools</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/stringtie/macros.xml
+++ b/tools/stringtie/macros.xml
@@ -1,5 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.7</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">stringtie</requirement>

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -1,4 +1,4 @@
-<tool id="stringtie" name="StringTie" version="@TOOL_VERSION@">
+<tool id="stringtie" name="StringTie" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>transcript assembly and quantification</description>
     <xrefs>
         <xref type="bio.tools">stringtie</xref>
@@ -78,6 +78,9 @@ $rna_strandness
 -M '$adv.bundle_fraction'
 $adv.disable_trimming
 $adv.multi_mapping
+#if $adv.point_features
+    --ptf $adv.point_features
+#end if
 #if $adv.abundance_estimation:
     -A '$gene_abundance_estimation'
 #end if
@@ -226,7 +229,7 @@ $adv.multi_mapping
             <param name="bundle_fraction" argument="-M" type="float" min="0.0" max="1.0" value="0.95" label="Fraction of bundle allowed to be covered by multi-hit reads"  help="Sets the maximum fraction of muliple-location-mapped reads that are allowed to be present at a given locus. Default: 0.95"/>
             <param name="disable_trimming" argument="-t" type="boolean" truevalue="-t" falsevalue="" checked="false" label="Disable trimming of predicted transcripts based on coverage" help="This parameter disables trimming at the ends of the assembled transcripts. By default StringTie adjusts the predicted transcript's start and/or stop coordinates based on sudden drops in coverage of the assembled transcript. Default: No" />
             <param name="multi_mapping" argument="-u" type="boolean" truevalue="-u" falsevalue="" checked="false" label="Disable multi-mapping correction" help="Default: No"/>
-            <param name="point_features" type="data" format="tabular" optional="True" label="Input point-features dataset" help="Loads a list of point-features from a text feature file to guide the transcriptome assembly. Accepted point features are transcription start sites (TSS) and polyadenylation sites (CPAS). There are four tab-delimited columns in the feature file. The first three define the location of the point feature on the cromosome (sequence name, coordinate and strand), and the last is the type of the feature (TSS or CPAS)."/>
+            <param name="point_features" type="data" format="tabular" optional="true" label="Input point-features dataset" help="Loads a list of point-features from a text feature file to guide the transcriptome assembly. Accepted point features are transcription start sites (TSS) and polyadenylation sites (CPAS). There are four tab-delimited columns in the feature file. The first three define the location of the point feature on the cromosome (sequence name, coordinate and strand), and the last is the type of the feature (TSS or CPAS)."/>
         </section>
     </inputs>
     <outputs>

--- a/tools/stringtie/stringtie_merge.xml
+++ b/tools/stringtie/stringtie_merge.xml
@@ -1,4 +1,4 @@
-<tool id="stringtie_merge" name="StringTie merge" version="@TOOL_VERSION@">
+<tool id="stringtie_merge" name="StringTie merge" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>transcripts</description>
     <xrefs>
         <xref type="bio.tools">stringtie</xref>


### PR DESCRIPTION
parameter was recently added to the inputs but not to the command:
https://github.com/galaxyproject/tools-iuc/pull/3964

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
