### PR TITLE
featurecounts: fix unused parameters

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -38,6 +38,12 @@
             -T \${GALAXY_SLOTS:-2}
 
             -s  $strand_specificity
+
+            -Q  $read_filtering_parameters.mapping_quality
+            $read_filtering_parameters.splitonly
+            $read_filtering_parameters.primary
+            $read_filtering_parameters.ignore_dup
+
             -t '$extended_parameters.gff_feature_type'
             -g '$extended_parameters.gff_feature_attribute'
                 $extended_parameters.summarization_level
@@ -66,14 +72,11 @@
 
                 $extended_parameters.by_read_group
 
-            -Q  $extended_parameters.mapping_quality
                 $extended_parameters.largest_overlap
             --minOverlap  $extended_parameters.min_overlap
             --fracOverlap $extended_parameters.frac_overlap
             --fracOverlapFeature $extended_parameters.frac_overlap_feature
                 $extended_parameters.read_reduction
-                $extended_parameters.primary
-                $extended_parameters.ignore_dup
                 #if $extended_parameters.R:
                     $extended_parameters.R
                 #end if
@@ -258,6 +261,33 @@
                 help="If specified, the chimeric fragments (those fragments that have their two ends aligned to different chromosomes) will NOT be included for summarization. This option is only applicable for paired-end read data." />
         </section>
 
+        <section name="read_filtering_parameters" title="Read filtering options">
+            <param name="mapping_quality"
+                   type="integer"
+                   value="0"
+                   argument="-Q"
+                   label="Minimum mapping quality per read"
+                   help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 0 by default." />
+            <param name="splitonly" type="select" display="radio" label="Filter split alignments" help="Split alignments are alignments with CIGAR string containing 'N', e.g. exon spanning reads in RNASeq.">
+                <option value="">No filtering: count split and non-split alignments</option>
+                <option value="--splitOnly">Count only split alignments (--splitOnly)</option>
+                <option value="--nonSplitOnly">Count only non-split alignments (--nonSplitOnly)</option>
+            </param>
+            <param type="boolean"
+                   truevalue=" --primary"
+                   falsevalue=""
+                   argument="--primary"
+                   label="Only count primary alignments"
+                   help="If specified, only primary alignments will be counted. Primary and secondary alignments are identified using bit 0x100 in theFlag field of SAM/BAM files. All primary alignments in a dataset will be counted regardless of whether they are from multi-mapping reads or not ('-M' is ignored)." />
+            <param name="ignore_dup"
+                   type="boolean"
+                   truevalue=" --ignoreDup"
+                   falsevalue=""
+                   argument="--ignoreDup"
+                   label="Ignore reads marked as duplicate"
+                   help="If specified, reads that were marked as duplicates will be ignored. Bit Ox400 in the FLAG field of a SAM/BAM file is used for identifying duplicate reads. In paired end data, the entire read pair will be ignored if at least one end is found to be a duplicate read." />
+        </section>
+
         <section name="extended_parameters" title="Advanced options">
             <param name="gff_feature_type"
                 type="text"
@@ -317,13 +347,6 @@
                             help="If specified, a fractional count 1/(x*y) will be generated, where x is the number of alignments (indicated by 'NH' tag) and y the number of overlapping features."/>
                 </when>
             </conditional>
-
-            <param name="mapping_quality"
-                   type="integer"
-                   value="0"
-                   argument="-Q"
-                   label="Minimum mapping quality per read"
-                   help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 0 by default." />
 
             <conditional name="exon_exon_junction_read_counting_enabled">
                 <param name="count_exon_exon_junction_reads" argument="-J" type="boolean" truevalue="-J" falsevalue=""
@@ -403,22 +426,6 @@
                 <option value="--read2pos 3">Reduce it to the 3' end</option>
             </param>
 
-            <param name="primary"
-                   type="boolean"
-                   truevalue=" --primary"
-                   falsevalue=""
-                   argument="--primary"
-                   label="Only count primary alignments"
-                   help="If specified, only primary alignments will be counted. Primary and secondary alignments are identified using bit 0x100 in theFlag field of SAM/BAM files. All primary alignments in a dataset will be counted regardless of whether they are from multi-mapping reads or not ('-M' is ignored)." />
-
-            <param name="ignore_dup"
-                   type="boolean"
-                   truevalue=" --ignoreDup"
-                   falsevalue=""
-                   argument="--ignoreDup"
-                   label="Ignore reads marked as duplicate"
-                   help="If specified, reads that were marked as duplicates will be ignored. Bit Ox400 in the FLAG field of a SAM/BAM file is used for identifying duplicate reads. In paired end data, the entire read pair will be ignored if at least one end is found to be a duplicate read." />
-
             <param type="boolean"
                    truevalue="-R BAM"
                    falsevalue=""
@@ -426,13 +433,6 @@
                    label="Annotates the alignment file with 'XS:Z:'-tags to described per read or read-pair the corresponding assigned feature(s)."
                    help="" />
 
-            <param name="count_split_alignments_only"
-                   type="boolean"
-                   truevalue=" --countSplitAlignmentsOnly"
-                   falsevalue=""
-                   argument="--countSplitAlignmentsOnly"
-                   label="Ignore unspliced alignments"
-                   help="If specified, only split alignments (CIGAR strings containing the letter `N') will be counted. All the other alignments will be ignored. An example of split alignments are exon-spanning reads in RNA-seq data." />
         </section>
     </inputs>
     <outputs>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -2,7 +2,7 @@
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files</description>
     <macros>
         <token name="@TOOL_VERSION@">2.0.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">subread</xref>

--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -620,7 +620,7 @@ Output format
 FeatureCounts produces a table containing counted reads, per gene, per row. Optionally the last column can be set to be the effective gene-length. These tables are compatible with the DESeq2, edgeR and limma-voom Galaxy wrappers by IUC.
 
 .. _Subread: http://subread.sourceforge.net/
-.. _`Subread User's Guide`: http://bioinf.wehi.edu.au/subread-package/SubreadUsersGuide.pdf
+.. _`Subread User's Guide`: https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf
 .. _`Subread package`: https://sourceforge.net/projects/subread/files/
     ]]></help>
     <citations>


### PR DESCRIPTION
tool defined a parameter `--countSplitAlignmentsOnly` that was unused in
the command section. Even worse such a parameter does not exist on the
CLI, but:

```
  --splitOnly         Count split alignments only (ie. alignments with CIGAR
                      string containing 'N'). An example of split alignments is
                      exon-spanning reads in RNA-seq data.

  --nonSplitOnly      If specified, only non-split alignments (CIGAR strings do
                      not contain letter 'N') will be counted. All the other
                      alignments will be ignored.
```

this has been fixed.

Furthermore some parameters from the large `Advanced options` section
have been moved to a new `Read filtering options` section (as suggested
by the nice featureCounts help output).

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
