### PR TITLE
Star limit genome generate RAM

### DIFF
--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -81,9 +81,17 @@
     <token name="@TEMPINDEX@"><![CDATA[
     ## Create temporary index for custom reference
     #if str($refGenomeSource.geneSource) == 'history':
+
+        if [ -z "\$GALAXY_MEMORY_MB" ] ; then
+            GALAXY_MEMORY_BYTES=31000000000 ;
+            else
+                GALAXY_MEMORY_BYTES=\$((GALAXY_MEMORY_MB * 1000000)) ;
+                fi ;
+
         mkdir -p tempstargenomedir &&
         STAR
             --runMode genomeGenerate
+            --limitGenomeGenerateRAM \${GALAXY_MEMORY_BYTES}
             --genomeDir 'tempstargenomedir'
             --genomeFastaFiles '${refGenomeSource.genomeFastaFiles}'
             ## Handle difference between indices with/without annotations

--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -81,13 +81,11 @@
     <token name="@TEMPINDEX@"><![CDATA[
     ## Create temporary index for custom reference
     #if str($refGenomeSource.geneSource) == 'history':
-
         if [ -z "\$GALAXY_MEMORY_MB" ] ; then
             GALAXY_MEMORY_BYTES=31000000000 ;
             else
                 GALAXY_MEMORY_BYTES=\$((GALAXY_MEMORY_MB * 1000000)) ;
                 fi ;
-
         mkdir -p tempstargenomedir &&
         STAR
             --runMode genomeGenerate


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Change solves error generated when STAR alignment is done with genome.fasta coming from history:
`EXITING because of FATAL PARAMETER ERROR: limitGenomeGenerateRAM=31000000000is too small for your genome
SOLUTION: please specify --limitGenomeGenerateRAM not less than 723897051178 and make that much RAM available`