### PR TITLE
proteinortho: add missing parameter

### DIFF
--- a/tools/proteinortho/proteinortho.xml
+++ b/tools/proteinortho/proteinortho.xml
@@ -53,6 +53,7 @@
             #end if
             --p=$p
             --e=$evalue
+            --conn=$conn
             #if $more_options.cov:
                 --cov=$more_options.cov
             #end if

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
    <token name="@TOOL_VERSION@">6.0.31</token>
-   <token name="@WRAPPER_VERSION@">0</token>
+   <token name="@WRAPPER_VERSION@">1</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
         <citations>


### PR DESCRIPTION
--conn was missing from cli

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
