### PR TITLE
meme*: add non_commercial_use to command

### DIFF
--- a/tools/meme/dreme.xml
+++ b/tools/meme/dreme.xml
@@ -1,4 +1,4 @@
-<tool id="meme_dreme" name="DREME" version="@WRAPPER_VERSION@.0">
+<tool id="meme_dreme" name="DREME" version="@TOOL_VERSION@.0">
     <description>- Discriminative Regular Expression Motif Elicitation</description>
     <macros>
         <import>macros.xml</import>
@@ -7,6 +7,7 @@
         <requirement type="package" version="2.7">python</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
+@CHECK_NON_COMMERCIAL_USE@
 dreme
     -o ./dreme_out
     -p '$pos_fasta_file'

--- a/tools/meme/fimo.xml
+++ b/tools/meme/fimo.xml
@@ -1,4 +1,4 @@
-<tool id="meme_fimo" name="FIMO" version="@WRAPPER_VERSION@.0">
+<tool id="meme_fimo" name="FIMO" version="@TOOL_VERSION@.0">
     <description>- Scan a set of sequences for motifs</description>
     <xrefs>
         <xref type="bio.tools">meme_fimo</xref>
@@ -8,6 +8,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+@CHECK_NON_COMMERCIAL_USE@
 fimo
     -o ./out/
     $scanrc

--- a/tools/meme/macros.xml
+++ b/tools/meme/macros.xml
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <macros>
-    <token name="@WRAPPER_VERSION@">5.0.5</token>
+    <token name="@TOOL_VERSION@">5.0.5</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="5.0.5">meme</requirement>
             <yield/>
         </requirements>
     </xml>
+    <token name="@CHECK_NON_COMMERCIAL_USE@"><![CDATA[
+        #if not $non_commercial_use
+            >&2 echo "this tool is only available for non commercial use";
+            exit 1
+        #end if
+    ]]></token>
 </macros>
 

--- a/tools/meme/meme.xml
+++ b/tools/meme/meme.xml
@@ -1,4 +1,4 @@
-<tool id="meme_meme" name="MEME" version="@WRAPPER_VERSION@.0">
+<tool id="meme_meme" name="MEME" version="@TOOL_VERSION@.0">
     <description>- Multiple EM for Motif Elicitation</description>
     <xrefs>
         <xref type="bio.tools">meme_meme</xref>
@@ -8,6 +8,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+@CHECK_NON_COMMERCIAL_USE@
 export TMPDIR=\${TMPDIR:-.};
 
 meme '$input1'

--- a/tools/meme/meme_psp_gen.xml
+++ b/tools/meme/meme_psp_gen.xml
@@ -1,10 +1,11 @@
-<tool id="meme_psp_gen" name="MEME psp-gen" version="@WRAPPER_VERSION@.0">
+<tool id="meme_psp_gen" name="MEME psp-gen" version="@TOOL_VERSION@.0">
     <description>- perform discriminative motif discovery</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+@CHECK_NON_COMMERCIAL_USE@
 ln -s '${primary_sequence}' meme_psp_input_pos.fa && 
 ln -s '${control_sequence}' meme_psp_input_neg.fa &&
 psp-gen

--- a/tools/meme_chip/macros.xml
+++ b/tools/meme_chip/macros.xml
@@ -1,11 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <macros>
-    <token name="@WRAPPER_VERSION@">4.11.2</token>
+    <token name="@TOOL_VERSION@">4.11.2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="1.3.23">graphicsmagick</requirement>
             <requirement type="package" version="4.11.2">meme</requirement>
         </requirements>
     </xml>
+    <token name="@CHECK_NON_COMMERCIAL_USE@"><![CDATA[
+        #if not $non_commercial_use
+            >&2 echo "this tool is only available for non commercial use";
+            exit 1
+        #end if
+    ]]></token>
 </macros>
 

--- a/tools/meme_chip/meme_chip.xml
+++ b/tools/meme_chip/meme_chip.xml
@@ -1,4 +1,4 @@
-<tool id="meme_chip" name="MEME-ChIP" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="meme_chip" name="MEME-ChIP" version="@TOOL_VERSION@+galaxy1">
     <description>- motif discovery, enrichment analysis and clustering on large nucleotide datasets</description>
     <macros>
         <import>macros.xml</import>
@@ -6,6 +6,7 @@
     <expand macro="requirements" />
     <code file="get_meme_motif_databases.py" />
     <command detect_errors="exit_code"><![CDATA[
+@CHECK_NON_COMMERCIAL_USE@
 #import os
 #set primary_output = $os.path.join($output.files_path, "index.html")
 meme-chip '$input'


### PR DESCRIPTION
I guess the validator should be sufficient, but maybe having this
additional if block can't hurt

will make the linter happy for https://github.com/galaxyproject/galaxy/pull/12724
alternatively we could extend the linter such that
parameters that do not appear on the command line
bu have a (expression) validator? are OK??

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
