### PR TITLE
iqtree: add missing seqtype param to command

### DIFF
--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -1,7 +1,6 @@
-<tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@+@VERSION_SUFFIX@" >
+<tool id="iqtree" name="IQ-TREE" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" >
     <description>Phylogenomic / evolutionary tree construction from multiple sequences</description>
     <macros>
-        <token name="@VERSION_SUFFIX@">galaxy2</token>
         <import>iqtree_macros.xml</import>
     </macros>
     <expand macro="requirements" />
@@ -23,7 +22,7 @@ iqtree
 #if $general_options.o
     -o '$general_options.o'
 #end if
-
+--seqtype $general_options.seqtype
 ## file
 #if $general_options.t
     -t '$general_options.t'
@@ -545,22 +544,22 @@ IQ-TREE also works for codon, binary and morphogical data.
                     </param>
                     <when value="none" />
                     <when value="p">
-                        <param argument="-p" type="data" format="nex" optional="true" label="Partition file" />
+                        <param argument="-p" name="model_file" type="data" format="nex" optional="true" label="Partition file" />
                         <param argument="--subsample" type="integer" optional="true" label="Subsample partitions" help="Use a negative value for complement" />
                         <param argument="--subsample-seed" type="integer" optional="true" label="Subsampling random seed" help="Use a negative value for complement" />
                     </when>
                     <when value="q">
-                        <param argument="-q" type="data" format="nex" optional="true" label="Partition file" />
+                        <param argument="-q" name="model_file" type="data" format="nex" optional="true" label="Partition file" />
                         <param argument="--subsample" type="integer" optional="true" label="Subsample partitions" help="Use a negative value for complement" />
                         <param argument="--subsample-seed" type="integer" optional="true" label="Subsampling random seed" help="Use a negative value for complement" />
                     </when>
                     <when value="Q">
-                        <param argument="-Q" type="data" format="nex" optional="true" label="Partition file" />
+                        <param argument="-Q" name="model_file" type="data" format="nex" optional="true" label="Partition file" />
                         <param argument="--subsample" type="integer" optional="true" label="Subsample partitions" help="Use a negative value for complement" />
                         <param argument="--subsample-seed" type="integer" optional="true" label="Subsampling random seed" help="Use a negative value for complement" />
                     </when>
                     <when value="S">
-                        <param argument="-S" type="data" format="nex" optional="true" label="Partition file" />
+                        <param argument="-S" name="model_file" type="data" format="nex" optional="true" label="Partition file" />
                         <param argument="--subsample" type="integer" optional="true" label="Subsample partitions" help="Use a negative value for complement" />
                         <param argument="--subsample-seed" type="integer" optional="true" label="Subsampling random seed" help="Use a negative value for complement" />
                     </when>
@@ -705,7 +704,7 @@ IQ-TREE also works for codon, binary and morphogical data.
     <tests>
         <test expect_num_outputs="5">
             <param name="seed" value="1257" />
-            <param name="seqtype" value="AA" />
+            <param name="seqtype" value="DNA" />
             <param name="s" value="example.phy" />
             <param name="m" value="TEST" />
             <param name="msub" value="nuclear" />
@@ -751,7 +750,7 @@ IQ-TREE also works for codon, binary and morphogical data.
         <test expect_num_outputs="5">
             <!-- bootstrap sans model -->
             <param name="seed" value="1257" />
-            <param name="seqtype" value="AA" />
+            <param name="seqtype" value="DNA" />
             <param name="s" value="example.phy" />
             <!-- <param name="m" value="TESTONLY" /> -->
             <param name="msub" value="nuclear" />
@@ -785,7 +784,7 @@ IQ-TREE also works for codon, binary and morphogical data.
         <test expect_num_outputs="5">
             <!-- model sans bootstrap -->
             <param name="seed" value="1257" />
-            <param name="seqtype" value="AA" />
+            <param name="seqtype" value="DNA" />
             <param name="s" value="example.phy" />
             <param name="m" value="TESTONLY" />
             <param name="msub" value="nuclear" />

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.2</token>
+    <token name="@VERSION_SUFFIX@">2</token>
 
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
