### PR TITLE
freebayes: use standard_filters param on command line

### DIFF
--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -1,4 +1,4 @@
-<tool id="freebayes" name="FreeBayes" version="@DEPENDENCY_VERSION@">
+<tool id="freebayes" name="FreeBayes" version="@TOOL_VERSION@+galaxy1">
     <description>bayesian genetic variant detector</description>
     <xrefs>
         <xref type="bio.tools">freebayes</xref>
@@ -175,27 +175,25 @@
 
         ##INPUT FILTERS
             #if str( $options_type.input_filters.input_filters_selector ) == "set":
+                $standard_filters
                 ${options_type.input_filters.use_duplicate_reads}
-                -m ${options_type.input_filters.m}
-                -q ${options_type.input_filters.q}
-                -R ${options_type.input_filters.R}
-                -Y ${options_type.input_filters.Y}
-                -e ${options_type.input_filters.e}
-                -F ${options_type.input_filters.F}
-                -C ${options_type.input_filters.C}
-                -G ${options_type.input_filters.G}
-
+                --min-mapping-quality ${options_type.input_filters.min_mapping_quality}
+                --min-base-quality ${options_type.input_filters.min_base_quality}
+                --min-supporting-allele-qsum ${options_type.input_filters.min_supporting_allele_qsum}
+                --min-supporting-mapping-qsum ${options_type.input_filters.min_supporting_mapping_qsum}
                 #if str( $options_type.input_filters.mismatch_filters.mismatch_filters_selector ) == "set":
-                  -Q ${options_type.input_filters.mismatch_filters.Q}
-                  #if str($options_type.input_filters.mismatch_filters.U)
-                      -U ${options_type.input_filters.mismatch_filters.U}
+                --mismatch-base-quality-threshold ${options_type.input_filters.mismatch_filters.mismatch_base_quality_threshold}
+                  #if str($options_type.input_filters.mismatch_filters.read_mismatch_limit)
+                    --read-mismatch-limit ${options_type.input_filters.mismatch_filters.read_mismatch_limit}
                   #end if
-                  -z ${options_type.input_filters.mismatch_filters.z}
-
+                  --read-max-mismatch-fraction ${options_type.input_filters.mismatch_filters.read_max_mismatch_fraction}
                   --read-snp-limit ${options_type.input_filters.mismatch_filters.read_snp_limit}
                 #end if
-
+                --read-indel-limit ${options_type.input_filters.read_indel_limit}
+                --min-alternate-fraction ${options_type.input_filters.min_alternate_fraction}
                 --min-alternate-qsum ${options_type.input_filters.min_alternate_qsum}
+                --min-alternate-count ${options_type.input_filters.min_alternate_count}
+                --min-alternate-total ${options_type.input_filters.min_alternate_total}
             #end if
 
         ## POPULATION AND MAPPABILITY PRIORS
@@ -471,21 +469,23 @@
 
                 <!-- input filters -->
                 <conditional name="input_filters">
-                    <param name="input_filters_selector" type="select" label="Input filters"
-                           help="Sets -4, -m, -q, -R, -Y, -Q, -U, -z, -&#36;, -e, -0, -F, -C, -3, -G, and -&#33; options">
+                    <param name="input_filters_selector" type="select" label="Input filters">
                         <option value="do_not_set" selected="true">No input filters (default)</option>
                         <option value="set">Set input filters</option>
                     </param>
                     <when value="set">
-                        <param name="use_duplicate_reads" argument="--use-duplicate-reads" type="boolean" truevalue="--use-duplicate-reads" falsevalue="" checked="false"
+                        <param argument="--standard-filters" type="boolean" truevalue="--standard-filters" falsevalue="" checked="false"
+                               label="Use stringent input base and mapping quality filters"
+                               help="--min-mapping-quality 30 --min-base-quality 20, --min-supporting-allele-qsum 0 --genotype-variant-threshold 0"/>
+                        <param argument="--use-duplicate-reads" type="boolean" truevalue="--use-duplicate-reads" falsevalue="" checked="false"
                                label="Include duplicate-marked alignments in the analysis" />
-                        <param name="m" argument="--min-mapping-quality" type="integer" value="1"
+                        <param argument="--min-mapping-quality" type="integer" value="1"
                                label="Exclude alignments from analysis if they have a mapping quality less than" />
-                        <param name="q" argument="--min-base-quality" type="integer" value="0"
+                        <param argument="--min-base-quality" type="integer" value="0"
                                label="Exclude alleles from analysis if their supporting base quality less than" />
-                        <param name="R" argument="--min-supporting-allele-qsum" type="integer" value="0"
+                        <param argument="--min-supporting-allele-qsum" type="integer" value="0"
                                label="Consider any allele in which the sum of qualities of supporting observations is at least" />
-                        <param name="Y" argument="--min-supporting-mapping-qsum" type="integer" value="0"
+                        <param argument="--min-supporting-mapping-qsum" type="integer" value="0"
                                label="Consider any allele in which and the sum of mapping qualities of supporting reads is at least" />
                         <conditional name="mismatch_filters">
                             <param name="mismatch_filters_selector" type="select" label="Mismatch filters"
@@ -494,12 +494,12 @@
                                 <option value="set">Set mismatch filters</option>
                             </param>
                             <when value="set">
-                                <param name="Q" argument="--mismatch-base-quality-threshold" type="integer" value="10"
+                                <param argument="--mismatch-base-quality-threshold" type="integer" value="10"
                                        label="Count mismatches toward -U (option below) if the base quality of the mismatch is >=" />
-                                <param name="U" type="integer" argument="--read-mismatch-limit" value="1000" optional="true"
+                                <param argument="--read-mismatch-limit" type="integer" value="1000" optional="true"
                                        label="Exclude reads with more than N mismatches where each mismatch has base quality >= mismatch-base-quality-threshold (option above)"
                                        help="default=~unbounded" />
-                                <param name="z" argument="--read-max-mismatch-fraction" type="float" value="1.0" min="0.0" max="1.0"
+                                <param argument="--read-max-mismatch-fraction" type="float" value="1.0" min="0.0" max="1.0"
                                        label="Exclude reads with more than N [0,1] fraction of mismatches where each mismatch has base quality >= mismatch-base-quality-threshold (second option above)" />
                                 <param name="read_snp_limit" argument="--read-snp-limit" type="integer" value="1000"
                                        label="Exclude reads with more than N base mismatches, ignoring gaps with quality >= mismatch-base-quality-threshold (third option above)"
@@ -507,19 +507,16 @@
                             </when>
                             <when value="do_not_set" />
                         </conditional>
-                        <param name="e" argument="--read-indel-limit" type="integer" value="1000"
+                        <param argument="--read-indel-limit" type="integer" value="1000"
                                label="Exclude reads with more than this number of separate gaps"
                                help="default=~unbounded" />
-                        <param name="standard_filters" argument="--standard-filters" type="boolean" truevalue="-0" falsevalue="" checked="false"
-                               label="Use stringent input base and mapping quality filters"
-                               help="Equivalent to -m 30 -q 20 -R 0 -S 0" />
-                        <param name="F" argument="--min-alternate-fraction" type="float" value="0.05"
+                        <param argument="--min-alternate-fraction" type="float" value="0.05"
                                label="Require at least this fraction of observations supporting an alternate allele within a single individual in the in order to evaluate the position" />
-                        <param name="C" argument="--min-alternate-count" type="integer" value="2"
-                               label="Require at least this count of observations supporting an alternate allele within a single individual in order to evaluate the position" />
-                        <param name="min_alternate_qsum" argument="--min-alternate-qsum" type="integer" value="0"
+                        <param argument="--min-alternate-qsum" type="integer" value="0"
                                label="Require at least this sum of quality of observations supporting an alternate allele within a single individual in order to evaluate the position" />
-                        <param name="G" argument="--min-alternate-total" type="integer" value="1"
+                        <param argument="--min-alternate-count" type="integer" value="2"
+                               label="Require at least this count of observations supporting an alternate allele within a single individual in order to evaluate the position" />
+                        <param argument="--min-alternate-total" type="integer" value="1"
                                label="Require at least this count of observations supporting an alternate allele within the total population in order to use the allele in analysis" />
                     </when>
                     <when value="do_not_set" />

--- a/tools/freebayes/leftalign.xml
+++ b/tools/freebayes/leftalign.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bamleftalign" name="BamLeftAlign" version="@DEPENDENCY_VERSION@">
+<tool id="bamleftalign" name="BamLeftAlign" version="@TOOL_VERSION@">
     <description> indels in BAM datasets</description>
     <xrefs>
         <xref type="bio.tools">freebayes</xref>

--- a/tools/freebayes/macros.xml
+++ b/tools/freebayes/macros.xml
@@ -1,8 +1,8 @@
 <macros>
-    <token name="@DEPENDENCY_VERSION@">1.3.1</token>
+    <token name="@TOOL_VERSION@">1.3.1</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@DEPENDENCY_VERSION@">freebayes</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">freebayes</requirement>
             <requirement type="package" version="1.9">samtools</requirement>
             <yield />
         </requirements>


### PR DESCRIPTION
and restructure the corresponding section a bit + use long args

Note: still the param is odd, because it may collide with other params from this and one from another section... 


bump and switch to TOOL_VERSION

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
