### PR TITLE
lastz: add lastz32 option and update version

### DIFF
--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -11,7 +11,12 @@
         <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        lastz
+        #if $whole_genome.lastz_32:
+            lastz_32
+        #else:
+            lastz
+        #end if
+
         @TARGET_INPUT_COMMAND_LINE@
         ## If --self is set: perform self alignment and ignore the query
         #if $where_to_look.self:
@@ -292,7 +297,9 @@
     <inputs>
         <expand macro="target_input"/>
         <param name="query" format="fasta,fastq,fasta.gz,fastq.gz,fastq.bz2" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
-
+        <section name="whole_genome" expanded="false" title="Whole Genomes">
+            <param name="lastz_32" type="boolean" checked="false" label="Use lastz_32" help="It is highly recommended to use lastz_32 instead of lastz if the refernece genome size is greater than 2G"/>
+        </section>
         <section name="where_to_look" expanded="False" title="Where to look">
             <param name="strand" type="select" display="radio" label="which strand to search" argument="--strand" help="Search both strands or choose plus or minus">
                 <option value="--strand=both" selected="True">Both</option>
@@ -646,6 +653,7 @@
             <param name="ref_source" value="history" />
             <param name="target" ftype="fasta.gz" value="chrM_human.fa.gz" />
             <param name="query" ftype="fastq" value="chrM_mouse.fq" />
+            <param name="lastz_32" value="true" />
             <param name="strand" value="--strand=both" />
             <param name="format" value="blastn" />
             <output name="output" value="test5.out" />

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,17 +1,17 @@
-<tool id="lastz_wrapper_2" name="LASTZ" version="@LASTZ_CONDA_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="lastz_wrapper_2" name="LASTZ" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>: align long sequences</description>
     <macros>
         <import>lastz_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
     <requirements>
-        <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">lastz</requirement>
         <requirement type="package" version="1.14">samtools</requirement>
         <requirement type="package" version="3.6.3">r-base</requirement>
         <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        #if $whole_genome.lastz_32:
+        #if $lastz_32:
             lastz_32
         #else:
             lastz
@@ -297,9 +297,7 @@
     <inputs>
         <expand macro="target_input"/>
         <param name="query" format="fasta,fastq,fasta.gz,fastq.gz,fastq.bz2" type="data" label="Select QUERY sequence(s)" help="These are the sequences that you are aligning against TARGET"/>
-        <section name="whole_genome" expanded="false" title="Whole Genomes">
-            <param name="lastz_32" type="boolean" checked="false" label="Use lastz_32" help="It is highly recommended to use lastz_32 instead of lastz if the refernece genome size is greater than 2G"/>
-        </section>
+        <param name="lastz_32" type="boolean" checked="false" label="Use lastz_32" help="It is highly recommended to use lastz_32 instead of lastz if the refernece genome size is greater than 2G"/>
         <section name="where_to_look" expanded="False" title="Where to look">
             <param name="strand" type="select" display="radio" label="which strand to search" argument="--strand" help="Search both strands or choose plus or minus">
                 <option value="--strand=both" selected="True">Both</option>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_wrapper_2" name="LASTZ" version="1.3.4">
+<tool id="lastz_wrapper_2" name="LASTZ" version="@LASTZ_CONDA_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>: align long sequences</description>
     <macros>
         <import>lastz_macros.xml</import>

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_wrapper_2" name="LASTZ" version="1.3.3">
+<tool id="lastz_wrapper_2" name="LASTZ" version="1.3.4">
     <description>: align long sequences</description>
     <expand macro="bio_tools"/>
     <macros>
@@ -6,9 +6,9 @@
     </macros>
     <requirements>
         <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
-        <requirement type="package" version="1.7">samtools</requirement>
-        <requirement type="package" version="3.4.2">r-base</requirement>
-        <requirement type="package" version="1.0.6">bzip2</requirement>
+        <requirement type="package" version="1.14">samtools</requirement>
+        <requirement type="package" version="3.6.3">r-base</requirement>
+        <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         lastz

--- a/tools/lastz/lastz.xml
+++ b/tools/lastz/lastz.xml
@@ -1,9 +1,9 @@
 <tool id="lastz_wrapper_2" name="LASTZ" version="1.3.4">
     <description>: align long sequences</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>lastz_macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <requirements>
         <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
         <requirement type="package" version="1.14">samtools</requirement>

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -1,11 +1,11 @@
-<tool id="lastz_d_wrapper" name="LASTZ_D" version="@LASTZ_CONDA_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="lastz_d_wrapper" name="LASTZ_D" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>: estimate substitution scores matrix</description>
     <macros>
     	<import>lastz_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
     <requirements>
-        <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">lastz</requirement>
         <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -6,7 +6,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
-        <requirement type="package" version="1.0.6">bzip2</requirement>
+        <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         lastz_D

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -1,9 +1,9 @@
 <tool id="lastz_d_wrapper" name="LASTZ_D" version="1.3.2">
     <description>: estimate substitution scores matrix</description>
-    <expand macro="bio_tools"/>
     <macros>
     	<import>lastz_macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <requirements>
         <requirement type="package" version="@LASTZ_CONDA_VERSION@">lastz</requirement>
         <requirement type="package" version="1.0.8">bzip2</requirement>

--- a/tools/lastz/lastz_d.xml
+++ b/tools/lastz/lastz_d.xml
@@ -1,4 +1,4 @@
-<tool id="lastz_d_wrapper" name="LASTZ_D" version="1.3.2">
+<tool id="lastz_d_wrapper" name="LASTZ_D" version="@LASTZ_CONDA_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>: estimate substitution scores matrix</description>
     <macros>
     	<import>lastz_macros.xml</import>

--- a/tools/lastz/lastz_macros.xml
+++ b/tools/lastz/lastz_macros.xml
@@ -1,5 +1,6 @@
 <macros>
     <token name="@LASTZ_CONDA_VERSION@">1.04.15</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@TARGET_INPUT_COMMAND_LINE@"><![CDATA[
         #if $source.ref_source=="history":
             #if $source.target.is_of_type('fasta.gz'):

--- a/tools/lastz/lastz_macros.xml
+++ b/tools/lastz/lastz_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@LASTZ_CONDA_VERSION@">1.04.15</token>
+    <token name="@TOOL_VERSION@">1.04.15</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@TARGET_INPUT_COMMAND_LINE@"><![CDATA[
         #if $source.ref_source=="history":

--- a/tools/lastz/lastz_macros.xml
+++ b/tools/lastz/lastz_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@LASTZ_CONDA_VERSION@">1.0.4</token>
+    <token name="@LASTZ_CONDA_VERSION@">1.04.15</token>
     <token name="@TARGET_INPUT_COMMAND_LINE@"><![CDATA[
         #if $source.ref_source=="history":
             #if $source.target.is_of_type('fasta.gz'):


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

1. Update lastz to latest 1.04.15 and apply recommend version format
2. Update all related tools (r-base, samtools, bzip2), because of compatibility in installation.
3. Add lastz_32 option. The lastz_32 is an additional build of lastz that allow the read genome larger than 2G. lastz will fail when hg38 is used for reference.

