### PR TITLE
Updating tools/delly from version 0.8.7 to 0.9.1

### DIFF
--- a/tools/delly/classify.xml
+++ b/tools/delly/classify.xml
@@ -105,7 +105,7 @@ $generic.pass
             </output>
             <output name="out_vcf">
                 <assert_contents>
-                    <has_size value="7762"/>
+                    <has_size value="7758"/>
                 </assert_contents>
             </output>
         </test>
@@ -140,7 +140,7 @@ $generic.pass
             </output>
             <output name="out_vcf">
                 <assert_contents>
-                    <has_size value="7762"/>
+                    <has_size value="7758"/>
                 </assert_contents>
             </output>
         </test>
@@ -167,7 +167,7 @@ $generic.pass
             </output>
             <output name="out_vcf">
                 <assert_contents>
-                    <has_size value="7665"/>
+                    <has_size value="7661"/>
                 </assert_contents>
             </output>
         </test>
@@ -197,7 +197,7 @@ $generic.pass
             </output>
             <output name="out_vcf">
                 <assert_contents>
-                    <has_size value="7665"/>
+                    <has_size value="7661"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/delly/filter.xml
+++ b/tools/delly/filter.xml
@@ -232,7 +232,7 @@ $generic.pass
             </output>
             <output name="out_vcf">
                 <assert_contents>
-                    <has_n_lines n="142"/>
+                    <has_n_lines n="143"/>
                     <has_line line="##fileformat=VCFv4.2"/>
                     <has_line line="#CHROM&#009;POS&#009;ID&#009;REF&#009;ALT&#009;QUAL&#009;FILTER&#009;INFO&#009;FORMAT&#009;NORMAL&#009;TUMOR"/>
                 </assert_contents>

--- a/tools/delly/macros.xml
+++ b/tools/delly/macros.xml
@@ -5,7 +5,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">delly</requirement>
-            <requirement type="package" version="1.14">bcftools</requirement>
+            <requirement type="package" version="1.12">bcftools</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/delly/macros.xml
+++ b/tools/delly/macros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">0.8.7</token>
+    <token name="@TOOL_VERSION@">0.9.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">delly</requirement>
-            <requirement type="package" version="1.10.2">bcftools</requirement>
+            <requirement type="package" version="1.14">bcftools</requirement>
         </requirements>
     </xml>
     <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/delly**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/delly from version 0.8.7 to 0.9.1.

**Project home page:** https://github.com/dellytools/delly/releases