### PR TITLE
Updating tools/iqtree from version 2.1.2 to
2.2.0.3

### DIFF
--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.1.4_beta</token>
+    <token name="@TOOL_VERSION@">2.2.0_beta</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.1.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.1.4_beta</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">
         <requirements>

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.0_beta</token>
+    <token name="@TOOL_VERSION@">2.2.0.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/iqtree**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/iqtree from version 2.1.2 to 2.1.4_beta.

**Project home page:** http://www.iqtree.org