### PR TITLE
Updating tools/last from version 1205 to
1453

### DIFF
--- a/tools/last/lastal.xml
+++ b/tools/last/lastal.xml
@@ -1,4 +1,4 @@
-<tool id="last_al" name="LASTal" version="@TOOL_VERSION@+galaxy1" profile="20.01">
+<tool id="last_al" name="LASTal" version="@TOOL_VERSION@+galaxy0" profile="20.01">
 
     <description>finds local alignments between query sequences, and reference sequences.</description>
     <expand macro="bio_tools"/>

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1420</token>
+    <token name="@TOOL_VERSION@">1422</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1447</token>
+    <token name="@TOOL_VERSION@">1448</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1389</token>
+    <token name="@TOOL_VERSION@">1411</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1448</token>
+    <token name="@TOOL_VERSION@">1449</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1445</token>
+    <token name="@TOOL_VERSION@">1447</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1422</token>
+    <token name="@TOOL_VERSION@">1445</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1449</token>
+    <token name="@TOOL_VERSION@">1450</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1418</token>
+    <token name="@TOOL_VERSION@">1420</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1450</token>
+    <token name="@TOOL_VERSION@">1453</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1411</token>
+    <token name="@TOOL_VERSION@">1418</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1356</token>
+    <token name="@TOOL_VERSION@">1389</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1268</token>
+    <token name="@TOOL_VERSION@">1270</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1270</token>
+    <token name="@TOOL_VERSION@">1281</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1205</token>
+    <token name="@TOOL_VERSION@">1256</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1257</token>
+    <token name="@TOOL_VERSION@">1260</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1296</token>
+    <token name="@TOOL_VERSION@">1356</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1293</token>
+    <token name="@TOOL_VERSION@">1296</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1282</token>
+    <token name="@TOOL_VERSION@">1293</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1260</token>
+    <token name="@TOOL_VERSION@">1268</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1281</token>
+    <token name="@TOOL_VERSION@">1282</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 

--- a/tools/last/macros_last.xml
+++ b/tools/last/macros_last.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1256</token>
+    <token name="@TOOL_VERSION@">1257</token>
     <token name="@LAST_HELP@"><![CDATA[
         Documentation : http://last.cbrc.jp/
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/last**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/last from version 1205 to 1256.

**Project home page:** http://last.cbrc.jp