### PR TITLE
Updating tools/transit from version 3.0.2 to 3.2.3

### DIFF
--- a/tools/transit/macros.xml
+++ b/tools/transit/macros.xml
@@ -17,8 +17,8 @@
 			<yield />
 		</requirements>
 	</xml>
-	<token name="@TOOL_VERSION@">3.0.2</token>
-	<token name="@VERSION_SUFFIX@">1</token>
+	<token name="@TOOL_VERSION@">3.2.3</token>
+	<token name="@VERSION_SUFFIX@">0</token>
 	<xml name="outputs">
         <yield />
         <data name="sites" from_work_dir="transit_out.txt" format="tabular" label="${tool.name} on ${on_string} Sites" />


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/transit**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/transit from version 3.0.2 to 3.2.3.

**Project home page:** https://github.com/mad-lab/transit/releases