### PR TITLE
replace @VERSION@ with @TOOL_VERSION@ in gff_prot wrapper

### DIFF
--- a/tools/transit/convert_gff.xml
+++ b/tools/transit/convert_gff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="gff_to_prot" name="Convert GFF3" version="@VERSION@+galaxy0">
+<tool id="gff_to_prot" name="Convert GFF3" version="@TOOL_VERSION@+galaxy0">
     <description>to prot_table for TRANSIT</description>
     <expand macro="bio_tools"/>
     <macros>


### PR DESCRIPTION
As part of Galaxy Australia's updates we have install gff_prot with version "@VERSION@+galaxy0".  This is because in the macros the token has changed to @TOOL_VERSION.  This is the only instance of @VERSION@ I could find in the /transit/ directory

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
