### PR TITLE
Updating tools/edger from version 3.34.0 to 3.36.0

### DIFF
--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -3,8 +3,8 @@
         Perform differential expression of count data
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">3.34.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">3.36.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">edger</xref>
@@ -19,7 +19,7 @@
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-edger</requirement>
-        <requirement type="package" version="3.48.0">bioconductor-limma</requirement>
+        <requirement type="package" version="3.50.0">bioconductor-limma</requirement>
         <requirement type="package" version="0.2.20">r-rjson</requirement>
         <requirement type="package" version="1.20.3">r-getopt</requirement>
         <requirement type="package" version="1.4.36">r-statmod</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/edger**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/edger from version 3.34.0 to 3.36.0.

**Project home page:** http://bioconductor.org/packages/release/bioc/html/edgeR.html