### PR TITLE
Updating tools/limma_voom from version 3.48.0 to 3.50.0

### DIFF
--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -1,9 +1,9 @@
-<tool id="limma_voom" name="limma" version="@TOOL_VERSION@+galaxy2">
+<tool id="limma_voom" name="limma" version="@TOOL_VERSION@+galaxy0">
     <description>
         Perform differential expression with limma-voom or limma-trend
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">3.48.0</token>
+        <token name="@TOOL_VERSION@">3.50.0</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">limma</xref>
@@ -18,13 +18,13 @@
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-limma</requirement>
-        <requirement type="package" version="3.34.0">bioconductor-edger</requirement>
+        <requirement type="package" version="3.36.0">bioconductor-edger</requirement>
         <requirement type="package" version="1.4.36">r-statmod</requirement>
         <requirement type="package" version="1.1.1">r-scales</requirement>
         <requirement type="package" version="0.2.20">r-rjson</requirement>
         <requirement type="package" version="1.20.3">r-getopt</requirement>
         <requirement type="package" version="3.1.1">r-gplots</requirement>
-        <requirement type="package" version="2.2.0">bioconductor-glimma</requirement>
+        <requirement type="package" version="2.4.0">bioconductor-glimma</requirement>
     </requirements>
 
     <version_command><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/limma_voom**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/limma_voom from version 3.48.0 to 3.50.0.

**Project home page:** http://bioconductor.org/packages/release/bioc/html/limma.html