### PR TITLE
Updating tools/raven from version 1.6.1 to 1.7.0

### DIFF
--- a/tools/raven/macros.xml
+++ b/tools/raven/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.6.1</token>
+    <token name="@TOOL_VERSION@">1.7.0</token>
     <token name="@PROFILE@">20.05</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/raven**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/raven from version 1.6.1 to 1.7.0.

**Project home page:** https://github.com/lbcb-sci/raven/releases