### PR TITLE
Add fastq,fastq.gz datatypes

### DIFF
--- a/tools/obitools/illuminapairedend.xml
+++ b/tools/obitools/illuminapairedend.xml
@@ -29,6 +29,7 @@
             --sanger
         #end if
         --without-progress-bar
+        --fastq-output
         --score-min='$score'
         -r fastq3p.fastq 
         fastq5p.fastq
@@ -44,7 +45,7 @@
         <param name="score" type="float" value="40.0" label="minimum score for keeping aligment"/>
     </inputs>
     <outputs>
-        <data name="output" format_source="inputfastq3p" label="${tool.name} on ${on_string}: assembly results" />
+        <data name="output" format="fastqsanger" label="${tool.name} on ${on_string}: assembly results" />
     </outputs>
 
     <tests>

--- a/tools/obitools/illuminapairedend.xml
+++ b/tools/obitools/illuminapairedend.xml
@@ -22,7 +22,7 @@
             ##input file is in fastq nucleic format produced by solexa sequencer
             --solexa
         #else if $inputfastq3p.ext.startswith("fastqillumina")
-            ##input file is in fastq nucleic format produced by solexa sequencer
+            ##input file is in fastq nucleic format produced by illumina sequencer
             --illumina
         #else
             ## input file is in sanger fastq nucleic format (standard fastq)

--- a/tools/obitools/illuminapairedend.xml
+++ b/tools/obitools/illuminapairedend.xml
@@ -40,8 +40,8 @@
         ]]>
     </command>
     <inputs>
-        <param name="inputfastq3p" type="data" format="fastq,fastq.gz" label="Read from file" help="file of 3p (1:) Illumina pair-end reads to assemble in sanger fastq nucleic format (standard fastq)" />
-        <param name="inputfastq5p" type="data" format="fastq,fastq.gz" label="Read from file" help="file of 5p (2:) Illumina pair-end reads to assemble in sanger fastq nucleic format (standard fastq)" />
+        <param name="inputfastq3p" type="data" format="@INPUT_FORMATS@" label="Read from file" help="file of 3p (1:) Illumina pair-end reads to assemble in sanger fastq nucleic format (standard fastq)" />
+        <param name="inputfastq5p" type="data" format="@INPUT_FORMATS@" label="Read from file" help="file of 5p (2:) Illumina pair-end reads to assemble in sanger fastq nucleic format (standard fastq)" />
         <param name="score" type="float" value="40.0" label="minimum score for keeping aligment"/>
     </inputs>
     <outputs>

--- a/tools/obitools/macros.xml
+++ b/tools/obitools/macros.xml
@@ -19,7 +19,7 @@
         </stdio>
     </xml>
 
-    <token name="@INPUT_FORMATS@">fastqsanger,fastqsanger.gz,fastqsolexa,fastqsolexa.gz,fasta,fasta.gz</token>
+    <token name="@INPUT_FORMATS@">fastq,fastq.gz,fastqsanger,fastqsanger.gz,fastqsolexa,fastqsolexa.gz,fasta,fasta.gz</token>
     <token name="@GUNZIP_INPUT@"><![CDATA[
         #if $input.ext.endswith(".gz")
             gunzip -c '$input' > input &&


### PR DESCRIPTION
Add fastq,fastq.gz datatypes as tools like illuminapairend output these formats but obigrep, who is a tool who can be used on output dataset from illuminapairend was not allowing fastq/fastq.gz input files. OR maybe better to update obigrep to also use this @INPUT_FORMATS@ ?

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
