### PR TITLE
Updating tools/nextclade from version 1.5.1 to 1.7.0

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.5.1</token>
+    <token name="@TOOL_VERSION@">1.7.0</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/nextalign.xml
+++ b/tools/nextclade/nextalign.xml
@@ -34,10 +34,6 @@ nextalign
     --nuc-min-seeds '${nuc_min_seeds}'
     --nuc-seed-spacing '${nuc_seed_spacing}'
     --nuc-mismatches-allowed '${nuc_mismatches_allowed}'
-    --aa-seed-length '${aa_seed_length}'
-    --aa-min-seeds '${aa_min_seeds}'
-    --aa-seed-spacing '${aa_seed_spacing}'
-    --aa-mismatches-allowed '${aa_mismatches_allowed}'
     ]]></command>
     <inputs>
         <expand macro="reference"/>
@@ -97,16 +93,6 @@ nextalign
         <param argument="--nuc-mismatches-allowed" type="integer" value="3" min="0"
             label="Maximum number of mismatching nucleotides."
             help="Maximum number of mismatching nucleotides allowed for a seed to be considered a match." />
-        <param argument="--aa-seed-length" type="integer" value="12" min="1"
-            label="Seed length for aminoacid alignment" />
-        <param argument="--aa-min-seeds" type="integer" value="10" min="1"
-            label="Minimum number of seeds to search for during aminoacid alignment."
-            help="Relevant for short sequences. In long sequences, the number of seeds is determined by the aminoacid seed spacing." />
-        <param argument="--aa-seed-spacing" type="integer" value="100" min="0"
-            label="Spacing between seeds during aminoacid alignment." />
-        <param argument="--aa-mismatches-allowed" type="integer" value="2" min="0"
-            label="Maximum number of mismatching aminoacids."
-            help="Maximum number of mismatching aminoacids allowed for a seed to be considered a match." />
     </inputs>
     <outputs>
         <data name="output_fasta" format="fasta" label="${tool.name} on ${on_string} (FASTA)"/>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.5.1 to 1.7.0.

**Project home page:** https://github.com/nextstrain/nextclade/releases