### PR TITLE
Updating tools/trycycler from version 0.5.1 to 0.5.3

### DIFF
--- a/tools/trycycler/macros.xml
+++ b/tools/trycycler/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.5.1</token>
+    <token name="@TOOL_VERSION@">0.5.3</token>
     <token name="@PIPELINE@">                                                                                
 **Trycycler pipeline**                                                                                  
                                                                                                         


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/trycycler**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/trycycler from version 0.5.1 to 0.5.3.

**Project home page:** https://github.com/rrwick/Trycycler/releases