### PR TITLE
CI: Check file sizes only for changed files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -228,8 +228,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Save repositories to file
-      run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
     - name: Check file sizes
       run: |
         find $(git diff --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,6 +27,7 @@ jobs:
       tool-list: ${{ steps.discover.outputs.tool-list }}
       chunk-count: ${{ steps.discover.outputs.chunk-count }}
       chunk-list: ${{ steps.discover.outputs.chunk-list }}
+      commit-range: ${{ steps.discover.outputs.commit-range }}
     strategy:
       matrix:
         python-version: ['3.7']
@@ -226,14 +227,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        fetch-depth: 0
     - name: Save repositories to file
       run: echo '${{ needs.setup.outputs.repository-list }}' > repository_list.txt
     - name: Check file sizes
       run: |
-        while read repo; do
-          find "$repo" -size +${{ env.MAX_FILE_SIZE }}
-        done < repository_list.txt > file_size_report.txt
+        find $(git diff --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt
@@ -384,7 +383,7 @@ jobs:
 
   determine-success:
     name: Check workflow success
-    needs: [setup, lint, flake8, lintr, combine_outputs]
+    needs: [setup, lint, flake8, lintr, file_sizes, combine_outputs]
     if: ${{ always() && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -396,6 +395,9 @@ jobs:
       run: exit 1
     - name: Indicate R script lint status
       if: ${{ needs.lintr.result != 'success' && needs.lintr.result != 'skipped' }}
+      run: exit 1
+    - name: Indicate file size check status
+      if: ${{ needs.file_sizes.result != 'success' && needs.file_sizes.result != 'skipped' }}
       run: exit 1
     - name: Check tool test status
       if: ${{ needs.combine_outputs.result != 'success' && needs.combine_outputs.result != 'skipped' }}


### PR DESCRIPTION
as pointed out here: https://github.com/galaxyproject/tools-iuc/pull/3973#issuecomment-944247753

reducing the size of test data does not decrease the repo size
if the files are already in. so we should only check for the sizes
of changed files and be strict with them

took this from https://github.com/galaxyproject/tools-iuc/pull/4077 .. which seems more controversial 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
