### PR TITLE
only check added files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,7 +231,8 @@ jobs:
     - name: Check file sizes
       run: |
         touch file_size_report.txt
-        GITDIFF=$(git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }})
+        GITDIFF=$(git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }} | tr '\n' ' ')
+        echo GITDIFF "$GITDIFF"
         if [ -n "$GITDIFF" ]; then
           find "$GITDIFF" -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
         fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,7 +230,7 @@ jobs:
         fetch-depth: 0
     - name: Check file sizes
       run: |
-        find $(git diff --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
+        find $(git diff --diff-filter A --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,7 +230,11 @@ jobs:
         fetch-depth: 0
     - name: Check file sizes
       run: |
-        find $(git diff --diff-filter A --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
+        touch file_size_report.txt
+        GITDIFF=$(git diff --diff-filter A --name-only ${{ needs.setup.outputs.commit-range }})
+        if [ -n "$GITDIFF" ]; then
+          find "$GITDIFF" -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
+        fi
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,7 +231,7 @@ jobs:
     - name: Check file sizes
       run: |
         touch file_size_report.txt
-        GITDIFF=$(git diff --diff-filter A --name-only ${{ needs.setup.outputs.commit-range }})
+        GITDIFF=$(git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }})
         if [ -n "$GITDIFF" ]; then
           find "$GITDIFF" -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
         fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,11 +231,10 @@ jobs:
     - name: Check file sizes
       run: |
         touch file_size_report.txt
-        GITDIFF=$(git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }} | tr '\n' ' ')
-        echo GITDIFF "$GITDIFF"
-        if [ -n "$GITDIFF" ]; then
-          find "$GITDIFF" -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
-        fi
+        git diff --diff-filter=d --name-only ${{ needs.setup.outputs.commit-range }} > git.diff
+        while read line; do
+          find "$line" -type f -size +${{ env.MAX_FILE_SIZE }} >> file_size_report.txt
+        done < git.diff
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt


### PR DESCRIPTION
otherwise find fails for deleted files

not sure if we should add more. here is the man

```
       --diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]
           Select only files that are Added (A), Copied (C), Deleted (D),
           Modified (M), Renamed (R), have their type (i.e. regular file,
           symlink, submodule, ...) changed (T), are Unmerged (U), are Unknown
           (X), or have had their pairing Broken (B). Any combination of the
           filter characters (including none) can be used. When *
           (All-or-none) is added to the combination, all paths are selected
           if there is any file that matches other criteria in the comparison;
           if there is no file that matches other criteria, nothing is
           selected.

           Also, these upper-case letters can be downcased to exclude. E.g.
           --diff-filter=ad excludes added and deleted paths.

           Note that not all diffs can feature all types. For instance, diffs
           from the index to the working tree can never have Added entries
           (because the set of paths included in the diff is limited by what
           is in the index). Similarly, copied and renamed entries cannot
           appear if detection for those types is disabled.
```


FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
