### PR TITLE
Updating tools/dexseq from version 1.28.1 to 1.48.0

### DIFF
--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -7,7 +7,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.20.3">r-getopt</requirement>
+        <requirement type="package" version="1.20.4">r-getopt</requirement>
         <requirement type="package" version="0.2.21">r-rjson</requirement>
     </expand>
     <code file="dexseq_helper.py" />

--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -8,7 +8,7 @@
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="1.20.3">r-getopt</requirement>
-        <requirement type="package" version="0.2.20">r-rjson</requirement>
+        <requirement type="package" version="0.2.21">r-rjson</requirement>
     </expand>
     <code file="dexseq_helper.py" />
     <stdio>

--- a/tools/dexseq/dexseq.xml
+++ b/tools/dexseq/dexseq.xml
@@ -1,4 +1,4 @@
-<tool id="dexseq" name="DEXSeq" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="dexseq" name="DEXSeq" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Determines differential exon usage from count tables</description>
     <xrefs>
         <xref type="bio.tools">dexseq</xref>
@@ -7,7 +7,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.20.2">r-getopt</requirement>
+        <requirement type="package" version="1.20.3">r-getopt</requirement>
         <requirement type="package" version="0.2.20">r-rjson</requirement>
     </expand>
     <code file="dexseq_helper.py" />

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.44.0</token>
+    <token name="@TOOL_VERSION@">1.46.0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.46.0</token>
+    <token name="@TOOL_VERSION@">1.48.0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.40.0</token>
+    <token name="@TOOL_VERSION@">1.44.0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.28.1</token>
+    <token name="@TOOL_VERSION@">1.40.0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/dexseq**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/dexseq from version 1.28.1 to 1.40.0.

**Project home page:** https://www.bioconductor.org/packages/release/bioc/html/DEXSeq.html