### PR TITLE
Exclude deleted files from file size check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,7 +230,7 @@ jobs:
         fetch-depth: 0
     - name: Check file sizes
       run: |
-        find $(git diff --name-only ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
+        find $(git diff --name-only --diff-filter=d ${{ needs.setup.outputs.commit-range }}) -type f -size +${{ env.MAX_FILE_SIZE }} > file_size_report.txt
         if [[ -s file_size_report.txt ]]; then
           echo "Files larger than ${{ env.MAX_FILE_SIZE }} found"
           cat file_size_report.txt


### PR DESCRIPTION
Deleting a file leads to an error with the file size check, as the file can no longer be found: https://github.com/galaxyproject/tools-iuc/runs/4580754087