### PR TITLE
Correctly calculate phred scrore mean

### DIFF
--- a/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
@@ -87,8 +87,11 @@ def fastq_read_pass_filter(fastq_read):
                     <param name="right_column_offset" type="float" min="0" max="100" value="0" label="Offset from 3' end" />
                 </when>
             </conditional>
-            <param name="score_operation" type="select" label="Aggregate read score for specified range"
-                help="Please note that phred scores are log values. The tool will calculate the mean based on the underlying `probabilities the scores represent <https://en.wikipedia.org/wiki/Phred_quality_score>`_.">
+            <param name="score_operation" type="select" label="Aggregate read score for specified range">
+                <help><![CDATA[
+                Please note that phred scores are log values. The tool will calculate
+                the mean based on the underlying `probabilities the scores represent
+                <https://en.wikipedia.org/wiki/Phred_quality_score>`_]]></help>
                 <option value="min" selected="true">min score</option>
                 <option value="max">max score</option>
                 <option value="sum">sum of scores</option>

--- a/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
@@ -87,7 +87,8 @@ def fastq_read_pass_filter(fastq_read):
                     <param name="right_column_offset" type="float" min="0" max="100" value="0" label="Offset from 3' end" />
                 </when>
             </conditional>
-            <param name="score_operation" type="select" label="Aggregate read score for specified range">
+            <param name="score_operation" type="select" label="Aggregate read score for specified range"
+                help="Please note that phred scores are log values. The tool will calculate the mean based on the underlying `probabilities the scores represent <https://en.wikipedia.org/wiki/Phred_quality_score>`_.">
                 <option value="min" selected="true">min score</option>
                 <option value="max">max score</option>
                 <option value="sum">sum of scores</option>

--- a/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
@@ -15,11 +15,19 @@ gx-fastq-filter '$input_file' '$fastq_filter_file' '$output_file' '$output_file.
     ]]></command>
     <configfiles>
         <configfile name="fastq_filter_file"><![CDATA[
+import math
+
+SCORE_PROBABILITIES = [10 ** (x * -0.1) for x in range(256)]
+
+def mean(score_list):
+    """Calculate the average of phred scores by calculating them back to probabilities
+       taking the average, and convert it back into a phred score."""
+    score_probabilities = SCORE_PROBABILITIES  # Only one global lookup.
+    sum_probabilities = sum(score_probabilities[score] for score in score_list)
+    average = sum_probabilities / float(len(score_list))
+    return -10 * math.log10(average)
+
 def fastq_read_pass_filter(fastq_read):
-
-    def mean(score_list):
-        return float(sum(score_list)) / float(len(score_list))
-
     if len(fastq_read) < $min_size:
         return False
     if $max_size > 0 and len(fastq_read) > $max_size:

--- a/tool_collections/galaxy_sequence_utils/macros.xml
+++ b/tool_collections/galaxy_sequence_utils/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.1.5</token>
+    <token name="@TOOL_VERSION@">1.1.6</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">galaxy_sequence_utils</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Hi, this is a pretty nasty bug in the filter. Take this example:

> A read with a length of two bases has quality scores 10 and 30 (`+?`). What is the mean?

Naive answer: 20. 

Correct answer: 
- 10 stands for 10 ** (10 / -10) == 10 ** -1 == 0.1
- 30 stands for 10 ** (30 / -10) == 10 ** -3 == 0.001
- Sum: 0.1 + 0.001 = 0.101
- Average = 0.101 / 2 == 0.0505. 
- Calculate back into phred score: -10 * log10(0.0505) ~= 12,97

Note that the naive answer mentions 20. Which stands for a probability of 0.01. Which means that the naive answer **overestimates** the quality by a factor of **five**! That is pretty big. I have a test FASTQ file on my system with 5 million reads (HiSEQ). None of them get filtered using the naive filter. About 4% gets filtered using the correct filter.
