### PR TITLE
Updating tools/abyss from version 2.3.3 to 2.3.4

### DIFF
--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -4,7 +4,7 @@
         <xref type="bio.tools">abyss</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">2.3.3</token>
+        <token name="@TOOL_VERSION@">2.3.4</token>
         <xml name="reads_conditional">
             <conditional name="reads">
                 <param name="reads_selector" type="select" label="Type of paired-end datasets">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/abyss**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/abyss from version 2.3.3 to 2.3.4.

**Project home page:** http://www.bcgsc.ca/platform/bioinfo/software/abyss