### PR TITLE
Updating tools/interproscan from version 5.52-86.0 to
5.54_87.0

### DIFF
--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -129,7 +129,7 @@ $iprlookup
         <test expect_num_outputs="1">
             <param name="input" value="prots.fa" />
             <param name="seqtype" value="p" />
-            <param name="database" value="5.52-86.0" />
+            <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <param name="oformat" value="TSV" />
             <output name="outfile_tsv">
@@ -144,7 +144,7 @@ $iprlookup
         <test expect_num_outputs="4">
             <param name="input" value="prots.fa" />
             <param name="seqtype" value="p" />
-            <param name="database" value="5.52-86.0" />
+            <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <param name="oformat" value="TSV,GFF3,XML,JSON" />
             <output name="outfile_tsv">
@@ -181,7 +181,7 @@ $iprlookup
         <test expect_num_outputs="4">
             <param name="input" value="transcripts.fa" />
             <param name="seqtype" value="n" />
-            <param name="database" value="5.52-86.0" />
+            <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <param name="oformat" value="TSV,GFF3,XML,JSON" />
             <output name="outfile_tsv">
@@ -218,7 +218,7 @@ $iprlookup
         <test expect_failure="true" expect_num_outputs="1">
             <param name="input" value="prots.fa" />
             <param name="seqtype" value="p" />
-            <param name="database" value="5.52-86.0" />
+            <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <conditional name="licensed">
                 <param name="use" value="true" />

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.52-86.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">5.52_86.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">
         <citations>

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -3,6 +3,7 @@
     <!--
         The version must use a "-" instead of a "_"
         Conda understands both notations, but the Galaxy tool requires the use of "-".
+        The version should also be bumped in test-data/interproscan.loc
     -->
     <token name="@TOOL_VERSION@">5.54-87.0</token>
     <token name="@VERSION_SUFFIX@">0</token>

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.54_87.0</token>
+    <!--
+        The version must use a "-" instead of a "_"
+        Conda understands both notations, but the Galaxy tool requires the use of "-".
+    -->
+    <token name="@TOOL_VERSION@">5.54-87.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.52_86.0</token>
+    <token name="@TOOL_VERSION@">5.54_87.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">

--- a/tools/interproscan/test-data/interproscan.loc
+++ b/tools/interproscan/test-data/interproscan.loc
@@ -5,4 +5,4 @@
 # value	description	interproscan_version	path
 #
 # for example
-5.52-86.0	InterProScan 5.52-86.0	5.52-86.0	${__HERE__}/fake_db/
+5.54-87.0	InterProScan 5.54-87.0	5.54-87.0	${__HERE__}/fake_db/


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/interproscan**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/interproscan from version 5.52-86.0 to 5.52_86.0.

**Project home page:** http://www.ebi.ac.uk/Tools/pfa/iprscan5