### PR TITLE
Updating tools/minia from version 3.2.4 to 3.2.6

### DIFF
--- a/tools/minia/minia.xml
+++ b/tools/minia/minia.xml
@@ -4,7 +4,7 @@
         <xref type="bio.tools">minia</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">3.2.4</token>
+        <token name="@TOOL_VERSION@">3.2.6</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">minia</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/minia**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/minia from version 3.2.4 to 3.2.6.

**Project home page:** https://gatb.inria.fr/software/minia