### PR TITLE
Updating tools/nextclade from version 1.7.0 to
1.9.0

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.8.1</token>
+    <token name="@TOOL_VERSION@">1.9.0</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.7.0</token>
+    <token name="@TOOL_VERSION@">1.8.1</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.7.0 to 1.8.1.

**Project home page:** https://github.com/nextstrain/nextclade/releases