### PR TITLE
Removing max limit to bcftools max-depth parameter

### DIFF
--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Annotate and edit VCF/BCF files</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">annotate</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_call.xml
+++ b/tools/bcftools/bcftools_call.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>SNP/indel variant calling from VCF/BCF</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">call</token>
         <import>macros.xml</import>
@@ -29,6 +28,7 @@
             #end if
         </token>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_cnv.xml
+++ b/tools/bcftools/bcftools_cnv.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
     <description>Call copy number variation from VCF B-allele frequency (BAF) and Log R Ratio intensity (LRR) values</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">cnv</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="matplotlib_requirement" />
     </expand>

--- a/tools/bcftools/bcftools_concat.xml
+++ b/tools/bcftools/bcftools_concat.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Concatenate or combine VCF/BCF files</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">concat</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_consensus.xml
+++ b/tools/bcftools/bcftools_consensus.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
     <description>Create consensus sequence by applying VCF variants to a reference fasta file</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">consensus</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
         <requirement type="package" version="5.0.1">gawk</requirement>

--- a/tools/bcftools/bcftools_convert_from_vcf.xml
+++ b/tools/bcftools/bcftools_convert_from_vcf.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@ from vcf" id="bcftools_@EXECUTABLE@_from_vcf" version="@TOOL_VERSION@">
     <description>Converts VCF/BCF to IMPUTE2/SHAPEIT formats</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">convert</token>
         <import>macros.xml</import>
@@ -45,6 +44,7 @@ SampleName SexDesignation:
 #end if
         </token>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_convert_to_vcf.xml
+++ b/tools/bcftools/bcftools_convert_to_vcf.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@ to vcf" id="bcftools_@EXECUTABLE@_to_vcf" version="@TOOL_VERSION@">
     <description>Converts other formats to VCF/BCFk</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">convert</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
     </expand>

--- a/tools/bcftools/bcftools_csq.xml
+++ b/tools/bcftools/bcftools_csq.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Haplotype aware consequence predictor</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">csq</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
     </expand>

--- a/tools/bcftools/bcftools_filter.xml
+++ b/tools/bcftools/bcftools_filter.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Apply fixed-threshold filters</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">filter</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_gtcheck.xml
+++ b/tools/bcftools/bcftools_gtcheck.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Check sample identity</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">gtcheck</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_isec.xml
+++ b/tools/bcftools/bcftools_isec.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Create intersections, unions and complements of VCF files</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">isec</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_merge.xml
+++ b/tools/bcftools/bcftools_merge.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Merge multiple VCF/BCF files from non-overlapping sample sets to create one multi-sample file</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">merge</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
     <description>Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files</description>
     <macros>
         <token name="@EXECUTABLE@">mpileup</token>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Generate VCF or BCF containing genotype likelihoods for one or multiple alignment (BAM or CRAM) files</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">mpileup</token>
         <import>macros.xml</import>
@@ -19,6 +18,7 @@
             <option value="1024">The read is a PCR or optical duplicate</option>
         </xml>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
     </expand>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -223,7 +223,7 @@ ${pasted_data}
         </section>
 
         <section name="sec_filtering" expanded="false" title="Input Filtering Options">
-            <param name="max_reads_per_bam" type="integer" value="250" max="1024" min="1" label="Max reads per BAM" help="--max-depth; default=250"/>
+            <param name="max_reads_per_bam" type="integer" value="250" min="1" label="Max reads per BAM" help="--max-depth; default=250"/>
             <param name="ignore_overlaps" type="boolean" truevalue="-x" falsevalue="" checked="False" label="Disable read-pair overlap detection" help="--ignore-overlaps"/>
             <param name="skip_anomalous_read_pairs" type="boolean" truevalue="-A" falsevalue="" checked="False" label="Do not skip anomalous read pairs in variant calling" help="--count-orphans"/>
             <conditional name="filter_by_flags">

--- a/tools/bcftools/bcftools_norm.xml
+++ b/tools/bcftools/bcftools_norm.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Left-align and normalize indels; check if REF alleles match the reference; split multiallelic sites into multiple rows; recover multiallelics from multiple rows</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">norm</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
         <!-- gawk only required for current bcftools norm bug workaround

--- a/tools/bcftools/bcftools_plugin_color_chrs.xml
+++ b/tools/bcftools/bcftools_plugin_color_chrs.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Color shared chromosomal segments, requires phased GTs</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">color-chrs</token>
         <token name="@PLUGIN_ID@">color_chrs</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_counts.xml
+++ b/tools/bcftools/bcftools_plugin_counts.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy1">
     <description>plugin  counts number of samples, SNPs, INDELs, MNPs and total sites</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">counts</token>
         <token name="@PLUGIN_ID@">counts</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <requirement type="package" version="3.7">python</requirement>
     </expand>

--- a/tools/bcftools/bcftools_plugin_dosage.xml
+++ b/tools/bcftools/bcftools_plugin_dosage.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin genotype dosage</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">dosage</token>
         <token name="@PLUGIN_ID@">dosage</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_fill_an_ac.xml
+++ b/tools/bcftools/bcftools_plugin_fill_an_ac.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Fill INFO fields AN and AC</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">fill-AN-AC</token>
         <token name="@PLUGIN_ID@">fill_an_ac</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_fill_tags.xml
+++ b/tools/bcftools/bcftools_plugin_fill_tags.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Set INFO tags AF, AN, AC, AC_Hom, AC_Het, AC_Hemi</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">fill-tags</token>
         <token name="@PLUGIN_ID@">fill_tags</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_fixploidy.xml
+++ b/tools/bcftools/bcftools_plugin_fixploidy.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin  Fix ploidy</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">fixploidy</token>
         <token name="@PLUGIN_ID@">fixploidy</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_frameshifts.xml
+++ b/tools/bcftools/bcftools_plugin_frameshifts.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Annotate frameshift indels</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">frameshifts</token>
         <token name="@PLUGIN_ID@">frameshifts</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_impute_info.xml
+++ b/tools/bcftools/bcftools_plugin_impute_info.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Add imputation information metrics to the INFO field</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">impute-info</token>
         <token name="@PLUGIN_ID@">impute_info</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_mendelian.xml
+++ b/tools/bcftools/bcftools_plugin_mendelian.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Count Mendelian consistent / inconsistent genotypes</description>
-    <expand macro="bio_tools" />  
     <macros>
         <token name="@EXECUTABLE@">mendelian</token>
         <token name="@PLUGIN_ID@">mendelian</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />  
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_missing2ref.xml
+++ b/tools/bcftools/bcftools_plugin_missing2ref.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Set missing genotypes</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">missing2ref</token>
         <token name="@PLUGIN_ID@">missing2ref</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_setgt.xml
+++ b/tools/bcftools/bcftools_plugin_setgt.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@">
     <description>plugin Sets genotypes</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">setGT</token>
         <token name="@PLUGIN_ID@">setgt</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_plugin_tag2tag.xml
+++ b/tools/bcftools/bcftools_plugin_tag2tag.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy1">
     <description>plugin Convert between similar tags, such as GL and GP</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">tag2tag</token>
         <token name="@PLUGIN_ID@">tag2tag</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_query.xml
+++ b/tools/bcftools/bcftools_query.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Extracts fields from VCF/BCF file and prints them in user-defined format</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">query</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_query_list_samples.xml
+++ b/tools/bcftools/bcftools_query_list_samples.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools List Samples" id="bcftools_@EXECUTABLE@_list_samples" version="@TOOL_VERSION@">
     <description>in VCF/BCF file</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">query</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_reheader.xml
+++ b/tools/bcftools/bcftools_reheader.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>Modify header of VCF/BCF files, change sample names</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">reheader</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_roh.xml
+++ b/tools/bcftools/bcftools_roh.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>HMM model for detecting runs of homo/autozygosity</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">roh</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/bcftools/bcftools_stats.xml
+++ b/tools/bcftools/bcftools_stats.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1" profile="18.01">
     <description>Parses VCF or BCF and produces stats which can be plotted using plot-vcfstats</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">stats</token>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements">
         <expand macro="samtools_requirement"/>
         <expand macro="matplotlib_requirement" />

--- a/tools/bcftools/bcftools_view.xml
+++ b/tools/bcftools/bcftools_view.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
     <description>VCF/BCF conversion, view, subset and filter VCF/BCF files</description>
-    <expand macro="bio_tools" />
     <macros>
         <token name="@EXECUTABLE@">view</token>
         <import>macros.xml</import>
@@ -9,9 +8,10 @@
             <option value="snps">snps</option>
             <option value="indels">indels</option>
             <option value="mnps">mnps</option>
-            <option value="other">mnps</option>
+            <option value="other">other</option>
         </xml>
     </macros>
+    <expand macro="bio_tools" />
     <expand macro="requirements" />
     <expand macro="version_command" />
     <command detect_errors="aggressive"><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Removing an upper limit to a parameter of bcftools mpilup, as per #4322 