### PR TITLE
Updating tools/interproscan from version 5.54-87.0 to 5.54_87.0

### DIFF
--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -5,7 +5,7 @@
         Conda understands both notations, but the Galaxy tool requires the use of "-".
         The version should also be bumped in test-data/interproscan.loc
     -->
-    <token name="@TOOL_VERSION@">5.54-87.0</token>
+    <token name="@TOOL_VERSION@">5.54_87.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/interproscan**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/interproscan from version 5.54-87.0 to 5.54_87.0.

**Project home page:** http://www.ebi.ac.uk/Tools/pfa/iprscan5