### PR TITLE
Updating tools/kallisto from version 0.46.2 to 0.48.0

### DIFF
--- a/tools/kallisto/macros.xml
+++ b/tools/kallisto/macros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">0.46.2</token>
+    <token name="@TOOL_VERSION@">0.48.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">kallisto</requirement>
-            <requirement type="package" version="1.12">samtools</requirement>
+            <requirement type="package" version="1.14">samtools</requirement>
         </requirements>
     </xml>
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/kallisto**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/kallisto from version 0.46.2 to 0.48.0.

**Project home page:** https://pachterlab.github.io/kallisto