### PR TITLE
Add parameter to VarDict to chunk up chromosome.

### DIFF
--- a/tools/vardict/macros.xml
+++ b/tools/vardict/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@TOOL_VERSION@">1.8.3</token>
     <xml name="ref_select">
         <conditional name="reference_source">

--- a/tools/vardict/split.py
+++ b/tools/vardict/split.py
@@ -3,7 +3,7 @@ import sys
 
 fai = sys.argv[1]
 chunk_size = int(sys.argv[2])
-overlap = 150  # Base pairs
+overlap = int(sys.argv[3])  # Base pairs
 with open(fai, 'r') as infile:
     for line in infile:
         name = line.split('\t')[0]

--- a/tools/vardict/split.py
+++ b/tools/vardict/split.py
@@ -1,0 +1,17 @@
+import sys
+
+
+fai = sys.argv[1]
+chunk_size = int(sys.argv[2])
+overlap = 150 # Base pairs
+with open(fai, 'r') as infile:
+    for line in infile:
+        name = line.split('\t')[0]
+        stop = int(line.split('\t')[1])
+        start = 1
+        while start < stop:
+            start = max(1, start-overlap)
+            out = '\t'.join([name, str(start), str(min(start+chunk_size, stop))])
+            print(out)
+            # outfile.write(out + '\n')
+            start += chunk_size

--- a/tools/vardict/split.py
+++ b/tools/vardict/split.py
@@ -12,5 +12,5 @@ with open(fai, 'r') as infile:
         while start < stop:
             start = max(1, start - overlap)
             print('\t'.join([name, str(start),
-                             str(min(start + chunk_size, stop))])
+                             str(min(start + chunk_size, stop))]))
             start += chunk_size

--- a/tools/vardict/split.py
+++ b/tools/vardict/split.py
@@ -3,15 +3,14 @@ import sys
 
 fai = sys.argv[1]
 chunk_size = int(sys.argv[2])
-overlap = 150 # Base pairs
+overlap = 150  # Base pairs
 with open(fai, 'r') as infile:
     for line in infile:
         name = line.split('\t')[0]
         stop = int(line.split('\t')[1])
         start = 1
         while start < stop:
-            start = max(1, start-overlap)
-            out = '\t'.join([name, str(start), str(min(start+chunk_size, stop))])
-            print(out)
-            # outfile.write(out + '\n')
+            start = max(1, start - overlap)
+            print('\t'.join([name, str(start),
+                             str(min(start + chunk_size, stop))])
             start += chunk_size

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -32,19 +32,7 @@
         #else
             ln -s ./ref.fa.fai ./chromosomes.fa.fai &&
         #end if
-        awk 'BEGIN{chunk=$chunksize}{
-			i=1;
-			while(i <= $2) {
-				printf $1"\t"i"\t";
-				if(i+chunk< $2){
-					print i+chunk
-				}
-				else {
-					print $2
-				};
-				i=i+chunk
-			}
-		}' ./chromosomes.fa.fai > ./regions.bed &&
+	python $__tool_directory__/split.py ./chromosomes.fa.fai '$chunksize' > ./regions.bed &&
 
         vardict-java
         #if $select_mode.mode == "paired"

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -33,7 +33,7 @@
         #else
             ln -s ./ref.fa.fai ./chromosomes.fa.fai &&
         #end if
-	python $__tool_directory__/split.py ./chromosomes.fa.fai '$chunksize' > ./regions.bed &&
+        python $__tool_directory__/split.py ./chromosomes.fa.fai "\${VARDICT_CHUNKSIZE:-1000000}" > ./regions.bed &&
 
         vardict-java
         #if $select_mode.mode == "paired"
@@ -112,7 +112,6 @@
             <param argument="-O" type="float" min="0" value="0" label="Minimum average mapping quality" />
             <param argument="-V" type="float" min="0.0" max="1.0" value="0.05" label="Maximum allowed variant allele fraction in the normal sample" />
         </section>
-		<param name="chunksize" type="integer" min="1000" max="10000000" value="1000000" label="The size of chunks to divide the genome into to reduce memory usage when calling"/>
         <expand macro="ref_select" />
     </inputs>
     <outputs>
@@ -130,9 +129,8 @@
                 <param name="reference_source_selector" value="history"/>
                 <param name="ref_file" ftype="fasta" value="genome.fasta" />
             </conditional>
-			<param name="chunksize" value="1000" />
-            
-			<output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
+
+            <output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
             <output name="passed_variants" compare="re_match_multiline" file="passed_variants_paired.vcf" />
         </test>
         <test expect_num_outputs="2">
@@ -145,8 +143,7 @@
                 <param name="reference_source_selector" value="cached"/>
                 <param name="ref_file" value="test_buildid"/>
             </conditional>
-			<param name="chunksize" value="10000" />
-						
+
             <output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
             <output name="passed_variants" compare="re_match_multiline" file="passed_variants_paired.vcf" />
         </test>

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -33,7 +33,7 @@
         #else
             ln -s ./ref.fa.fai ./chromosomes.fa.fai &&
         #end if
-        python '$__tool_directory__/split.py' ./chromosomes.fa.fai "\${VARDICT_CHUNKSIZE:-1000000}" > ./regions.bed &&
+        python '$__tool_directory__/split.py' ./chromosomes.fa.fai "\${VARDICT_CHUNKSIZE:-1000000}" "\${VARDICT_OVERLAP:-150}" > ./regions.bed &&
 
         vardict-java
         #if $select_mode.mode == "paired"

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -4,6 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
+	<requirement type="package" version="3.10.2">python</requirement>
         <requirement type="package" version="@TOOL_VERSION@">vardict-java</requirement>
         <requirement type="package" version="5.1.0">gawk</requirement>
         <requirement type="package" version="1.14">samtools</requirement>

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -32,7 +32,19 @@
         #else
             ln -s ./ref.fa.fai ./chromosomes.fa.fai &&
         #end if
-        awk 'BEGIN {FS=OFS="\t"} {print $1, "1", $2}' ./chromosomes.fa.fai > ./regions.bed &&
+        awk 'BEGIN{chunk=$chunksize}{
+			i=1;
+			while(i <= $2) {
+				printf $1"\t"i"\t";
+				if(i+chunk< $2){
+					print i+chunk
+				}
+				else {
+					print $2
+				};
+				i=i+chunk
+			}
+		}' ./chromosomes.fa.fai > ./regions.bed &&
 
         vardict-java
         #if $select_mode.mode == "paired"
@@ -111,6 +123,7 @@
             <param argument="-O" type="float" min="0" value="0" label="Minimum average mapping quality" />
             <param argument="-V" type="float" min="0.0" max="1.0" value="0.05" label="Maximum allowed variant allele fraction in the normal sample" />
         </section>
+		<param name="chunksize" type="integer" min="1000" max="10000000" value="1000000" label="The size of chunks to divide the genome into to reduce memory usage when calling"/>
         <expand macro="ref_select" />
     </inputs>
     <outputs>
@@ -128,7 +141,9 @@
                 <param name="reference_source_selector" value="history"/>
                 <param name="ref_file" ftype="fasta" value="genome.fasta" />
             </conditional>
-            <output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
+			<param name="chunksize" value="1000" />
+            
+			<output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
             <output name="passed_variants" compare="re_match_multiline" file="passed_variants_paired.vcf" />
         </test>
         <test expect_num_outputs="2">
@@ -141,6 +156,8 @@
                 <param name="reference_source_selector" value="cached"/>
                 <param name="ref_file" value="test_buildid"/>
             </conditional>
+			<param name="chunksize" value="10000" />
+						
             <output name="all_variants" compare="re_match_multiline" file="all_variants_paired.vcf" />
             <output name="passed_variants" compare="re_match_multiline" file="passed_variants_paired.vcf" />
         </test>

--- a/tools/vardict/vardict.xml
+++ b/tools/vardict/vardict.xml
@@ -4,7 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-	<requirement type="package" version="3.10.2">python</requirement>
+        <requirement type="package" version="3.10.2">python</requirement>
         <requirement type="package" version="@TOOL_VERSION@">vardict-java</requirement>
         <requirement type="package" version="5.1.0">gawk</requirement>
         <requirement type="package" version="1.14">samtools</requirement>
@@ -33,7 +33,7 @@
         #else
             ln -s ./ref.fa.fai ./chromosomes.fa.fai &&
         #end if
-        python $__tool_directory__/split.py ./chromosomes.fa.fai "\${VARDICT_CHUNKSIZE:-1000000}" > ./regions.bed &&
+        python '$__tool_directory__/split.py' ./chromosomes.fa.fai "\${VARDICT_CHUNKSIZE:-1000000}" > ./regions.bed &&
 
         vardict-java
         #if $select_mode.mode == "paired"


### PR DESCRIPTION
To prevent OutOfMemoryError the genome needs to be split into smaller chunks, as suggested here:
- https://github.com/AstraZeneca-NGS/VarDictJava/issues/197
- https://github.com/AstraZeneca-NGS/VarDictJava/wiki/Error-java.lang.OutOfMemoryError:-GC-overhead-limit-exceeded

In the current state vardict will crash when the regions are to large but it will keep on running endlessly in galaxy.
With this additional parameter this can be prevented.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
