### PR TITLE
Spades: include write_tsv_script.py in .shed.yml

### DIFF
--- a/tools/spades/.shed.yml
+++ b/tools/spades/.shed.yml
@@ -18,6 +18,7 @@ repositories:
       - test-data
       - spades.xml
       - macros.xml
+      - write_tsv_script.py
     owner: nml
 
   spades_rnaviralspades:
@@ -28,6 +29,7 @@ repositories:
       - test-data
       - rnaviralspades.xml
       - macros.xml
+      - write_tsv_script.py
 
   rnaspades:
     description: De novo transcriptome assembler.
@@ -46,6 +48,7 @@ repositories:
       - test-data
       - plasmidspades.xml
       - macros.xml
+      - write_tsv_script.py
 
   spades_metaviralspades:
     description: Extract and assembly viral genomes from metagenomic data.
@@ -55,6 +58,7 @@ repositories:
       - test-data
       - metaviralspades.xml
       - macros.xml
+      - write_tsv_script.py
 
   metaspades:
     description: A pipeline for metagenomic data sets.
@@ -64,6 +68,7 @@ repositories:
       - test-data
       - metaspades.xml
       - macros.xml
+      - write_tsv_script.py
     owner: nml
     
   spades_metaplasmidspades:
@@ -74,6 +79,7 @@ repositories:
       - test-data
       - metaplasmidspades.xml
       - macros.xml
+      - write_tsv_script.py
 
   spades_coronaspades:
     description: SARS-CoV-2 de novo genome assembler.
@@ -84,6 +90,7 @@ repositories:
       - test-data
       - coronaspades.xml
       - macros.xml
+      - write_tsv_script.py
 
   spades_biosyntheticspades:
     description: Biosynthetic gene cluster assembly.
@@ -93,6 +100,7 @@ repositories:
       - test-data
       - biosyntheticspades.xml
       - macros.xml
+      - write_tsv_script.py
     
 suite:
   name: "suite_spades"

--- a/tools/spades/metaspades.xml
+++ b/tools/spades/metaspades.xml
@@ -136,12 +136,12 @@ metaspades.py
             <output_collection name="out_cr" type="list" count="3">
                 <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -149,12 +149,12 @@ spades.py --rnaviral
             <output_collection name="out_cr" type="list" count="2">
                 <element name="ecoli_1K_1.fastq.gz.fastq0_0.cor">
                     <assert_contents>
-                        <has_size value="34468" delta="1000"/>
+                        <has_size value="34468" delta="2000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K_2.fastq.gz.fastq0_0.cor">
                     <assert_contents>
-                        <has_size value="34468" delta="1000"/>
+                        <has_size value="34468" delta="2000"/>
                     </assert_contents>
                 </element>
             </output_collection>

--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -308,12 +308,12 @@ spades.py
             <output_collection name="out_cr" type="list" count="3">
                 <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
@@ -340,12 +340,12 @@ spades.py
             <output_collection name="out_cr" type="list" count="3">
                 <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
@@ -404,12 +404,12 @@ spades.py
             <output_collection name="out_cr" type="list" count="3">
                 <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
@@ -436,12 +436,12 @@ spades.py
             <output_collection name="out_cr" type="list" count="3">
                 <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
                     <assert_contents>
-                        <has_size value="130317" delta="1000"/>
+                        <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
                 <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Some of the tests are breaking for spades tools because of a missing file `write_tsv_script.py`

Include write_tsv_script.py in the .shed.yml file for all of the repositories except rnaspades.

Increase the tolerance of some of the has_size assertion tests.