### PR TITLE
InterProScan: try to fix broken revision on TS

### DIFF
--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -6,7 +6,7 @@
         The version should also be bumped in test-data/interproscan.loc
     -->
     <token name="@TOOL_VERSION@">5.54-87.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="citations">
         <citations>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

It looks like the revision uploaded to TS in #4308 is somewhat broken, ans resetting metadata doesn't help...
So trying to bump the version suffix to trigger a new upload!?