### PR TITLE
Updating tools/icescreen from version 1.0.1 to 1.0.3

### DIFF
--- a/tools/icescreen/icescreen.xml
+++ b/tools/icescreen/icescreen.xml
@@ -1,7 +1,7 @@
 <tool id="icescreen" name="ICEscreen" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.09">
     <description>detects and annotates ICEs (Integrative and Conjugative Elements) and IMEs (Integrative and Mobilizable Elements) in Firmicutes genomes.</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.0.1</token>
+        <token name="@TOOL_VERSION@">1.0.3</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/icescreen**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/icescreen from version 1.0.1 to 1.0.3.

**Project home page:** https://icescreen.migale.inrae.fr