### PR TITLE
Updating tools/ncbi_datasets from version 12.27.1 to 12.30.0

### DIFF
--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">12.27.1</token>
+    <token name="@TOOL_VERSION@">12.30.0</token>
     <token name="@PROFILE@">20.01</token>
     <token name="@LICENSE@">MIT</token>
     <token name="@PROFILE_AND_LICENSE@">profile="@PROFILE@" license="@LICENSE@"</token>
@@ -10,7 +10,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">ncbi-datasets-cli</requirement>
-            <requirement type="package" version="2021.5.30">ca-certificates</requirement>
+            <requirement type="package" version="2021.10.8">ca-certificates</requirement>
             <requirement type="package" version="16.02">p7zip</requirement>
         </requirements>
     </xml>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ncbi_datasets**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ncbi_datasets from version 12.27.1 to 12.30.0.

**Project home page:** https://www.ncbi.nlm.nih.gov/datasets