### PR TITLE
Updating tools/pangolin from version 3.1.17 to 3.1.19

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,7 +1,7 @@
-<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy1" profile="20.01">
+<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.17</token>
+        <token name="@TOOL_VERSION@">3.1.19</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pangolin**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pangolin from version 3.1.17 to 3.1.19.

**Project home page:** https://github.com/cov-lineages/pangolin/releases