### PR TITLE
Updating tools/proteinortho from version 6.0.32 to
6.1.2

### DIFF
--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.1</token>
+   <token name="@TOOL_VERSION@">6.1.2</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -17,7 +17,7 @@
             <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.13.0">blast</requirement>
             <requirement type="package" version="36">blat</requirement>
-            <requirement type="package" version="1411">last</requirement>
+            <requirement type="package" version="1418">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.0</token>
+   <token name="@TOOL_VERSION@">6.1.1</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -15,9 +15,9 @@
             <!-- blast, blat, and last are not in the biopython requirements
                  diamond is, but latest version does not work: https://gitlab.com/paulklemm_PHD/proteinortho/-/issues/55 -->
             <requirement type="package" version="2.0.15">diamond</requirement>
-            <requirement type="package" version="2.12.0">blast</requirement>
+            <requirement type="package" version="2.13.0">blast</requirement>
             <requirement type="package" version="36">blat</requirement>
-            <requirement type="package" version="1296">last</requirement>
+            <requirement type="package" version="1411">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.0.32</token>
+   <token name="@TOOL_VERSION@">6.0.33</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -14,7 +14,7 @@
             <requirement type="package" version="@TOOL_VERSION@">proteinortho</requirement>
             <!-- blast, blat, and last are not in the biopython requirements
                  diamond is, but latest version does not work: https://gitlab.com/paulklemm_PHD/proteinortho/-/issues/55 -->
-            <requirement type="package" version="2.0.9">diamond</requirement>
+            <requirement type="package" version="2.0.14">diamond</requirement>
             <requirement type="package" version="2.12.0">blast</requirement>
             <requirement type="package" version="36">blat</requirement>
             <requirement type="package" version="1257">last</requirement>

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.0.33</token>
+   <token name="@TOOL_VERSION@">6.0.34</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -14,10 +14,10 @@
             <requirement type="package" version="@TOOL_VERSION@">proteinortho</requirement>
             <!-- blast, blat, and last are not in the biopython requirements
                  diamond is, but latest version does not work: https://gitlab.com/paulklemm_PHD/proteinortho/-/issues/55 -->
-            <requirement type="package" version="2.0.14">diamond</requirement>
+            <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.12.0">blast</requirement>
             <requirement type="package" version="36">blat</requirement>
-            <requirement type="package" version="1257">last</requirement>
+            <requirement type="package" version="1281">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.0.35</token>
+   <token name="@TOOL_VERSION@">6.1.0</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.0.34</token>
+   <token name="@TOOL_VERSION@">6.0.35</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -17,7 +17,7 @@
             <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.12.0">blast</requirement>
             <requirement type="package" version="36">blat</requirement>
-            <requirement type="package" version="1281">last</requirement>
+            <requirement type="package" version="1296">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/proteinortho**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/proteinortho from version 6.0.32 to 6.0.33.

**Project home page:** https://gitlab.com/paulklemm_PHD/proteinortho