### PR TITLE
Updating tools/rpfba from version 5.11.1 to 5.12.1

### DIFF
--- a/tools/rpfba/rpfba.xml
+++ b/tools/rpfba/rpfba.xml
@@ -1,7 +1,7 @@
 <tool id="rpfba" name="Flux balance analysis" version="@TOOL_VERSION@" profile="19.09">
     <description>for the RetroPath2.0 heterologous pathways</description>
     <macros>
-        <token name="@TOOL_VERSION@">5.11.1</token>
+        <token name="@TOOL_VERSION@">5.12.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rptools</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rpfba**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rpfba from version 5.11.1 to 5.12.1.

**Project home page:** https://github.com/brsynth/rptools/blob/master/rptools/rpfba/releases