### PR TITLE
Updating tools/spaln from version 2.4.6 to 2.4.7

### DIFF
--- a/tools/spaln/macros.xml
+++ b/tools/spaln/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4.6</token>
+    <token name="@TOOL_VERSION@">2.4.7</token>
 </macros>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/spaln**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/spaln from version 2.4.6 to 2.4.7.

**Project home page:** http://www.genome.ist.i.kyoto-u.ac.jp/~aln_user/spaln