### PR TITLE
InterProScan DM: fix indexing of sfld and superfamily

### DIFF
--- a/data_managers/data_manager_interproscan/data_manager/interproscan.xml
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.xml
@@ -1,7 +1,9 @@
-<tool id="data_manager_interproscan" name="InterProScan data manager" version="0.0.1" tool_type="manage_data" profile="20.01">
+<tool id="data_manager_interproscan" name="InterProScan data manager" version="0.0.2" tool_type="manage_data" profile="20.01">
     <requirements>
-        <requirement type="package" version="5.52-86.0">interproscan</requirement>
+        <requirement type="package" version="5.54-87.0">interproscan</requirement>
         <requirement type="package" version="2.26.0">requests</requirement>
+        <!-- Forcing an old hmmer version for indexing due to https://github.com/ebi-pf-team/interproscan/issues/232 -->
+        <requirement type="package" version="3.1b2">hmmer</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python -u '$__tool_directory__/interproscan.py'


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Currently the interproscan data manager fails to index 2 member hmm databases: sfld and superfamily
This is due to a change in recent versions (>=3.2) of hmmer being less tolerant with duplicated ids in hmm files, there's [an issue upstream for that](https://github.com/ebi-pf-team/interproscan/issues/232).
This PR is a workaround for this problem: it forces the use of an older hmmer version for indexing only. It seems to work fine like this (no change in the index content between hmmer versions).
With this, we'll be able to get rid of an annoying thing in [the annotation tutorial](https://github.com/galaxyproject/training-material/blob/a072065d713efd9bbe370d7f606269fc97f5daac/topics/genome-annotation/tutorials/funannotate/tutorial.md?plain=1#L315).