### PR TITLE
Updating tools/nextclade from version 1.10.1 to 1.10.2

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.10.1</token>
+    <token name="@TOOL_VERSION@">1.10.2</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/nextclade.xml
+++ b/tools/nextclade/nextclade.xml
@@ -6,7 +6,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nextclade</requirement>
-        <requirement type="package" version="8.31">coreutils</requirement>
+        <requirement type="package" version="9.0">coreutils</requirement>
     </requirements>
     <version_command>nextclade --version-detailed</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.10.1 to 1.10.2.

**Project home page:** https://github.com/nextstrain/nextclade/releases