### PR TITLE
Updating tools/pretext from version 0.1.8 to 0.1.9

### DIFF
--- a/tools/pretext/pretext_map.xml
+++ b/tools/pretext/pretext_map.xml
@@ -1,12 +1,12 @@
 <tool id="pretext_map" name="PretextMap" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
     <description>converts SAM or BAM files into genome contact maps</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.1.8</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">0.1.9</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pretextmap</requirement>
-        <requirement type="package" version="1.13">samtools</requirement>
+        <requirement type="package" version="1.14">samtools</requirement>
     </requirements>
     <version_command>PretextMap --version</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pretext**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pretext from version 0.1.8 to 0.1.9.

**Project home page:** https://github.com/wtsi-hpag/PretextSnapshot/releases