### PR TITLE
Update (Fix) Cutadapt when used with pe collections which are gz or bz

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -93,13 +93,8 @@ cutadapt
 #else:
     @read1_options@
     @read2_options@
-    #if $library.type == "paired"
-        --output='$out1'
-        --paired-output='$out2'
-    #else
-        --output='$out_pairs.forward'
-        --paired-output='$out_pairs.reverse'
-    #end if
+    --output='$out1'
+    --paired-output='$out2'
 #end if
 
 --error-rate=$adapter_options.error_rate
@@ -172,6 +167,12 @@ $read_mod_options.zero_cap
 
 #if 'report' in $output_selector:
     > report.txt
+#end if
+
+## Move paired-end collection result to the good place for galaxy:
+#if $library_type == 'paired_collection':
+    && mv '$out1' '$out_pairs.forward'
+    && mv '$out2' '$out_pairs.reverse'
 #end if
     ]]></command>
     <inputs>

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.5</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@FASTQ_TYPES@">fastq.gz,fastq,fasta</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
