### PR TITLE
Update to latest version and fix error in some input names

### DIFF
--- a/tools/drep/drep_compare.xml
+++ b/tools/drep/drep_compare.xml
@@ -1,24 +1,20 @@
-<tool id="drep_compare" name="dRep compare" version="@VERSION@.0" python_template_version="3.5">
+<tool id="drep_compare" name="dRep compare" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@" python_template_version="3.5">
     <description>compare a list of genomes</description>
-    <expand macro="bio_tools" />
+    <expand macro="biotools" />
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-         @PREPARE_GENOMES@         
-         dRep compare outdir
-         @GENOME_COMPARISON_OPTIONS@
-         @CLUSTERING_OPTIONS@
-         @TAXONOMY_OPTIONS@
-         @WARNING_OPTIONS@        
-         @GENOMES@
+@PREPARE_GENOMES@
+dRep compare outdir
+@GENOMES@
+@COMPARISON_CLUSTERING_OPTIONS@
+@WARNING_OPTIONS@
     ]]></command>
     <inputs>
         <expand macro="genomes"/>
-        <expand macro="genome_comparison_options"/>
-        <expand macro="clustering_options"/>
-        <expand macro="taxonomy_options"/>
+        <expand macro="comparison_clustering_options"/>
         <expand macro="warning_options"/>
         <expand macro="select_outputs"/>
     </inputs>
@@ -26,9 +22,24 @@
         <expand macro="common_outputs" />
     </outputs>
     <tests>
-        <expand macro="test_defaults_log">
-            <has_text text="dRep compare finished" />
-        </expand>
+        <test expect_num_outputs="4">
+            <expand macro="test_string_inputs"/>
+            <expand macro="test_default_comparison_clustering_options"/>
+            <expand macro="test_default_warning_options"/>
+            <expand macro="test_default_select_outputs"/>
+            <expand macro="test_log_output">
+                <has_text text="dRep compare finished" />
+            </expand>
+        </test>
+        <test expect_num_outputs="4">
+            <expand macro="test_integer_inputs"/>
+            <expand macro="test_default_comparison_clustering_options"/>
+            <expand macro="test_default_warning_options"/>
+            <expand macro="test_default_select_outputs"/>
+            <expand macro="test_log_output">
+                <has_text text="dRep compare finished" />
+            </expand>
+        </test>
     </tests>
     <help><![CDATA[
 **dRep compare**
@@ -40,9 +51,9 @@
 dRep performs this in two steps:
 
   - first with a rapid primary algorithm (Mash)
-  - second with a more sensitive algorithm (ANIm). 
+  - second with a more sensitive algorithm (ANIm).
 
-We can’t just use Mash because, while incredibly fast, it is not robust to genome incompletenss (see `Choosing parameters <https://drep.readthedocs.io/en/latest/choosing_parameters.html>`_ and `Module Descriptions <https://drep.readthedocs.io/en/latest/module_descriptions.html>`_) and only provides an “estimate” of ANI. ANIm is robust to genome incompleteness and is more accurate, but too slow to perform pair-wise comparisons of longer genome lists.
+We can't just use Mash because, while incredibly fast, it is not robust to genome incompletenss (see `Choosing parameters <https://drep.readthedocs.io/en/latest/choosing_parameters.html>`_ and `Module Descriptions <https://drep.readthedocs.io/en/latest/module_descriptions.html>`_) and only provides an “estimate” of ANI. ANIm is robust to genome incompleteness and is more accurate, but too slow to perform pair-wise comparisons of longer genome lists.
 
 dRep first compares all genomes using Mash, and then only runs the secondary algorithm (ANIm or gANI) on sets of genomes that have at least 90% Mash ANI. This results in a great decrease in the number of (slow) secondary comparisons that need to be run while maintaining the sensitivity of ANIm.
 

--- a/tools/drep/drep_dereplicate.xml
+++ b/tools/drep/drep_dereplicate.xml
@@ -1,34 +1,34 @@
-<tool id="drep_dereplicate" name="dRep dereplicate" version="@VERSION@.0" python_template_version="3.5">
+<tool id="drep_dereplicate" name="dRep dereplicate" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@" python_template_version="3.5">
     <description>De-replicate a list of genomes</description>
-    <expand macro="bio_tools" />
+    <expand macro="biotools" />
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements" />
+    <expand macro="requirements">
+        <requirement type="package" version="1.1.3">checkm-genome</requirement>
+    </expand>
     <command detect_errors="exit_code"><![CDATA[
-         @PREPARE_GENOMES@
-         dRep dereplicate outdir
-         @FILTER_OPTIONS@
-         @GENOME_COMPARISON_OPTIONS@
-         @CLUSTERING_OPTIONS@
-         @SCORING_OPTIONS@
-         @TAXONOMY_OPTIONS@
-         @WARNING_OPTIONS@        
-         @GENOMES@
-         --debug
-         || (rc=\$?; 
-             ls -ltr `find outdir -type f`;
-             cat outdir/data/checkM/checkM_outdir/checkm.log;
-             cat outdir/log/logger.log;
-             exit \$rc)
+@PREPARE_GENOMES@
+dRep dereplicate outdir
+@GENOMES@
+@FILTER_OPTIONS@
+@QUALITY_ASSESSMENT_OPTIONS@
+@COMPARISON_CLUSTERING_OPTIONS@
+@SCORING_OPTIONS@
+@WARNING_OPTIONS@
+--debug
+|| (rc=\$?;
+    ls -ltr `find outdir -type f`;
+    cat outdir/data/checkM/checkM_outdir/checkm.log;
+    cat outdir/log/logger.log;
+    exit \$rc)
     ]]></command>
     <inputs>
         <expand macro="genomes"/>
         <expand macro="filtering_options"/>
-        <expand macro="genome_comparison_options"/>
-        <expand macro="clustering_options"/>
+        <expand macro="quality_assessment_options"/>
+        <expand macro="comparison_clustering_options"/>
         <expand macro="scoring_options"/>
-        <expand macro="taxonomy_options"/>
         <expand macro="warning_options"/>
         <expand macro="select_drep_outputs"/>
     </inputs>
@@ -39,33 +39,35 @@
         <expand macro="drep_outputs" />
     </outputs>
     <tests>
-        <expand macro="test_defaults_log">
-            <has_text text="dRep dereplicate finished" />
-        </expand>
-        <test>
-            <param name="genomes" ftype="fasta" value="Enterococcus_casseliflavus_EC20.fasta,Enterococcus_faecalis_T2.fna,Enterococcus_faecalis_TX0104.fa"/>
-            <conditional name="filter">
-                <param name="set_options" value="yes"/>
-                <conditional name="quality">
-                    <param name="source" value="checkm"/>
-                    <param name="checkM_method" value="taxonomy_wf"/>
-                </conditional>
-            </conditional>
-            <output name="log">
-                <assert_contents>
-                    <has_text text="dRep dereplicate finished" />
-                </assert_contents>
-            </output>
+        <test expect_num_outputs="8">
+            <expand macro="test_string_inputs"/>
+            <expand macro="test_default_filtering_options"/>
+            <expand macro="test_default_quality_assessment_options"/>
+            <expand macro="test_default_comparison_clustering_options"/>
+            <expand macro="test_default_scoring_options"/>
+            <expand macro="test_default_warning_options"/>
+            <expand macro="test_default_select_drep_outputs"/>
+            <expand macro="test_log_output">
+                <has_text text="dRep dereplicate finished" />
+            </expand>
+        </test>
+        <test expect_num_outputs="8">
+            <expand macro="test_integer_inputs"/>
+            <expand macro="test_default_filtering_options"/>
+            <expand macro="test_default_quality_assessment_options"/>
+            <expand macro="test_default_comparison_clustering_options"/>
+            <expand macro="test_default_scoring_options"/>
+            <expand macro="test_default_warning_options"/>
+            <expand macro="test_default_select_drep_outputs"/>
+            <expand macro="test_log_output">
+                <has_text text="dRep dereplicate finished" />
+            </expand>
         </test>
     </tests>
     <help><![CDATA[
 **dRep dereplicate**
 
 `dRep <https://drep.readthedocs.io/en/latest/overview.html>`_ performs rapid pair-wise comparison of genome sets.
-
-
-
-
 
 `De-replication <https://drep.readthedocs.io/en/latest/overview.html#genome-de-replication>`_ is the process of identifying sets of genomes that are the “same” in a list of genomes, and removing all but the “best” genome from each redundant set. How similar genomes need to be to be considered “same”, how to determine which genome is “best”, and other important decisions are discussed in `Choosing parameters. <https://drep.readthedocs.io/en/latest/choosing_parameters.html>`_   Detailed options for each module are described at: https://drep.readthedocs.io/en/latest/module_descriptions.html
 
@@ -88,12 +90,12 @@ The steps to this process are:
 **OUTPUTS**
 
   - `Figures <https://drep.readthedocs.io/en/latest/example_output.html#figures>`_ that show the relationship of the Genome inputs.
-  - `Warnings <https://drep.readthedocs.io/en/latest/example_output.html#warnings>`_ report two things: de-replicated genome similarity and secondary clusters that were almost different. 
+  - `Warnings <https://drep.readthedocs.io/en/latest/example_output.html#warnings>`_ report two things: de-replicated genome similarity and secondary clusters that were almost different.
   - A Dataset collection of the “best” genome of each secondary cluster.
-  - `Tables from intermediate steps <https://drep.readthedocs.io/en/latest/advanced_use.html>`_ 
+  - `Tables from intermediate steps <https://drep.readthedocs.io/en/latest/advanced_use.html>`_
 
     * Chdb.csv # CheckM results for Bdb
-    * Widb.csv # Winning genomes' checkM information 
+    * Widb.csv # Winning genomes' checkM information
 
 
     ]]></help>

--- a/tools/drep/macros.xml
+++ b/tools/drep/macros.xml
@@ -1,8 +1,16 @@
+<?xml version="1.0"?>
 <macros>
-    <token name="@VERSION@">2.5.4</token>
+    <token name="@TOOL_VERSION@">3.2.2</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">20.01</token>
+    <xml name="biotools">
+        <xrefs>
+            <xref type="bio.tools">drep</xref>
+        </xrefs>
+    </xml>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@VERSION@">drep</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">drep</requirement>
             <yield/>
         </requirements>
     </xml>
@@ -12,255 +20,296 @@
             <yield />
         </citations>
     </xml>
-    <xml name="bio_tools">
-        <xrefs>
-            <xref type="bio.tools">drep</xref>
-        </xrefs>
-    </xml>
 
     <xml name="genomes">
-        <param argument="--genomes" type="data" format="fasta" label="genomes fasta files" multiple="true"/>
+        <param argument="--genomes" type="data" format="fasta" multiple="true" label="Genomes to filer"/>
     </xml>
+
+<!-- Addition of ".fasta" after names to avoid string to be read as integer
+Bug in dRep: probably fixed in next version -->
     <token name="@PREPARE_GENOMES@"><![CDATA[
-    #import re 
-    #set $genomefiles = [] 
-    #for $genome in $genomes
-        #set $input_name = $re.sub('[^\w\-_.]', '_',str($genome.element_identifier.split('/')[-1]))
-        ln -s '${genome}' '${input_name}' &&
-        $genomefiles.append($input_name)
-    #end for
-]]></token>
+#import re
+#set $genomefiles = []
+#for $genome in $genomes
+    #set $input_name = $re.sub('[^\w\-_.]', '_',str($genome.element_identifier.split('/')[-1]))
+ln -s '${genome}' '${input_name}.fasta' &&
+$genomefiles.append($input_name)
+#end for
+    ]]></token>
     <token name="@GENOMES@"><![CDATA[
-    -g 
-    #for $genomefile in $genomefiles
-    '${genomefile}' 
-    #end for
-]]></token>
-
-
-    <xml name="checkm_method">
-        <param argument="--checkM_method" type="select" label="checkm method" optional="true">
-           <option value="taxonomy_wf">taxonomy_wf (faster)</option>
-           <option value="lineage_wf">lineage_wf (more accurate)</option>
-        </param>
-    </xml>
-    <token name="@CHECKM_METHOD@"><![CDATA[
-    #if $checkM_method:
-    --checkM_method $checkM_method 
-    #end if
-]]></token>
+    -g
+#for $genomefile in $genomefiles
+    '${genomefile}.fasta'
+#end for
+    ]]></token>
 
     <xml name="filtering_options">
-        <conditional name="filter">
-            <param name="set_options" type="select" label="set filtering options">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No (use --checkM_method taxonomy_wf)</option>
-            </param>
-            <when value="yes">
-                <param argument="--length" type="integer" value="50000" label="Minimum genome length"/>
-                <param argument="--completeness" type="integer" value="75" min="0" max="100" label="Minimum genome completeness percent"/>
-                <param argument="--contamination" type="integer" value="25" min="0" max="100" label="Maximum genome contamination percent"/>
-                 
-                <conditional name="quality">
-                    <param argument="source" type="select" label="genome quality">
-                        <help>
-                            --ignoreGenomeQuality is useful with
-                            bacteriophages or eukaryotes or things where checkM
-                            scoring does not work. Will only choose genomes based
-                            on length and N50. 
-                        </help>
-                        <option value="checkm" selected="true">Run checkM</option>
-                        <option value="genomeInfo">User supplied genomeInfo csv file</option>
-                        <option value="ignoreGenomeQuality">--ignoreGenomeQuality (NOT RECOMMENDED!)</option>
-                    </param>
-                    <when value="checkm">
-                        <param argument="--checkM_method" type="select" label="checkm method" optional="true">
-                            <help>
-                                Using the checkm method of lineage_wf can require more than 40Gb of RAM.
-                            </help>
-                            <option value="taxonomy_wf">taxonomy_wf (faster)</option>
-                            <option value="lineage_wf">lineage_wf (more accurate)</option>
-                        </param>
-                    </when>
-                    <when value="genomeInfo">
-                        <param argument="--genomeInfo" type="data" format="csv" label="genomes fasta files">
-                            <help><![CDATA[
-                            A CSV dataset that must contain: [
-                            "genome"(history dataset name of .fasta dataset of that genome), 
-                            "completeness"(0-100 value for completeness of the genome), 
-                            "contamination"(0-100 value of the contamination of the genome)] 
-                            ]]></help>
-                        </param>
-                    </when>
-                    <when value="ignoreGenomeQuality"/>
-                </conditional>
-            </when>
-            <when value="no"/>
-        </conditional>
+        <section name="filter" title="Genome filtering" expanded="true">
+            <param argument="--length" type="integer" value="50000" label="Minimum genome length"/>
+            <param argument="--completeness" type="integer" value="75" min="0" max="100" label="Minimum genome completeness percent"/>
+            <param argument="--contamination" type="integer" value="25" min="0" max="100" label="Maximum genome contamination percent"/>
+        </section>
+    </xml>
+    <xml name="test_default_filtering_options">
+        <section name="filter">
+            <param name="length" value="50000"/>
+            <param name="completeness" value="75"/>
+            <param name="contamination" value="100"/>
+        </section>
     </xml>
     <token name="@FILTER_OPTIONS@"><![CDATA[
-        #if $filter.set_options == 'yes':
-            --length $filter.length
-            --completeness $filter.completeness
-            --contamination $filter.contamination
-            #if $filter.quality.source == 'checkm'
-                --checkM_method $filter.quality.checkM_method
-            #elif $filter.quality.source == 'genomeInfo'
-                --genomeInfo $filter.quality.genomeInfo 
-            #elif $filter.quality.source == 'ignoreGenomeQuality'
-                --ignoreGenomeQuality
-            #end if
-        #else
-            --checkM_method taxonomy_wf
-        #end if
+    --length $filter.length
+    --completeness $filter.completeness
+    --contamination $filter.contamination
 ]]></token>
 
-    <xml name="genome_comparison_options">
-        <conditional name="genome_comparison">
-            <param name="set_options" type="select" label="set genome comparison options">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No</option>
+    <xml name="quality_assessment_options">
+        <conditional name="quality">
+            <param name="source" type="select" label="Genome quality filtering" help="No checkM or quality filtering is not recommened but with bacteriophages or eukaryotes or things where checkM scoring does not work. Will only choose genomes based on length and N50.">
+                <option value="checkm" selected="true">Run checkM</option>
+                <option value="genomeInfo">Provide quality information on the genome (CSV file)</option>
+                <option value="ignoreGenomeQuality">Don't run checkM or do any quality filtering (--ignoreGenomeQuality) - NOT RECOMMENDED!</option>
             </param>
-            <when value="yes">
-                <param argument="--MASH_sketch" type="integer" value="1000" label="MASH sketch size"/>
-                <param argument="--S_algorithm" type="select" label="Algorithm for secondary clustering comaprisons">
-                    <option value="ANImf" selected="true">ANImf = (RECOMMENDED) Align whole genomes with nucmer; filter alignment; compare aligned regions</option>
-                    <option value="ANIn">ANIn  = Align whole genomes with nucmer; compare aligned regions</option>
-                    <option value="gANI">gANI  = Identify and align ORFs; compare aligned ORFS</option>
+            <when value="checkm">
+                <param argument="--checkM_method" type="select" label="CheckM method">
+                    <option value="lineage_wf" selected="true">lineage_wf: Lineage-specific Workflow - quality estimates with lineage-specific markers (more accurate)</option>
+                    <option value="taxonomy_wf">taxonomy_wf: Taxonomic-specific Workflow - quality estimates with taxonomic-specific markers (faster)</option>
                 </param>
-                <param argument="-n_PRESET" type="select" label="Presets to pass to nucmer">
-                    <option value="normal" selected="true">normal  = default ANIn parameters (default: normal)</option>
-                    <option value="tight">tight   = only align highly conserved regions</option>
+                <param argument="--set_recursion" type="integer" optional="true" label="Increases the python recursion limit" help="NOT RECOMMENDED unless checkM is crashing due to recursion issues. Recommended to set to 2000 if needed, but setting this could crash Python"/>
+                <param argument="--checkm_group_size" type="integer" value="2000" min="1" label="Number of genomes passed to checkM at a time" help="Increasing this increases RAM but makes checkM faster"/>
+            </when>
+            <when value="genomeInfo">
+                <param argument="--genomeInfo" type="data" format="csv" label="Quality information on the genomes">
+                    <help><![CDATA[
+                    A CSV dataset that must contain: [
+                    "genome"(history dataset name of .fasta dataset of that genome),
+                    "completeness"(0-100 value for completeness of the genome),
+                    "contamination"(0-100 value of the contamination of the genome)]
+                    ]]></help>
                 </param>
             </when>
-            <when value="no"/>
+            <when value="ignoreGenomeQuality"/>
         </conditional>
     </xml>
-    <token name="@GENOME_COMPARISON_OPTIONS@"><![CDATA[
-        #if $genome_comparison.set_options == 'yes':
-            --MASH_sketch $genome_comparison.MASH_sketch
-            --S_algorithm $genome_comparison.S_algorithm
-            -n_PRESET $genome_comparison.n_PRESET
-        #end if
+    <xml name="test_default_quality_assessment_options">
+        <conditional name="quality">
+            <param name="source" value="checkm"/>
+            <param name="checkM_method" value="taxonomy_wf"/>
+            <param name="checkm_group_size" value="2000"/>
+        </conditional>
+    </xml>
+    <token name="@QUALITY_ASSESSMENT_OPTIONS@"><![CDATA[
+#if $quality.source == 'checkm'
+    --checkM_method '$quality.checkM_method'
+    #if str($quality.set_recursion) != ''
+    --set_recurison $filter.set_recursion
+    #end if
+    --checkm_group_size $quality.checkm_group_size
+#else if $quality.source == 'genomeInfo'
+    --genomeInfo '$quality.genomeInfo'
+#else if $quality.source == 'ignoreGenomeQuality'
+    --ignoreGenomeQuality
+#end if
 ]]></token>
 
-    <xml name="clustering_options">
+    <xml name="mash">
+        <param argument="--MASH_sketch" type="integer" value="1000" min="0" label="MASH sketch size"/>
+        <param argument="--P_ani" type="float" value="0.9" min="0." max="1." label="ANI threshold to form primary clusters"/>
+        <param argument="--multiround_primary_clustering" type='boolean' checked="false" truevalue='--multiround_primary_clustering' falsevalue='' label="Cluster each primary clunk separately and merge at the end with single linkage?" help="Decreases RAM usage and        increases speed, and the cost of a minor loss in precision and the inability to plot primary_clustering_dendrograms. Especially helpful when clustering 5000+ genomes. Will be done with single linkage clustering"/>
+        <param argument="--primary_chunksize" type="integer" value="5000" min="1" label="Impacts multiround_primary_clusterings" help=" If you have more than this many genomes, process them in chunks of this size"/>
+    </xml>
+    <xml name="test_default_mash">
+        <param name="MASH_sketch" value="1000"/>
+        <param name="P_ani" value="0.9"/>
+        <param name="multiround_primary_clustering" value=''/>
+        <param name="primary_chunksize" value="5000"/>
+    </xml>
+    <token name="@MASH@"><![CDATA[
+    --MASH_sketch '$comp_clust.steps.MASH_sketch'
+    --P_ani $comp_clust.steps.P_ani
+    $comp_clust.steps.multiround_primary_clustering
+    --primary_chunksize $comp_clust.steps.primary_chunksize
+]]></token>
+
+    <xml name="nucmer">
+        <param argument="--n_PRESET" type="select" label="Presets to pass to nucmer">
+            <option value="normal" selected="true">normal: default ANIn parameters</option>
+            <option value="tight">tight: only align highly conserved regions</option>
+        </param>
+    </xml>
+    <xml name="test_default_nucmer">
+        <param name="n_PRESET" value="normal"/>
+    </xml>
+    <token name="@NUCMER@"><![CDATA[
+    --n_PRESET '$comp_clust.steps.clustering.n_PRESET'
+]]></token>
+
+    <xml name="coverage_method">
+        <param argument="--coverage_method" type="select" label="Method to calculate coverage of an alignment">
+            <option value="larger" selected="true">Larger = max((aligned length / genome 1), (aligned_length / genome2))</option>
+            <option value="total">Total = 2*(aligned length) / (sum of total genome lengths)</option>
+        </param>
+    </xml>
+    <xml name="test_default_coverage_method">
+        <param name="coverage_method" value="larger"/>
+    </xml>
+    <token name="@COVERAGE_METHOD@"><![CDATA[
+    --coverage_method '$comp_clust.steps.clustering.coverage_method'
+]]></token>
+
+    <xml name="secondary_clustering">
         <conditional name="clustering">
-            <param name="set_options" type="select" label="set clustering options">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No</option>
+            <param argument="--S_algorithm" type="select" label="Algorithm for secondary clustering comparisons">
+                <option value="fastANI">fastANI: Kmer-based approach - very fast</option>
+                <option value="ANImf" selected="true">ANImf: Align whole genomes with nucmer; filter alignment; compare aligned regions - RECOMMENDED</option>
+                <option value="ANIn">ANIn: Align whole genomes with nucmer; compare aligned regions</option>
+                <option value="gANI">gANI: Identify and align ORFs; compare aligned ORFS</option>
+                <option value="goANI">Open source version of gANI; requires nsmimscan</option>
             </param>
-            <when value="yes">
-                <param argument="--P_ani" type="float" value="0.9" min="0." max="1." label="ANI threshold to form primary (MASH) clusters"/>
-                <param argument="--S_ani" type="float" value="0.99" min="0." max="1." label="ANI threshold to form secondary clusters"/>
-
-                <param argument="--SkipMash" type="boolean" truevalue="--SkipMash" falsevalue="" checked="false" label="Skip MASH clustering, just do secondary clustering on all genomes"/>
-                <param argument="--SkipSecondary" type="boolean" truevalue="--SkipSecondary" falsevalue="" checked="false" label="Skip secondary clustering, just perform MASH clustering"/>
-                <param argument="--cov_thresh" type="float" value="0.1" min="0." max="1." label="Minmum level of overlap between genomes when doing secondary comparisons"/>
-                <param argument="--coverage_method" type="select" label="Method to calculate coverage of an alignment">
-                    <help>(for ANIn/ANImf only; gANI can only do larger method)</help>
-                    <option value="larger" selected="true">arger  = max((aligned length / genome 1), (aligned_length / genome2))</option>
-                    <option value="total">total   = 2*(aligned length) / (sum of total genome lengths)</option>
-                </param>
-                <param argument="--clusterAlg" type="select" label="Algorithm used to cluster genomes">
-                    <help>(passed to  scipy.cluster.hierarchy.linkage)</help>
-                    <option value="average" selected="true">average</option>
-                </param>
+            <when value="fastANI">
+                <param argument="--greedy_secondary_clustering" type='boolean' checked="false" truevalue='--greedy_secondary_clustering' falsevalue='' label="Use a heuristic to avoid pair-wise comparisons when doing secondary clustering?" help="Will be done with single linkage clustering"/>
             </when>
-            <when value="no"/>
+            <when value="ANImf">
+                <expand macro="nucmer"/>
+                <expand macro="coverage_method"/>
+            </when>
+            <when value="ANIn">
+                <expand macro="nucmer"/>
+                <expand macro="coverage_method"/>
+            </when>
+            <when value="gANI"/>
+            <when value="goANI"/>
         </conditional>
+        <param argument="--S_ani" type="float" value="0.99" min="0." max="1." label="ANI threshold to form secondary clusters"/>
+        <param argument="--cov_thresh" type="float" value="0.1" min="0." max="1." label="Minmum level of overlap between genomes when doing secondary comparisons"/>
     </xml>
-    <token name="@CLUSTERING_OPTIONS@"><![CDATA[
-        #if $clustering.set_options == 'yes':
-            --P_ani $clustering.P_ani
-            --S_ani $clustering.S_ani
-            $clustering.SkipMash
-            $clustering.SkipSecondary
-            --cov_thresh $clustering.cov_thresh
-            --coverage_method $clustering.coverage_method
-            --clusterAlg $clustering.clusterAlg
-        #end if
+    <xml name="test_default_secondary_clustering">
+        <conditional name="clustering">
+            <param name="S_algorithm" value="ANImf"/>
+            <expand macro="test_default_nucmer"/>
+            <expand macro="test_default_coverage_method"/>
+        </conditional>
+        <param name="S_ani" value="0.99"/>
+        <param name="cov_thresh" value="0.1"/>
+    </xml>
+    <token name="@SECONDARY_CLUSTERING@"><![CDATA[
+    --S_algorithm '$comp_clust.steps.clustering.S_algorithm'
+    #if $comp_clust.steps.clustering.S_algorithm == 'fastANI'
+    $comp_clust.steps.clustering.greedy_secondary_clustering
+    #else if $comp_clust.steps.clustering.S_algorithm == 'ANImf'
+    @NUCMER@
+    @COVERAGE_METHOD@
+    #else if $comp_clust.steps.clustering.S_algorithm == 'ANIn'
+    @NUCMER@
+    @COVERAGE_METHOD@
+    #end if
+    --S_ani $comp_clust.steps.S_ani
+    --cov_thresh $comp_clust.steps.cov_thresh
+]]></token>
+
+    <xml name="comparison_clustering_options">
+        <section name="comp_clust" title="Genome comparison and clustering" expanded="false">
+            <conditional name="steps">
+                <param name="select" type="select" label="Steps in genome comparison">
+                    <option value="default" selected="true">Default: Run MASH clustering and a secondary clustering</option>
+                    <option value="SkipMash">Skip MASH clustering, just do secondary clustering on all genomes</option>
+                    <option value="SkipSecondary">Skip secondary clustering, just perform MASH clustering</option>
+                </param>
+                <when value="default">
+                    <expand macro="mash"/>
+                    <expand macro="secondary_clustering"/>
+                </when>
+                <when value="SkipMash">
+                    <expand macro="secondary_clustering"/>
+                </when>
+                <when value="SkipSecondary">
+                    <expand macro="mash"/>
+                </when>
+            </conditional>
+            <param argument="--clusterAlg" type="select" label="Algorithm used to cluster genomes" help="Passed to scipy.cluster.hierarchy.linkage">
+                <option value="average" selected="true">average</option>
+                <option value="ward">ward</option>
+                <option value="single">single</option>
+                <option value="median">median</option>
+                <option value="centroid">centroid</option>
+                <option value="weighted">weighted</option>
+            </param>
+            <param argument="--run_tertiary_clustering" type='boolean' checked="false" truevalue='--run_tertiary_clustering' falsevalue='' label="Run an additional round of clustering on the final genome set?" help="This is especially useful when greedy clustering is performed and/or to handle cases where similar genomes end up in different primary clusters."/>
+        </section>
+    </xml>
+    <xml name="test_default_comparison_clustering_options">
+        <section name="comp_clust">
+            <conditional name="steps">
+                <param name="select" value="default" />
+                <expand macro="test_default_mash"/>
+                <expand macro="test_default_secondary_clustering"/>
+            </conditional>
+            <param name="clusterAlg" value="average"/>
+            <param name="run_tertiary_clustering" value=''/>
+        </section>
+    </xml>
+    <token name="@COMPARISON_CLUSTERING_OPTIONS@"><![CDATA[
+#if $comp_clust.steps.select == 'default'
+    @MASH@
+    @SECONDARY_CLUSTERING@
+#else if $comp_clust.steps.select == 'SkipMash'
+    --SkipMash
+    @SECONDARY_CLUSTERING@
+#else
+    @MASH@
+    --SkipSecondary
+#end if
+    --clusterAlg '$comp_clust.clusterAlg'
+    $comp_clust.run_tertiary_clustering
 ]]></token>
 
     <xml name="scoring_options">
-        <conditional name="scoring">
-            <param name="set_options" type="select" label="set scoring options">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No</option>
-            </param>
-            <when value="yes">
-                <param argument="--completeness_weight" type="float" value="1" label="completeness weight">
-                    <help>
-Based off of the formula:
-A*Completeness - B*Contamination + C*(Contamination * (strain_heterogeneity/100)) + D*log(N50) + E*log(size)
-A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weight; D = N50_weight; E = size_weight;
-                    </help>
-                </param>
-                <param argument="--contamination_weight" type="float" value="5" label="contamination weight"/>
-                <param argument="--strain_heterogeneity_weight" type="float" value="1" min="0." max="1." label="strain heterogeneity weight"/>
-                <param argument="--N50_weight" type="float" value=".5" label="weight of log(genome N50)"/>
-                <param argument="--size_weight" type="float" value="0" label="weight of log(genome size)"/>
-            </when>
-            <when value="no"/>
-        </conditional>
+        <section name="scoring" title="Scoring criteria" expanded="false" help="Based off of the formula: A*Completeness - B*Contamination + C*(Contamination * (strain_heterogeneity/100)) + D*log(N50) + E*log(size) + F*(centrality - S_ani). With A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weight; D = N50_weight; E = size_weight; F = cent_weight">
+            <param argument="--completeness_weight" type="float" value="1" label="Completeness weight"/>
+            <param argument="--contamination_weight" type="float" value="5" label="Contamination weight"/>
+            <param argument="--strain_heterogeneity_weight" type="float" value="1" min="0." max="1." label="Strain heterogeneity weight"/>
+            <param argument="--N50_weight" type="float" value=".5" label="Weight of log(genome N50)"/>
+            <param argument="--size_weight" type="float" value="0" label="Weight of log(genome size)"/>
+            <param argument="--centrality_weight" type="float" value="1" label="Weight of (centrality - S_ani)"/>
+        </section>
+    </xml>
+    <xml name="test_default_scoring_options">
+        <section name="scoring">
+            <param name="completeness_weight" value="1"/>
+            <param name="contamination_weight" value="5"/>
+            <param name="strain_heterogeneity_weight" value="1"/>
+            <param name="N50_weight" value=".5" />
+            <param name="size_weight" value="0"/>
+            <param name="centrality_weight" value="1"/>
+        </section>
     </xml>
     <token name="@SCORING_OPTIONS@"><![CDATA[
-        #if $scoring.set_options == 'yes':
-            --completeness_weight $scoring.completeness_weight
-            --contamination_weight $scoring.contamination_weight
-            --strain_heterogeneity_weight $scoring.strain_heterogeneity_weight
-            --N50_weight $scoring.N50_weight
-            --size_weight $scoring.size_weight
-        #end if
+    --completeness_weight $scoring.completeness_weight
+    --contamination_weight $scoring.contamination_weight
+    --strain_heterogeneity_weight $scoring.strain_heterogeneity_weight
+    --N50_weight $scoring.N50_weight
+    --size_weight $scoring.size_weight
+    --centrality_weight $scoring.centrality_weight
 ]]></token>
 
-    <xml name="taxonomy_options">
-        <conditional name="taxonomy">
-            <param name="set_options" type="select" label="generate taxonomy information">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No</option>
-            </param>
-            <when value="yes">
-                <param argument="--tax_method" type="select" label="Method of determining taxonomy">
-                    <help>(for ANIn/ANImf only; gANI can only do larger method)</help>
-                    <option value="percent" selected="true">percent = The most descriptive taxonimic level with at least (per) hits</option>
-                    <option value="max">max = The centrifuge taxonomic level with the most overall hits</option>
-                </param>
-                <param argument="--percent" type="float" value="50" min="0" max="100" label="minimum percent for percent method"/>
-                <param argument="--cent_index" type="data" format="" label="centrifuge index"/>
-            </when>
-            <when value="no"/>
-        </conditional>
+    <xml name="warning_options">
+        <section name="warning" title="Warnings" expanded="false">
+            <param argument="--warn_dist" type="float" value="0.25" min="0" max="1" label="How far from the threshold to throw cluster warnings"/>
+            <param argument="--warn_sim" type="float" value="0.98" min="0" max="1" label="Similarity threshold for warnings between dereplicated genomes"/>
+            <param argument="--warn_aln" type="float" value="0.25" min="0" max="1" label="Minimum aligned fraction for warnings between dereplicated genomes (ANIn)"/>
+        </section>
     </xml>
-    <token name="@TAXONOMY_OPTIONS@"><![CDATA[
-        #if $taxonomy.set_options == 'yes':
-            --run_tax
-            --tax_method $taxonomy.tax_method
-            --percent $taxonomy.percent
-            --cent_index $taxonomy.cent_index
-        #end if
-]]></token>
-
-   <xml name="warning_options">
-        <conditional name="warning">
-            <param name="set_options" type="select" label="set warning options">
-                <option value="yes">Yes</option>
-                <option value="no" selected="true">No</option>
-            </param>
-            <when value="yes">
-                <param argument="--warn_dist" type="float" value="0.25" min="0" max="1" label="How far from the threshold to throw cluster warnings"/>
-                <param argument="--warn_sim" type="float" value="0.98" min="0" max="1" label="Similarity threshold for warnings between dereplicated genomes"/>
-                <param argument="--warn_aln" type="float" value="0.25" min="0" max="1" label="Minimum aligned fraction for warnings between dereplicated genomes (ANIn)"/>
-            </when>
-            <when value="no"/>
-        </conditional>
+    <xml name="test_default_warning_options">
+        <section name="warning">
+            <param name="warn_dist" value="0.25"/>
+            <param name="warn_sim" value="0.98"/>
+            <param name="warn_aln" value="0.25"/>
+        </section>
     </xml>
     <token name="@WARNING_OPTIONS@"><![CDATA[
-        #if $warning.set_options == 'yes':
-            --warn_dist $warning.warn_dist
-            --warn_sim $warning.warn_sim
-            --warn_aln $warning.warn_aln
-        #end if
+    --warn_dist $warning.warn_dist
+    --warn_sim $warning.warn_sim
+    --warn_aln $warning.warn_aln
 ]]></token>
 
     <xml name="select_outputs">
@@ -282,8 +331,14 @@ A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weig
             <option value="Chdb">Chdb.tsv</option>
         </expand>
     </xml>
+    <xml name="test_default_select_drep_outputs">
+        <param name="select_outputs" value="log,warnings,Primary_clustering_dendrogram,Clustering_scatterplots,Cluster_scoring,Winning_genomes,Widb" />
+    </xml>
+    <xml name="test_default_select_outputs">
+        <param name="select_outputs" value="log,warnings,Primary_clustering_dendrogram,Clustering_scatterplots" />
+    </xml>
 
-   <xml name="common_outputs">
+    <xml name="common_outputs">
         <data name="log" format="txt" label="${tool.name} on ${on_string}: Log" from_work_dir="outdir/log/logger.log">
             <filter>'log' in select_outputs or not select_outputs</filter>
         </data>
@@ -303,8 +358,6 @@ A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weig
             <filter>'Clustering_scatterplots' in select_outputs</filter>
         </data>
     </xml>
-
-
     <xml name="drep_outputs">
         <expand macro="common_outputs"/>
         <data name="Cluster_scoring" format="pdf" label="${tool.name} on ${on_string}: Cluster_scoring.pdf" from_work_dir="outdir/figures/Cluster_scoring.pdf">
@@ -320,19 +373,19 @@ A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weig
             <filter>'Chdb' in select_outputs</filter>
         </data>
     </xml>
-
-    
-    <xml name="test_defaults_log">
-        <test>
-            <param name="genomes" ftype="fasta" value="Enterococcus_casseliflavus_EC20.fasta,Enterococcus_faecalis_T2.fna,Enterococcus_faecalis_TX0104.fa"/>
-            <output name="log">
-                <assert_contents>
-                    <yield/>
-                </assert_contents>
-            </output>
-        </test>
+    <xml name="test_string_inputs">
+        <param name="genomes" ftype="fasta" value="Enterococcus_casseliflavus_EC20.fasta,Enterococcus_faecalis_T2.fna,Enterococcus_faecalis_TX0104.fa"/>
     </xml>
-
+    <xml name="test_integer_inputs">
+        <param name="genomes" ftype="fasta" value="001,002,003"/>
+    </xml>
+    <xml name="test_log_output">
+        <output name="log">
+            <assert_contents>
+                <yield/>
+            </assert_contents>
+        </output>
+    </xml>
     <token name="@GENOMES_HELP@"><![CDATA[
 I/O PARAMETERS:
   -g [GENOMES [GENOMES ...]], --genomes [GENOMES [GENOMES ...]]
@@ -341,7 +394,6 @@ I/O PARAMETERS:
 
 
 ]]></token>
-
     <token name="@FILTERING_HELP@"><![CDATA[
 FILTERING OPTIONS:
   -l LENGTH, --length LENGTH
@@ -368,7 +420,6 @@ FILTERING OPTIONS:
 
 
 ]]></token>
-
     <token name="@GENOME_COMPARISON_HELP@"><![CDATA[
 GENOME COMPARISON PARAMETERS:
   -ms MASH_SKETCH, --MASH_sketch MASH_SKETCH
@@ -387,7 +438,6 @@ GENOME COMPARISON PARAMETERS:
                         normal  = default ANIn parameters (default: normal)
 
 ]]></token>
-
     <token name="@CLUSTERING_HELP@"><![CDATA[
 CLUSTERING PARAMETERS:
   -pa P_ANI, --P_ani P_ANI
@@ -417,10 +467,9 @@ CLUSTERING PARAMETERS:
                         scipy.cluster.hierarchy.linkage (default: average)
 
 ]]></token>
-
     <token name="@SCORING_HELP@"><![CDATA[
 SCORING CRITERIA
-Based off of the formula: 
+Based off of the formula:
 A*Completeness - B*Contamination + C*(Contamination * (strain_heterogeneity/100)) + D*log(N50) + E*log(size)
 
 A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weight; D = N50_weight; E = size_weight:
@@ -437,7 +486,6 @@ A = completeness_weight; B = contamination_weight; C = strain_heterogeneity_weig
 
 
 ]]></token>
-
     <token name="@TAXONOMY_HELP@"><![CDATA[
 TAXONOMY:
   --run_tax             generate taxonomy information (Tdb)
@@ -461,7 +509,6 @@ TAXONOMY:
                         (default: None)
 
 ]]></token>
-
     <token name="@WARNINGS_HELP@"><![CDATA[
 WARNINGS:
   --warn_dist WARN_DIST
@@ -473,6 +520,4 @@ WARNINGS:
                         dereplicated genomes (ANIn) (default: 0.25)
 
 ]]></token>
-
-
 </macros>

--- a/tools/drep/test-data/001
+++ b/tools/drep/test-data/001
@@ -1,0 +1,1 @@
+Enterococcus_casseliflavus_EC20.fasta

--- a/tools/drep/test-data/002
+++ b/tools/drep/test-data/002
@@ -1,0 +1,1 @@
+Enterococcus_faecalis_T2.fna

--- a/tools/drep/test-data/003
+++ b/tools/drep/test-data/003
@@ -1,0 +1,1 @@
+Enterococcus_faecalis_TX0104.fa


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

---

We figured out that the tool does not end correctly (no error but empty outputs) if the names of the datasets could be interpreted as numbers (e.g. `001`). It is a [bug in the upstream tool I reported and probably fixed](https://github.com/MrOlm/drep/issues/140). 
Until a new release is available, I made a quick fix in the wrapper (adding `.fasta` to the input names during the symlink step).

I also updated the wrapper to the latest version, restructuring a bit the parameters using `sections` and also `conditional` for dependent parameters