### PR TITLE
InterProScan: fix java ignoring $HOME

### DIFF
--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -16,6 +16,9 @@ mkdir -p \$HOME/.interproscan-5
 &&
 sed 's|^\(data.directory=\).*$|\1${database.fields.path}/data|' \$(dirname \$(readlink -f \$(command -v interproscan.sh)))/interproscan.properties > \$HOME/.interproscan-5/interproscan.properties
 &&
+## Java doesn't read the HOME env var
+export _JAVA_OPTIONS=-Duser.home=\$HOME
+&&
 
 ## Now run interproscan
 interproscan.sh

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -6,7 +6,7 @@
         The version should also be bumped in test-data/interproscan.loc
     -->
     <token name="@TOOL_VERSION@">5.54-87.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
 
     <xml name="citations">
         <citations>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Fix interproscan not seeing its config file placed in the job specific HOME dir