### PR TITLE
Updating tools/bwameth from version 0.2.3 to 0.2.4

### DIFF
--- a/tools/bwameth/bwameth.xml
+++ b/tools/bwameth/bwameth.xml
@@ -1,7 +1,7 @@
 <tool id="bwameth" name="bwameth" version="@TOOL_VERSION@+galaxy0" profile="20.05">
     <description>Fast and accurate aligner of BS-Seq reads.</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.2.3</token>
+        <token name="@TOOL_VERSION@">0.2.4</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bwameth</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bwameth**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bwameth from version 0.2.3 to 0.2.4.

**Project home page:** https://github.com/brentp/bwa-meth/releases