### PR TITLE
some inconsistencies between mothods and method

### DIFF
--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -13,14 +13,14 @@
 @CMD_imports@
 @CMD_read_inputs@
 
-#if $method.method == "pp.regress_out"
+#if $methods.method == "pp.regress_out"
 sc.pp.regress_out(
    adata=adata,
-   #set $keys = [str(x.strip()) for x in str($method.keys).split(',')]
+   #set $keys = [str(x.strip()) for x in str($methods.keys).split(',')]
    keys=$keys,
    copy=False)
 
-#else if $method.method == "pp.mnn_correct"
+#else if $methods.method == "pp.mnn_correct"
     #for i, filepath in enumerate($methods.extra_adata)
 adata_$i = ad.read('$filepath')
     #end for
@@ -31,32 +31,32 @@ sc.pp.mnn_correct(
     adata_$i,
     #end for
     #if str($methods.var_subset) != ''
-    #set $var_subset=([x.strip() for x in str($method.var_subset).split(',')])
+    #set $var_subset=([x.strip() for x in str($methods.var_subset).split(',')])
     var_subset=$var_subset,
     #end if
-    batch_key='$method.batch_key',
-    index_unique='$method.index_unique'
+    batch_key='$methods.batch_key',
+    index_unique='$methods.index_unique'
     #if str($methods.batch_categories) != ''
-    #set $batch_categories=([x.strip() for x in str($method.batch_categories).split(',')])
+    #set $batch_categories=([x.strip() for x in str($methods.batch_categories).split(',')])
     batch_categories=$batch_categories,
     #end if
-    k=$method.k,
-    sigma=$method.sigma,
-    cos_norm_in=$method.cos_norm_in,
-    cos_norm_out=$method.cos_norm_out,
-    svd_dim=$method.svd_dim,
-    var_adj=$method.var_adj,
-    compute_angle=$method.compute_angle,
-    mnn_order='$method.mnn_order',
-    svd_mode='$method.svd_mode',
+    k=$methods.k,
+    sigma=$methods.sigma,
+    cos_norm_in=$methods.cos_norm_in,
+    cos_norm_out=$methods.cos_norm_out,
+    svd_dim=$methods.svd_dim,
+    var_adj=$methods.var_adj,
+    compute_angle=$methods.compute_angle,
+    mnn_order='$methods.mnn_order',
+    svd_mode='$methods.svd_mode',
     do_concatenate=True,
     save_raw=True,
     n_jobs=\${GALAXY_SLOTS:-4})
 
-#else if $method.method == "pp.combat"
+#else if $methods.method == "pp.combat"
 sc.pp.combat(
     adata,
-    key='$method.key',
+    key='$methods.key',
     inplace=True)
 
 #end if
@@ -66,7 +66,7 @@ sc.pp.combat(
     </configfiles>
     <inputs>
         <expand macro="inputs_anndata"/>
-        <conditional name="method">
+        <conditional name="methods">
             <param argument="method" type="select" label="Method used for plotting">
                 <option value="pp.regress_out">Regress out unwanted sources of variation, using 'pp.regress_out'</option>
                 <option value="pp.mnn_correct">Correct batch effects by matching mutual nearest neighbors, using 'pp.mnn_correct'</option>
@@ -125,7 +125,7 @@ sc.pp.combat(
         <test>
             <!-- test 0 -->
             <param name="adata" value="krumsiek11.h5ad" />
-            <conditional name="method">
+            <conditional name="methods">
                 <param name="method" value="pp.regress_out"/>
                 <param name="keys" value="cell_type"/>
             </conditional>
@@ -143,7 +143,7 @@ sc.pp.combat(
         <!--<test>
             < test 2 >
             <param name="adata" value="krumsiek11.h5ad" />
-            <conditional name="method">
+            <conditional name="methods">
                 <param name="method" value="pp.mnn_correct"/>
                 <param name="reg_keys" value="cell_type"/>
             </conditional>
@@ -156,7 +156,7 @@ sc.pp.combat(
         <test>
             <!-- test 1 -->
             <param name="adata" value="blobs.h5ad" />
-            <conditional name="method">
+            <conditional name="methods">
                 <param name="method" value="pp.combat"/>
                 <param name="key" value="blobs"/>
             </conditional>


### PR DESCRIPTION
We got this error report:

```
Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 243, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/server/lib/galaxy/jobs/__init__.py", line 1161, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 450, in build
    raise e
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 446, in build
    self.__build_config_files()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 520, in __build_config_files
    self.__write_workdir_file(config_filename, config_text, param_dict, is_template=is_template)
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 614, in __write_workdir_file
    value = fill_template(content, context=context, python_template_version=self.tool.python_template_version)
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 107, in fill_template
    raise first_exception or e
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/opt/galaxy/server/lib/galaxy/util/__init__.py", line 1060, in unicodify
    value = str(value)
  File "/opt/galaxy/venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1644563691_9006531_67624.py", line 112, in respond
NameMapper.NotFound: cannot find 'methods'
```

@bebatut does this look in general good to you? I think there are some tests missing, but maybe that is a start.