### PR TITLE
FASTQ-splitter: add output labels to identify forward and reverse

### DIFF
--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_paired_end_splitter" name="FASTQ splitter" version="@TOOL_VERSION@">
+<tool id="fastq_paired_end_splitter" name="FASTQ splitter" version="@TOOL_VERSION@+galaxy1">
     <description>on joined paired end reads</description>
     <macros>
         <import>macros.xml</import>
@@ -17,8 +17,8 @@ gx-fastq-paired-end-splitter '$input1_file' '${input1_file.extension[len('fastq'
         <param name="input1_file" type="data" format="fastqsanger,fastqcssanger,fastqsanger.gz,fastqcssanger.gz,fastqsanger.bz2,fastqcssanger.bz2" label="FASTQ reads" />
     </inputs>
     <outputs>
-        <data name="output1_file" format_source="input1_file" />
-        <data name="output2_file" format_source="input1_file" />
+        <data name="output1_file" format_source="input1_file" label="${tool.name} on ${on_string}: Left-hand reads"/>
+        <data name="output2_file" format_source="input1_file" label="${tool.name} on ${on_string}: Right-hand reads"/>
     </outputs>
     <tests>
         <test>

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
@@ -17,8 +17,8 @@ gx-fastq-paired-end-splitter '$input1_file' '${input1_file.extension[len('fastq'
         <param name="input1_file" type="data" format="fastqsanger,fastqcssanger,fastqsanger.gz,fastqcssanger.gz,fastqsanger.bz2,fastqcssanger.bz2" label="FASTQ reads" />
     </inputs>
     <outputs>
-        <data name="output1_file" format_source="input1_file" label="${tool.name} on ${on_string}: Left-hand reads"/>
-        <data name="output2_file" format_source="input1_file" label="${tool.name} on ${on_string}: Right-hand reads"/>
+        <data name="output1_file" format_source="input1_file" label="${tool.name} on ${on_string}: Forward"/>
+        <data name="output2_file" format_source="input1_file" label="${tool.name} on ${on_string}: Reverse"/>
     </outputs>
     <tests>
         <test>
@@ -32,7 +32,7 @@ gx-fastq-paired-end-splitter '$input1_file' '${input1_file.extension[len('fastq'
 
 Splits a single fastq dataset representing paired-end run into two datasets (one for each end). This tool works only for datasets where both ends have **the same** length.
 
-Sequence identifiers will have /1 or /2 appended for the split left-hand and right-hand reads, respectively.
+Sequence identifiers will have /1 or /2 appended for the split forward and reverse reads, respectively.
 
 -----
 
@@ -49,14 +49,14 @@ A multiple-fastq file, for example::
 
 **Outputs**
 
-Left-hand Read::
+Forward Read::
 
     @HWI-EAS91_1_30788AAXX:7:21:1542:1758/1
     GTCAATTGTACTGGTCAATACTAAAAGAATAGGATC
     +HWI-EAS91_1_30788AAXX:7:21:1542:1758/1
     hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
 
-Right-hand Read::
+Reverse Read::
 
     @HWI-EAS91_1_30788AAXX:7:21:1542:1758/2
     GCTCCTAGCATCTGGAGTCTCTATCACCTGAGCCCA


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
