### PR TITLE
Updating tools/freebayes from version 1.3.5 to 1.3.6

### DIFF
--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -696,7 +696,7 @@
             <param name="ref_file" ftype="fasta" value="freebayes-phix174.fasta"/>
             <param name="input_bams" ftype="cram" value="freebayes-phix174.cram"/>
             <param name="options_type_selector" value="simple"/>
-            <output name="output_vcf" file="freebayes-phix174-test1.vcf" lines_diff="4" />
+            <output name="output_vcf" file="freebayes-phix174-test1.vcf" lines_diff="6" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -10,6 +10,7 @@
         <requirement type="package" version="5.1.0">gawk</requirement>
         <requirement type="package" version="20211222">parallel</requirement>
     </expand>
+    <expand macro="version_command" />
     <command detect_errors="exit_code"><![CDATA[
     ##set up input files
 

--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -1,4 +1,4 @@
-<tool id="freebayes" name="FreeBayes" version="@TOOL_VERSION@+galaxy1">
+<tool id="freebayes" name="FreeBayes" version="@TOOL_VERSION@+galaxy0">
     <description>bayesian genetic variant detector</description>
     <xrefs>
         <xref type="bio.tools">freebayes</xref>
@@ -8,7 +8,7 @@
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="5.1.0">gawk</requirement>
-        <requirement type="package" version="20211022">parallel</requirement>
+        <requirement type="package" version="20211222">parallel</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
     ##set up input files

--- a/tools/freebayes/leftalign.xml
+++ b/tools/freebayes/leftalign.xml
@@ -8,6 +8,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
+    <expand macro="version_command" />
     <command detect_errors="exit_code"><![CDATA[
         ##set up input files
         #set $reference_fasta_filename = "localref.fa"

--- a/tools/freebayes/macros.xml
+++ b/tools/freebayes/macros.xml
@@ -1,9 +1,9 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.3.5</token>
+    <token name="@TOOL_VERSION@">1.3.6</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">freebayes</requirement>
-            <requirement type="package" version="1.12">samtools</requirement>
+            <requirement type="package" version="1.14">samtools</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/freebayes/macros.xml
+++ b/tools/freebayes/macros.xml
@@ -7,6 +7,9 @@
             <yield />
         </requirements>
     </xml>
+    <xml name="version_command">
+        <version_command>freebayes --version | cut -d v -f 3</version_command>
+    </xml>
     <xml name="citations">
         <citations>
             <citation type="bibtex">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/freebayes**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/freebayes from version 1.3.5 to 1.3.6.

**Project home page:** https://github.com/ekg/freebayes/releases