### PR TITLE
Updating tools/spades from version 3.15.3 to 3.15.4

### DIFF
--- a/tools/spades/macros.xml
+++ b/tools/spades/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.15.3</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">3.15.4</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">spades</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/spades**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/spades from version 3.15.3 to 3.15.4.

**Project home page:** https://github.com/ablab/spades/releases