### PR TITLE
Allow porechop to detect fastq and fastq.gz files

### DIFF
--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -32,7 +32,7 @@ porechop
 
     ]]></command>
     <inputs>
-        <param name="input_file" type="data" format="fasta,fasta.gz,fastqsanger,fastqsanger.gz" label="Input FASTA/FASTQ" help="FASTA/FASTQ of input reads" />
+        <param name="input_file" type="data" format="fasta,fasta.gz,fastqsanger,fastqsanger.gz,fastq,fastq.gz" label="Input FASTA/FASTQ" help="FASTA/FASTQ of input reads" />
         <param name="format" type="select" label="Output format for the reads" help="Output format for the reads">
             <option selected="True" value="fasta">fasta</option>
             <option value="fastq">fastq</option>

--- a/tools/porechop/porechop.xml
+++ b/tools/porechop/porechop.xml
@@ -1,4 +1,4 @@
-<tool id="porechop" name="Porechop" version="@WRAPPER_VERSION@" profile="20.01">
+<tool id="porechop" name="Porechop" version="@WRAPPER_VERSION@+galaxy0" profile="20.01">
     <description>adapter trimmer for Oxford Nanopore reads</description>
     <macros>
         <token name="@WRAPPER_VERSION@">0.2.4</token>
@@ -101,6 +101,11 @@ porechop
         </test>
         <test>
             <param name="input_file" ftype="fastqsanger.gz" value="test_format.fastq.gz"/>
+            <param name="format" value="fastq"/>
+            <output name="outfile" ftype="fastqsanger" file="out.fastq"/>
+        </test>
+        <test>
+            <param name="input_file" ftype="fastq.gz" value="test_format.fastq.gz"/>
             <param name="format" value="fastq"/>
             <output name="outfile" ftype="fastqsanger" file="out.fastq"/>
         </test>


### PR DESCRIPTION
Porechop was not finding files determined as formats of `fastq` or `fastq.gz` so just adding them to the formats allowed

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
