### PR TITLE
Updating tools/busco from version 5.2.2 to
5.3.1

### DIFF
--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.3.0</token>
+    <token name="@TOOL_VERSION@">5.3.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.2.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">5.3.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">
         <citations>

--- a/tools/busco/test-data/genome_results_metaeuk_auto/full_table
+++ b/tools/busco/test-data/genome_results_metaeuk_auto/full_table
@@ -1,4 +1,4 @@
-# BUSCO version is: 5.2.2 
+# BUSCO version is: 5.3.1 
 # The lineage dataset is: eukaryota_odb10 (Creation date: 2020-09-10, number of genomes: 70, number of BUSCOs: 255)
 # Busco id	Status	Sequence	Gene Start	Gene End	Strand	Score	Length
 39650at2759	Missing

--- a/tools/busco/test-data/genome_results_metaeuk_auto/missing_buscos_list
+++ b/tools/busco/test-data/genome_results_metaeuk_auto/missing_buscos_list
@@ -1,4 +1,4 @@
-# BUSCO version is: 5.2.2 
+# BUSCO version is: 5.3.1 
 # The lineage dataset is: eukaryota_odb10 (Creation date: 2020-09-10, number of genomes: 70, number of BUSCOs: 255)
 # Busco id
 1001705at2759

--- a/tools/busco/test-data/genome_results_metaeuk_auto/short_summary
+++ b/tools/busco/test-data/genome_results_metaeuk_auto/short_summary
@@ -1,4 +1,4 @@
-# BUSCO version is: 5.2.2 
+# BUSCO version is: 5.3.1 
 # The lineage dataset is: eukaryota_odb10 (Creation date: 2020-09-10, number of genomes: 70, number of BUSCOs: 255)
 # Summarized benchmarking in BUSCO notation for file /tmp/tmp5e3tdhzs/files/c/9/b/dataset_c9b61090-5a2d-4dd0-8fd1-d147a4e1573c.dat
 # BUSCO was run in mode: genome


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/busco**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/busco from version 5.2.2 to 5.3.0.

**Project home page:** http://busco.ezlab.org