### PR TITLE
Updating tools/cutadapt from version 3.5 to 3.7

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -534,7 +534,7 @@ $read_mod_options.zero_cap
             </section>
             <param name="output_selector" value="rest_file,json_stats"/>
             <output name="out1" file="cutadapt_rest.out" ftype="fasta"/>
-            <output name="json_stats" file="cutadapt_rest.json" ftype="json"/>
+            <output name="json_stats" file="cutadapt_rest.json" ftype="json" lines_diff="4"/> <!--allow for differing cutadapt and python version-->
             <output name="rest_output" file="cutadapt_rest2.out" ftype="fasta"/>
         </test>
         <!-- Ensure nextseq-trim option works -->

--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -4,8 +4,8 @@
         <import>macros.xml</import>
     </macros>
     <expand macro='edam_ontology' />
-    <expand macro='requirements' />
     <expand macro='xrefs'/>
+    <expand macro='requirements' />
     <version_command>cutadapt --version</version_command>
 
     <command detect_errors="exit_code"><![CDATA[
@@ -1333,11 +1333,17 @@ The following placeholders are currently available for single-end reads:
         * {id} – the read ID, that is, the part of the header before the first whitespace
         * {comment} – the part of the header after the whitespace following the ID
         * {adapter_name} – the name of adapter that was found in this read or no_adapter if there was none adapter match. If you use --times to do multiple rounds of adapter matching, this is the name of the last found adapter.
+        * {match_sequence} – the sequence of the read that matched the adapter (including errors). If there was no adapter match, this is set to an empty string. If you use a linked adapter, this is to the two matching strings, separated by a comma.
         * {cut_prefix} – the prefix removed by the --cut (or -u) option (that is, when used with a positive length argument)
         * {cut_suffix} – the suffix removed by the --cut (or -u) option (that is, when used with a negative length argument)
+        * {rc} – this is replaced with the string rc if the read was reverse complemented. This only applies when reverse complementing was requested
 
 If the --rename option is used with paired-end data, the template is applied separately to both R1 and R2. That is, for R1, the placeholders are replaced with values from R1, and for R2, the placeholders are replaced with values from R2. For example, {comment} becomes R1’s comment in R1 and it becomes R2’s comment in R2.
 
+For paired-end data, the placeholder {rn} is available (“read number”), and it is replaced with 1 in R1 and with 2 in R2.
+
+In addition, it is possible to write a placeholder as {r1.placeholdername} or {r2.placeholdername}, which always takes the replacement value from R1 or R2, respectively.
+The {r1.placeholder} and {r2.placeholder} notation is available for all placeholders except {rn} and {id} because the read ID needs to be identical for both reads.
 
 --------------------
 

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.5</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">3.7</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@FASTQ_TYPES@">fastq.gz,fastq,fasta</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -269,7 +269,7 @@
                     <param name="single_noindels" type="boolean" truevalue=";noindels" falsevalue="" checked="false" label="Disallow indels for this adapter"/>
                 </repeat>
 
-                <param name="cut" argument="--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
+                <param argument="--cut" type="integer" value="0" optional="True" label="Cut bases from reads before adapter trimming" help="Remove bases from each read (first read only if paired). If positive, remove bases from the beginning. If negative, remove bases from the end. This is applied *before* adapter trimming." />
 
             </section>
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cutadapt**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cutadapt from version 3.5 to 3.7.

**Project home page:** https://cutadapt.readthedocs.org/en/stable