### PR TITLE
Updating tools/tracy from version 0.6.1 to
0.7.5

### DIFF
--- a/tools/tracy/macros.xml
+++ b/tools/tracy/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7.1</token>
+    <token name="@TOOL_VERSION@">0.7.2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tracy</requirement>

--- a/tools/tracy/macros.xml
+++ b/tools/tracy/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7.3</token>
+    <token name="@TOOL_VERSION@">0.7.5</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tracy</requirement>

--- a/tools/tracy/macros.xml
+++ b/tools/tracy/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.6.1</token>
+    <token name="@TOOL_VERSION@">0.7.1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tracy</requirement>

--- a/tools/tracy/macros.xml
+++ b/tools/tracy/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7.2</token>
+    <token name="@TOOL_VERSION@">0.7.3</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tracy</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/tracy**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/tracy from version 0.6.1 to 0.7.1.