### PR TITLE
Fix ivar trim's amplicon info on the fly generation

### DIFF
--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -5,6 +5,7 @@
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="3.8.1">python</requirement>
+        <requirement type="package" version="1.15">samtools</requirement>
     </expand>
     <expand macro="version_command" />
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_trim" name="ivar trim" version="@VERSION@+galaxy2">
+<tool id="ivar_trim" name="ivar trim" version="@VERSION@+galaxy3">
     <description>Trim reads in aligned BAM</description>
     <macros>
         <import>macros.xml</import>
@@ -14,8 +14,8 @@
             cp '$primer.cached_bed.fields.path' bed.bed &&
         #end if
         python '$__tool_directory__/sanitize_bed.py' bed.bed &&
-        #if $amplicons.filter_by == 'yes' or $amplicons.filter_by == 'yes_computed'
-            #if $amplicons.filter_by == 'yes_computed':
+        #if $amplicons.filter_by == 'yes' or $amplicons.filter_by == 'yes_compute'
+            #if $amplicons.filter_by == 'yes_compute':
                 python '$__tool_directory__/write_amplicon_info_file.py' bed.bed amplicon_info_raw.tsv &&
             #else
                 ln -s '$amplicons.amplicon_info' amplicon_info_raw.tsv &&
@@ -132,6 +132,9 @@
                 <param name="filter_by" value="yes_compute" />
             </conditional>
             <param name="input_bam" value="sars-cov-2/sars_cov2_untrimmed.bam" ftype="bam" />
+            <assert_command>
+                <has_text text="write_amplicon_info_file" />
+            </assert_command>
             <output name="output_bam" file="sars-cov-2/sars_cov2_trimmed.bam" compare="sim_size" delta="100000"/>
         </test>
     </tests>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Due to an option name mismatch auto-generation of the amplicon info file never happened in previous versions.
