### PR TITLE
Update legsta to preserve file name

### DIFF
--- a/tools/legsta/legsta.xml
+++ b/tools/legsta/legsta.xml
@@ -7,8 +7,13 @@
     <expand macro="requirements"/>
 
     <command detect_errors="exit_code"><![CDATA[
+        #import re
+        #set safe_names=[]
+
         #for $i in $contigs
-            ln -s '$i' '$i.name';
+            #set safe_name=re.sub('[^\s\w\-]', '_', str($i.element_identifier))
+            $safe_names.append($safe_name)
+            ln -s '$i' '$safe_name';
         #end for
 
         legsta
@@ -16,8 +21,8 @@
         $noheader
         $csv
 
-        #for $i in $contigs
-            '$i.name'
+        #for $safe_name in $safe_names
+            '$safe_name'
         #end for
 
         > '$output'

--- a/tools/legsta/legsta.xml
+++ b/tools/legsta/legsta.xml
@@ -11,7 +11,7 @@
         #set safe_names=[]
 
         #for $i in $contigs
-            #set safe_name=re.sub('[^\s\w\-]', '_', str($i.element_identifier))
+            #set safe_name=re.sub('[^\s\w\-.]', '_', str($i.element_identifier))
             $safe_names.append($safe_name)
             ln -s '$i' '$safe_name';
         #end for

--- a/tools/legsta/legsta.xml
+++ b/tools/legsta/legsta.xml
@@ -45,7 +45,7 @@
             <output name="output">
                 <assert_contents>
                     <has_text text="SBT,flaA,pilE,asd,mip,mompS,proA,neuA" />
-                    <has_text text="1,1,4,3,1,1,1,1" />
+                    <has_text text="NC_006368.fna.bz2,1,1,4,3,1,1,1,1" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/legsta/legsta.xml
+++ b/tools/legsta/legsta.xml
@@ -7,13 +7,17 @@
     <expand macro="requirements"/>
 
     <command detect_errors="exit_code"><![CDATA[
+        #for $i in $contigs
+            ln -s '$i' '$i.name';
+        #end for
+
         legsta
 
         $noheader
         $csv
 
         #for $i in $contigs
-            '$i'
+            '$i.name'
         #end for
 
         > '$output'

--- a/tools/legsta/legsta.xml
+++ b/tools/legsta/legsta.xml
@@ -1,4 +1,4 @@
-<tool id="legsta" name="legsta" version="@TOOL_VERSION@" profile="20.01">
+<tool id="legsta" name="legsta" version="@TOOL_VERSION@+galaxy1" profile="20.01">
     <description>Legionella pneumophila sequence based typing</description>
 
     <macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

As legsta preserves the file name in its output, the file name shown isn't very informative to the user:

```
FILE,SBT,flaA,pilE,asd,mip,mompS,proA,neuA
dataset_1.dat,1,1,4,3,1,1,1,1
```

I've used symbolic links to preserve file names:

```
#for $i in $contigs
    ln -s '$i' '$i.name';
#end for
```

Which should now output:

```
FILE,SBT,flaA,pilE,asd,mip,mompS,proA,neuA
NC_006368.fna.bz2,1,1,4,3,1,1,1,1
```

Please let me know if there's another preferred way of doing this.