### PR TITLE
Change the validator for set_id, add test, bump version

### DIFF
--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -118,8 +118,8 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                         Note that in case of tab-delimited file, the coordinates POS, FROM and TO are one-based and inclusive.
                         ]]></help>
                     </param>
-                    <param name="header_file" type="data" format="txt" label="Header Lines File" optional="True" help="lines which should be appended to the VCF header" />
-                    <param name="header_lines" type="text" area="True" label="Header Lines" optional="True" help="lines which should be appended to the VCF header" >
+                    <param name="header_file" type="data" format="txt" label="Header Lines File" optional="true" help="lines which should be appended to the VCF header" />
+                    <param name="header_lines" type="text" area="true" label="Header Lines" optional="true" help="lines which should be appended to the VCF header" >
                         <help><![CDATA[
                         ##INFO=<ID=NUMERIC_TAG,Number=1,Type=Integer,Description="Example header line">
                         ##INFO=<ID=STRING_TAG,Number=1,Type=String,Description="Yet another header line">
@@ -128,9 +128,9 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                     </param>
                 </when>
             </conditional>
-            <param name="mark_sites" type="text" value="" label="Mark Sites TAG"
+            <param argument="--mark-sites" type="text" value="" label="Mark Sites TAG"
                 help="add INFO/TAG flag to sites which are (&quot;+&quot;) or are not (&quot;-&quot;) listed in the annotations file" />
-            <param name="set_id" type="text" value="" optional="true" label="Set Id">
+            <param argument="--set-id" type="text" value="" optional="true" label="Set Id">
                 <help>Assign ID on the fly using the given format.
                 By default all existing IDs are replaced.
                 If the format string is preceded by "+", only missing IDs will be set.
@@ -141,7 +141,7 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
             </param>
         </section>
         <section name="sec_annotate" expanded="false" title="Change Annotations">
-            <param name="remove" type="text" value="" label="Remove annotations" optional="true">
+            <param argument="--remove" type="text" value="" label="Remove annotations" optional="true">
                 <help><![CDATA[
                  List of annotations to remove.
                  Use "FILTER" to remove all filters or "FILTER/SomeFilter" to remove a specific filter.
@@ -151,7 +151,7 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                 ]]></help>
                 <validator type="regex" message="">^(\^?[A-Z]+(/\w+)?(,\^?[A-Z]+(/\w+)?)*)?$</validator>
             </param>
-            <param name="rename_chrs" type="data" format="tabular" label="Rename CHROM" optional="True"
+            <param argument="--rename-chrs" type="data" format="tabular" label="Rename CHROM" optional="true"
                    help="rename chromosomes according to the map in file, with old_name new_name pairs separated by whitespaces, each on a separate line." />
         </section>
         <section name="sec_restrict" expanded="false" title="Restrict to">

--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -137,7 +137,7 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                 For example: '%CHROM\_%POS\_%REF\_%FIRST_ALT'
                 </help>
                 <sanitizer sanitize="False"/>
-                <validator type="regex" message="">^([+]?(%[A-Z_]+)(\\\_%[A-Z_]+)*)?$</validator>
+                <validator type="regex" message="">^([+]?(%[A-Z_]+)(\\_%[A-Z_]+)*)?$</validator>
             </param>
         </section>
         <section name="sec_annotate" expanded="false" title="Change Annotations">

--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy1">
     <description>Annotate and edit VCF/BCF files</description>
     <macros>
         <token name="@EXECUTABLE@">annotate</token>
@@ -137,7 +137,7 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
                 For example: '%CHROM\_%POS\_%REF\_%FIRST_ALT'
                 </help>
                 <sanitizer sanitize="False"/>
-                <validator type="regex" message="">^([+]?(%[A-Z]+)(\_%[A-Z]+)*)?$</validator>
+                <validator type="regex" message="">^([+]?(%[A-Z_]+)(\\\_%[A-Z_]+)*)?$</validator>
             </param>
         </section>
         <section name="sec_annotate" expanded="false" title="Change Annotations">
@@ -186,10 +186,14 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
             <param name="annotations" value="annotate2.tab" />
             <param name="header_file" value="annotate.hdr" />
             <param name="columns" value="CHROM,FROM,TO,T_STR" />
+            <section name="sec_annofile">
+                <param name="set_id" value="%CHROM\_%POS\_%REF\_%FIRST_ALT" />
+            </section>
             <param name="output_type" value="v" />
             <output name="output_file">
                 <assert_contents>
                     <has_text text="T_STR=region_3000150_3106154" />
+                    <has_text text="1_3062915_GTTT_G" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -182,11 +182,13 @@ $sec_annofile.annofile.header_lines.__str__.strip()#slurp
         </test>
         <test>
             <param name="input_file" ftype="vcf" value="annotate.vcf" />
-            <param name="anno_fmt" value="tab" />
-            <param name="annotations" value="annotate2.tab" />
-            <param name="header_file" value="annotate.hdr" />
-            <param name="columns" value="CHROM,FROM,TO,T_STR" />
             <section name="sec_annofile">
+                <param name="columns" value="CHROM,FROM,TO,T_STR" />
+                <conditional name="annofile">
+                    <param name="anno_fmt" value="tab" />
+                    <param name="annotations" value="annotate2.tab" />
+                    <param name="header_file" value="annotate.hdr" />
+                </conditional>
                 <param name="set_id" value="%CHROM\_%POS\_%REF\_%FIRST_ALT" />
             </section>
             <param name="output_type" value="v" />

--- a/tools/bcftools/bcftools_annotate.xml
+++ b/tools/bcftools/bcftools_annotate.xml
@@ -17,7 +17,7 @@
 #if $section.annofile.anno_fmt == 'vcf':
   #if $section.annofile.annotations.is_of_type('vcf')
     #set $annotation_file = 'annotations.vcf.gz'
-    bgzip -c "$section.annofile.annotations" > $annotation_file &&
+    bgzip -c '$section.annofile.annotations' > $annotation_file &&
     bcftools index $annotation_file &&
   #elif $section.annofile.annotations.is_of_type('bcf')
     #set $annotation_file = 'annotations.bcf'
@@ -31,18 +31,18 @@
 #elif $section.annofile.anno_fmt == 'tab':
   #if $section.annofile.annotations.is_of_type('bed')
     #set $annotation_file = 'annotations.bed.gz'
-    bgzip -c "$section.annofile.annotations" > $annotation_file &&
+    bgzip -c '$section.annofile.annotations' > $annotation_file &&
     tabix -s 1 -b 2 -e 3 $annotation_file &&
   #else:
     #set $annotation_file = 'annotations.tab.gz'
-    bgzip -c "$section.annofile.annotations" > $annotation_file &&
+    bgzip -c '$section.annofile.annotations' > $annotation_file &&
     tabix -s 1 -b 2 -e 2 $annotation_file &&
   #end if
   #if $section.annofile.header_file:
     #set $annotation_hdr = $section.annofile.header_file
   #elif $section.annofile.header_lines:
     #set $annotation_hdr = 'annotation.hdr'
-    grep '^\#\#INFO' ${hdr_file} > $annotation_hdr &&
+    grep '^\#\#INFO' '${hdr_file}' > $annotation_hdr &&
   #end if
 #end if
 #set $section = $sec_restrict
@@ -53,25 +53,25 @@ bcftools @EXECUTABLE@
 #set $section = $sec_annofile
 @COLUMNS@
 #if $annotation_file:
-  --annotations "${annotation_file}"
+  --annotations '${annotation_file}'
 #end if
 #if $annotation_hdr:
-    --header-lines "${annotation_hdr}"
+    --header-lines '${annotation_hdr}'
 #end if
 
 #if $section.set_id:
-  --set-id "${section.set_id}"
+  --set-id '${section.set_id}'
 #end if
 #if $section.mark_sites:
-  --mark-sites "${section.mark_sites}"
+  --mark-sites '${section.mark_sites}'
 #end if
 
 #set $section = $sec_annotate
 #if $section.rename_chrs:
-  --rename-chrs "${section.rename_chrs}"
+  --rename-chrs '${section.rename_chrs}'
 #end if
 #if $section.remove:
-  --remove "${section.remove}"
+  --remove '${section.remove}'
 #end if
 
 ## Default section


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [X] - This PR updates an existing tool or tool collection

Regex modified to allow backslash (`\_` between tags for command line) and underscores in tags (for `%FIRST_ALT`) for the `--set-id` option. The example given on the interface works (used in the test: `%CHROM\_%POS\_%REF\_%FIRST_ALT`)
I've modified the second test (add an assert_contents: `<has_text text="1_3062915_GTTT_G" />`
