### PR TITLE
Updating tools/bracken from version 2.6.1 to
2.7

### DIFF
--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.6.2</token>
+    <token name="@TOOL_VERSION@">2.7</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bracken</requirement>

--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.6.1</token>
+    <token name="@TOOL_VERSION@">2.6.2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bracken</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bracken**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bracken from version 2.6.1 to 2.6.2.

**Project home page:** https://ccb.jhu.edu/software/bracken