### PR TITLE
Updating tools/nextclade from version 1.10.3 to 1.11.0

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.10.3</token>
+    <token name="@TOOL_VERSION@">1.11.0</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/nextclade.xml
+++ b/tools/nextclade/nextclade.xml
@@ -116,7 +116,7 @@
             <param name="organism" value="sars-cov-2" />
             <output name="report_tsv">
                 <assert_contents>
-                    <has_n_columns n="62" />
+                    <has_n_columns n="63" />
                     <has_text text="20A" />
                 </assert_contents>
             </output>
@@ -127,7 +127,7 @@
             <param name="organism" value="sars-cov-2" />
             <output name="report_tsv">
                 <assert_contents>
-                    <has_n_columns n="62" />
+                    <has_n_columns n="63" />
                     <has_text text="20A" />
                 </assert_contents>
             </output>
@@ -152,7 +152,7 @@
             </conditional>
             <output name="report_tsv">
                 <assert_contents>
-                    <has_n_columns n="62" />
+                    <has_n_columns n="63" />
                     <has_text text="mediocre" />
                 </assert_contents>
             </output>
@@ -167,7 +167,7 @@
             </conditional>
             <output name="report_tsv">
                 <assert_contents>
-                    <has_n_columns n="62" />
+                    <has_n_columns n="63" />
                     <has_text text="mediocre" />
                 </assert_contents>
             </output>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.10.3 to 1.11.0.

**Project home page:** https://github.com/nextstrain/nextclade/releases