### PR TITLE
Add code owners for viral lineage assignment tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@
 /tools/minia/                           @nsoranzo
 /tools/mothur/                          @shiltemann
 /tools/ncbi_entrez_eutils/              @hexylena
+/tools/nextclade/                       @pvanheus @wm75
+/tools/pangolin/                        @pvanheus @wm75
 /tools/progressivemauve/                @hexylena
 /tools/prokka/                          @nsoranzo
 /tools/raxml/                           @nsoranzo


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Picking up https://github.com/galaxyproject/tools-iuc/pull/4464#issuecomment-1074877902.
@pvanheus if you agree of course, and putting myself there only as a backup for you.