### PR TITLE
Updating tools/pygenometracks from version 3.6 to 3.7

### DIFF
--- a/tools/pygenometracks/macros.xml
+++ b/tools/pygenometracks/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.6</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">3.7</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">pygenometracks</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pygenometracks**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pygenometracks from version 3.6 to 3.7.

**Project home page:** https://github.com/deeptools/pyGenomeTracks/releases