### PR TITLE
Updating tools/repeatmodeler from version 2.0.2a to 2.0.3

### DIFF
--- a/tools/repeatmodeler/macros.xml
+++ b/tools/repeatmodeler/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.0.2a</token>
+    <token name="@TOOL_VERSION@">2.0.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/repeatmodeler**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/repeatmodeler from version 2.0.2a to 2.0.3.

**Project home page:** https://www.repeatmasker.org/RepeatModeler