### PR TITLE
pathview: fix version token

### DIFF
--- a/tools/pathview/pathview.xml
+++ b/tools/pathview/pathview.xml
@@ -1,14 +1,14 @@
-<tool id="pathview" name="Pathview" version="@TOOL_VERSION@+@VERSION_SUFFIX@" profile="20.05">
+<tool id="pathview" name="Pathview" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05">
     <description>for pathway based data integration and visualization</description>
     <xrefs>
         <xref type="bio.tools">pathview</xref>
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">1.24.0</token>
-        <token name="@VERSION_SUFFIX@">galaxy1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
-        <requirement type="package" version="@VERSION@">bioconductor-pathview</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">bioconductor-pathview</requirement>
         <requirement type="package" version="3.8.2">bioconductor-org.ag.eg.db</requirement>
         <requirement type="package" version="3.8.2">bioconductor-org.at.tair.db</requirement>
         <requirement type="package" version="3.8.2">bioconductor-org.bt.eg.db</requirement>


### PR DESCRIPTION
Noticed accidentally that the weekly tests need forever for pathview, because the tests tried for a long time to build the container and failed with it.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
