### PR TITLE
Updating tools/busco from version 5.3.1 to 5.3.2

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -266,9 +266,9 @@ busco
                 </conditional>
             </conditional>
             <param name="outputs" value="short_summary,missing,image" />
-            <output name="busco_sum" file="genome_results_metaeuk_auto/short_summary" compare="diff" lines_diff="4" />
-            <output name="busco_table" file="genome_results_metaeuk_auto/full_table" compare="diff" lines_diff="0" />
-            <output name="busco_missing" file="genome_results_metaeuk_auto/missing_buscos_list" compare="diff" lines_diff="0" />
+            <output name="busco_sum" file="genome_results_metaeuk_auto/short_summary" compare="diff" lines_diff="6" />
+            <output name="busco_table" file="genome_results_metaeuk_auto/full_table" compare="diff" lines_diff="2" />
+            <output name="busco_missing" file="genome_results_metaeuk_auto/missing_buscos_list" compare="diff" lines_diff="2" />
             <output name="summary_image" file="genome_results_metaeuk_auto/summary.png" compare="sim_size" />
         </test>
     </tests>

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.3.1</token>
+    <token name="@TOOL_VERSION@">5.3.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/busco**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/busco from version 5.3.1 to 5.3.2.

**Project home page:** http://busco.ezlab.org