### PR TITLE
Updating tools/datamash from version 1.1.0 to
1.8

### DIFF
--- a/tools/datamash/macros.xml
+++ b/tools/datamash/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.7</token>
+    <token name="@TOOL_VERSION@">1.8</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="inputs_outputs">

--- a/tools/datamash/macros.xml
+++ b/tools/datamash/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">1.7</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="inputs_outputs">
         <inputs>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/datamash**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/datamash from version 1.1.0 to 1.7.

**Project home page:** https://www.gnu.org/software/datamash