### PR TITLE
Updating tools/pathview from version 1.24.0 to 1.34.0

### DIFF
--- a/tools/pathview/pathview.xml
+++ b/tools/pathview/pathview.xml
@@ -4,31 +4,31 @@
         <xref type="bio.tools">pathview</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">1.24.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">1.34.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-pathview</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.ag.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.at.tair.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.bt.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.ce.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.cf.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.dm.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.dr.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.eck12.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.ecsakai.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.gg.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.hs.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.mm.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.mmu.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.pf.plasmo.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.pt.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.rn.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.sc.sgd.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.ss.eg.db</requirement>
-        <requirement type="package" version="3.8.2">bioconductor-org.xl.eg.db</requirement>
-        <requirement type="package" version="1.6.2">r-optparse</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.ag.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.at.tair.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.bt.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.ce.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.cf.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.dm.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.dr.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.eck12.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.ecsakai.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.gg.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.hs.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.mm.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.mmu.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.pf.plasmo.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.pt.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.rn.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.sc.sgd.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.ss.eg.db</requirement>
+        <requirement type="package" version="3.14.0">bioconductor-org.xl.eg.db</requirement>
+        <requirement type="package" version="1.7.1">r-optparse</requirement>
     </requirements>
     <version_command><![CDATA[
 echo $(R --version | grep version | grep -v GNU)", pathview version" $(R --vanilla --slave -e "library(pathview); cat(sessionInfo()\$otherPkgs\$pathview\$Version)" 2> /dev/null | grep -v -i "WARNING: ")", optparse version" $(R --vanilla --slave -e "library(optparse); cat(sessionInfo()\$otherPkgs\$optparse\$Version)" 2> /dev/null | grep -v -i "WARNING: ")", dplyr version" $(R --vanilla --slave -e "library(dplyr); cat(sessionInfo()\$otherPkgs\$dplyr\$Version)" 2> /dev/null | grep -v -i "WARNING: ")", ggplot2 version" $(R --vanilla --slave -e "library(ggplot2); cat(sessionInfo()\$otherPkgs\$ggplot2\$Version)" 2> /dev/null | grep -v -i "WARNING: ")


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pathview**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pathview from version 1.24.0 to 1.34.0.

**Project home page:** https://bioconductor.org/packages/release/bioc/html/pathview.html