### PR TITLE
Updating tools/biom_format from version 2.1.10 to 2.1.12

### DIFF
--- a/tools/biom_format/macros.xml
+++ b/tools/biom_format/macros.xml
@@ -5,7 +5,7 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">2.1.10</token>
+    <token name="@TOOL_VERSION@">2.1.12</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.05</token>
     <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/biom_format**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/biom_format from version 2.1.10 to 2.1.12.

**Project home page:** https://github.com/biocore/biom-format/releases