### PR TITLE
Updating tools/pangolin from version 4.0.5 to
4.1.1

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,7 +1,7 @@
 <tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.0.6</token>
+        <token name="@TOOL_VERSION@">4.1.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>

--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,11 +1,11 @@
 <tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.0.5</token>
+        <token name="@TOOL_VERSION@">4.0.6</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>
-        <requirement type="package" version="0.3.16">scorpio</requirement>
+        <requirement type="package" version="0.3.17">scorpio</requirement>
         <requirement type="package" version="0.23.0">csvtk</requirement>
     </requirements>
     <version_command><![CDATA[pangolin --version]]></version_command>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pangolin**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pangolin from version 4.0.5 to 4.0.6.

**Project home page:** https://github.com/cov-lineages/pangolin/releases