### PR TITLE
Updating tools/read_it_and_keep from version 0.2.2 to 0.3.0

### DIFF
--- a/tools/read_it_and_keep/read-it-and-keep.xml
+++ b/tools/read_it_and_keep/read-it-and-keep.xml
@@ -1,7 +1,7 @@
 <tool id="read_it_and_keep" name="Read It and Keep" version="@TOOL_VERSION@+galaxy0" profile="20.09">
     <macros>
         <token name="@INPUT_FORMATS@">fasta,fastq,fasta.gz,fastq.gz</token>
-        <token name="@TOOL_VERSION@">0.2.2</token>
+        <token name="@TOOL_VERSION@">0.3.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">read-it-and-keep</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/read_it_and_keep**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/read_it_and_keep from version 0.2.2 to 0.3.0.

**Project home page:** https://github.com/GenomePathogenAnalysisService/read-it-and-keep/releases