### PR TITLE
InterProScan: add new subapp

### DIFF
--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -76,6 +76,7 @@ $iprlookup
             <option value="PRINTS" selected="true">PRINTS: group of conserved motifs (fingerprints) used to characterise a protein family</option>
             <option value="PIRSR" selected="true">PIRSR: protein families based on hidden Markov models (HMMs) and Site Rules</option>
             <option value="PrositePatterns" selected="true">PROSITE Pattern: protein domains, families and functional sites as well as associated patterns to identify them</option>
+            <option value="AntiFam" selected="true">AntiFam: a resource of profile-HMMs designed to identify spurious protein predictions.</option>
             <option value="Pfam" selected="true">Pfam: protein families, each represented by multiple sequence alignments and hidden Markov models</option>
             <option value="MobiDBLite" selected="true">MobiDBLite: Prediction of intrinsically disordered regions in proteins</option>
             <option value="PIRSF" selected="true">PIRSF: non-overlapping clustering of UniProtKB sequences into a hierarchical order (evolutionary relationships)</option>

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -6,7 +6,7 @@
         The version should also be bumped in test-data/interproscan.loc
     -->
     <token name="@TOOL_VERSION@">5.55-88.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
 
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Forgot to add this new option in #4529, here it is.
I've tested this new version on galaxy.genouest.org, it seems to work (with this PR and https://github.com/bioconda/bioconda-recipes/pull/34597), @bgruening it'd be great if you could run the data manager on .eu + make the manual changes for restricted tools as for the previous version!

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
