### PR TITLE
FastQC: detects compression directly instead of depending on user input

### DIFF
--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -25,10 +25,10 @@
         #else
             #set format = 'fastq'
         #end if
-        detected_suffix=`file --mime-type "${input_file}"
+        detected_suffix=\$(file --mime-type "${input_file}"
                          | grep -e "bzip2" -e "gzip"
                          | sed "s/.*application\///"
-                         | sed "s/.*bzip2/.bz2/" | sed "s/.*gzip/.gz/"` &&
+                         | sed "s/.*bzip2/.bz2/" | sed "s/.*gzip/.gz/") &&
         ln -s '${input_file}' '${input_name}'\$detected_suffix &&
         mkdir -p '${html_file.files_path}' &&
         fastqc

--- a/tools/fastqc/rgFastQC.xml
+++ b/tools/fastqc/rgFastQC.xml
@@ -1,4 +1,4 @@
-<tool id="fastqc" name="FastQC" version="0.73+galaxy0">
+<tool id="fastqc" name="FastQC" version="0.73+galaxy1">
     <description>Read Quality reports</description>
     <xrefs>
         <xref type="bio.tools">fastqc</xref>
@@ -18,14 +18,6 @@
         #import re
         #set input_name = re.sub('[^\w\-\s]', '_', str($input_file.element_identifier))
 
-        #if $input_file.ext.endswith('.gz'):
-            #set input_file_sl = $input_name + '.gz'
-        #elif $input_file.ext.endswith('.bz2'):
-            #set input_file_sl = $input_name + '.bz2'
-        #else
-            #set input_file_sl = $input_name
-        #end if
-
         #if 'bam' in $input_file.ext:
             #set format = 'bam'
         #elif 'sam' in $input_file.ext:
@@ -33,8 +25,11 @@
         #else
             #set format = 'fastq'
         #end if
-
-        ln -s '${input_file}' '${input_file_sl}' &&
+        detected_suffix=`file --mime-type "${input_file}"
+                         | grep -e "bzip2" -e "gzip"
+                         | sed "s/.*application\///"
+                         | sed "s/.*bzip2/.bz2/" | sed "s/.*gzip/.gz/"` &&
+        ln -s '${input_file}' '${input_name}'\$detected_suffix &&
         mkdir -p '${html_file.files_path}' &&
         fastqc
             --outdir '${html_file.files_path}'
@@ -58,7 +53,7 @@
             $nogroup
             --kmers $kmers
             -f '${format}'
-            '${input_file_sl}'
+            '${input_name}'\$detected_suffix
 
         && cp '${html_file.files_path}'/*/fastqc_data.txt output.txt
         && cp '${html_file.files_path}'/*\.html output.html


### PR DESCRIPTION
Users sometimes make mistakes when specifying the type of input files (fastqsanger instead of fastqsanger.gz, etc.)
Fastqc is finicky about this - requiring that gzipped files have a .gz extension.

This switches out the user-specified file format detection for a more reliable direct detection using the file command.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
