### PR TITLE
Modify anndata modify_loom so it doesn't write to the input

### DIFF
--- a/tools/anndata/export.xml
+++ b/tools/anndata/export.xml
@@ -110,8 +110,8 @@ adata.write_csvs('.', sep="\t", skip_data = False)
     </tests>
     <help><![CDATA[
 This tool exports an AnnData dataset to a Loom file
-(`write_loom method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.write_loom.html>`__)
-or a Tabular file (`write_csvs method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.write_csvs.html>`__)
+(`write_loom method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.write_loom.html>`__)
+or a Tabular file (`write_csvs method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.write_csvs.html>`__)
 
 It can also create a series of tabular files from an input loom dataset.
 

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -298,10 +298,10 @@ adata.write('anndata.h5ad')
 
 This tool creates an AnnData or loom dataset from several input types:
 
-- Loom (`read_loom method <https://anndata.readthedocs.io/en/latest/anndata.read_loom.html>`__)
-- Tabular (`read_csv method <https://anndata.readthedocs.io/en/latest/anndata.read_csv.html>`__)
-- Matrix Market (mtx), from Cell ranger or not (`read_mtx method <https://anndata.readthedocs.io/en/latest/anndata.read_mtx.html>`__)
-- UMI tools (`read_umi_tools method <https://anndata.readthedocs.io/en/latest/anndata.read_umi_tools.html>`__)
+- Loom (`read_loom method <https://anndata.readthedocs.io/en/latest/generated/anndata.read_loom.html>`__)
+- Tabular (`read_csv method <https://anndata.readthedocs.io/en/latest/generated/anndata.read_csv.html>`__)
+- Matrix Market (mtx), from Cell ranger or not (`read_mtx method <https://anndata.readthedocs.io/en/latest/generated/anndata.read_mtx.html>`__)
+- UMI tools (`read_umi_tools method <https://anndata.readthedocs.io/en/latest/generated/anndata.read_umi_tools.html>`__)
 
 @HELP@
     ]]></help>

--- a/tools/anndata/inspect.xml
+++ b/tools/anndata/inspect.xml
@@ -487,7 +487,7 @@ This tool inspects a AnnData dataset and returns:
 
 - General information about the object as text
 - The full data matrix (`X`) as a Tabular
-- A chunk of the data matrix as a Tabular, using the `chunk_X method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.chunk_X.html>`__
+- A chunk of the data matrix as a Tabular, using the `chunk_X method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.chunk_X.html>`__
 - Key-indexed observations annotation (`obs`) as a Tabular
 - Key-indexed annotation of variables/features (`var`) as a Tabular
 

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -46,7 +46,7 @@ of statistics (`Hastie et al., 2009 <https://web.stanford.edu/~hastie/ElemStatLe
 and machine learning packages in Python (statsmodels, scikit-learn).
 
 More details on the `AnnData documentation
-<https://anndata.readthedocs.io/en/latest/anndata.AnnData.html>`__
+<https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.html>`__
 
 
 **Loom data**

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -390,29 +390,29 @@ This tool takes a AnnData dataset, manipulates it and returns it.
 
 The possible manipulations are: 
 
-- Concatenate along the observations axis (`concatenate method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.concatenate.html>`__) 
+- Concatenate along the observations axis (`concatenate method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.concatenate.html>`__)
 
     The `uns`, `varm` and `obsm` attributes are ignored.
 
     If you use `join='outer'` this fills 0s for sparse data when variables are absent in a batch. Use this with care. Dense data is filled with `NaN`
 
-- Makes the obs index unique by appending '1', '2', etc (`obs_names_make_unique method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.obs_names_make_unique.html>`__) 
+- Makes the obs index unique by appending '1', '2', etc (`obs_names_make_unique method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.obs_names_make_unique.html>`__)
 
     The first occurance of a non-unique value is ignored.
 
-- Makes the var index unique by appending '1', '2', etc (`var_names_make_unique method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.var_names_make_unique.html>`__) 
+- Makes the var index unique by appending '1', '2', etc (`var_names_make_unique method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.var_names_make_unique.html>`__)
 
     The first occurance of a non-unique value is ignored.
 
-- Rename categories of annotation `key` in `obs`, `var` and `uns` (`rename_categories method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.rename_categories.html>`__) 
+- Rename categories of annotation `key` in `obs`, `var` and `uns` (`rename_categories method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.rename_categories.html>`__)
 
     Besides calling `self.obs[key].cat.categories = categories` - similar for `var` - this also renames categories in unstructured annotation that uses the categorical annotation `key`
 
-- Transform string annotations to categoricals (`strings_to_categoricals method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.strings_to_categoricals.html>`__) 
+- Transform string annotations to categoricals (`strings_to_categoricals method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.strings_to_categoricals.html>`__)
 
     Only affects string annotations that lead to less categories than the total number of observations.
 
-- Transpose the data matrix, leaving observations and variables interchanged (`transpose method <https://anndata.readthedocs.io/en/latest/anndata.AnnData.transpose.html>`__)
+- Transpose the data matrix, leaving observations and variables interchanged (`transpose method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.transpose.html>`__)
 
     Data matrix is transposed, observations and variables are interchanged.
 

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -1,4 +1,4 @@
-<tool id="modify_loom" name="Manipulate loom object" version="@VERSION@+@GALAXY_VERSION@">
+<tool id="modify_loom" name="Manipulate loom object" version="@VERSION@+galaxy1">
     <description>Add layers, or row/column attributes to a loom file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -6,7 +6,8 @@
     <expand macro="requirements"/>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[
-python '$__tool_directory__/modify_loom.py' -f '${input}'
+cp '${input}' loom_add_out.loom &&
+python '$__tool_directory__/modify_loom.py' -f 'loom_add_out.loom'
 #if $which_add.add_type == "cols":
     -a cols -c '${which_add.cols}'
 #else if $which_add.add_type == "cols":
@@ -14,7 +15,6 @@ python '$__tool_directory__/modify_loom.py' -f '${input}'
 #else if $which_add.add_type == "layers":
     -a layers -l '${which_add.layers}'
 #end if
-&& cp '${input}' loom_add_out.loom
       ]]></command>
     <inputs>
         <param name="input" type="data" format="loom" label="Loom file"/>


### PR DESCRIPTION
As it is currently, it modifies the input, then copies the input to the output. This just moves the copy up front: copy the input to the output, then modify the output.

I could update the galaxyN version, but that would affect all the tools in the suite, right?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
