### PR TITLE
Fix pangoLEARN mode, update scorpio

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,16 +1,16 @@
-<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy1" profile="20.01">
+<tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy2" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
         <token name="@TOOL_VERSION@">4.0.5</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pangolin</requirement>
-        <requirement type="package" version="0.3.16">scorpio</requirement>
+        <requirement type="package" version="0.3.17">scorpio</requirement>
         <requirement type="package" version="0.23.0">csvtk</requirement>
     </requirements>
     <version_command><![CDATA[pangolin --version]]></version_command>
     <command detect_errors="exit_code"><![CDATA[
-      #if $engine.use_assignment_cache and str($db.source) != "download":
+      #if $str($engine.analysis_mode) == 'usher' and $engine.use_assignment_cache and str($db.source) != "download":
         ## This is no good. Better to fail immediately instead of downloading a lot of data first.
         echo "Using the latest assignment cache requires downloading the latest version of pangolin-data." 1>&2; exit 1
       #else:
@@ -22,7 +22,7 @@
         #else if str($db.source) == "builtin"
             ln -s $db.db_release.fields.path datadir &&
         #end if
-        #if $engine.use_assignment_cache:
+        #if str($engine.analysis_mode) == 'usher' and $engine.use_assignment_cache:
             ## We need to install also the latest UShER assignment cache data.
             ## Pangolin has functionality to do so, but uses it incorrectly.
             ## We use the pangolin function to install into --datadir here,
@@ -216,6 +216,16 @@
                     <has_n_columns n="16" />
                 </assert_contents>
             </output>
+        </test>
+        <!-- Test that use of latest assignment cache requires downloaded other data -->
+        <test expect_failure="true">
+            <param name="input1" value="multiple_alignment.fasta.gz"/>
+            <conditional name="engine">
+                <param name="use_assignment_cache" value="true" />
+            </conditional>
+            <conditional name="db">
+                <param name="source" value="default" />
+            </conditional>
         </test>
         <!-- test with extra expanded_lineage column -->
         <test expect_num_outputs="1">


### PR DESCRIPTION
This changeset

- fixes pangolin's pangoLEARN mode broken by the previous update by
  taking into account that $engine.use_assignment_cache is only defined
  in UShER mode
- ensures that recombinant-parents defined in constellations >= 0.1.7 do
  not prevent lineage assignment by updating scorpio to a version that
  knows how to handle them (see
  https://github.com/cov-lineages/constellations/releases/tag/v0.1.7 and
  https://github.com/cov-lineages/pangolin/issues/445)
- adds a test for failure with incompatible UShER mode settings

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
