### PR TITLE
freebayes leftalign: fix failing weekly CI test

### DIFF
--- a/tools/freebayes/leftalign.xml
+++ b/tools/freebayes/leftalign.xml
@@ -61,7 +61,7 @@
             <param name="ref_file" ftype="fasta" value="leftalign.fa"/>
             <param name="input_bam" ftype="bam" value="left-align-input.bam"/>
             <param name="iterations" value="5"/>
-            <output name="output_bam" file="left-align-output.bam" />
+            <output name="output_bam" file="left-align-output.bam" ftype="bam" lines_diff="2" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
if ftype is not given comparison is made for binary files and not diff of sam files

not sure if this broke due to a change in Galaxy.. its kind of odd, isn't it?


FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
