### PR TITLE
allow user to set sample ID in stacks2_ustacks

### DIFF
--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -3,8 +3,8 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">stacks</requirement>
-            <requirement type="package" version="3.7">python</requirement>
-            <requirement type="package" version="4.6.0">findutils</requirement>
+<!--             <requirement type="package" version="3.7">python</requirement> -->
+<!--             <requirement type="package" version="4.6.0">findutils</requirement> -->
             <yield/>
         </requirements>
     </xml>
@@ -631,5 +631,9 @@ $identifier#slurp
             <option value="--inline_index">@TYPE@ is inline with sequence on single-end read and occurs in FASTQ header (from either i5 or i7 read) (--inline_index)</option>
             <option value="--index_inline">@TYPE@ occurs in FASTQ header (Illumina i5 or i7 read) and is inline with sequence on single-end read (if single read data) or paired-end read (if paired data) (--index_inline)</option>
         </expand>
+    </xml>
+    <!-- for tests that check the output for "stacks completed" -->
+    <xml name="test_element_stacks_completed" token_element_name="">
+        <element name="@ELEMENT_NAME@"><assert_contents><has_text text="stacks completed on" /></assert_contents></element>
     </xml>
 </macros>

--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -3,8 +3,8 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">stacks</requirement>
-<!--             <requirement type="package" version="3.7">python</requirement> -->
-<!--             <requirement type="package" version="4.6.0">findutils</requirement> -->
+            <requirement type="package" version="3.7">python</requirement>
+            <requirement type="package" version="4.6.0">findutils</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/tools/stacks2/macros.xml
+++ b/tools/stacks2/macros.xml
@@ -10,7 +10,7 @@
     </xml>
 
     <token name="@TOOL_VERSION@">2.55</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">20.05</token>
 
     <xml name="citation">

--- a/tools/stacks2/stacks_cstacks.xml
+++ b/tools/stacks2/stacks_cstacks.xml
@@ -110,9 +110,9 @@ $report_mmatches
             <param name="add_log" value="yes"/>
             <output name="output_log"><assert_contents><has_text text="done."/></assert_contents></output>
             <output_collection name="catalog" type="list">
-                <element name="catalog.alleles"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
-                <element name="catalog.snps"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
-                <element name="catalog.tags"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="catalog.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="catalog.snps" />
+                <expand macro="test_element_stacks_completed" element_name="catalog.tags" />
             </output_collection>
         </test>
         <!-- test w non default options (wo gapped, because tested already in ustacks) -->
@@ -139,9 +139,9 @@ $report_mmatches
             <param name="add_log" value="no"/>
             <assert_stderr><has_text text="done."/></assert_stderr>
             <output_collection name="catalog" type="list">
-                <element name="catalog.alleles"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
-                <element name="catalog.snps"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
-                <element name="catalog.tags"><assert_contents><has_text text="# cstacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="catalog.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="catalog.snps" />
+                <expand macro="test_element_stacks_completed" element_name="catalog.tags" />
             </output_collection>
         </test>
     </tests>

--- a/tools/stacks2/stacks_denovomap.xml
+++ b/tools/stacks2/stacks_denovomap.xml
@@ -107,12 +107,7 @@ $pe_options.rm_pcr_duplicates
                         <has_text text="# ustacks version" />
                     </assert_contents>
                 </element>
-                <element name="PopA_01.alleles">
-                    <assert_contents>
-                        <has_text text="# ustacks completed on " />
-                        <has_text_matching expression="1\s+\d+\s+AC\s+50\.00\s+9" />
-                    </assert_contents>
-                </element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
                 <element name="PopA_02.tags">
                     <assert_contents>
                         <has_text text="# ustacks version" />
@@ -123,12 +118,7 @@ $pe_options.rm_pcr_duplicates
                         <has_text text="# ustacks version" />
                     </assert_contents>
                 </element>
-                <element name="PopA_02.alleles">
-                    <assert_contents>
-                        <has_text text="# ustacks completed on " />
-                        <has_text_matching expression="2\s+\d+\s+AC\s+50\.00\s+6" />
-                    </assert_contents>
-                </element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
             <output_collection name="catalog" type="list" count="3">
                 <element name="catalog.alleles">

--- a/tools/stacks2/stacks_denovomap.xml
+++ b/tools/stacks2/stacks_denovomap.xml
@@ -96,36 +96,110 @@ $pe_options.rm_pcr_duplicates
             </param>
             <param name="popmap" ftype="tabular" value="denovo_map/popmap_cstacks.tsv"/>
             <output ftype="txt" name="output_log"><assert_contents><has_text text="denovo_map.pl is done."/></assert_contents></output>
-            <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags" file="ustacks/PopA_01.tags.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_01.snps" file="ustacks/PopA_01.snps.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_01.alleles" file="ustacks/PopA_01.alleles.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_02.tags" file="ustacks/PopA_02.tags.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_02.snps" file="ustacks/PopA_02.snps.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_02.alleles" file="ustacks/PopA_02.alleles.tsv" ftype="tabular" lines_diff="4"/>
+            <output_collection name="tabs" type="list" count="6">
+                <element name="PopA_01.tags">
+                <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_01.snps">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_01.alleles">
+                    <assert_contents>
+                        <has_text text="# ustacks completed on " />
+                        <has_text_matching expression="1\s+\d+\s+AC\s+50\.00\s+9" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_02.tags">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_02.snps">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_02.alleles">
+                    <assert_contents>
+                        <has_text text="# ustacks completed on " />
+                        <has_text_matching expression="2\s+\d+\s+AC\s+50\.00\s+6" />
+                    </assert_contents>
+                </element>
             </output_collection>
             <output_collection name="catalog" type="list" count="3">
-                <element name="catalog.alleles" file="cstacks/catalog.alleles.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="catalog.snps" file="cstacks/catalog.snps.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="catalog.tags" file="cstacks/catalog.tags.tsv" ftype="tabular" lines_diff="4"/>
+                <element name="catalog.alleles">
+                    <assert_contents>
+                        <has_text text="# cstacks version " />
+                    </assert_contents>
+                </element>
+                <element name="catalog.snps" >
+                    <assert_contents>
+                        <has_text text="# cstacks version" />
+                    </assert_contents>
+                </element>
+                <element name="catalog.tags">
+                    <assert_contents>
+                        <has_text text="# cstacks version" />
+                    </assert_contents>
+                </element>
             </output_collection>
             <output_collection name="matches" type="list" count="2">
-                <element name="PopA_01.matches" file="sstacks/PopA_01.matches.tsv" ftype="tabular" lines_diff="4"/>
-                <element name="PopA_02.matches" file="sstacks/PopA_02.matches.tsv" ftype="tabular" lines_diff="4"/>
+                <element name="PopA_01.matches">
+                    <assert_contents>
+                        <has_text text="# sstacks version" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_02.matches" >
+                    <assert_contents>
+                        <has_text text="# sstacks version" />
+                    </assert_contents>
+                </element>
             </output_collection>
             <output_collection name="bams" type="list" count="2">
-                <element name="PopA_01.matches" file="tsv2bam/PopA_01.matches.bam" ftype="bam"/>
-                <element name="PopA_02.matches" file="tsv2bam/PopA_02.matches.bam" ftype="bam"/>
+                <element name="PopA_01.matches">
+                    <assert_contents>
+                        <has_size value="1153" delta="200" />
+                    </assert_contents>
+                </element>
+                <element name="PopA_02.matches" >
+                    <assert_contents>
+                        <has_size value="1169" delta="200" />
+                    </assert_contents>
+                </element>
             </output_collection>
             <output_collection name="gstacks_out" type="list" count="2">
-                <element name="catalog.calls.vcf" file="gstacks/catalog.calls.vcf" ftype="vcf" lines_diff="4"/>
-                <element name="catalog.fa.gz" file="gstacks/catalog.fa.gz" ftype="fasta.gz" compare="diff"/>
+                <element name="catalog.calls.vcf">
+                    <assert_contents>
+                        <has_text text="##fileformat=VCFv4.2" />
+                    </assert_contents>
+                </element>
+                <element name="catalog.fa.gz" >
+                    <assert_contents>
+                        <has_size value="334" delta="100" />
+                    </assert_contents>
+                </element>
             </output_collection>
-            <output ftype="tabular" name="out_haplotypes" value="populations/populations.haplotypes.tsv"/>
-            <output ftype="tabular" name="out_hapstats" value="populations/populations.hapstats.tsv" compare="diff"/>
+            <output name="out_haplotypes">
+                <assert_contents>
+                    <has_text_matching expression="\#\s+Catalog\s+Locus\s+ID\s+Cnt" />
+                </assert_contents>
+            </output>
+            <output name="out_hapstats">
+                <assert_contents>
+                    <has_text_matching expression="\#\s+Locus\s+ID\s+Chr\s+BP" />
+                </assert_contents>
+            </output>
             <output ftype="txt" name="out_populations_log_distribs" value="populations/populations.log.distribs"/>
             <output ftype="tabular" name="out_sumstats_sum" value="populations/populations.sumstats_summary.tsv"/>
-            <output ftype="tabular" name="out_sumstats" value="populations/populations.sumstats.tsv"/>
+            <output name="out_sumstats">
+                <assert_contents>
+                    <has_text_matching expression="\#\s+Locus\s+ID\s+Chr\s+BP" />
+                </assert_contents>
+            </output>
         </test>
         <!-- SE input as multi selection, defaults testing against the output of the pipeline components -->
         <test expect_num_outputs="11">

--- a/tools/stacks2/stacks_sstacks.xml
+++ b/tools/stacks2/stacks_sstacks.xml
@@ -114,8 +114,8 @@ $x
             </assert_command>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="done."/></assert_contents></output>
             <output_collection name="matches" type="list" count="2">
-                <element name="PopA_01.matches"><assert_contents><has_text text="# sstacks completed on "/></assert_contents></element>
-                <element name="PopA_02.matches"><assert_contents><has_text text="# sstacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.matches" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.matches" />
             </output_collection>
         </test>
 
@@ -149,8 +149,8 @@ $x
             </assert_command>
             <assert_stderr><has_text text="done."/></assert_stderr>
             <output_collection name="matches" type="list" count="2">
-                <element name="PopA_01.matches"><assert_contents><has_text text="# sstacks completed on "/></assert_contents></element>
-                <element name="PopA_02.matches"><assert_contents><has_text text="# sstacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.matches" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.matches" />
             </output_collection>
         </test>
     </tests>

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -126,7 +126,11 @@ true
             <!-- 1st test checks for file content allowing differences in the 2 comment lines that contain date and version -->
             <output_collection name="tabs" type="list" count="6">
                 <element name="PopA_01.tags" ftype="tabular" file="ustacks/PopA_01.tags.tsv" lines_diff="4"/>
-                <element name="PopA_01.snps" ftype="tabular" file="ustacks/PopA_01.snps.tsv" lines_diff="4"/>
+                <element name="PopA_01.snps">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
                 <element name="PopA_01.alleles">
                     <assert_contents>
                         <has_text text="# ustacks completed on " />
@@ -134,7 +138,11 @@ true
                     </assert_contents>
                 </element>
                 <element name="PopA_02.tags" ftype="tabular" file="ustacks/PopA_02.tags.tsv" lines_diff="4"/>
-                <element name="PopA_02.snps" ftype="tabular" file="ustacks/PopA_02.snps.tsv" lines_diff="4"/>
+                <element name="PopA_02.snps">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
                 <element name="PopA_02.alleles">
                     <assert_contents>
                         <has_text text="# ustacks completed on " />

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -11,7 +11,7 @@
 trap ">&2 cat '$output_log'" err exit &&
 mkdir stacks_inputs stacks_outputs &&
 
-#set $ID=1
+#set $ID=int($processing_options.i)
 #for $sample in $input_type.fqinputs
     #set ($create_links, $data_path, $name, $inputype) = $fastq_input_foo($sample, "forward", ".1")
     $create_links
@@ -89,6 +89,9 @@ true
         <!-- SNP Model options -->
         <section name="snp_options" title="SNP Model Options (ustacks options)" expanded="False">
             <expand macro="snp_options_full"/>
+        </section>
+        <section name="processing_options" title="Processing options" expanded="True">
+            <param argument="-i" type="integer" value="1" label="Start identifier at" help="If you are combining multiple ustack runs at the cstacks stage, use this to make sure the samples don't have the same identifier."/>
         </section>
         <expand macro="in_log"/>
     </inputs>
@@ -255,6 +258,23 @@ true
                 <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
             </output_collection>
         </test>
+        <!-- test setting i -->
+        <test expect_num_outputs="2">
+            <param name="input_type|input_type_select" value="single"/>
+            <param name="input_type|fqinputs" value="demultiplexed/PopA_01.1.fq,demultiplexed/PopA_02.1.fq" ftype="fastqsanger"/>
+            <param name="add_log" value="yes"/>
+            <param name="i" value="42"/>
+            <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
+            <output_collection name="tabs" count="6">
+                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+            </output_collection>
+        </test>
+
     </tests>
 
     <help>

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -90,8 +90,8 @@ true
         <section name="snp_options" title="SNP Model Options (ustacks options)" expanded="False">
             <expand macro="snp_options_full"/>
         </section>
-        <section name="processing_options" title="Processing options" expanded="True">
-            <param argument="-i" type="integer" value="1" label="Start identifier at" help="If you are combining multiple ustack runs at the cstacks stage, use this to make sure the samples don't have the same identifier."/>
+        <section name="processing_options" title="Processing options" expanded="False">
+            <param argument="-i" type="integer" value="1" label="Start identifier at" help="If you are combining multiple ustacks runs at the cstacks stage, use this option to avoid having different samples with the same identifier."/>
         </section>
         <expand macro="in_log"/>
     </inputs>
@@ -127,10 +127,20 @@ true
             <output_collection name="tabs" type="list" count="6">
                 <element name="PopA_01.tags" ftype="tabular" file="ustacks/PopA_01.tags.tsv" lines_diff="4"/>
                 <element name="PopA_01.snps" ftype="tabular" file="ustacks/PopA_01.snps.tsv" lines_diff="4"/>
-                <element name="PopA_01.alleles" ftype="tabular" file="ustacks/PopA_01.alleles.tsv" lines_diff="4"/>
+                <element name="PopA_01.alleles">
+                    <assert_contents>
+                        <has_text text="# ustacks completed on " />
+                        <has_text_matching expression="1\s+\d+\s+AC\s+50\.00\s+9" />
+                    </assert_contents>
+                </element>
                 <element name="PopA_02.tags" ftype="tabular" file="ustacks/PopA_02.tags.tsv" lines_diff="4"/>
                 <element name="PopA_02.snps" ftype="tabular" file="ustacks/PopA_02.snps.tsv" lines_diff="4"/>
-                <element name="PopA_02.alleles" ftype="tabular" file="ustacks/PopA_02.alleles.tsv" lines_diff="4"/>
+                <element name="PopA_02.alleles">
+                    <assert_contents>
+                        <has_text text="# ustacks completed on " />
+                        <has_text_matching expression="2\s+\d+\s+AC\s+50\.00\s+6" />
+                    </assert_contents>
+                </element>
             </output_collection>
         </test>
         <!-- manual selected list of elements + default args, test for file equality -->

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -156,12 +156,12 @@ true
             <param name="add_log" value="yes"/>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
             <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
         <!-- manual selected list of elements + non-default short args, test for file presence -->
@@ -183,12 +183,12 @@ true
             </assert_command>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
             <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
         <!-- paired list, non-default model options, disabled gapped alignment, test for file presence -->
@@ -229,12 +229,12 @@ true
             </assert_command>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
             <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
         <!-- list of fwd reads, nondefault assembly and gapped alignment options, test for file presence -->
@@ -266,12 +266,12 @@ true
             </assert_command>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
             <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
         <!-- test setting i -->
@@ -282,12 +282,12 @@ true
             <param name="i" value="42"/>
             <output name="output_log" ftype="txt"><assert_contents><has_text text="ustacks is done."/></assert_contents></output>
             <output_collection name="tabs" count="6">
-                <element name="PopA_01.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_01.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.tags"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.snps"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
-                <element name="PopA_02.alleles"><assert_contents><has_text text="# ustacks completed on "/></assert_contents></element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.tags" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.snps" />
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
 

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -135,12 +135,7 @@ true
                         <has_text text="# ustacks version" />
                     </assert_contents>
                 </element>
-                <element name="PopA_01.alleles">
-                    <assert_contents>
-                        <has_text text="# ustacks completed on " />
-                        <has_text_matching expression="1\s+\d+\s+AC\s+50\.00\s+9" />
-                    </assert_contents>
-                </element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_01.alleles" />
                 <element name="PopA_02.tags">
                     <assert_contents>
                         <has_text text="# ustacks version" />
@@ -151,12 +146,7 @@ true
                         <has_text text="# ustacks version" />
                     </assert_contents>
                 </element>
-                <element name="PopA_02.alleles">
-                    <assert_contents>
-                        <has_text text="# ustacks completed on " />
-                        <has_text_matching expression="2\s+\d+\s+AC\s+50\.00\s+6" />
-                    </assert_contents>
-                </element>
+                <expand macro="test_element_stacks_completed" element_name="PopA_02.alleles" />
             </output_collection>
         </test>
         <!-- manual selected list of elements + default args, test for file equality -->

--- a/tools/stacks2/stacks_ustacks.xml
+++ b/tools/stacks2/stacks_ustacks.xml
@@ -125,7 +125,11 @@ true
             <output name="output_log"><assert_contents><has_text text="done."/></assert_contents></output>
             <!-- 1st test checks for file content allowing differences in the 2 comment lines that contain date and version -->
             <output_collection name="tabs" type="list" count="6">
-                <element name="PopA_01.tags" ftype="tabular" file="ustacks/PopA_01.tags.tsv" lines_diff="4"/>
+                <element name="PopA_01.tags">
+                <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
                 <element name="PopA_01.snps">
                     <assert_contents>
                         <has_text text="# ustacks version" />
@@ -137,7 +141,11 @@ true
                         <has_text_matching expression="1\s+\d+\s+AC\s+50\.00\s+9" />
                     </assert_contents>
                 </element>
-                <element name="PopA_02.tags" ftype="tabular" file="ustacks/PopA_02.tags.tsv" lines_diff="4"/>
+                <element name="PopA_02.tags">
+                    <assert_contents>
+                        <has_text text="# ustacks version" />
+                    </assert_contents>
+                </element>
                 <element name="PopA_02.snps">
                     <assert_contents>
                         <has_text text="# ustacks version" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

---

Hi,

Some Galaxy Australia users want to combine the output of multiple `ustacks` runs at the `cstacks` (catalog building) stage. The current wrapper sets the sample ID for the first sample to 1 and then increments by 1 for each sample. This means sample IDs collide across `ustacks` runs, which causes an error in `cstacks`.

I've added a new parameter (and a test) to `ustacks` to allow the user to set the ID for the first sample. I couldn't think of a lower-impact way of doing it.

Unrelated: one of the existing ustacks tests is failing. I think this might be because the locus ID in the ustacks output changes between runs. I had to modify the tests from diff to `assert_contents`.

Gruß!
Tom