### PR TITLE
Updating tools/ggplot2 from version 3.3.5 to 3.3.6

### DIFF
--- a/tools/ggplot2/ggplot2_heatmap.xml
+++ b/tools/ggplot2/ggplot2_heatmap.xml
@@ -6,10 +6,10 @@
     <requirements>
         <requirement type="package" version="1.1.1">r-cowplot</requirement>
         <requirement type="package" version="0.4.5">r-egg</requirement>
-        <requirement type="package" version="0.1.22">r-ggdendro</requirement>
-        <requirement type="package" version="1.0.7">r-dplyr</requirement>
+        <requirement type="package" version="0.1.23">r-ggdendro</requirement>
+        <requirement type="package" version="1.0.9">r-dplyr</requirement>
         <requirement type="package" version="1.4.4">r-reshape2</requirement>
-        <requirement type="package" version="2.0.0">r-svglite</requirement>
+        <requirement type="package" version="2.1.0">r-svglite</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 cat '$script' &&

--- a/tools/ggplot2/ggplot2_pca.xml
+++ b/tools/ggplot2/ggplot2_pca.xml
@@ -4,8 +4,8 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="0.4.13">r-ggfortify</requirement>
-        <requirement type="package" version="2.0.0">r-svglite</requirement>
+        <requirement type="package" version="0.4.14">r-ggfortify</requirement>
+        <requirement type="package" version="2.1.0">r-svglite</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 cat '$script' &&

--- a/tools/ggplot2/ggplot_histogram.xml
+++ b/tools/ggplot2/ggplot_histogram.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="1.4.4">r-reshape2</requirement>
-        <requirement type="package" version="2.0.0">r-svglite</requirement>
+        <requirement type="package" version="2.1.0">r-svglite</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 cat '$script' &&

--- a/tools/ggplot2/ggplot_point.xml
+++ b/tools/ggplot2/ggplot_point.xml
@@ -4,7 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="2.0.0">r-svglite</requirement>
+        <requirement type="package" version="2.1.0">r-svglite</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 cat '$script' &&

--- a/tools/ggplot2/ggplot_violin.xml
+++ b/tools/ggplot2/ggplot_violin.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="requirements">
         <requirement type="package" version="1.4.4">r-reshape2</requirement>
-        <requirement type="package" version="2.0.0">r-svglite</requirement>
+        <requirement type="package" version="2.1.0">r-svglite</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 cat '$script' &&

--- a/tools/ggplot2/macros.xml
+++ b/tools/ggplot2/macros.xml
@@ -12,7 +12,7 @@
             <xref type="bio.tools">ggplot2</xref>
         </xrefs>
     </xml>
-    <token name="@TOOL_VERSION@">3.3.5</token>
+    <token name="@TOOL_VERSION@">3.3.6</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ggplot2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ggplot2 from version 3.3.5 to 3.3.6.

**Project home page:** https://github.com/tidyverse/ggplot2/releases