### PR TITLE
Updating tools/heatmap2 from version 3.1.1 to 3.1.3

### DIFF
--- a/tools/heatmap2/heatmap2.xml
+++ b/tools/heatmap2/heatmap2.xml
@@ -1,7 +1,7 @@
 <tool id="ggplot2_heatmap2" name="heatmap2" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <macros>
-        <token name="@TOOL_VERSION@">3.1.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">3.1.3</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">r-gplots</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/heatmap2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/heatmap2 from version 3.1.1 to 3.1.3.

**Project home page:** https://github.com/cran/gplots/releases