### PR TITLE
fix tool version requirement in goseq

### DIFF
--- a/tools/goseq/goseq.xml
+++ b/tools/goseq/goseq.xml
@@ -14,7 +14,7 @@
         <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
-        <requirement type="package" version="@VERSION@">bioconductor-goseq</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">bioconductor-goseq</requirement>
         <requirement type="package" version="3.13.0">bioconductor-org.hs.eg.db</requirement>
         <requirement type="package" version="3.13.0">bioconductor-org.dm.eg.db</requirement>
         <requirement type="package" version="3.13.0">bioconductor-org.dr.eg.db</requirement>


### PR DESCRIPTION
I'm not really sure why those tool test pass, I assume Docker can not be build but the conda packages are installed?