### PR TITLE
Updating tools/purge_dups from version 1.2.5 to 1.2.6

### DIFF
--- a/tools/purge_dups/macros.xml
+++ b/tools/purge_dups/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.2.5</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@TOOL_VERSION@">1.2.6</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="xrefs">
         <xrefs>
             <xref type="bio.tools">purge_dups</xref>
@@ -75,7 +75,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">purge_dups</requirement>
-            <requirement type="package" version="3.4.2">matplotlib-base</requirement>
+            <requirement type="package" version="3.5.2">matplotlib-base</requirement>
         </requirements>
     </xml>
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/purge_dups**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/purge_dups from version 1.2.5 to 1.2.6.

**Project home page:** https://github.com/dfguan/purge_dups/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).