### PR TITLE
Update pyega3.xml: missing --start

### DIFF
--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -32,7 +32,7 @@
       --max-retries 10
       #if $action.range.reference_name
         --reference-name '$action.range.reference_name'
-        #if $action.range.start+1
+        #if $action.range.start.length()
           --start $action.range.start
         #end if
         #if $action.range.end
@@ -52,7 +52,7 @@
           --max-retries 10
           #if $action.range.reference_name
           --reference-name '$action.range.reference_name'
-          #if $action.range.start+1
+          #if $action.range.start.length()
             --start $action.range.start
           #end if
           #if $action.range.end

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -32,7 +32,7 @@
       --max-retries 10
       #if $action.range.reference_name
         --reference-name '$action.range.reference_name'
-        #if $action.range.start.length()
+        #if not($action.range.start="")
           --start $action.range.start
         #end if
         #if $action.range.end
@@ -52,7 +52,7 @@
           --max-retries 10
           #if $action.range.reference_name
           --reference-name '$action.range.reference_name'
-          #if $action.range.start.length()
+          #if not($action.range.start="")
             --start $action.range.start
           #end if
           #if $action.range.end

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -32,7 +32,7 @@
       --max-retries 10
       #if $action.range.reference_name
         --reference-name '$action.range.reference_name'
-        #if $action.range.start != ""
+        #if $action.range.start+1
           --start $action.range.start
         #end if
         #if $action.range.end
@@ -52,7 +52,7 @@
           --max-retries 10
           #if $action.range.reference_name
           --reference-name '$action.range.reference_name'
-          #if $action.range.start != ""
+          #if $action.range.start+1
             --start $action.range.start
           #end if
           #if $action.range.end

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -32,7 +32,7 @@
       --max-retries 10
       #if $action.range.reference_name
         --reference-name '$action.range.reference_name'
-        #if not($action.range.start="")
+        #if str($action.range.start)
           --start $action.range.start
         #end if
         #if $action.range.end
@@ -52,7 +52,7 @@
           --max-retries 10
           #if $action.range.reference_name
           --reference-name '$action.range.reference_name'
-          #if not($action.range.start="")
+          #if str($action.range.start)
             --start $action.range.start
           #end if
           #if $action.range.end

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,4 +1,4 @@
-<tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy0" profile="21.01" >
+<tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy0.1" profile="21.01" >
     <macros>
         <token name="@TOOL_VERSION@">4.0.0</token>
     </macros>
@@ -165,7 +165,7 @@
             <param name="action_type" value="download_file"/>
             <param name="file_id" value="EGAF00001753756"/>
             <param name="reference_name" value="1"/>
-            <param name="start" value="100"/>
+            <param name="start" value="0"/>
             <param name="end" value="10000"/>
             <output name="downloaded_file" ftype="bam" md5="e576a38748feec45aa45191f6e902ce2"/>
         </test>
@@ -183,11 +183,11 @@
             <param name="id_table" value="filelist2.tabular"/>
             <param name="id_column" value="1"/>
             <param name="reference_name" value="1"/>
-            <param name="start" value="100"/>
+            <param name="start" value="0"/>
             <param name="end" value="10000"/>
             <output_collection name="downloaded_file_collection" count="2">
-                <element name="NA19239_genomic_range_1_100_10000" md5="bcdcf18846233cbe5cc8afd95168552c" />
-                <element name="NA19240_genomic_range_1_100_10000" md5="e576a38748feec45aa45191f6e902ce2" />
+                <element name="NA19239_genomic_range_1_0_10000" md5="bcdcf18846233cbe5cc8afd95168552c" />
+                <element name="NA19240_genomic_range_1_0_10000" md5="e576a38748feec45aa45191f6e902ce2" />
             </output_collection>
         </test>
     </tests>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,4 +1,4 @@
-<tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy0.1" profile="21.01" >
+<tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy1" profile="21.01" >
     <macros>
         <token name="@TOOL_VERSION@">4.0.0</token>
     </macros>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -32,7 +32,7 @@
       --max-retries 10
       #if $action.range.reference_name
         --reference-name '$action.range.reference_name'
-        #if $action.range.start
+        #if $action.range.start != ""
           --start $action.range.start
         #end if
         #if $action.range.end
@@ -52,7 +52,7 @@
           --max-retries 10
           #if $action.range.reference_name
           --reference-name '$action.range.reference_name'
-          #if $action.range.start
+          #if $action.range.start != ""
             --start $action.range.start
           #end if
           #if $action.range.end


### PR DESCRIPTION
When providing the start position 0 to the pyega3 tool it will skip the argument, since the if will see a 0.
I think this change should fix it?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
