### PR TITLE
Updating tools/drep from version 3.2.2 to 3.3.0

### DIFF
--- a/tools/drep/drep_dereplicate.xml
+++ b/tools/drep/drep_dereplicate.xml
@@ -5,7 +5,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.1.3">checkm-genome</requirement>
+        <requirement type="package" version="1.2.0">checkm-genome</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
 @PREPARE_GENOMES@

--- a/tools/drep/macros.xml
+++ b/tools/drep/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">3.2.2</token>
+    <token name="@TOOL_VERSION@">3.3.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.01</token>
     <xml name="biotools">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/drep**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/drep from version 3.2.2 to 3.3.0.

**Project home page:** https://github.com/MrOlm/drep/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).