### PR TITLE
spyboat: allow 1 line difference in output

### DIFF
--- a/tools/spyboat/spyboat.xml
+++ b/tools/spyboat/spyboat.xml
@@ -1,7 +1,8 @@
-<tool id="spyboat" name="SpyBOAT" version="@TOOL_VERSION@" profile="20.01"  license="GPL-3.0-or-later">
+<tool id="spyboat" name="SpyBOAT" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01"  license="GPL-3.0-or-later">
 <description>wavelet analyzes image stacks</description>
     <macros>
         <token name="@TOOL_VERSION@">0.1.1</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">spyboat</requirement>
@@ -150,7 +151,8 @@
                     <has_size value="1764430" delta="10000" />
                 </assert_contents>
             </output>
-            <output name="html_out" file="output1.html" ftype="html"/>
+            <!--allow for 1 differing line due to number of CPUs which might change-->
+            <output name="html_out" file="output1.html" ftype="html" lines_diff="2"/>
         </test>
         <test expect_num_outputs="4">
             <section name="wavana">


### PR DESCRIPTION
which contains the number of used cores

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
