### PR TITLE
vg deconstruct: sort test data

### DIFF
--- a/tools/vg/deconstruct.xml
+++ b/tools/vg/deconstruct.xml
@@ -1,4 +1,4 @@
-<tool id="vg_deconstruct" name="vg deconstruct" version="@TOOL_VERSION@">
+<tool id="vg_deconstruct" name="vg deconstruct" version="@TOOL_VERSION@+galaxy1">
     <description>construct a dynamic succinct variation graph</description>
     <macros>
         <import>macros.xml</import>
@@ -67,7 +67,7 @@ $path_traversals  ## -e
             <param name="infile" value="hla.xg" />
             <param name="path" value="gi|568815592:29791752-29792749" />
             <param name="path_traversals" value="true" />
-            <output name="output" file="hla_variants.vcf" />
+            <output name="output" file="hla_variants.vcf" sort="true" />
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
currently failing CI because if different line ordering

might be due to the use of two cores?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
