### PR TITLE
Updating tools/anndata from version 0.7.5 to 0.10.8

### DIFF
--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.9.5">scanpy</requirement>
+        <requirement type="package" version="1.9.6">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.9.1">scanpy</requirement>
+        <requirement type="package" version="1.9.3">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.9.3">scanpy</requirement>
+        <requirement type="package" version="1.9.5">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.9.8">scanpy</requirement>
+        <requirement type="package" version="1.10.1">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.9.6">scanpy</requirement>
+        <requirement type="package" version="1.9.8">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -13,7 +13,7 @@
         </xml>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.7.0">scanpy</requirement>
+        <requirement type="package" version="1.9.1">scanpy</requirement>
     </expand>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.8.0</token>
+    <token name="@TOOL_VERSION@">0.9.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.1</token>
+    <token name="@TOOL_VERSION@">0.10.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.2</token>
+    <token name="@TOOL_VERSION@">0.10.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.9.2</token>
+    <token name="@TOOL_VERSION@">0.10.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.3</token>
+    <token name="@TOOL_VERSION@">0.10.4</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.9.1</token>
+    <token name="@TOOL_VERSION@">0.9.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.7</token>
+    <token name="@TOOL_VERSION@">0.10.8</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.5.post1</token>
+    <token name="@TOOL_VERSION@">0.10.6</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.6</token>
+    <token name="@TOOL_VERSION@">0.10.7</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.10.4</token>
+    <token name="@TOOL_VERSION@">0.10.5.post1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,10 +1,10 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7.5</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">0.8.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">anndata</requirement>
-            <requirement type="package" version="2.0.17">loompy</requirement>
+            <requirement type="package" version="3.0.6">loompy</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -1,4 +1,4 @@
-<tool id="modify_loom" name="Manipulate loom object" version="@TOOL_VERSION@+galaxy1">
+<tool id="modify_loom" name="Manipulate loom object" version="@TOOL_VERSION@+galaxy0">
     <description>Add layers, or row/column attributes to a loom file</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/anndata**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/anndata from version 0.7.5 to 0.8.0.

**Project home page:** https://anndata.readthedocs.io

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).