### PR TITLE
medaka: copy fasta file

### DIFF
--- a/tools/medaka/macros.xml
+++ b/tools/medaka/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.4.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">20.01</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">21.01</token>
     <xml name="bio_tools">
         <xrefs>
             <xref type="bio.tools">medaka</xref>

--- a/tools/medaka/macros.xml
+++ b/tools/medaka/macros.xml
@@ -166,6 +166,6 @@ r941_prom_hac_g303 should be used with PromethION data and the high accuracy bas
     ]]></token>
 
     <token name="@REFERENCES@"><![CDATA[
-More information are available in the `manual <https://nanoporetech.github.io/medaka/index.html>`_ and `github <https://github.com/nanoporetech/medaka>`_.
+More information are available in the `manual <https://github.com/nanoporetech/medaka/tree/master/docs>`_ and `github <https://github.com/nanoporetech/medaka>`_.
     ]]></token>
 </macros>

--- a/tools/medaka/medaka_consensus.xml
+++ b/tools/medaka/medaka_consensus.xml
@@ -126,7 +126,7 @@ The *medaka_consensus* pipeline performs assembly polishing via neural networks.
 
 **Input**
 
-An *assembly* in .fasta format and *basecalls* in .fasta or .fastq format are required. See `Creating a Draft Assembly  <https://nanoporetech.github.io/medaka/walkthrough.html#basecalling-and-draft-assembly>`_ for a detailed example of one method of obtaining these.
+An *assembly* in .fasta format and *basecalls* in .fasta or .fastq format are required. See `Creating a Draft Assembly  <https://github.com/nanoporetech/medaka/blob/master/docs/walkthrough.rst>`_ for a detailed example of one method of obtaining these.
 
 ----
 

--- a/tools/medaka/medaka_consensus.xml
+++ b/tools/medaka/medaka_consensus.xml
@@ -6,7 +6,8 @@
     <expand macro="requirements"/>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[
-ln -s '$d' 'input_assembly.fa' &&
+## symlink seems insuffiencient (fai file is still created next to link target)
+cp '$d' 'input_assembly.fa' &&
 medaka_consensus
 ## optional
 -m ${m}


### PR DESCRIPTION
linking is insufficient (fai file is still created next to the link target)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
