### PR TITLE
Lofreq fixes

### DIFF
--- a/tools/lofreq/lofreq_alnqual.xml
+++ b/tools/lofreq/lofreq_alnqual.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_alnqual" name="Add LoFreq alignment quality scores" version="@TOOL_VERSION@+galaxy0" profile="18.01">
+<tool id="lofreq_alnqual" name="Add LoFreq alignment quality scores" version="@TOOL_VERSION@+galaxy1" profile="18.01">
     <description>to aligned read SAM/BAM records</description>
     <macros>
         <import>macros.xml</import>
@@ -23,7 +23,7 @@
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="ref_selector" value="history" />
             <param name="ref" ftype="fasta" value="pBR322.fa" />
-            <output name="output" file="alnqual-out1.bam" />
+            <output name="output" file="alnqual-out1.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
@@ -32,7 +32,7 @@
             <conditional name="alnqual_choice">
                 <param name="alnquals_to_use" value="-B" />
             </conditional>
-            <output name="output" file="alnqual-out2.bam" />
+            <output name="output" file="alnqual-out2.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
@@ -41,7 +41,7 @@
             <conditional name="alnqual_choice">
                 <param name="alnquals_to_use" value="-A" />
             </conditional>
-            <output name="output" file="alnqual-out3.bam" />
+            <output name="output" file="alnqual-out3.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
@@ -50,14 +50,14 @@
             <conditional name="alnqual_choice">
                 <param name="extended_baq" value="false" />
             </conditional>
-            <output name="output" file="alnqual-out4.bam" />
+            <output name="output" file="alnqual-out4.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="ref_selector" value="history" />
             <param name="ref" ftype="fasta" value="pBR322.fa" />
             <param name="recompute" value="true" />
-            <output name="output" file="alnqual-out5.bam" />
+            <output name="output" file="alnqual-out5.bam" ftype="bam" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/lofreq/lofreq_call.xml
+++ b/tools/lofreq/lofreq_call.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy1" profile="18.01">
+<tool id="lofreq_call" name="Call variants" version="@TOOL_VERSION@+galaxy2" profile="18.01">
     <description>with LoFreq</description>
     <macros>
         <import>macros.xml</import>
@@ -103,6 +103,7 @@
                 && gzip -df variants.vcf.gz
             #end if
         #end if
+        && echo $filter_control.filter_type
     ]]></command>
     <inputs>
         <param type="data" name="reads" format="bam" label="Input reads in BAM format" />
@@ -285,7 +286,13 @@
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="ref_selector" value="history" />
             <param name="ref" ftype="fasta" value="pBR322.fa" />
-            <output name="variants" file="call-out1.vcf" lines_diff="4" />
+            <!-- lines_diff="4" should be sufficient, but https://github.com/CSB5/lofreq/issues/131 -->
+            <output name="variants" file="call-out1.vcf" lines_diff="6" />
+            <assert_command>
+                <has_text text="--sig 1"/>
+                <has_text text="--bonf 1"/>
+                <has_text text="--no-default-filter"/>
+            </assert_command>
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
@@ -294,7 +301,8 @@
             <conditional name="call_control">
                 <param name="set_call_options" value="yes" />
             </conditional>
-            <output name="variants" file="call-out1.vcf" lines_diff="4" />
+            <!-- lines_diff="4" should be sufficient, but https://github.com/CSB5/lofreq/issues/131 -->
+            <output name="variants" file="call-out1.vcf" lines_diff="6" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
@@ -310,7 +318,8 @@
                     </conditional>
                 </section>
             </conditional>
-            <output name="variants" file="call-out1.vcf" lines_diff="4" />
+            <!-- lines_diff="4" should be sufficient, but https://github.com/CSB5/lofreq/issues/131 -->
+            <output name="variants" file="call-out1.vcf" lines_diff="6" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />

--- a/tools/lofreq/lofreq_call.xml
+++ b/tools/lofreq/lofreq_call.xml
@@ -289,9 +289,9 @@
             <!-- lines_diff="4" should be sufficient, but https://github.com/CSB5/lofreq/issues/131 -->
             <output name="variants" file="call-out1.vcf" lines_diff="6" />
             <assert_command>
-                <has_text text="--sig 1"/>
-                <has_text text="--bonf 1"/>
-                <has_text text="--no-default-filter"/>
+                <has_text text="--sig 0.01"/>
+                <has_text text="--bonf dynamic"/>
+                <has_text text="--no-default-filter" negate="true"/>
             </assert_command>
         </test>
         <test>

--- a/tools/lofreq/lofreq_indelqual.xml
+++ b/tools/lofreq/lofreq_indelqual.xml
@@ -1,4 +1,4 @@
-<tool id="lofreq_indelqual" name="Insert indel qualities" version="@TOOL_VERSION@+galaxy0" profile="18.01">
+<tool id="lofreq_indelqual" name="Insert indel qualities" version="@TOOL_VERSION@+galaxy1" profile="18.01">
     <description>into a BAM file</description>
     <macros>
         <import>macros.xml</import>
@@ -47,20 +47,20 @@
             <param name="selector" value="uniform" />
             <param name="insertions" value="20" />
             <param name="deletions" value="30" />
-            <output name="output" file="indelqual-out1.bam" />
+            <output name="output" file="indelqual-out1.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="selector" value="dindel" />
             <param name="ref_selector" value="history" />
             <param name="ref" ftype="fasta" value="pBR322.fa" />
-            <output name="output" file="indelqual-out2.bam" />
+            <output name="output" file="indelqual-out2.bam" ftype="bam" />
         </test>
         <test>
             <param name="reads" ftype="bam" value="lofreq-in1.bam" />
             <param name="selector" value="uniform" />
             <param name="insertions" value="20" />
-            <output name="output" file="indelqual-out3.bam" />
+            <output name="output" file="indelqual-out3.bam" ftype="bam" />
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
- set `ftype` .. otherwise bam are compared binary (@mvdbeek is this expected .. maybe its a Galaxy bug? But setting ftype also does not hurt here)
- increase lines_diff (xref https://github.com/CSB5/lofreq/issues/131)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
