### PR TITLE
Datamash: add --narm option to ignore NA or NaN values

### DIFF
--- a/tools/datamash/datamash-ops.xml
+++ b/tools/datamash/datamash-ops.xml
@@ -125,6 +125,25 @@
                 </assert_contents>
             </output>
         </test>
+        <test><!-- test with a file containing NA and NaN values and the -narm parameter " -->
+            <param name="in_file" value="na_values_input.tsv" ftype="tabular" />
+            <param name="grouping" value="2" />
+            <param name="header_in" value="true" />
+            <param name="print_full_line" value="false" />
+            <param name="need_sort" value="true" />
+            <param name="narm" value="true" />
+            <repeat name="operations">
+                <param name="op_name" value="mean" />
+                <param name="op_column" value="3" />
+            </repeat>
+            <output name="out_file" ftype="tabular">
+                <assert_contents>
+                    <has_n_lines n="2"/>
+                    <has_line_matching expression="DE\t173.5"/>
+                    <has_line_matching expression="NL\t177.5"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help>
 <![CDATA[

--- a/tools/datamash/datamash-ops.xml
+++ b/tools/datamash/datamash-ops.xml
@@ -13,6 +13,7 @@
                 $need_sort
                 $print_full_line
                 $ignore_case
+                $narm
                 @FIELD_SEPARATOR@
                 #if str($grouping) != ''
                     --group '$grouping'
@@ -41,6 +42,7 @@
         <param argument="--header-out" type="boolean" truevalue="--header-out" falsevalue="" label="Print header line" />
         <param argument="--full" name="print_full_line" type="boolean" truevalue="--full" falsevalue="" label="Print all fields from input file" />
         <param argument="--ignore-case" type="boolean" truevalue="--ignore-case" falsevalue="" label="Ignore case when grouping" />
+        <param argument="--narm" type="boolean" truevalue="--narm" falsevalue="" label="Skip NA or NaN values" />
         <repeat name="operations" default="1" min="1" title="Operation to perform on each group">
             <param name="op_name" type="select" label="Type">
                 <option value="count">count</option>

--- a/tools/datamash/macros.xml
+++ b/tools/datamash/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="inputs_outputs">
         <inputs>

--- a/tools/datamash/test-data/na_values_input.tsv
+++ b/tools/datamash/test-data/na_values_input.tsv
@@ -1,0 +1,7 @@
+Name	Country	Height
+Alice	NL	178
+Bob	DE	165
+Charlie	NL	NA
+Doris	DE	182
+Eve	NL	177
+Francis	DE	NaN


### PR DESCRIPTION
Adds the `--narm` option in datamash, which can be set in order to ignore `NA` and `NaN` values when computing e.g. a mean over a column.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
