### PR TITLE
concoct: fix test

### DIFF
--- a/tools/concoct/concoct.xml
+++ b/tools/concoct/concoct.xml
@@ -77,7 +77,7 @@ $advanced.converge_out
             <param name="coverage_file" value="input1.tabular" ftype="tabular"/>
             <param name="composition_file" value="input1.fa.gz" ftype="fasta.gz"/>
             <param name="output_process_log" value="yes"/>
-            <output name="process_log" file="process_log.txt" ftype="txt" compare="contains"/>
+            <output name="process_log" file="process_log.txt" ftype="txt" compare="re_match"/>
             <output name="output_pca_components" ftype="tabular">
                 <assert_contents>
                     <has_size value="367636"/>

--- a/tools/concoct/macros.xml
+++ b/tools/concoct/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.0.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/concoct/test-data/process_log.txt
+++ b/tools/concoct/test-data/process_log.txt
@@ -1,10 +1,10 @@
-Results created at
-Successfully loaded composition data.
-Successfully loaded coverage data.
-Performed PCA, resulted in 154 dimensions
-Wrote PCA transformed file.
-Wrote PCA components file.
-PCA transformed data.
-Will call vbgmm with parameters: outdir/, 400, 1000, 1
-Wrote assign file.
-CONCOCT Finished
+.*:Results created at
+.*:Successfully loaded composition data\.
+.*:Successfully loaded coverage data\.
+.*:Performed PCA, resulted in 154 dimensions
+.*:Wrote PCA transformed file\.
+.*:Wrote PCA components file\.
+.*:PCA transformed data\.
+.*:Will call vbgmm with parameters: outdir/, 400, 1000, \d+
+.*:Wrote assign file\.
+.*:CONCOCT Finished


### PR DESCRIPTION
due to recent CI change the number of used CPUs changed
which is included in the log file.

test is fixed by using compare="re_match"

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
