### PR TITLE
remove max value from nb_mismatches in tradis tool

### DIFF
--- a/tool_collections/biotradis/bacteria_tradis.xml
+++ b/tool_collections/biotradis/bacteria_tradis.xml
@@ -67,7 +67,7 @@
             <when value="yes">
                 
                 <param name="sequence" type="text" value="" help="" /> 
-                <param name="nb_mismatches" type="integer" value="2" min="0" max="1" help="If there is evidence for low-quality bases in the transposon tag (from FastQC, for instance), setting this to 1 or 2 may result in higher recovery of insertion sites. Higher than 2 is not advisable with the typical transposon tag lengths (10 - 12 bases) produced by TraDIS protocols, but may be appropriate with protocols that produce significantly longer transposon tags." />         
+                <param name="nb_mismatches" type="integer" value="2" min="0" help="If there is evidence for low-quality bases in the transposon tag (from FastQC, for instance), setting this to 1 or 2 may result in higher recovery of insertion sites. Higher than 2 is not advisable with the typical transposon tag lengths (10 - 12 bases) produced by TraDIS protocols, but may be appropriate with protocols that produce significantly longer transposon tags." />         
                 <param name="tagdir" type="select" label="Direction of the transposon tag" help="" >
                     <option value="3" selected="true">3'</option>
                     <option value="5">5bacteria_tradis.xml'</option>


### PR DESCRIPTION
From Matrix:

> hi, I'm using 'Transposon Insertion Sequencing'-'Bio-TraDis reads to counts'. And  I'm trying to set the parameter 2nb_mismatches in the 'search for a transposon tag' setting, but I cannot chose more than 1. How can I get this fixed?

