### PR TITLE
Updating tools/nextclade from version 1.11.0 to 2.2.0

### DIFF
--- a/tools/nextclade/macros.xml
+++ b/tools/nextclade/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!-- same version number is used for nextclade and nextalign releases, even though they are distinct tools -->
-    <token name="@TOOL_VERSION@">1.11.0</token>
+    <token name="@TOOL_VERSION@">2.2.0</token>
     <xml name="citations">
         <citations>
             <citation type="bibtex">@online{nextclade,

--- a/tools/nextclade/nextclade.xml
+++ b/tools/nextclade/nextclade.xml
@@ -6,7 +6,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nextclade</requirement>
-        <requirement type="package" version="9.0">coreutils</requirement>
+        <requirement type="package" version="9.1">coreutils</requirement>
     </requirements>
     <version_command>nextclade --version-detailed</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextclade**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextclade from version 1.11.0 to 2.2.0.

**Project home page:** https://github.com/nextstrain/nextclade/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).