### PR TITLE
velvet: add OMP_THREAD_LIMIT

### DIFF
--- a/tools/velvet/velvetg.xml
+++ b/tools/velvet/velvetg.xml
@@ -1,11 +1,11 @@
 <tool id="velvetg" name="velvetg" version="@WRAPPER_VERSION@.2">
   <description>Velvet sequence assembler for very short reads</description>
-  <xrefs>
-      <xref type="bio.tools">velvet</xref>
-  </xrefs>
   <macros>
     <import>macros.xml</import>
   </macros>
+  <xrefs>
+      <xref type="bio.tools">velvet</xref>
+  </xrefs>
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <version_command><![CDATA[
@@ -222,9 +222,11 @@ Velvet currently takes in short read sequences, removes errors then produces hig
 
 Read the Velvet `documentation`__ for details on using the Velvet Assembler.
 
-.. _Velvet: http://www.ebi.ac.uk/~zerbino/velvet/
+.. _Velvet: https://github.com/dzerbino/velvet/
 
-.. __: http://www.ebi.ac.uk/~zerbino/velvet/Manual.pdf
+.. __: https://raw.githubusercontent.com/dzerbino/velvet/master/Manual.pdf
+
+
 
 ------
 

--- a/tools/velvet/velveth.xml
+++ b/tools/velvet/velveth.xml
@@ -1,4 +1,4 @@
-<tool id="velveth" name="velveth" version="@WRAPPER_VERSION@.3">
+<tool id="velveth" name="velveth" version="@WRAPPER_VERSION@.4">
   <description>Prepare a dataset for the Velvet velvetg Assembler</description>
   <xrefs>
       <xref type="bio.tools">velvet</xref>
@@ -13,6 +13,7 @@
   ]]></version_command>
   <command><![CDATA[
     export OMP_NUM_THREADS="\${GALAXY_SLOTS:-1}" &&
+    export OMP_THREAD_LIMIT="\${GALAXY_SLOTS:-1}" &&
     mkdir -p '${outfile.extra_files_path}' &&
     velveth
       '$outfile.extra_files_path'
@@ -91,7 +92,7 @@
       <param name="strand_specific" value="" />
       <output name="outfile" file="velveth_paireds.out">
         <extra_files type="file" name='Sequences' value="velveth_paireds/Sequences" compare="diff" />
-        <extra_files type="file" name='Roadmaps' value="velveth_paireds/Roadmaps" compare="diff" />
+        <extra_files type="file" name='Roadmaps' value="velveth_paireds/Roadmaps" compare="diff" sort="true" />
       </output>
     </test>
     <test>

--- a/tools/velvet/velveth.xml
+++ b/tools/velvet/velveth.xml
@@ -1,11 +1,11 @@
 <tool id="velveth" name="velveth" version="@WRAPPER_VERSION@.4">
   <description>Prepare a dataset for the Velvet velvetg Assembler</description>
-  <xrefs>
-      <xref type="bio.tools">velvet</xref>
-  </xrefs>
   <macros>
     <import>macros.xml</import>
   </macros>
+  <xrefs>
+      <xref type="bio.tools">velvet</xref>
+  </xrefs>
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <version_command><![CDATA[
@@ -143,9 +143,9 @@ Velvet currently takes in short read sequences, removes errors then produces hig
 
 Read the Velvet `documentation`__ for details on using the Velvet Assembler.
 
-.. _Velvet: http://www.ebi.ac.uk/~zerbino/velvet/
+.. _Velvet: https://github.com/dzerbino/velvet/
 
-.. __: http://www.ebi.ac.uk/~zerbino/velvet/Manual.pdf
+.. __: https://raw.githubusercontent.com/dzerbino/velvet/master/Manual.pdf
 
 ------
 


### PR DESCRIPTION
if not set the roadmap files (and assemblies?) differ when using different numbers of cores

see also https://www.biostars.org/p/86907/

.. does not work for 1 CPU https://github.com/dzerbino/velvet/issues/56

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
