### PR TITLE
bbmap: update test data sizes

### DIFF
--- a/tools/bbtools/bbmap.xml
+++ b/tools/bbtools/bbmap.xml
@@ -137,16 +137,16 @@ renamebyinsert='$output_options.renamebyinsert'
     out='all_reads.bam'
     outu='unmapped_reads.bam'
     outm='mapped_reads.bam'
-    && samtools sort -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_all_reads' 'all_reads.bam'
-    && samtools sort -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_unmapped_reads' 'unmapped_reads.bam'
-    && samtools sort -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_mapped_reads' 'mapped_reads.bam'
+    && samtools sort --no-PG -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_all_reads' 'all_reads.bam'
+    && samtools sort --no-PG -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_unmapped_reads' 'unmapped_reads.bam'
+    && samtools sort --no-PG -@\${GALAXY_SLOTS:-4} -T "\${TMPDIR:-.}" -O bam -o '$output_mapped_reads' 'mapped_reads.bam'
 #elif str($output_options.output_sort) == 'name':
     out='all_reads.bam'
     outu='unmapped_reads.bam'
     outm='mapped_reads.bam'
-    && samtools sort -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_all_reads' 'all_reads.bam'
-    && samtools sort -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_unmapped_reads' 'unmapped_reads.bam'
-    && samtools sort -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_mapped_reads' 'mapped_reads.bam'
+    && samtools sort --no-PG -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_all_reads' 'all_reads.bam'
+    && samtools sort --no-PG -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_unmapped_reads' 'unmapped_reads.bam'
+    && samtools sort --no-PG -n -@\${GALAXY_SLOTS:-4} -T '\${TMPDIR:-.}' -O bam -o '$output_mapped_reads' 'mapped_reads.bam'
 #else:
     out='all_reads.bam'
     outu='unmapped_reads.bam'
@@ -269,19 +269,19 @@ renamebyinsert='$output_options.renamebyinsert'
             <output name="output_all_reads" ftype="bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="9433" delta="300"/>
+                    <has_size value="9639" delta="300"/>
                 </assert_contents>
             </output>
             <output name="output_unmapped_reads" ftype="bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="9432" delta="300"/>
+                    <has_size value="9639" delta="300"/>
                 </assert_contents>
             </output>
             <output name="output_mapped_reads" ftype="bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="938" delta="100"/>
+                    <has_size value="851" delta="100"/>
                 </assert_contents>
             </output>
         </test>
@@ -294,19 +294,19 @@ renamebyinsert='$output_options.renamebyinsert'
             <output name="output_all_reads" ftype="qname_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="17103" delta="600"/>
+                    <has_size value="17540" delta="600"/>
                 </assert_contents>
             </output>
             <output name="output_unmapped_reads" ftype="qname_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="17105" delta="600"/>
+                    <has_size value="17540" delta="600"/>
                 </assert_contents>
             </output>
             <output name="output_mapped_reads" ftype="qname_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="967" delta="100"/>
+                    <has_size value="860" delta="100"/>
                 </assert_contents>
             </output>
         </test>
@@ -325,19 +325,19 @@ renamebyinsert='$output_options.renamebyinsert'
             <output name="output_all_reads" ftype="qname_input_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="17059" delta="600"/>
+                    <has_size value="17602" delta="600"/>
                 </assert_contents>
             </output>
             <output name="output_unmapped_reads" ftype="qname_input_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="17059" delta="600"/>
+                    <has_size value="17602" delta="600"/>
                 </assert_contents>
             </output>
             <output name="output_mapped_reads" ftype="qname_input_sorted.bam">
                 <metadata name="dbkey" value="89"/>
                 <assert_contents>
-                    <has_size value="906" delta="100"/>
+                    <has_size value="878" delta="100"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
changed for some reason

also add --no-PG lines to samtools calls

Alternatively we could also increase delta?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
