### PR TITLE
instrain: add zip requirement to all

### DIFF
--- a/tools/instrain/instrain_profile.xml
+++ b/tools/instrain/instrain_profile.xml
@@ -4,9 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="edam_ontology"/>
-    <expand macro="requirements">
-        <requirement type="package" version="3.0">zip</requirement>
-    </expand>
+    <expand macro="requirements"/>
     <version_command>inStrain profile --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
 #set ext=$mapping_input.datatype.file_ext

--- a/tools/instrain/macros.xml
+++ b/tools/instrain/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.5.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">20.01</token>
     <xml name="edam_ontology">
         <edam_topics>
@@ -17,6 +17,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">instrain</requirement>
+            <requirement type="package" version="3.0">zip</requirement>
             <yield/>
         </requirements>
     </xml>


### PR DESCRIPTION
tool currently fails CI

compare also calls unzip and should have the requirement

tool still fails, because Galaxy unzips the zip inputs: I see `ZIP file contained more than one file, only the first file was added to Galaxy.` in the Dataset Info of the input datasets (and the actual tool fails with `unzip: short read`).

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
