### PR TITLE
hisat2, bowtie2: add sort attribute to bam test outputs

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bowtie2" name="Bowtie2" version="@TOOL_VERSION@+galaxy0" profile="20.05">
+<tool id="bowtie2" name="Bowtie2" version="@TOOL_VERSION@+galaxy1" profile="20.05">
     <description>- map reads against reference genome</description>
     <xrefs>
         <xref type="bio.tools">bowtie2</xref>
@@ -662,7 +662,7 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq" ftype="fastqsanger"/>
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="3">
             <!-- test on list paired collection -->
@@ -678,7 +678,7 @@ bowtie2
                 </collection>
             </param>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on paired-end datasets with read group info -->
@@ -693,7 +693,7 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq" ftype="fastqsanger"/>
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test2.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test2.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="2">
             <!-- test on paired-end datasets with stats output -->
@@ -706,7 +706,7 @@ bowtie2
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
             <param name="save_mapping_stats" value="true" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
             <output name="mapping_stats">
                 <assert_contents>
                     <has_text text="of these" />
@@ -725,7 +725,7 @@ bowtie2
             <param name="source" value="history" />
             <param name="input_1" value="bowtie2-fq_il.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test_il.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test_il.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fastqsanger.gz paired-end datasets -->
@@ -737,7 +737,7 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq.gz" ftype="fastqsanger.gz"/>
             <param name="input_2" value="bowtie2-fq2.fq.gz" ftype="fastqsanger.gz"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fastqsanger.bz2 paired-end datasets -->
@@ -749,7 +749,7 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq.bz2" ftype="fastqsanger.bz2"/>
             <param name="input_2" value="bowtie2-fq2.fq.bz2" ftype="fastqsanger.bz2"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets -->
@@ -761,7 +761,7 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fa" ftype="fasta"/>
             <param name="input_2" value="bowtie2-fq2.fa" ftype="fasta"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test_fasta_in.bam" ftype="bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test_fasta_in.bam" ftype="bam" lines_diff="4" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets with bam_native as output -->
@@ -775,7 +775,7 @@ bowtie2
             <param name="own_file" value="bowtie2-ref.fasta" />
             <param name="sam_options_selector" value="yes" />
             <param name="reorder" value="true" />
-            <output name="output" file="bowtie2-test_fasta_in_bam_qname_input_sorted.bam" ftype="qname_input_sorted.bam" compare="sim_size"/>
+            <output name="output" file="bowtie2-test_fasta_in_bam_qname_input_sorted.bam" ftype="qname_input_sorted.bam" lines_diff="4"/>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets with sam as output -->

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,11 +1,11 @@
 <tool id="bowtie2" name="Bowtie2" version="@TOOL_VERSION@+galaxy1" profile="20.05">
     <description>- map reads against reference genome</description>
-    <xrefs>
-        <xref type="bio.tools">bowtie2</xref>
-    </xrefs>
     <macros>
         <import>bowtie2_macros.xml</import>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">bowtie2</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bowtie2</requirement>
         <requirement type="package" version="1.14">samtools</requirement>
@@ -662,7 +662,9 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq" ftype="fastqsanger"/>
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="3">
             <!-- test on list paired collection -->
@@ -678,7 +680,9 @@ bowtie2
                 </collection>
             </param>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on paired-end datasets with read group info -->
@@ -693,7 +697,9 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq" ftype="fastqsanger"/>
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test2.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test2.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="2">
             <!-- test on paired-end datasets with stats output -->
@@ -706,7 +712,9 @@ bowtie2
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
             <param name="save_mapping_stats" value="true" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
             <output name="mapping_stats">
                 <assert_contents>
                     <has_text text="of these" />
@@ -725,7 +733,9 @@ bowtie2
             <param name="source" value="history" />
             <param name="input_1" value="bowtie2-fq_il.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test_il.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test_il.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fastqsanger.gz paired-end datasets -->
@@ -737,7 +747,9 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq.gz" ftype="fastqsanger.gz"/>
             <param name="input_2" value="bowtie2-fq2.fq.gz" ftype="fastqsanger.gz"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fastqsanger.bz2 paired-end datasets -->
@@ -749,7 +761,9 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fq.bz2" ftype="fastqsanger.bz2"/>
             <param name="input_2" value="bowtie2-fq2.fq.bz2" ftype="fastqsanger.bz2"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets -->
@@ -761,7 +775,9 @@ bowtie2
             <param name="input_1" value="bowtie2-fq1.fa" ftype="fasta"/>
             <param name="input_2" value="bowtie2-fq2.fa" ftype="fasta"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
-            <output name="output" file="bowtie2-test_fasta_in.bam" ftype="bam" lines_diff="4" sort="true"/>
+            <output name="output" file="bowtie2-test_fasta_in.bam" ftype="bam" lines_diff="4" sort="true">
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets with bam_native as output -->
@@ -775,7 +791,9 @@ bowtie2
             <param name="own_file" value="bowtie2-ref.fasta" />
             <param name="sam_options_selector" value="yes" />
             <param name="reorder" value="true" />
-            <output name="output" file="bowtie2-test_fasta_in_bam_qname_input_sorted.bam" ftype="qname_input_sorted.bam" lines_diff="4"/>
+            <output name="output" file="bowtie2-test_fasta_in_bam_qname_input_sorted.bam" ftype="qname_input_sorted.bam" lines_diff="4">
+                <metadata name="sort_order" value="unsorted"/>
+            </output>
         </test>
         <test expect_num_outputs="1">
             <!-- test on fasta paired-end datasets with sam as output -->
@@ -790,6 +808,7 @@ bowtie2
             <param name="sam_options_selector" value="yes" />
             <param name="sam_options|sam_opt" value="true" />
             <output name="output" ftype="sam">
+                <metadata name="sort_order" value="unsorted"/>
                 <assert_contents>
                     <has_text text="M01368:8:000000000-A3GHV:1:1101:6911:8255" />
                 </assert_contents>

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -1,11 +1,11 @@
 <tool id="hisat2" name="HISAT2" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05">
     <description>A fast and sensitive alignment program</description>
-    <xrefs>
-        <xref type="bio.tools">hisat2</xref>
-    </xrefs>
     <macros>
         <import>hisat2_macros.xml</import>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">hisat2</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">hisat2</requirement>
         <requirement type="package" version="1.12">samtools</requirement>
@@ -564,8 +564,8 @@ hisat2
                     <param name="no_unal" argument="--no-unal" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Suppress SAM records for reads that failed to align." help="Default: false"/>
                     <conditional name="read_groups">
                         <param name="rg_labels" type="select" label="Edit Read Group IDs">
-                            <option value="No" />
-                            <option value="Yes" />
+                            <option value="No">No</option>
+                            <option value="Yes">Yes</option>
                         </param>
                         <when value="No"/>
                         <when value="Yes">

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -761,7 +761,9 @@ hisat2
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <param name="adv|reporting_options|reporting_options_selector" value="advanced"/>
             <param name="novel_splicesite_outfile" value="false" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure advanced scoring options work -->
         <test expect_num_outputs="1" >
@@ -771,7 +773,9 @@ hisat2
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <param name="adv|scoring_options|coefficient" value="-0.3"/>
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure built-in reference works -->
         <test expect_num_outputs="1">
@@ -779,7 +783,9 @@ hisat2
             <param name="source" value="indexed" />
             <param name="input_1" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_reverse.fastq" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure trimming works -->
         <test expect_num_outputs="1">
@@ -791,7 +797,9 @@ hisat2
             <param name="trim5" value="15" />
             <param name="input_1" ftype="fastqsanger" value="hisat_input_2_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_2_reverse.fastq" />
-            <output name="output_alignments" file="hisat_output_2.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_2.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure paired options works -->
         <test expect_num_outputs="1">
@@ -806,7 +814,9 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure single unaligned output works -->
         <test expect_num_outputs="2">
@@ -845,7 +855,9 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure fastqsanger.bz2 works -->
         <test expect_num_outputs="1">
@@ -860,7 +872,9 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure paired strandness works -->
         <test expect_num_outputs="1">
@@ -870,7 +884,9 @@ hisat2
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <param name="rna_strandness" value="FR" />
-            <output name="output_alignments" file="hisat_output_4.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_4.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure summary file output works -->
         <test expect_num_outputs="2">
@@ -889,7 +905,9 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_interleaved.fastq" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure interleaved bz input works -->
         <test expect_num_outputs="1" >
@@ -897,7 +915,9 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger.bz2" value="hisat_input_1_interleaved.fastq.bz2" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure interleaved gz input works -->
         <test expect_num_outputs="1" >
@@ -905,7 +925,9 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger.gz" value="hisat_input_1_interleaved.fastq.gz" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure interleaved fasta input works -->
         <test expect_num_outputs="1" >
@@ -913,7 +935,9 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fasta" value="hisat_input_1_interleaved.fasta" />
-            <output name="output_alignments" file="hisat_output_1_noqual.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_1_noqual.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
         <!-- Ensure novel splicesite file output works -->
         <test>
@@ -924,7 +948,9 @@ hisat2
             <param name="rna_strandness" value="R" />
             <param name="adv|spliced_options|spliced_options_selector" value="advanced"/>
             <param name="adv|spliced_options|novel_splicesite_outfile" value="true" />
-            <output name="output_alignments" file="hisat_output_spliced_1.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_spliced_1.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
             <output name="novel_splicesite_output" file="novel_splicesite_out.tab" ftype="tabular" />
         </test>
         <!-- Ensure SAM output settings work -->
@@ -944,7 +970,9 @@ hisat2
             </repeat>          
             <param name="adv|sam_options|chr_text" value="--add-chrname"/>
             <param name="adv|sam_options|omit_sec_seq" value="True"/>                        
-            <output name="output_alignments" file="hisat_output_5.bam" ftype="bam" lines_diff="2" sort="true" />
+            <output name="output_alignments" file="hisat_output_5.bam" ftype="bam" lines_diff="2" sort="true" >
+                <metadata name="sort_order" value="coordinate"/>
+            </output>
         </test>
     </tests>
 

--- a/tools/hisat2/hisat2.xml
+++ b/tools/hisat2/hisat2.xml
@@ -771,7 +771,7 @@ hisat2
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <param name="adv|scoring_options|coefficient" value="-0.3"/>
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure built-in reference works -->
         <test expect_num_outputs="1">
@@ -779,7 +779,7 @@ hisat2
             <param name="source" value="indexed" />
             <param name="input_1" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" dbkey="phiX" value="hisat_input_1_reverse.fastq" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure trimming works -->
         <test expect_num_outputs="1">
@@ -791,7 +791,7 @@ hisat2
             <param name="trim5" value="15" />
             <param name="input_1" ftype="fastqsanger" value="hisat_input_2_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_2_reverse.fastq" />
-            <output name="output_alignments" file="hisat_output_2.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_2.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure paired options works -->
         <test expect_num_outputs="1">
@@ -806,7 +806,7 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure single unaligned output works -->
         <test expect_num_outputs="2">
@@ -845,7 +845,7 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure fastqsanger.bz2 works -->
         <test expect_num_outputs="1">
@@ -860,7 +860,7 @@ hisat2
             <param name="paired_options_selector" value="advanced" />
             <param name="no_mixed" value="True" />
             <param name="no_discordant" value="True" />
-            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_3.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure paired strandness works -->
         <test expect_num_outputs="1">
@@ -870,7 +870,7 @@ hisat2
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_forward.fastq" />
             <param name="input_2" ftype="fastqsanger" value="hisat_input_1_reverse.fastq" />
             <param name="rna_strandness" value="FR" />
-            <output name="output_alignments" file="hisat_output_4.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_4.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure summary file output works -->
         <test expect_num_outputs="2">
@@ -889,7 +889,7 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger" value="hisat_input_1_interleaved.fastq" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure interleaved bz input works -->
         <test expect_num_outputs="1" >
@@ -897,7 +897,7 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger.bz2" value="hisat_input_1_interleaved.fastq.bz2" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure interleaved gz input works -->
         <test expect_num_outputs="1" >
@@ -905,7 +905,7 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fastqsanger.gz" value="hisat_input_1_interleaved.fastq.gz" />
-            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure interleaved fasta input works -->
         <test expect_num_outputs="1" >
@@ -913,7 +913,7 @@ hisat2
             <param name="source" value="history" />
             <param name="history_item" ftype="fasta" value="phiX.fa" />
             <param name="input_1" ftype="fasta" value="hisat_input_1_interleaved.fasta" />
-            <output name="output_alignments" file="hisat_output_1_noqual.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_1_noqual.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
         <!-- Ensure novel splicesite file output works -->
         <test>
@@ -924,7 +924,7 @@ hisat2
             <param name="rna_strandness" value="R" />
             <param name="adv|spliced_options|spliced_options_selector" value="advanced"/>
             <param name="adv|spliced_options|novel_splicesite_outfile" value="true" />
-            <output name="output_alignments" file="hisat_output_spliced_1.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_spliced_1.bam" ftype="bam" lines_diff="2" sort="true" />
             <output name="novel_splicesite_output" file="novel_splicesite_out.tab" ftype="tabular" />
         </test>
         <!-- Ensure SAM output settings work -->
@@ -944,7 +944,7 @@ hisat2
             </repeat>          
             <param name="adv|sam_options|chr_text" value="--add-chrname"/>
             <param name="adv|sam_options|omit_sec_seq" value="True"/>                        
-            <output name="output_alignments" file="hisat_output_5.bam" ftype="bam" lines_diff="2" />
+            <output name="output_alignments" file="hisat_output_5.bam" ftype="bam" lines_diff="2" sort="true" />
         </test>
     </tests>
 

--- a/tools/hisat2/hisat2_macros.xml
+++ b/tools/hisat2/hisat2_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.2.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     
     <xml name="paired_end_options">
 


### PR DESCRIPTION
due to different number of used processors the order of the lines
in the (S)BAM may differ (not sure if due to hisat/samtools ..
but this does not matter I guess)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
