### PR TITLE
Harmonize hAMRonize:summarize's name to convention of prefixing

### DIFF
--- a/tools/hamronization/hamronize_summarize.xml
+++ b/tools/hamronization/hamronize_summarize.xml
@@ -1,4 +1,4 @@
-<tool id="hamronize_summarize" name="summarize" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@"> 
+<tool id="hamronize_summarize" name="hamronize: summarize" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@"> 
     <description> harmorization reports</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

I had a student report not finding the summarize tool, hence this PR to prefix the name with "hamronize", like we do with other tool suites (seqtk, bedtools, circos.)