### PR TITLE
Tolerate empty lines in ivar helper scripts inputs

### DIFF
--- a/tools/ivar/ivar_removereads.xml
+++ b/tools/ivar/ivar_removereads.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_removereads" name="ivar removereads" version="@VERSION@+galaxy2">
+<tool id="ivar_removereads" name="ivar removereads" version="@VERSION@+galaxy3" profile="21.01">
     <description>Remove reads from trimmed BAM file</description>
     <macros>
         <import>macros.xml</import>
@@ -22,7 +22,7 @@
         ln -s '$input_bam' sorted.bam &&
         ln -s '${input_bam.metadata.bam_index}' sorted.bam.bai &&
 
-        ivar removereads 
+        ivar removereads
         -i sorted.bam
         -b binding_sites.bed
         -p removed_reads.bam
@@ -109,7 +109,7 @@ be TAB-separated with one line per amplicon.
    Preprocessing of the BAM input with ivar trim is essential for this tool to
    work because only ``ivar trim`` can add required primer information to the
    BAM auxillary data of every read.
-        
+
 ivar documentation can be found at `<https://andersen-lab.github.io/ivar/html/manualpage.html>`__.
     ]]></help>
     <expand macro="citations" />

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_trim" name="ivar trim" version="@VERSION@+galaxy3">
+<tool id="ivar_trim" name="ivar trim" version="@VERSION@+galaxy4" profile="21.01">
     <description>Trim reads in aligned BAM</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ivar/prepare_amplicon_info.py
+++ b/tools/ivar/prepare_amplicon_info.py
@@ -11,7 +11,10 @@ import sys
 primer_starts = {}
 with open(sys.argv[1]) as i:
     for line in i:
-        f = line.strip().split('\t')
+        line = line.strip()
+        if not line:
+            continue
+        f = line.split('\t')
         try:
             if f[5] == '+':
                 primer_starts[f[3]] = int(f[1])
@@ -32,8 +35,11 @@ with open(sys.argv[1]) as i:
 with open(sys.argv[2]) as i:
     ret_lines = []
     for line in i:
+        line = line.strip()
+        if not line:
+            continue
         first = last = None
-        for pname in line.strip().split('\t'):
+        for pname in line.split('\t'):
             try:
                 primer_start = primer_starts[pname]
             except KeyError:

--- a/tools/ivar/sanitize_bed.py
+++ b/tools/ivar/sanitize_bed.py
@@ -9,10 +9,11 @@ with open(sys.argv[1]) as i:
 sanitized_data = []
 try:
     for record in bed_data:
-        fields = record.split('\t')
-        sanitized_data.append(
-            '\t'.join(fields[:4] + ['60'] + fields[5:])
-        )
+        if record.strip():
+            fields = record.split('\t')
+            sanitized_data.append(
+                '\t'.join(fields[:4] + ['60'] + fields[5:])
+            )
 except IndexError:
     pass  # leave column number issue to getmasked
 else:

--- a/tools/ivar/write_amplicon_info_file.py
+++ b/tools/ivar/write_amplicon_info_file.py
@@ -10,7 +10,10 @@ AMPLICON_PAT = re.compile(r'.*_(?P<num>\d+).*_(?P<name>L(?:EFT)?|R(?:IGHT)?)')
 def write_amplicon_info_file(bed_file, amplicon_info_file):
     amplicon_sets = {}
     for line in bed_file:
-        fields = line.strip().split('\t')
+        line = line.strip()
+        if not line:
+            continue
+        fields = line.split('\t')
         start = int(fields[1])
         name = fields[3]
         re_match = AMPLICON_PAT.match(name)


### PR DESCRIPTION
This fixes a common stumbling block for users of the ivar trim and
removereads tools where even a single trailing extra line in the primer
bed or amplicon info file will cause the tools to fail witha hard to
understand traceback. With the changes here, empty (whitespace-only)
lines in either of the two files will simply be ignored by all relevant
Galaxy-specific helper scripts.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
