### PR TITLE
fraggenescan: compare sorted fasta

### DIFF
--- a/tools/fraggenescan/fraggenescan.xml
+++ b/tools/fraggenescan/fraggenescan.xml
@@ -53,8 +53,8 @@ run_FragGeneScan.pl
             <param name="complete" value="False"/>
             <param name="train" value="complete"/>
             <output name="coord" ftype="tabular" value="contigs.out"/>
-            <output name="nt_seq" ftype="fasta" value="contigs.ffn"/>
-            <output name="prot_seq" ftype="fasta" value="contigs.faa"/>
+            <output name="nt_seq" ftype="fasta" value="contigs.ffn" sort="true"/>
+            <output name="prot_seq" ftype="fasta" value="contigs.faa" sort="true"/>
             <output name="gff" ftype="gff" value="contigs.gff"/>
         </test>
         <test>
@@ -62,8 +62,8 @@ run_FragGeneScan.pl
             <param name="complete" value="True"/>
             <param name="train" value="complete"/>
             <output name="coord" ftype="tabular" value="NC_000913.out"/>
-            <output name="nt_seq" ftype="fasta" value="NC_000913.ffn"/>
-            <output name="prot_seq" ftype="fasta" value="NC_000913.faa"/>
+            <output name="nt_seq" ftype="fasta" value="NC_000913.ffn" sort="true"/>
+            <output name="prot_seq" ftype="fasta" value="NC_000913.faa" sort="true"/>
             <output name="gff" ftype="gff" value="NC_000913.gff"/>
         </test>
         <test>
@@ -71,8 +71,8 @@ run_FragGeneScan.pl
             <param name="complete" value="False"/>
             <param name="train" value="454_10"/>
             <output name="coord" ftype="tabular" value="NC_000913-454.out"/>
-            <output name="nt_seq" ftype="fasta" value="NC_000913-454.ffn"/>
-            <output name="prot_seq" ftype="fasta" value="NC_000913-454.faa"/>
+            <output name="nt_seq" ftype="fasta" value="NC_000913-454.ffn" sort="true"/>
+            <output name="prot_seq" ftype="fasta" value="NC_000913-454.faa" sort="true"/>
             <output name="gff" ftype="gff" value="NC_000913-454.gff"/>
         </test>
     </tests>


### PR DESCRIPTION
different numbers of used CPUs lead to different order of sequences

tool fails CI at the moment

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
