### PR TITLE
schicexplorer: cp input file

### DIFF
--- a/tools/schicexplorer/scHicConsensusMatrices.xml
+++ b/tools/schicexplorer/scHicConsensusMatrices.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicconsensusmatrices" name="@BINARY@" version="@WRAPPER_VERSION@.1">
     <description>creates per cluster one average matrix</description>
     <macros>
         <token name="@BINARY@">scHicConsensusMatrices</token>
@@ -23,7 +23,6 @@
         <expand macro="matrix_scooler_macro"/>
         <param name='clusters' type='data' format='txt' label='Cluster file' help='Cluster file created by scHicCluster, scHicClusterCompartments, scHicClusterMinHash or scHicClusterSVL'/>
         
-        <param name='chromosomes' type='text' label='List of chromosomes to consider' help='Please separate the chromosomes by space'/>
     </inputs>
     <outputs>
         <data name="outFileName" from_work_dir="consensus_matrix.scool" format="scool" label="${tool.name} on ${on_string}: Consensus matrices"/>

--- a/tools/schicexplorer/scHicPlotClusterProfiles.xml
+++ b/tools/schicexplorer/scHicPlotClusterProfiles.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicplotclusterprofiles" name="@BINARY@" version="@WRAPPER_VERSION@.1">
     <description>plot single-cell Hi-C interaction matrices cluster profiles</description>
     <macros>
         <token name="@BINARY@">scHicPlotClusterProfiles</token>
@@ -14,7 +14,7 @@
             #set $chromosome = ' '.join([ '\'%s\'' % $chrom for $chrom in str($chromosomes).split(' ') ])
             --chromosomes $chromosome
         #end if
-        
+        $maximalDistance
         #if $order_by_conditional.order_by_selection == 'orderByFile':
             --orderBy $order_by_conditional.order_by_selection
         #elif $order_by_conditional.order_by_selection == 'svl':

--- a/tools/schicexplorer/scHicQualityControl.xml
+++ b/tools/schicexplorer/scHicQualityControl.xml
@@ -1,4 +1,4 @@
-<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@WRAPPER_VERSION@.0">
+<tool id="schicexplorer_schicqualitycontrol" name="@BINARY@" version="@WRAPPER_VERSION@.1">
     <description>quality control for single-cell Hi-C interaction matrices</description>
     <macros>
         <token name="@BINARY@">scHicQualityControl</token>
@@ -6,9 +6,11 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
+        cp '$matrix_scooler' matrix.scooler &&
+
         @BINARY@
 
-        --matrix '$matrix_scooler'
+        --matrix 'matrix.scooler'
         #if $chromosomes:
             #set $chromosome = ' '.join([ '\'%s\'' % $chrom for $chrom in str($chromosomes).split(' ') ])
             --chromosomes $chromosome


### PR DESCRIPTION
library opens the file `r+` because it assumes that src and dst
can be the same

https://github.com/open2c/cooler/blob/987e87dd357c99a0a070b8a25cb7aaef86f1655c/cooler/fileops.py#L277

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
