### PR TITLE
Spades fixes

### DIFF
--- a/tools/spades/macros.xml
+++ b/tools/spades/macros.xml
@@ -598,32 +598,32 @@
     <xml name="out_ag">
         <data name="out_ag" format="fastg" from_work_dir="output/assembly_graph.fastg" label="${tool.name} on ${on_string}: Assembly graph">
             <filter>'ag' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_ags">
         <data name="out_ags" format="txt" from_work_dir="output/assembly_graph_with_scaffolds.gfa" label="${tool.name} on ${on_string}: Assembly graph with scaffolds">
             <filter>'ags' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or  operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_cn">
         <data name="out_cn" format="fasta" from_work_dir="output/contigs.fasta" label="${tool.name} on ${on_string}: Contigs">
             <filter>'cn' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or  operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_cp">
         <data name="out_cp" format="txt" from_work_dir="output/contigs.paths" label="${tool.name} on ${on_string}: Contigs paths">
             <filter>'cp' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or  operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_cr">
         <!-- some mode combinations create fastq, some fasta -->
         <collection name="out_cr" type="list" label="${tool.name} on ${on_string}: Corrected reads">
             <filter>'cr' in optional_output</filter>
-            <filter> operation_mode != '--only-assembler'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-assembler'</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.+)\.fastq\.gz" format="fastq" directory="output/corrected"/>
             <discover_datasets pattern="(?P&lt;designation&gt;.+)\.fasta\.gz" format="fasta" directory="output/corrected"/>
         </collection>
@@ -634,7 +634,7 @@
                 <action name="column_names" type="metadata" default="name,length,coverage"/>
             </actions>
             <filter>'cs' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_l">
@@ -645,13 +645,13 @@
     <xml name="out_sc">
         <data name="out_sc" format="fasta" from_work_dir="output/scaffolds.fasta" label="${tool.name} on ${on_string}: Scaffolds">
             <filter>'sc' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_sp">
         <data name="out_sp" format="txt" from_work_dir="output/scaffolds.paths" label="${tool.name} on ${on_string}: Scaffolds paths">
             <filter>'sp' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_ss">
@@ -660,7 +660,7 @@
                 <action name="column_names" type="metadata" default="name,length,coverage"/>
             </actions>
             <filter>'ss' in optional_output</filter>
-            <filter> operation_mode != '--only-error-correction'</filter>
+            <filter>'operation_mode' not in vars() or operation_mode != '--only-error-correction'</filter>
         </data>
     </xml>
     <xml name="out_rs">

--- a/tools/spades/macros.xml
+++ b/tools/spades/macros.xml
@@ -624,8 +624,8 @@
         <collection name="out_cr" type="list" label="${tool.name} on ${on_string}: Corrected reads">
             <filter>'cr' in optional_output</filter>
             <filter>'operation_mode' not in vars() or operation_mode != '--only-assembler'</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.fastq\.gz" format="fastq" directory="output/corrected"/>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.fasta\.gz" format="fasta" directory="output/corrected"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.cor\.fastq\.gz" format="fastq" directory="output/corrected"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.cor\.fasta\.gz" format="fasta" directory="output/corrected"/>
         </collection>
     </xml>
     <xml name="out_cs">

--- a/tools/spades/metaplasmidspades.xml
+++ b/tools/spades/metaplasmidspades.xml
@@ -21,6 +21,7 @@
 
 ## run
 spades.py --meta --plasmid
+    $operation_mode
     -o 'output'
     @RESOURCES@
     @INPUT_READS_MAIN@
@@ -41,6 +42,7 @@ spades.py --meta --plasmid
     @CORRECTED@
     ]]></command>
     <inputs>
+        <expand macro="operation_mode" help="To run read error correction, reads should be in FASTQ format."/>
         <expand macro="input_files_paired" format="fastq, fastq.gz,fastqsanger.gz" label="FASTQ file(s)"/>
         <expand macro="input_additional_files_paired" format="fastq,fastq.gz,fastqsanger.gz" label="FASTQ file(s)"/>
         <section name="arf" title="Additional read files">

--- a/tools/spades/metaplasmidspades.xml
+++ b/tools/spades/metaplasmidspades.xml
@@ -128,17 +128,17 @@ spades.py --meta --plasmid
                 </assert_contents>
             </output>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="423" delta="100"/>
                     </assert_contents>
@@ -188,17 +188,17 @@ spades.py --meta --plasmid
             <param name="operation_mode" value="--only-error-correction"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="423" delta="100"/>
                     </assert_contents>

--- a/tools/spades/metaspades.xml
+++ b/tools/spades/metaspades.xml
@@ -134,17 +134,17 @@ metaspades.py
             </conditional>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_1.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_2.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="20" delta="5"/>
                     </assert_contents>

--- a/tools/spades/metaviralspades.xml
+++ b/tools/spades/metaviralspades.xml
@@ -126,17 +126,17 @@ spades.py --metaviral
                 </assert_contents>
             </output>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="423" delta="100"/>
                     </assert_contents>
@@ -186,17 +186,17 @@ spades.py --metaviral
             <param name="operation_mode" value="--only-error-correction"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="71752" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="423" delta="100"/>
                     </assert_contents>

--- a/tools/spades/plasmidspades.xml
+++ b/tools/spades/plasmidspades.xml
@@ -161,17 +161,17 @@ plasmidspades.py
                 </assert_contents>
             </output>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="392" delta="100"/>
                     </assert_contents>
@@ -250,17 +250,17 @@ plasmidspades.py
             </conditional>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="392" delta="100"/>
                     </assert_contents>
@@ -282,17 +282,17 @@ plasmidspades.py
             </conditional>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="392" delta="100"/>
                     </assert_contents>
@@ -326,17 +326,17 @@ plasmidspades.py
             <param name="mode_sel" value="--careful"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="pl1.fq.gz.fastq.00.0_0.cor">
+                <element name="pl1.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl2.fq.gz.fastq.00.0_0.cor">
+                <element name="pl2.fq.gz.fastq.00.0_0">
                     <assert_contents>
                         <has_size value="72173" delta="1000"/>
                     </assert_contents>
                 </element>
-                <element name="pl_unpaired.00.0_0.cor">
+                <element name="pl_unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="392" delta="100"/>
                     </assert_contents>

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -20,6 +20,7 @@
 
 ## run
 spades.py --rnaviral
+    $operation_mode
     -o 'output'    
     @RESOURCES@
     @INPUT_READS_MAIN@
@@ -40,6 +41,7 @@ spades.py --rnaviral
     @CORRECTED@
     ]]></command>
     <inputs>
+        <expand macro="operation_mode" help="To run read error correction, reads should be in FASTQ format."/>
         <expand macro="input_files_all" format="fastq,fasta,fastq.gz,fastqsanger.gz,fasta.gz" label="FASTQ RNA-seq file(s)"/>
         <expand macro="input_additional_files_all" format="fastq,fastq.gz,fastqsanger.gz,fasta,fasta.gz" label="FASTQ RNA-seq file(s)"/>
         <section name="arf" title="Additional read files">

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -39,7 +39,6 @@ spades.py --rnaviral
     ## postprocessing
     @STATS@
     @CORRECTED@
-    && ls output/corrected
     ]]></command>
     <inputs>
         <expand macro="operation_mode" help="To run read error correction, reads should be in FASTQ format."/>

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -143,7 +143,7 @@ spades.py --rnaviral
                     <has_n_lines n="0"/>
                 </assert_contents>
             </output>
-            <output_collection name="out_cr" type="list" count="4">
+            <output_collection name="out_cr" type="list" count="2">
                 <element name="ecoli_1K_1.fastq.gz.fastq0_0.cor">
                     <assert_contents>
                         <has_size value="34468" delta="2000"/>

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -146,12 +146,12 @@ spades.py --rnaviral
                 </assert_contents>
             </output>
             <output_collection name="out_cr" type="list" count="2">
-                <element name="ecoli_1K_1.fastq.gz.fastq0_0.cor">
+                <element name="ecoli_1K_1.fastq.gz.fastq0_0">
                     <assert_contents>
                         <has_size value="34468" delta="2000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K_2.fastq.gz.fastq0_0.cor">
+                <element name="ecoli_1K_2.fastq.gz.fastq0_0">
                     <assert_contents>
                         <has_size value="34468" delta="2000"/>
                     </assert_contents>

--- a/tools/spades/rnaviralspades.xml
+++ b/tools/spades/rnaviralspades.xml
@@ -39,6 +39,7 @@ spades.py --rnaviral
     ## postprocessing
     @STATS@
     @CORRECTED@
+    && ls output/corrected
     ]]></command>
     <inputs>
         <expand macro="operation_mode" help="To run read error correction, reads should be in FASTQ format."/>

--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -311,17 +311,17 @@ spades.py
             <param name="mode_sel" value="--careful"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_1.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_2.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="20" delta="5"/>
                     </assert_contents>
@@ -343,17 +343,17 @@ spades.py
             <param name="mode_sel" value="--careful,--sc"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_1.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_2.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="20" delta="5"/>
                     </assert_contents>
@@ -407,17 +407,17 @@ spades.py
             </conditional>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_1.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_2.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="20" delta="5"/>
                     </assert_contents>
@@ -439,17 +439,17 @@ spades.py
             <param name="mode_sel" value="--sc"/>
             <param name="optional_output" value="cr,l"/>
             <output_collection name="out_cr" type="list" count="3">
-                <element name="ecoli_1K.fastq.gz_1.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_1.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz_2.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz_2.00.0_0">
                     <assert_contents>
                         <has_size value="130317" delta="5000"/>
                     </assert_contents>
                 </element>
-                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0.cor">
+                <element name="ecoli_1K.fastq.gz__unpaired.00.0_0">
                     <assert_contents>
                         <has_size value="20" delta="5"/>
                     </assert_contents>


### PR DESCRIPTION
f37ce4136944e04dc14952bbfdca489ceda88d7d fixes current CI failure

Instead of 879ce2ee31c993faf0183f27d6d13bb1458c1e20 we could also define the `operation_mode` parameter in all tools?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
