### PR TITLE
concoct: fix test

### DIFF
--- a/tools/concoct/concoct.xml
+++ b/tools/concoct/concoct.xml
@@ -78,7 +78,7 @@ concoct
             </section>
             <output name="process_log" ftype="txt" compare="contains">
                 <assert_contents>
-                    <has_size value="786"/>
+                    <has_size value="786" delta="4"/>
                     <has_text text="CONCOCT Finished"/>
                 </assert_contents>
             </output>


### PR DESCRIPTION
fails CI with

```
Output process_log:  different than expected
Expected file size of 786+-0 found 787
```

I guess this is because the log contains the job working dir, eg
`/tmp/tmpnp9yg8__/job_working_directory/000/3/working/outdir`.
if the job is executed later the jobid may be larger than 3, ie
the log gets longer.

Assuming that the part that is `3` in the example can not
get longer than 5 digits I allow a delta of 4

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
