### PR TITLE
ngmlr: fix test for multiprocessing

### DIFF
--- a/tools/ngmlr/ngmlr.xml
+++ b/tools/ngmlr/ngmlr.xml
@@ -151,23 +151,23 @@
         <test>
             <param name="reference" value="ngmlr-ref1.fa" />
             <param name="query" value="ngmlr-in1.fa" />
-            <output name="alignments" file="ngmlr-out1.sam" lines_diff="2" />
+            <output name="alignments" file="ngmlr-out1.sam" lines_diff="2" sort="true" />
         </test>
         <test>
             <param name="reference" value="ngmlr-ref2.fa" />
             <param name="query" value="ngmlr-in2.fa" />
-            <output name="alignments" file="ngmlr-out2.sam" lines_diff="2" />
+            <output name="alignments" file="ngmlr-out2.sam" lines_diff="2" sort="true" />
         </test>
         <test>
             <param name="reference" value="ngmlr-ref3.fa.gz" />
             <param name="query" value="ngmlr-in3.fa.gz" />
             <param name="min_residues" value="0.01" />
-            <output name="alignments" file="ngmlr-out3.sam" lines_diff="2" />
+            <output name="alignments" file="ngmlr-out3.sam" lines_diff="2" sort="true" />
         </test>
         <test>
             <param name="reference" value="ngmlr-ref3.fa.gz" />
             <param name="query" value="ngmlr-in3.fa.gz" />
-            <output name="alignments" file="ngmlr-out4.sam" lines_diff="2" />
+            <output name="alignments" file="ngmlr-out4.sam" lines_diff="2" sort="true" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
output order differs depending on the # of used cores

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
