### PR TITLE
Have Snpeff build detect genbank input file compression without any magic

### DIFF
--- a/tool_collections/snpeff/gbk2fa.py
+++ b/tool_collections/snpeff/gbk2fa.py
@@ -36,7 +36,7 @@ args = parser.parse_args()
 
 gbk_open = get_opener(args.genbank_file)
 with gbk_open(args.genbank_file, 'rt') as input_handle, \
-    open(args.fasta_file, 'w') as output_handle:
+     open(args.fasta_file, 'w') as output_handle:
     for seq_record in SeqIO.parse(input_handle, 'genbank'):
         if args.remove_version:
             seq_id = seq_record.id.split('.')[0]

--- a/tool_collections/snpeff/gbk2fa.py
+++ b/tool_collections/snpeff/gbk2fa.py
@@ -1,43 +1,47 @@
 import argparse
 import bz2
-import contextlib
 import gzip
-import sys
 
-import magic
 from Bio import SeqIO
 
+
+def get_opener(gbk_filename):
+    try:
+        bz2.open(gbk_filename).read(1)
+        return bz2.open
+    except OSError:
+        pass
+    try:
+        gzip.open(gbk_filename).read(1)
+        return gzip.open
+    except OSError:
+        return open
+
+
 parser = argparse.ArgumentParser()
-parser.add_argument("genbank_file", help="GenBank input file. Can be compressed with gzip or bzip2")
-parser.add_argument("fasta_file", help="FASTA output datset")
-parser.add_argument("--remove_version", dest="remove_version", action="store_true", help="Remove version number from NCBI form formatted accession numbers. For example, this would convert 'B000657.2' to 'B000657'")
+parser.add_argument(
+    "genbank_file",
+    help="GenBank input file. Can be compressed with gzip or bzip2"
+)
+parser.add_argument(
+    "fasta_file", help="FASTA output datset"
+)
+parser.add_argument(
+    "--remove_version", action="store_true",
+    help="Remove version number from NCBI form formatted accession numbers. "
+         "For example, this would convert 'B000657.2' to 'B000657'"
+)
 args = parser.parse_args()
 
-gbk_filename = args.genbank_file
-fa_filename = args.fasta_file
 
-
-@contextlib.contextmanager
-def get_file_handle(gbk_filename):
-    f_type = magic.from_file(args.genbank_file, mime=True)
-    if f_type == 'text/plain':
-        input_handle = open(gbk_filename, "r")
-    elif f_type == 'application/gzip' or f_type == 'application/x-gzip':
-        input_handle = gzip.open(gbk_filename, "rt")
-    elif f_type == 'application/x-bzip2':
-        input_handle = bz2.open(gbk_filename, "rt")
-    else:
-        sys.exit("Cannot process file of type {}. Only plain, gzip'ed, and bzip2'ed genbank files are accepted ".format(f_type))
-    yield input_handle
-    input_handle.close()
-
-
-with get_file_handle(gbk_filename) as input_handle, open(fa_filename, "w") as output_handle:
-
-    for seq_record in SeqIO.parse(input_handle, "genbank"):
+gbk_open = get_opener(args.genbank_file)
+with gbk_open(args.genbank_file, 'rt') as input_handle, \
+    open(args.fasta_file, 'w') as output_handle:
+    for seq_record in SeqIO.parse(input_handle, 'genbank'):
         if args.remove_version:
             seq_id = seq_record.id.split('.')[0]
         else:
             seq_id = seq_record.id
         print('Writing FASTA record: {}'.format(seq_id))
-        output_handle.write(">{}\n{}\n".format(seq_id, seq_record.seq))
+        print('>' + seq_id, file=output_handle)
+        print(seq_record.seq, file=output_handle)

--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -50,7 +50,17 @@
         echo '${genome_version}.codonTable : ${codon_table}' >> '${snpeff_output.files_path}'/snpEff.config
     ]]></command>
     <inputs>
-        <param name="genome_version" type="text" value="" label="Name for the database" help="For E. coli K12 you may want to use 'EcK12' etc.">
+        <param name="genome_version" type="text" value="" label="Name for the database" help="For E. coli K12, for example, you may want to use 'EcK12'. Note: Spaces are not allowed in the name and will get converted to underscores.">
+            <sanitizer>
+                <valid initial="string.ascii_letters,string.digits">
+                    <add value="_" />
+                    <add value="." />
+                    <add value="-" />
+                </valid>
+                <mapping>
+                    <add source=" " target="_" />
+                </mapping>
+            </sanitizer>
             <validator type="empty_field" message="A genome version name is required" />
         </param>
         <conditional name="input_type">

--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -1,25 +1,19 @@
-<tool id="snpEff_build_gb" name="SnpEff build:" version="@WRAPPER_VERSION@.galaxy4">
+<tool id="snpEff_build_gb" name="SnpEff build:" version="@WRAPPER_VERSION@.galaxy5">
     <description> database from Genbank or GFF record</description>
     <macros>
         <import>snpEff_macros.xml</import>
     </macros>
     <requirements>
         <expand macro="requirement" />
-        <requirement type="package" version="3.6">python</requirement>
-        <requirement type="package" version="1.70">biopython</requirement>
-        <requirement type="package" version="0.4.15">python-magic</requirement>
-        <requirement type="package" version="5.32">libmagic</requirement>
+        <requirement type="package" version="1.79">biopython</requirement>
     </requirements>
     <expand macro="stdio" />
     <expand macro="version_command" />
     <command><![CDATA[
         #if str( $input_type.input_type_selector ) == "gb":
             #if str( $input_type.fasta ) == "yes":
-                python3 '$__tool_directory__/gbk2fa.py' '${input_type.input_gbk}' '${output_fasta}'
-                #if $input_type.remove_version:
-                    '${input_type.remove_version}'
-                #end if
-                &&
+                python3 '$__tool_directory__/gbk2fa.py'
+                    '${input_type.input_gbk}' '${output_fasta}' ${input_type.remove_version} &&
             #end if
         #end if
 
@@ -27,32 +21,32 @@
 
         #if str( $input_type.input_type_selector ) == "gb":
             #if $input_type.input_gbk.is_of_type("genbank"):
-                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}'/'${genome_version}'/genes.gbk &&
+                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}/${genome_version}/genes.gbk' &&
             #elif $input_type.input_gbk.is_of_type("genbank.gz"):
-                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}'/'${genome_version}'/genes.gbk.gz &&
+                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}/${genome_version}/genes.gbk.gz' &&
             #end if
         #elif str( $input_type.input_type_selector ) == "gff":
 	        #if $input_type.reference_source.reference_source_selector == "history":
-			  #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
-                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa &&
+			    #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
+                    ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
 	            #elif $input_type.reference_source.input_fasta.is_of_type("fasta.gz"):
-	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa.gz &&
+	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa.gz' &&
 	            #end if
 			#elif $input_type.reference_source.reference_source_selector == "cached":
-			  ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa &&
+			    ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
 			#end if
-            ln -s '${input_type.input_gff}' '${snpeff_output.files_path}'/'${genome_version}'/genes.gff &&
+            ln -s '${input_type.input_gff}' '${snpeff_output.files_path}/${genome_version}/genes.gff' &&
         #elif str( $input_type.input_type_selector ) == "gtf":
 	        #if $input_type.reference_source.reference_source_selector == "history":
-			  #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
-                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa &&
+			    #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
+                    ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
 	            #elif $input_type.reference_source.input_fasta.is_of_type("fasta.gz"):
-	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa.gz &&
+	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa.gz' &&
 	            #end if
 			#elif $input_type.reference_source.reference_source_selector == "cached":
-			  ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}'/'${genome_version}'/sequences.fa &&
+			    ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
 			#end if
-            ln -s '${input_type.input_gtf}' '${snpeff_output.files_path}'/'${genome_version}'/genes.gtf &&
+            ln -s '${input_type.input_gtf}' '${snpeff_output.files_path}/${genome_version}/genes.gtf' &&
         #end if
 
         snpEff @JAVA_OPTIONS@ build -v
@@ -66,9 +60,8 @@
             -gtf22
         #end if
         -dataDir '${snpeff_output.files_path}' '${genome_version}' &&
-        echo "${genome_version}.genome : ${genome_version}" >> '${snpeff_output.files_path}'/snpEff.config &&
-        echo "${genome_version}.codonTable : ${codon_table}" >> '${snpeff_output.files_path}'/snpEff.config
-
+        echo '${genome_version}.genome : ${genome_version}' >> '${snpeff_output.files_path}'/snpEff.config &&
+        echo '${genome_version}.codonTable : ${codon_table}' >> '${snpeff_output.files_path}'/snpEff.config
     ]]></command>
     <inputs>
         <param name="genome_version" type="text" value="" label="Name for the database" help="For E. coli K12 you may want to use 'EcK12' etc.">
@@ -86,7 +79,7 @@
                         <option value="yes" selected="true">Yes</option>
                         <option value="no">No</option>
                 </param>
-                <param argument="--remove_version" type="boolean" truevalue="--remove_version" falsevalue="" checked="true" label="Remove sequence version label?" help="Genbank sequences have vesion numbers such as B000564.2. This option removes them leaving only B000564" />
+                <param argument="--remove_version" type="boolean" truevalue="--remove_version" falsevalue="" checked="true" label="Remove sequence version label?" help="Genbank sequences have version numbers such as B000564.2. This option removes them leaving only B000564" />
             </when>
             <when value="gff">
                 <param name="input_gff" type="data" format="gff3" label="GFF dataset to build database from" help="This GFF file will be used to generate snpEff database"/>

--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -10,22 +10,19 @@
     <expand macro="stdio" />
     <expand macro="version_command" />
     <command><![CDATA[
-        #if str( $input_type.input_type_selector ) == "gb":
-            #if str( $input_type.fasta ) == "yes":
-                python3 '$__tool_directory__/gbk2fa.py'
-                    '${input_type.input_gbk}' '${output_fasta}' ${input_type.remove_version} &&
-            #end if
+        #if str($input_type.input_type_selector) == "gb" and str($input_type.fasta) == "yes":
+            python3 '$__tool_directory__/gbk2fa.py' '${input_type.input}' '${output_fasta}' ${input_type.remove_version} &&
         #end if
 
         mkdir -p '${snpeff_output.files_path}'/'${genome_version}' &&
 
-        #if str( $input_type.input_type_selector ) == "gb":
-            #if $input_type.input_gbk.is_of_type("genbank"):
-                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}/${genome_version}/genes.gbk' &&
-            #elif $input_type.input_gbk.is_of_type("genbank.gz"):
-                ln -s '${input_type.input_gbk}' '${snpeff_output.files_path}/${genome_version}/genes.gbk.gz' &&
+        #if str($input_type.input_type_selector) == "gb":
+            #if $input_type.input.is_of_type("genbank"):
+                ln -s '${input_type.input}' '${snpeff_output.files_path}/${genome_version}/genes.gbk' &&
+            #elif $input_type.input.is_of_type("genbank.gz"):
+                ln -s '${input_type.input}' '${snpeff_output.files_path}/${genome_version}/genes.gbk.gz' &&
             #end if
-        #elif str( $input_type.input_type_selector ) == "gff":
+        #else:
 	        #if $input_type.reference_source.reference_source_selector == "history":
 			    #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
                     ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
@@ -35,28 +32,17 @@
 			#elif $input_type.reference_source.reference_source_selector == "cached":
 			    ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
 			#end if
-            ln -s '${input_type.input_gff}' '${snpeff_output.files_path}/${genome_version}/genes.gff' &&
-        #elif str( $input_type.input_type_selector ) == "gtf":
-	        #if $input_type.reference_source.reference_source_selector == "history":
-			    #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
-                    ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
-	            #elif $input_type.reference_source.input_fasta.is_of_type("fasta.gz"):
-	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa.gz' &&
-	            #end if
-			#elif $input_type.reference_source.reference_source_selector == "cached":
-			    ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
-			#end if
-            ln -s '${input_type.input_gtf}' '${snpeff_output.files_path}/${genome_version}/genes.gtf' &&
+            ln -s '${input_type.input}' '${snpeff_output.files_path}/${genome_version}/genes.${input_type.input_type_selector}' &&
         #end if
 
         snpEff @JAVA_OPTIONS@ build -v
         -configOption '${genome_version}'.genome='${genome_version}'
         -configOption '${genome_version}'.codonTable='${codon_table}'
-        #if str( $input_type.input_type_selector ) == "gb":
+        #if str($input_type.input_type_selector) == "gb":
             -genbank
-        #elif str( $input_type.input_type_selector ) == "gff":
+        #elif str($input_type.input_type_selector) == "gff":
             -gff3
-        #elif str( $input_type.input_type_selector ) == "gtf":
+        #elif str($input_type.input_type_selector) == "gtf":
             -gtf22
         #end if
         -dataDir '${snpeff_output.files_path}' '${genome_version}' &&
@@ -74,7 +60,7 @@
                 <option value="gtf">GTF</option>
             </param>
             <when value="gb">
-                <param name="input_gbk" type="data" format="genbank,genbank.gz" label="Genbank dataset to build database from" help="This Genbank file will be used to generate snpEff database"/>
+                <param name="input" type="data" format="genbank,genbank.gz" label="Genbank dataset to build database from" help="This Genbank file will be used to generate snpEff database"/>
                 <param name="fasta" type="select" display="radio" label="Parse Genbank into Fasta" help="This will generate an additional dataset containing all sequences from Genbank file in FASTA format">
                         <option value="yes" selected="true">Yes</option>
                         <option value="no">No</option>
@@ -82,38 +68,12 @@
                 <param argument="--remove_version" type="boolean" truevalue="--remove_version" falsevalue="" checked="true" label="Remove sequence version label?" help="Genbank sequences have version numbers such as B000564.2. This option removes them leaving only B000564" />
             </when>
             <when value="gff">
-                <param name="input_gff" type="data" format="gff3" label="GFF dataset to build database from" help="This GFF file will be used to generate snpEff database"/>
-                <conditional name="reference_source">
-		            <param name="reference_source_selector" type="select" label="Choose the source for the reference genome">
-		                <option value="cached">Locally cached</option>
-		                <option value="history">History</option>
-		            </param>
-		            <when value="cached">
-		                <param name="ref_file" type="select" label="Select reference genome">
-		                    <options from_data_table="fasta_indexes"/>
-		                </param>
-		            </when>
-		            <when value="history"> 
-		                <param name="input_fasta" type="data" format="fasta,fasta.gz" label="Genome in FASTA format" help="This dataset is required for generating SnpEff database. See help section below."/>
-		            </when>
-		        </conditional>
+                <param name="input" type="data" format="gff3" label="GFF dataset to build database from" help="This GFF file will be used to generate snpEff database"/>
+                <expand macro="ref_select" />
             </when>
             <when value="gtf">
-                <param name="input_gtf" type="data" format="gtf" label="GTF dataset to build database from" help="This GTF file will be used to generate snpEff database"/>
-                <conditional name="reference_source">
-		            <param name="reference_source_selector" type="select" label="Choose the source for the reference genome">
-		                <option value="cached">Locally cached</option>
-		                <option value="history">History</option>
-		            </param>
-		            <when value="cached">
-		                <param name="ref_file" type="select" label="Select reference genome">
-		                    <options from_data_table="fasta_indexes"/>
-		                </param>
-		            </when>
-		            <when value="history"> 
-		                <param name="input_fasta" type="data" format="fasta,fasta.gz" label="Genome in FASTA format" help="This dataset is required for generating SnpEff database. See help section below."/>
-		            </when>
-		        </conditional>
+                <param name="input" type="data" format="gtf" label="GTF dataset to build database from" help="This GTF file will be used to generate snpEff database"/>
+                <expand macro="ref_select" />
             </when>
         </conditional>
         <param name="codon_table" type="select" label="Select genetic code for this sequence" help="If this sequence uses non-standard genetic code, select one from these options">
@@ -155,7 +115,7 @@
         <test>
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gb"/>
-            <param name="input_gbk" value="pBR322.gbk" />
+            <param name="input" value="pBR322.gbk" />
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text text="pBR322" />
@@ -166,7 +126,7 @@
         <test>
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gb"/>
-            <param name="input_gbk" value="pBR322.gbk.gz" />
+            <param name="input" value="pBR322.gbk.gz" />
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text text="pBR322" />
@@ -179,7 +139,7 @@
             <param name="input_type_selector" value="gff"/>
             <param name="reference_source_selector" value="history"/>
             <param name="input_fasta" value="pBR322_test2.fna" />
-            <param name="input_gff" value="pBR322.gff3"/>
+            <param name="input" value="pBR322.gff3"/>
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text text="pBR322" />
@@ -191,7 +151,7 @@
             <param name="input_type_selector" value="gff"/>
             <param name="reference_source_selector" value="history"/>
             <param name="input_fasta" value="pBR322_test2.fna.gz" />
-            <param name="input_gff" value="pBR322.gff3"/>
+            <param name="input" value="pBR322.gff3"/>
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text text="pBR322" />
@@ -203,7 +163,7 @@
             <param name="input_type_selector" value="gtf"/>
             <param name="reference_source_selector" value="history"/>
             <param name="input_fasta" value="Saccharomyces_mito.fa.gz" />
-            <param name="input_gtf" value="Saccharomyces_mito.gtf" />
+            <param name="input" value="Saccharomyces_mito.gtf" />
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text text="Saccharomyces_mito" />

--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -23,15 +23,15 @@
                 ln -s '${input_type.input}' '${snpeff_output.files_path}/${genome_version}/genes.gbk.gz' &&
             #end if
         #else:
-	        #if $input_type.reference_source.reference_source_selector == "history":
-			    #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
+            #if $input_type.reference_source.reference_source_selector == "history":
+                #if $input_type.reference_source.input_fasta.is_of_type("fasta"):
                     ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
-	            #elif $input_type.reference_source.input_fasta.is_of_type("fasta.gz"):
-	                ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa.gz' &&
-	            #end if
-			#elif $input_type.reference_source.reference_source_selector == "cached":
-			    ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
-			#end if
+                #elif $input_type.reference_source.input_fasta.is_of_type("fasta.gz"):
+                    ln -s '${input_type.reference_source.input_fasta}' '${snpeff_output.files_path}/${genome_version}/sequences.fa.gz' &&
+                #end if
+            #elif $input_type.reference_source.reference_source_selector == "cached":
+                ln -s '${input_type.reference_source.ref_file.fields.path}' '${snpeff_output.files_path}/${genome_version}/sequences.fa' &&
+            #end if
             ln -s '${input_type.input}' '${snpeff_output.files_path}/${genome_version}/genes.${input_type.input_type_selector}' &&
         #end if
 

--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -18,6 +18,22 @@ snpEff -version
   <token name="@SNPEFF_VERSION@">SnpEff4.3</token>
   <token name="@SNPEFF_DATABASE_URL@">https://sourceforge.net/projects/snpeff/files/databases/v4_3/</token>
   <token name="@JAVA_OPTIONS@">-Xmx\${GALAXY_MEMORY_MB:-8192}m</token>
+  <xml name="ref_select">
+    <conditional name="reference_source">
+        <param name="reference_source_selector" type="select" label="Choose the source for the reference genome">
+            <option value="cached">Locally cached</option>
+            <option value="history">History</option>
+        </param>
+        <when value="cached">
+            <param name="ref_file" type="select" label="Select reference genome">
+                <options from_data_table="fasta_indexes"/>
+            </param>
+        </when>
+        <when value="history">
+            <param name="input_fasta" type="data" format="fasta,fasta.gz" label="Genome in FASTA format" help="This dataset is required for generating SnpEff database. See help section below."/>
+        </when>
+    </conditional>
+  </xml>
   <token name="@EXTERNAL_DOCUMENTATION@">
 
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

The current version of the tool is failing on up-to-date instances of Galaxy (usegalaxy.org and usegalaxy.eu) because the tool magically picks up incompatible magic data from the Galaxy venv:
- `magic.MagicException: b"File 5.32 supports only version 14 magic files. /cvmfs/[main.galaxyproject.org/venv/lib/python3.8/site-packages/pylibmagic/magic.mgc](http://main.galaxyproject.org/venv/lib/python3.8/site-packages/pylibmagic/magic.mgc)' is version 16"` on usegalaxy.org
- `magic.MagicException: b"File 5.32 supports only version 14 magic files. /opt/galaxy/venv/lib64/python3.8/site-packages/pylibmagic/magic.mgc' is version 16"` on usegalaxy.eu

It's not entirely clear to me how that happens and I find this a bit disturbing, but from the tool wrapper point of view the whole magic business is a lot of overhead for a simple task anyway and gets removed in this PR.