### PR TITLE
Fix maker error when single_length is specified

### DIFF
--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -231,7 +231,7 @@ keep_preds=${advanced.keep_preds} # Concordance threshold to add unsupported gen
 split_hit=${advanced.split_hit} # length for the splitting of hits (expected max intron size for evidence alignments)
 single_exon=${advanced.single_exon.single_exon} # consider single exon EST evidence when generating annotations, 1 = yes, 0 = no
 #if $advanced.single_exon.single_exon == '1'
-single_length=${advanced.single_length} # min length required for single exon ESTs if 'single_exon is enabled'
+single_length=${advanced.single_exon.single_length} # min length required for single exon ESTs if 'single_exon is enabled'
 #else
 single_length=250 # min length required for single exon ESTs if 'single_exon is enabled'
 #end if


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

A Galaxy Australia user has reported a bug when they choose the advanced option "Consider single exon EST evidence when generating annotations"
