### PR TITLE
CheckM: Add filter for empty extra output

### DIFF
--- a/tools/checkm/analyze.xml
+++ b/tools/checkm/analyze.xml
@@ -36,7 +36,7 @@ checkm analyze
         <data name="bin_stats_analyze" format="tabular" from_work_dir="output/storage/bin_stats.analyze.tsv" label="${tool.name} on ${on_string}: Marker gene bin stats" />
         <data name="checkm_hmm_info" format="zip" from_work_dir="output/storage/checkm_hmm_info.pkl.gz" label="${tool.name} on ${on_string}: Marker gene HMM info for each bin" />
         <collection name="hmmer_analyze_ali" type="list" label="${tool.name} on ${on_string}: HMMER alignment file for each bin">
-            <filter>ali and 'hmmer_analyze_ali' in extra_outputs</filter>
+            <filter>ali and extra_outputs and 'hmmer_analyze_ali' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.analyze\.ali\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
     </outputs>

--- a/tools/checkm/lineage_wf.xml
+++ b/tools/checkm/lineage_wf.xml
@@ -66,65 +66,64 @@ checkm lineage_wf
         <data name="results" format="tabular" label="${tool.name} on ${on_string}: Bin statistics"/>
         <!--tree outputs-->
         <data name="phylo_hmm_info" format="zip" from_work_dir="output/storage/phylo_hmm_info.pkl.gz" label="${tool.name} on ${on_string}: Phylogenetic HMM model info for each bin">
-            <filter>'phylo_hmm_info' in extra_outputs</filter>
+            <filter>extra_outputs and 'phylo_hmm_info' in extra_outputs</filter>
         </data>
         <data name="bin_stats_tree" format="tabular" from_work_dir="output/storage/bin_stats.tree.tsv" label="${tool.name} on ${on_string}: Phylogenetic bin stats">
-            <filter>'bin_stats_tree' in extra_outputs</filter>
+            <filter>extra_outputs and 'bin_stats_tree' in extra_outputs</filter>
         </data>
         <collection name="hmmer_tree" type="list" label="${tool.name} on ${on_string}: Phylogenetic HMM hits to each bin">
-            <filter>'hmmer_tree' in extra_outputs</filter>
+            <filter>extra_outputs and 'hmmer_tree' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.tree\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <data name="concatenated_fasta" format="fasta" from_work_dir="output/storage/tree/concatenated.fasta" label="${tool.name} on ${on_string}: Concatenated masked sequences">
-            <filter>'concatenated_fasta' in extra_outputs</filter>
+            <filter>extra_outputs and 'concatenated_fasta' in extra_outputs</filter>
         </data>
         <data name="concatenated_tre" format="phyloxml" from_work_dir="output/storage/tree/concatenated.tre" label="${tool.name} on ${on_string}: Concatenated tree">
-            <filter>'concatenated_tre' in extra_outputs</filter>
+            <filter>extra_outputs and 'concatenated_tre' in extra_outputs</filter>
         </data>
         <collection name="hmmer_tree_ali" type="list" label="${tool.name} on ${on_string}: Phylogenetic HMMER alignment file for each bin">
-            <filter>tree_analyze['ali'] and 'hmmer_tree_ali' in extra_outputs</filter>
+            <filter>tree_analyze['ali'] and extra_outputs and 'hmmer_tree_ali' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.tree\.ali\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <data name="concatenated_pplacer_json" format="json" from_work_dir="output/storage/tree/concatenated.pplacer.json" label="${tool.name} on ${on_string}: Concatenated pplacer JSON">
-            <filter>'concatenate_pplacer_json' in extra_outputs</filter>
+            <filter>extra_outputs and 'concatenate_pplacer_json' in extra_outputs</filter>
         </data>
         <collection name="genes_fna" type="list" label="${tool.name} on ${on_string}: Protein gene sequences for each bin">
-            <filter>not tree_analyze['genes'] and tree_analyze['nt'] and 'genes_fna' in extra_outputs</filter>
+            <filter>not tree_analyze['genes'] and tree_analyze['nt'] and extra_outputs and 'genes_fna' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.fna" format="fasta" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <collection name="genes_faa" type="list" label="${tool.name} on ${on_string}: Nucleotide gene sequences for each bin">
-            <filter>'genes_faa' in extra_outputs</filter>
+            <filter>extra_outputs and 'genes_faa' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.faa" format="fasta" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <collection name="genes_gff" type="list" label="${tool.name} on ${on_string}: Gene feature files for each bin">
-            <filter>not tree_analyze['genes'] and 'genes_gff' in extra_outputs</filter>
+            <filter>not tree_analyze['genes'] and extra_outputs and 'genes_gff' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.gff" format="gff" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <!--lineage_set outputs-->
         <data name="marker_file" format="tabular" from_work_dir="output/lineage.ms" label="${tool.name} on ${on_string}: Marker genes">
-            <filter>'marker_file' in extra_outputs</filter>
+            <filter>extra_outputs and 'marker_file' in extra_outputs</filter>
         </data>
         <!--analyze outputs-->
         <collection name="hmmer_analyze" type="list" label="${tool.name} on ${on_string}: Marker gene HMM hits to each bin">
-            <filter>'hmmer_analyze' in extra_outputs</filter>
+            <filter>extra_outputs and 'hmmer_analyze' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.analyze\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <data name="bin_stats_analyze" format="tabular" from_work_dir="output/storage/bin_stats.analyze.tsv" label="${tool.name} on ${on_string}: Marker gene bin stats">
-            <filter>'bin_stats_analyze' in extra_outputs</filter>
+            <filter>extra_outputs and 'bin_stats_analyze' in extra_outputs</filter>
         </data>
         <data name="checkm_hmm_info" format="zip" from_work_dir="output/storage/checkm_hmm_info.pkl.gz" label="${tool.name} on ${on_string}: Marker gene HMM info for each bin" >
-            <filter>'checkm_hmm_info' in extra_outputs</filter>
+            <filter>extra_outputs and 'checkm_hmm_info' in extra_outputs</filter>
         </data>
         <collection name="hmmer_analyze_ali" type="list" label="${tool.name} on ${on_string}: HMMER alignment file for each bin">
-            <filter>tree_analyze['ali'] and 'hmmer_analyze_ali' in extra_outputs</filter>
+            <filter>tree_analyze['ali'] and extra_outputs and 'hmmer_analyze_ali' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.analyze\.ali\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <!--qa outputs-->
         <data name="bin_stats_ext" format="tabular" from_work_dir="output/storage/bin_stats_ext.tsv" label="${tool.name} on ${on_string}: Marker gene bin extensive stats">
-            <filter>'bin_stats_ext' in extra_outputs</filter>
+            <filter>extra_outputs and 'bin_stats_ext' in extra_outputs</filter>
         </data>
         <expand macro="qa_extra_outputs" />
-
     </outputs>
     <tests>
         <test expect_num_outputs="1">

--- a/tools/checkm/macros.xml
+++ b/tools/checkm/macros.xml
@@ -119,7 +119,7 @@ ln -s '$i' 'inputs/bins/${identifier}/hmmer.tree.txt' &&
             <filter>'alignment_file' in extra_outputs</filter>
         </data>-->
         <data name="marker_gene_stats" format="tabular" from_work_dir="output/storage/marker_gene_stats.tsv"  label="${tool.name} on ${on_string}: Marker gene statistics">
-            <filter>'marker_gene_stats' in extra_outputs</filter>
+            <filter>extra_outputs and 'marker_gene_stats' in extra_outputs</filter>
         </data>
     </xml>
     <xml name="rank_taxon">

--- a/tools/checkm/taxonomy_wf.xml
+++ b/tools/checkm/taxonomy_wf.xml
@@ -54,30 +54,30 @@ checkm taxonomy_wf
         <data name="results" format="tabular" label="${tool.name} on ${on_string}: Bin statistics"/>
         <!-- taxon_set outputs -->
         <data name="marker_file" format="tabular" from_work_dir="output/*.ms" label="${tool.name} on ${on_string}: Marker genes">
-            <filter>'marker_file' in extra_outputs</filter>
+            <filter>extra_outputs and 'marker_file' in extra_outputs</filter>
         </data>
         <!--analyze outputs-->
         <collection name="hmmer_analyze" type="list" label="${tool.name} on ${on_string}: Marker gene HMM hits to each bin">
-            <filter>'hmmer_analyze' in extra_outputs</filter>
+            <filter>extra_outputs and 'hmmer_analyze' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.analyze\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <data name="bin_stats_analyze" format="tabular" from_work_dir="output/storage/bin_stats.analyze.tsv" label="${tool.name} on ${on_string}: Marker gene bin stats">
-            <filter>'bin_stats_analyze' in extra_outputs</filter>
+            <filter>extra_outputs and 'bin_stats_analyze' in extra_outputs</filter>
         </data>
         <data name="checkm_hmm_info" format="zip" from_work_dir="output/storage/checkm_hmm_info.pkl.gz" label="${tool.name} on ${on_string}: Marker gene HMM info for each bin" >
-            <filter>'checkm_hmm_info' in extra_outputs</filter>
+            <filter>extra_outputs and 'checkm_hmm_info' in extra_outputs</filter>
         </data>
         <collection name="hmmer_analyze_ali" type="list" label="${tool.name} on ${on_string}: HMMER alignment file for each bin">
-            <filter>analyze['ali'] and 'hmmer_analyze_ali' in extra_outputs</filter>
+            <filter>analyze['ali'] and extra_outputs and 'hmmer_analyze_ali' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.analyze\.ali\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <!--qa outputs-->
         <data name="bin_stats_ext" format="tabular" from_work_dir="output/storage/bin_stats_ext.tsv" label="${tool.name} on ${on_string}: Marker gene bin extensive stats">
-            <filter>'bin_stats_ext' in extra_outputs</filter>
+            <filter>extra_outputs and 'bin_stats_ext' in extra_outputs</filter>
         </data>
         <expand macro="qa_extra_outputs" />
         <data name="marker_gene_stats" format="tabular" from_work_dir="output/storage/marker_gene_stats.tsv"  label="${tool.name} on ${on_string}: Marker gene statistics">
-            <filter>'marker_gene_stats' in extra_outputs</filter>
+            <filter>extra_outputs and 'marker_gene_stats' in extra_outputs</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/checkm/tree.xml
+++ b/tools/checkm/tree.xml
@@ -38,22 +38,22 @@ checkm tree
         <data name="concatenated_fasta" format="fasta" from_work_dir="output/storage/tree/concatenated.fasta" label="${tool.name} on ${on_string}: Concatenated masked sequences"/>
         <data name="concatenated_tre" format="phyloxml" from_work_dir="output/storage/tree/concatenated.tre" label="${tool.name} on ${on_string}: Concatenated tree"/>
         <collection name="hmmer_tree_ali" type="list" label="${tool.name} on ${on_string}: Phylogenetic HMMER alignment file for each bin">
-            <filter>ali and 'hmmer_tree_ali' in extra_outputs</filter>
+            <filter>ali and extra_outputs and 'hmmer_tree_ali' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/hmmer\.tree\.ali\.txt" format="txt" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <data name="concatenated_pplacer_json" format="json" from_work_dir="output/storage/tree/concatenated.pplacer.json" label="${tool.name} on ${on_string}: Concatenated pplacer JSON">
-            <filter>'concatenate_pplacer_json' in extra_outputs</filter>
+            <filter>extra_outputs and 'concatenate_pplacer_json' in extra_outputs</filter>
         </data>
         <collection name="genes_fna" type="list" label="${tool.name} on ${on_string}: Protein gene sequences for each bin">
-            <filter>not genes and nt and 'genes_fna' in extra_outputs</filter>
+            <filter>not genes and nt and extra_outputs and 'genes_fna' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.fna" format="fasta" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <collection name="genes_faa" type="list" label="${tool.name} on ${on_string}: Nucleotide gene sequences for each bin">
-            <filter>'genes_faa' in extra_outputs</filter>
+            <filter>extra_outputs and 'genes_faa' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.faa" format="fasta" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
         <collection name="genes_gff" type="list" label="${tool.name} on ${on_string}: Gene feature files for each bin">
-            <filter>not genes and 'genes_gff' in extra_outputs</filter>
+            <filter>not genes and extra_outputs and 'genes_gff' in extra_outputs</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)/genes\.gff" format="gff" directory="output/bins/" recurse="true" match_relative_path="true"/>
         </collection>
     </outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

---

All outputs are generated by defaults (and displayed in the workflow) if no options are selected for `extra_output` parameter (see [Galaxy issue](https://github.com/galaxyproject/galaxy/issues/7465#issuecomment-1207970222))