### PR TITLE
sansa: fix tests

### DIFF
--- a/tools/sansa/annotate.xml
+++ b/tools/sansa/annotate.xml
@@ -93,7 +93,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="57072"/>
+                    <has_size value="57072" delta="20"/>
                 </assert_contents>
             </output>
             <output name="out_query">
@@ -126,7 +126,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="57072"/>
+                    <has_size value="57072" delta="20"/>
                 </assert_contents>
             </output>
             <output name="out_query">
@@ -154,7 +154,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="2408"/>
+                    <has_size value="2408" delta="45"/>
                 </assert_contents>
             </output>
             <output name="out_query">
@@ -186,7 +186,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="2408"/>
+                    <has_size value="2408" delta="45"/>
                 </assert_contents>
             </output>
             <output name="out_query">
@@ -217,7 +217,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="57072"/>
+                    <has_size value="57072" delta="20"/>
                 </assert_contents>
             </output>
             <output name="out_query">
@@ -257,7 +257,7 @@ sansa annotate
             </section>
             <output name="out_anno">
                 <assert_contents>
-                    <has_size value="57072"/>
+                    <has_size value="57072" delta="20"/>
                 </assert_contents>
             </output>
             <output name="out_query">


### PR DESCRIPTION
currently failing CI

bcf output size apparently changed, I guess due either to

- outputs_to_workingdir
- or updated requirements

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
