### PR TITLE
chromeister: add profile

### DIFF
--- a/tools/chromeister/chromeister.xml
+++ b/tools/chromeister/chromeister.xml
@@ -1,7 +1,8 @@
-<tool id="chromeister" name="Chromeister" version="@TOOL_VERSION@">
+<tool id="chromeister" name="Chromeister" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <description>ultra-fast pairwise genome comparisons</description>
     <macros>
         <token name="@TOOL_VERSION@">1.5.a</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">chromeister</requirement>


### PR DESCRIPTION
currently failing CI because stderr contains:

```
Fontconfig error: No writable cache directories
```

but exit_code is 0.

stderr is ignored if a up to date profile is used.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
