### PR TITLE
fsd-td: remove unused nproc param

### DIFF
--- a/tools/fsd/td.xml
+++ b/tools/fsd/td.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<tool id="td" name="TD:" version="1.0.2" profile="19.01">
+<tool id="td" name="TD:" version="1.0.3" profile="19.01">
     <description>Tag distance analysis of duplex tags</description>
     <macros>
         <import>fsd_macros.xml</import>
@@ -30,7 +29,6 @@
         <param name="onlyDCS" type="boolean" label="Include only DCS in the analysis?" truevalue="" falsevalue="--only_DCS" checked="False" help="Include only tags forming duplex families (e.g. present in ab and ba configurations)."/>
         <param name="rel_freq" type="boolean" label="Relative frequency" truevalue="" falsevalue="--rel_freq" checked="False" help="If True, the relative frequencies instead of the absolute values are displayed in the plots."/>
         <param name="subsetTag" type="integer" label="Shorten tag in the analysis?" value="0" help="Use this parameter to simulate shorted tag lengths. Set to '0' to keep the original length. Default = 0"/>
-        <param name="nproc" type="integer" label="Number of processors" value="8" help="Number of processor used for computing."/>
         <param name="nr_above_bars" type="boolean" label="Include numbers above bars?" truevalue="--nr_above_bars" falsevalue="" checked="True" help="The absolute and relative values of the data can be included or removed from the plots. "/>
     </inputs>
     <outputs>


### PR DESCRIPTION
which is set automatically

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
