### PR TITLE
fix odgi build

### DIFF
--- a/tools/odgi/build.xml
+++ b/tools/odgi/build.xml
@@ -1,12 +1,14 @@
-<tool id="odgi_build" name="odgi build" version="@TOOL_VERSION@">
+<tool id="odgi_build" name="odgi build" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <description>construct a dynamic succinct variation graph</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
+cp '$gfa' input.gfa &&
+
 odgi build
--g '$gfa'
+-g input.gfa
 -o '$odgi_output'
 $sort
 #if $to_gfa:

--- a/tools/odgi/macros.xml
+++ b/tools/odgi/macros.xml
@@ -6,6 +6,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">0.3</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="citations">
         <citations>
             <yield />


### PR DESCRIPTION
currently fails CI due to

```
|  odgi: /opt/conda/conda-bld/odgi_1616839257024/work/deps/gfakluge/src/gfakluge.hpp:569: size_t gfak::mmap_open(const string&, char*&, int&): Assertion `false' failed.
|  /tmp/tmpdi1icj3u/job_working_directory/000/2/tool_script.sh: line 22:     7 Aborted                 (core dumped) odgi build -g '/tmp/tmpdi1icj3u/files/b/0/4/dataset_b04a44e9-eafd-415b-a3a8-0e671b31ff1d.dat' -o '/tmp/tmpdi1icj3u/job_working_directory/000/2/outputs/galaxy_dataset_6817b8a3-8f3d-4f14-a7ad-d73d11568ad8.dat' --sort --to-gfa > '/tmp/tmpdi1icj3u/job_working_directory/000/2/outputs/galaxy_dataset_38a641a6-89d8-4d27-baf0-00a9e665dd58.dat'
```

which is because https://github.com/edawson/gfakluge/issues/65

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
