### PR TITLE
Allow value -1 for --twopass1readsN

### DIFF
--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -313,7 +313,7 @@
             </when>
             <when value="Basic --twopass1readsN">
                 <param name="sj_precalculated" type="hidden" value="" />
-                <param argument="--twopass1readsN" name="twopass_read_subset" type="integer" min="1" value="50000" label="Number of reads to map in the first pass"/>
+                <param argument="--twopass1readsN" name="twopass_read_subset" type="integer" min="-1" value="50000" label="Number of reads to map in the first pass"/>
             </when>
             <when value="None --sjdbFileChrStartEnd">
                 <param name="twopass_read_subset" type="hidden" value="" />


### PR DESCRIPTION
The minimum value for --twopass1readsN is currently 1, however it should allow a -1 value. I don't know if it should allow a 0, but -1 is actually the default value, see the manual.

https://physiology.med.cornell.edu/faculty/skrabanek/lab/angsd/lecture_notes/STARmanual.pdf

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
