### PR TITLE
fix arriba

### DIFF
--- a/tools/arriba/arriba.xml
+++ b/tools/arriba/arriba.xml
@@ -55,7 +55,7 @@
         -c '$chimeric'
     #end if
     -a '$genome_assembly'
-    -g '$genome_annotation'
+    -g 'genome.gtf'
     #if $blacklist
         -b '$blacklist_file'
     #end if
@@ -71,17 +71,17 @@
     #if $tags
         -t '$tags_file'
     #end if
-    #if str($wgs.use_wgs) == "yes"
-        -d '$wgs.wgs'
-        #if str($wgs.max_genomic_breakpoint_distance)
-            -D $wgs.max_genomic_breakpoint_distance
+    #if str($wgs_cond.use_wgs) == "yes"
+        -d '$wgs_cond.wgs'
+        #if str($wg_cond.max_genomic_breakpoint_distance)
+            -D $wgs_cond.max_genomic_breakpoint_distance
         #end if
     #end if
     -o fusions.tsv
-#if $output_fusions_discarded
+    #if $output_fusions_discarded
     -O fusions.discarded.tsv 
-#end if
-## Arriba options
+    #end if
+    ## Arriba options
     #if $options.gtf_features
         -G '$options.gtf_features'
     #end if
@@ -186,13 +186,13 @@
         </param>
         <param name="tags" argument="-t" type="data" format="tabular" optional="true" label="File containing tag names for a fusion."
                help="This can be the known fusions if that input has a third column with a name"/>
-        <conditional name="wgs">
+        <conditional name="wgs_cond">
             <param name="use_wgs" type="select" label="Use whole-genome sequencing data">
                 <option value="no">no</option>
                 <option value="yes">Yes</option>
             </param>
             <when value="yes">
-                <param name="wgs" argument="-d" type="data" format="tabular" label="whole-genome sequencing structural variant data"
+                <param name="wgs" argument="-d" type="data" format="tabular,vcf" label="whole-genome sequencing structural variant data"
                        help="These coordinates serve to increase sensitivity towards weakly expressed fusions and to eliminate fusions with low evidence."/>
                 <param name="max_genomic_breakpoint_distance" argument="-D" type="integer" value="100000" min="0" label="Max genomic breakpoint distance"
                        help="determines how far a genomic breakpoint may be away from a transcriptomic breakpoint to consider it as a related event."/>

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.3.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">arriba</requirement>
@@ -58,12 +58,7 @@
     ]]></token>
     <token name="@GTF_SOURCE@"><![CDATA[
 #if str($genome_gtf.gtf_source) == "history"
-    #if $genome_gtf.annotation.is_of_type('gtf.gz')
-        #set $genome_annotation = 'genome.gtf.gz'
-    #else
-        #set $genome_annotation = 'genome.gtf'
-    #end if
-    ln -sf '$genome_gtf.annotation' $genome_annotation &&
+    ln -sf '$genome_gtf.annotation' genome.gtf &&
 #end if
     ]]></token>
 
@@ -300,7 +295,6 @@ draw_fusions.R
     #if str($visualization.options.pdfHeight)
         --pdfHeight=$visualization.options.pdfHeight
     #end if
-    # fontFamily
     #if $visualization.options.fontFamily
         --fontFamily=$visualization.options.fontFamily
     #end if


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/4799

problem was that the conditional and the contained parameter had the same name `wgs`.

also:

- wgs parameter should also (explicitly) accept vcf as documented
- do not check for gtf.gz datattype which does not exist in Galaxy and is also not allowed as input
- remove bash comment

TODO

- [ ] If anyone has an idea for a test vcf / tabular for a test I'm happy to extend the test

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
