### PR TITLE
Fix typo Arriba

### DIFF
--- a/tools/arriba/arriba.xml
+++ b/tools/arriba/arriba.xml
@@ -73,7 +73,7 @@
     #end if
     #if str($wgs_cond.use_wgs) == "yes"
         -d '$wgs_cond.wgs'
-        #if str($wg_cond.max_genomic_breakpoint_distance)
+        #if str($wgs_cond.max_genomic_breakpoint_distance)
             -D $wgs_cond.max_genomic_breakpoint_distance
         #end if
     #end if

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.3.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">arriba</requirement>


### PR DESCRIPTION
`wgs_cond` was typed as `wg_cond` at line 76 causing an error when using SV data in Arriba. Part of fix #4801 

FOR CONTRIBUTOR:

- [x] I have read the CONTRIBUTING.md document and this tool is appropriate for the tools-iuc repo.
- [x] License permits unrestricted use (educational + commercial)
- [ ] This PR adds a new tool or tool collection
- [x] This PR updates an existing tool or tool collection
- [ ] This PR does something else (explain below)