### PR TITLE
Updating tools/metaeuk from version 5.34c21f2 to 6.a5d39d9

### DIFF
--- a/tools/metaeuk/metaeuk_easy_predict.xml
+++ b/tools/metaeuk/metaeuk_easy_predict.xml
@@ -4,7 +4,7 @@
         <xref type="bio.tools">MetaEuk</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">5.34c21f2</token>
+        <token name="@TOOL_VERSION@">6.a5d39d9</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">metaeuk</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/metaeuk**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/metaeuk from version 5.34c21f2 to 6.a5d39d9.

**Project home page:** https://github.com/soedinglab/metaeuk/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).