### PR TITLE
Fix SpyBOAT wrapper license

### DIFF
--- a/tools/spyboat/spyboat.xml
+++ b/tools/spyboat/spyboat.xml
@@ -1,4 +1,4 @@
-<tool id="spyboat" name="SpyBOAT" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01"  license="GPL-3.0-or-later">
+<tool id="spyboat" name="SpyBOAT" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01" license="MIT">
 <description>wavelet analyzes image stacks</description>
     <macros>
         <token name="@TOOL_VERSION@">0.1.1</token>


### PR DESCRIPTION
The `license` attribute refers to the wrapper's license, not the license of the underlying tool(s), see https://docs.galaxyproject.org/en/master/dev/schema.html#attributes

xref. https://github.com/galaxy-iuc/standards/issues/72

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
