### PR TITLE
vcf2maf: Added partially missing ncbi_build parameter

### DIFF
--- a/tools/vcf2maf/vcf2maf.xml
+++ b/tools/vcf2maf/vcf2maf.xml
@@ -1,7 +1,8 @@
-<tool id="vcf2maf" name="Convert VCF to MAF" version="@TOOL_VERSION@">
+<tool id="vcf2maf" name="Convert VCF to MAF" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
 	<description>with vcf2maf</description>
 	<macros>
 		<token name="@TOOL_VERSION@">1.6.21</token>
+		<token name="@VERSION_SUFFIX@">1</token>
 		<token name="@DB_VERSION@">106</token>
 	</macros>
 	<requirements>
@@ -135,6 +136,9 @@
 			<param name="ref_source" value="history" />
 			<param name="ref" dbkey="hg19" value="test1.fa" ftype="fasta" />
 			<param name="annotation_cache.source" value="no_vep" />
+			<assert_command>
+				<has_text text="--ncbi-build 'GRCh37'"/>
+			</assert_command>
 			<output name="output1" file="output_test1.tabular" ftype="tabular" />
 		</test>
 		<test expect_num_outputs="1">
@@ -142,6 +146,9 @@
 			<param name="ref_source" value="cached" />
 			<param name="ref" value="hg19test" />
 			<param name="annotation_cache.source" value="no_vep" />
+			<assert_command>
+				<has_text text="--ncbi-build 'GRCh37'"/>
+			</assert_command>
 			<output name="output1" file="output_test1.tabular" ftype="tabular" />
 		</test>
 		<test expect_num_outputs="1">
@@ -150,6 +157,9 @@
 			<param name="ref" dbkey="dm6" value="test2.fa" ftype="fasta" />
 			<param name="source" value="restricted" />
 			<param name="cache_file" value="drosophila_melanogaster_vep_106_BDGP6.32" />
+			<assert_command>
+				<has_text text="--ncbi-build 'BDGP6.32'"/>
+			</assert_command>
 			<output name="output1" file="output_test2.tabular" ftype="tabular" />
 		</test>
 	</tests>

--- a/tools/vcf2maf/vcf2maf.xml
+++ b/tools/vcf2maf/vcf2maf.xml
@@ -9,6 +9,9 @@
 		<requirement type="package" version="@DB_VERSION@.1">ensembl-vep</requirement>
 	</requirements>
 	<command detect_errors="exit_code"><![CDATA[
+		## cBioPortal only supports human and mouse but requires their assembly name in NCBI format so we have to translate the dbkey for those
+		#set $ncbi_names = {"hg19": "GRCh37", "hg38": "GRCh38", "mm10": "GRCm38", "mm39": "GRCm39"}
+
 		ln -s '${input1}' MainInput.vcf &&
 		#if $ref_seq.ref_source == "cached":
 			ln -s '${ref_seq.ref.fields.path}' reference.fa &&
@@ -18,6 +21,11 @@
 		vcf2maf.pl --input-vcf MainInput.vcf --output-maf MainOutput.maf --ref-fasta reference.fa
 		#if $annotation_cache.source == "no_vep":
 			--inhibit-vep
+			#if $input1.metadata.dbkey in $ncbi_names:
+				--ncbi-build '${ncbi_names[$input1.metadata.dbkey]}'
+			#else:
+				--ncbi-build '${input1.metadata.dbkey}'
+			#end if
 		#else:
 			--vep-path \$(dirname \$(which vep))
 			--vep-data '${annotation_cache.cache_file.fields.path}'

--- a/tools/vcf2maf/vcf2maf.xml
+++ b/tools/vcf2maf/vcf2maf.xml
@@ -19,7 +19,7 @@
 		#elif $ref_seq.ref_source == "history":
 			ln -s '${ref_seq.ref}' reference.fa &&
 		#end if
-		vcf2maf.pl --input-vcf MainInput.vcf --output-maf MainOutput.maf --ref-fasta reference.fa
+		vcf2maf.pl --input-vcf MainInput.vcf --output-maf #if $include_header then 'MainOutput.maf' else 'temp.maf'# --ref-fasta reference.fa
 		#if $annotation_cache.source == "no_vep":
 			--inhibit-vep
 			#if $input1.metadata.dbkey in $ncbi_names:
@@ -65,6 +65,9 @@
 		#end if
 		#if $adv_opt.retain_ann:
 			--retain-ann '${adv_opt.retain_ann}'
+		#end if
+		#if not $include_header:
+			&& tail -n+3 temp.maf > MainOutput.maf
 		#end if
 	]]></command>
 	<inputs>
@@ -117,6 +120,7 @@
 		<param argument="--normal-id" type="text" optional="true" label="Enter normal sample ID (optional)" help="Used to fill the Matched_Norm_Sample_Barcode column of the output MAF with the normal sample ID."/>
 		<param argument="--vcf-tumor-id" type="text" optional="true" label="Enter name of tumor genotype column (optional)" help="VCFs from variant callers like VarScan use hardcoded sample IDs TUMOR/NORMAL to name genotype columns. Use this parameter to have vcf2maf correctly locate these columns to parse genotypes, while still printing proper sample IDs in the output MAF."/>
 		<param argument="--vcf-normal-id" type="text" optional="true" label="Enter name of normal genotype column (optional)" help="VCFs from variant callers like VarScan use hardcoded sample IDs TUMOR/NORMAL to name genotype columns. Use this parameter to have vcf2maf correctly locate these columns to parse genotypes, while still printing proper sample IDs in the output MAF."/>
+		<param name="include_header" type="boolean" checked="true" label="Include MAF header in output file" help="The MAF header consists of a comment row indicating the MAF version and a second row containing column headers."/>
 		
 		<section name="adv_opt" title="Advanced options">
 			<param argument="--any-allele" type="boolean" optional="true" checked="false" label="Allow also mismatched variant alleles when reporting co-located variants"/>
@@ -150,6 +154,20 @@
 				<has_text text="--ncbi-build 'GRCh37'"/>
 			</assert_command>
 			<output name="output1" file="output_test1.tabular" ftype="tabular" />
+		</test>
+		<test expect_num_outputs="1">
+			<param name="input1" dbkey="hg19" value="input_test1.vcf" ftype="vcf" />
+			<param name="ref_source" value="cached" />
+			<param name="ref" value="hg19test" />
+			<param name="annotation_cache.source" value="no_vep" />
+			<param name="include_header" value="False" />
+			<output name="output1" ftype="tabular" >
+				<assert_contents>
+					<has_n_lines n="1" />
+					<not_has_text text="#version 2.4" />
+					<not_has_text text="Hugo_Symbol" />
+				</assert_contents>
+			</output>
 		</test>
 		<test expect_num_outputs="1">
 			<param name="input1" dbkey="dm6" value="input_test2.vcf" ftype="vcf" />

--- a/tools/vcf2maf/vcf2maf.xml
+++ b/tools/vcf2maf/vcf2maf.xml
@@ -67,7 +67,7 @@
 			--retain-ann '${adv_opt.retain_ann}'
 		#end if
 		#if not $include_header:
-			&& tail -n+3 temp.maf > MainOutput.maf
+			&& tail -n+2 temp.maf > MainOutput.maf
 		#end if
 	]]></command>
 	<inputs>
@@ -120,7 +120,7 @@
 		<param argument="--normal-id" type="text" optional="true" label="Enter normal sample ID (optional)" help="Used to fill the Matched_Norm_Sample_Barcode column of the output MAF with the normal sample ID."/>
 		<param argument="--vcf-tumor-id" type="text" optional="true" label="Enter name of tumor genotype column (optional)" help="VCFs from variant callers like VarScan use hardcoded sample IDs TUMOR/NORMAL to name genotype columns. Use this parameter to have vcf2maf correctly locate these columns to parse genotypes, while still printing proper sample IDs in the output MAF."/>
 		<param argument="--vcf-normal-id" type="text" optional="true" label="Enter name of normal genotype column (optional)" help="VCFs from variant callers like VarScan use hardcoded sample IDs TUMOR/NORMAL to name genotype columns. Use this parameter to have vcf2maf correctly locate these columns to parse genotypes, while still printing proper sample IDs in the output MAF."/>
-		<param name="include_header" type="boolean" checked="true" label="Include MAF header in output file" help="The MAF header consists of a comment row indicating the MAF version and a second row containing column headers."/>
+		<param name="include_header" type="boolean" checked="true" label="Include MAF version header in output file" help="The MAF version header is a comment that indicates the MAF version and is written into the first row of the ouput file. This is required by some downstream tools. The row containing column headers follows next."/>
 		
 		<section name="adv_opt" title="Advanced options">
 			<param argument="--any-allele" type="boolean" optional="true" checked="false" label="Allow also mismatched variant alleles when reporting co-located variants"/>
@@ -163,9 +163,8 @@
 			<param name="include_header" value="False" />
 			<output name="output1" ftype="tabular" >
 				<assert_contents>
-					<has_n_lines n="1" />
+					<has_n_lines n="2" />
 					<not_has_text text="#version 2.4" />
-					<not_has_text text="Hugo_Symbol" />
 				</assert_contents>
 			</output>
 		</test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Previously, --ncbi_build was not set in the "no_vep"-case and therefore defaulted to "GRCh37". With this update, the parameter is set according to the dbkey of the input VCF file. Human and mouse are special cases as cBioPortal requires their assembly names in NCBI notation. Therefore, the dbkey of these is translated before. 