### PR TITLE
Add map_param_value expression tool

### DIFF
--- a/tools/map_param_value/.shed.yml
+++ b/tools/map_param_value/.shed.yml
@@ -1,0 +1,10 @@
+categories:
+- Text Manipulation
+description: Map a parameter value to another value
+homepage_url:
+long_description: |
+  This tool can be used in workflows to transform one value to another, for instance you can map a string like "unstranded" to a particular awk script, and "stranded" to another awk script.
+name: map_param_value
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/map_param_value
+type: unrestricted

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -100,7 +100,7 @@ return { output: coerceToOutput(source) };
 **What it does**
 
 Maps a parameter value to another value.
-This can be used to transform any non-data value value (text, integer, float and boolean) to a different value of a different type.
+This can be used to transform any non-data value (text, integer, float and boolean) to a different value of a different type.
 
 **Settings**
 

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -1,0 +1,57 @@
+<tool name="Map parameter value" id="map_param_value" version="0.1.0" tool_type="expression" profile="22.01">
+    <expression type="ecma5.1">
+        <![CDATA[{
+const source = $job.input_text_param;
+const mappings = $job.mappings;
+for ( var i = 0; i < mappings.length; i++ ) {
+    if ( mappings[i].from == source ) {
+        return { output: mappings[i].to };
+    }
+}
+if ( $job.fail_unmapped ) {
+    return { __error_message: `text_param ${source} not found in mapping values.` };
+}
+return { output: source };
+}]]>
+    </expression>
+    <inputs>
+        <param name="input_text_param" type="text" label="Text parameter to map to a different value" />
+        <repeat name="mappings" label="Add value mapping">
+            <param name="from" type="text" label="Map from this value"></param>
+            <param name="to" type="text" label="to this value"></param>
+        </repeat>
+        <param name="fail_unmapped" type="boolean" label="Fail if parameter not found in mappings?" />
+    </inputs>
+    <outputs>
+        <output type="text" name="output_text_param" from="output"></output>
+    </outputs>
+    <help><![CDATA[
+Maps a text parameter value to another value. If the value is not found in the mapping the unmodified value is returned by default. Set "Fail if parameter not found in mappings?" to true to fail the job if the input value has not been mapped to another value.
+    ]]></help>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="input_text_param" value="A" />
+            <repeat name="mappings">
+                <param name="from" value="A" />
+                <param name="to" value="B" />
+            </repeat>
+            <output name="output_text_param" value_json="&quot;B&quot;" />
+        </test>
+        <test expect_num_outputs="1">
+            <param name="input_text_param" value="C" />
+            <repeat name="mappings">
+                <param name="from" value="A" />
+                <param name="to" value="B" />
+            </repeat>
+            <output name="output_text_param" value_json="&quot;C&quot;" />
+        </test>
+        <test expect_num_outputs="1" expect_failure="true">
+            <param name="input_text_param" value="C" />
+            <repeat name="mappings">
+                <param name="from" value="A" />
+                <param name="to" value="B" />
+            </repeat>
+            <param name="fail_unmapped" value="true" />
+        </test>
+    </tests>
+</tool>

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -53,5 +53,17 @@ Maps a text parameter value to another value. If the value is not found in the m
             </repeat>
             <param name="fail_unmapped" value="true" />
         </test>
+        <test expect_num_outputs="1">
+            <param name="input_text_param" value="C" />
+            <repeat name="mappings">
+                <param name="from" value="A" />
+                <param name="to" value="B" />
+            </repeat>
+            <repeat name="mappings">
+                <param name="from" value="C" />
+                <param name="to" value="D" />
+            </repeat>
+            <param name="output_text_param" value_json="&quot;D&quot;" />
+        </test>
     </tests>
 </tool>

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -97,7 +97,47 @@ return { output: coerceToOutput(source) };
         </output>
     </outputs>
     <help><![CDATA[
-Maps a text parameter value to another value. If the value is not found in the mapping the unmodified value is returned by default. Select "Fail if input parameter value not found in mappings" if you wish the job to fail if an input could not be mapped, or select "Provide a default value to use if input parameter value not found in mappings" to provide a default value to use in case the input parameter value could not be mapped.
+**What it does**
+
+Maps a parameter value to another value.
+This can be used to transform any non-data value value (text, integer, float and boolean) to a different value of a different type.
+
+**Settings**
+
+ If the value is not found in the mapping the unmodified value is returned by default.
+ Select ``Fail if input parameter value not found in mappings`` if you wish the job to fail if an input could not be mapped.
+
+ Select ``Provide a default value to use if input parameter value not found in mappings`` to provide a default value to use in case the input parameter value could not be mapped.
+ Select the proper input and output parameter types based on your workflow input and output connections.
+
+**Examples**
+
+You want a user to select from 3 simple options in a workflow, e.g. ``low``, ``medium``, ``high``, which correspond to distinct integer values.
+
+Turn ``Map this parameter value to a different value`` into a a connectable workflow input by clicking on "Add connection to module".
+
+Set the input parameter type to ``Text``, and add 3 mappings:
+
+..
+
+  #.
+
+    * Map from this value: ``low``
+    * to this value: ``1``
+
+  #.
+
+    * Map from this value: ``medium``
+    * to this value: ``2``
+
+  #.
+
+    * Map from this value: ``high``
+    * to this value: ``3``
+
+Set ``Select type of parameter to output`` to ``Integer``.
+You can now connect the output to any connectable Integer input in your workflow.
+
     ]]></help>
     <tests>
         <test expect_num_outputs="1">

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -96,49 +96,6 @@ return { output: coerceToOutput(source) };
             <filter>output_param_type == 'boolean'</filter>
         </output>
     </outputs>
-    <help><![CDATA[
-**What it does**
-
-Maps a parameter value to another value.
-This can be used to transform any non-data value (text, integer, float and boolean) to a different value of a different type.
-
-**Settings**
-
- If the value is not found in the mapping the unmodified value is returned by default.
- Select ``Fail if input parameter value not found in mappings`` if you wish the job to fail if an input could not be mapped.
-
- Select ``Provide a default value to use if input parameter value not found in mappings`` to provide a default value to use in case the input parameter value could not be mapped.
- Select the proper input and output parameter types based on your workflow input and output connections.
-
-**Examples**
-
-You want a user to select from 3 simple options in a workflow, e.g. ``low``, ``medium``, ``high``, which correspond to distinct integer values.
-
-Turn ``Map this parameter value to a different value`` into a a connectable workflow input by clicking on "Add connection to module".
-
-Set the input parameter type to ``Text``, and add 3 mappings:
-
-..
-
-  #.
-
-    * Map from this value: ``low``
-    * to this value: ``1``
-
-  #.
-
-    * Map from this value: ``medium``
-    * to this value: ``2``
-
-  #.
-
-    * Map from this value: ``high``
-    * to this value: ``3``
-
-Set ``Select type of parameter to output`` to ``Integer``.
-You can now connect the output to any connectable Integer input in your workflow.
-
-    ]]></help>
     <tests>
         <test expect_num_outputs="1">
             <conditional name="input_param_type">
@@ -268,4 +225,47 @@ You can now connect the output to any connectable Integer input in your workflow
             <param name="output_param_float" value_json="2" />
         </test>
     </tests>
+    <help><![CDATA[
+**What it does**
+
+Maps a parameter value to another value.
+This can be used to transform any non-data value (text, integer, float and boolean) to a different value of a different type.
+
+**Settings**
+
+ If the value is not found in the mapping the unmodified value is returned by default.
+ Select ``Fail if input parameter value not found in mappings`` if you wish the job to fail if an input could not be mapped.
+
+ Select ``Provide a default value to use if input parameter value not found in mappings`` to provide a default value to use in case the input parameter value could not be mapped.
+ Select the proper input and output parameter types based on your workflow input and output connections.
+
+**Examples**
+
+You want a user to select from 3 simple options in a workflow, e.g. ``low``, ``medium``, ``high``, which correspond to distinct integer values.
+
+Turn ``Map this parameter value to a different value`` into a a connectable workflow input by clicking on "Add connection to module".
+
+Set the input parameter type to ``Text``, and add 3 mappings:
+
+..
+
+  #.
+
+    * Map from this value: ``low``
+    * to this value: ``1``
+
+  #.
+
+    * Map from this value: ``medium``
+    * to this value: ``2``
+
+  #.
+
+    * Map from this value: ``high``
+    * to this value: ``3``
+
+Set ``Select type of parameter to output`` to ``Integer``.
+You can now connect the output to any connectable Integer input in your workflow.
+
+    ]]></help>
 </tool>

--- a/tools/map_param_value/map_param_value.xml
+++ b/tools/map_param_value/map_param_value.xml
@@ -1,69 +1,231 @@
 <tool name="Map parameter value" id="map_param_value" version="0.1.0" tool_type="expression" profile="22.01">
+    <macros>
+        <xml name="when_element" tokens="type_selection">
+            <param name="input_param" type="@TYPE_SELECTION@" optional="true" label="Map this parameter value to a different value"/>
+            <repeat name="mappings" label="Add value mapping">
+                <param name="from" type="@TYPE_SELECTION@" optional="true" label="Map from this value"></param>
+                <param name="to" type="text" label="to this value" help="This value must be coercable to the selected output parameter type"></param>
+            </repeat>
+        </xml>
+    </macros>
     <expression type="ecma5.1">
         <![CDATA[{
-const source = $job.input_text_param;
-const mappings = $job.mappings;
-for ( var i = 0; i < mappings.length; i++ ) {
-    if ( mappings[i].from == source ) {
-        return { output: mappings[i].to };
+const source = $job.input_param_type.input_param;
+const mappings = $job.input_param_type.mappings;
+
+const coerceToOutput = function(value) {
+    switch($job.output_param_type) {
+        case "integer":
+            return parseInt(value)
+        case "float":
+            return parseFloat(value)
+        case "boolean":
+            if (value == "false" || value == "False") {
+                return false
+            }
+            return !!value
+        case "text":
+            return value
     }
 }
-if ( $job.fail_unmapped ) {
-    return { __error_message: `text_param ${source} not found in mapping values.` };
+
+for ( var i = 0; i < mappings.length; i++ ) {
+    if ( String(mappings[i].from) == source ) {
+        return { output: coerceToOutput(mappings[i].to) };
+    }
 }
-return { output: source };
+if ( $job.unmapped.on_unmapped == "fail" ) {
+    return { __error_message: `text_param ${source} not found in mapping values.` };
+} else if ( $job.unmapped.on_unmapped == "default" ) {
+    return { output: coerceToOutput($job.unmapped.default_value) };
+}
+return { output: coerceToOutput(source) };
 }]]>
     </expression>
     <inputs>
-        <param name="input_text_param" type="text" label="Text parameter to map to a different value" />
-        <repeat name="mappings" label="Add value mapping">
-            <param name="from" type="text" label="Map from this value"></param>
-            <param name="to" type="text" label="to this value"></param>
-        </repeat>
-        <param name="fail_unmapped" type="boolean" label="Fail if parameter not found in mappings?" />
+        <conditional name="input_param_type">
+            <param name="type" type="select" label="Select type of input parameter to match">
+                <option value="text" selected="true">Text</option>
+                <option value="integer">Integer</option>
+                <option value="float">Float</option>
+                <option value="boolean">Boolean</option>
+            </param>
+            <when value="text">
+                <expand macro="when_element" type_selection="text"/>
+            </when>
+            <when value="integer">
+                <expand macro="when_element" type_selection="integer"/>
+            </when>
+            <when value="float">
+                <expand macro="when_element" type_selection="float"/>
+            </when>
+            <when value="boolean">
+                <expand macro="when_element" type_selection="boolean"/>
+            </when>
+        </conditional>
+        <param name="output_param_type" type="select" label="Select type of parameter to output">
+            <option value="text">Text</option>
+            <option value="integer">Integer</option>
+            <option value="float">Float</option>
+            <option value="boolean">Boolean</option>
+        </param>
+        <conditional name="unmapped">
+            <param name="on_unmapped" type="select" label="Select how">
+                <option value="input">Use unmodified input parameter value if input parameter value not found in mappings</option>
+                <option value="fail">Fail if input parameter value not found in mappings</option>
+                <option value="default">Provide a default value to use if input parameter value not found in mappings</option>
+            </param>
+            <when value="input" />
+            <when value="fail" />
+            <when value="default">
+                <param name="default_value" type="text" label="Use this value if the input parameter value was not found in mappings"/>
+            </when>
+        </conditional>
     </inputs>
     <outputs>
-        <output type="text" name="output_text_param" from="output"></output>
+        <output type="text" name="output_param_text" from="output">
+            <filter>output_param_type == 'text'</filter>
+        </output>
+        <output type="integer" name="output_param_integer" from="output">
+            <filter>output_param_type == 'integer'</filter>
+        </output>
+        <output type="float" name="output_param_float" from="output">
+            <filter>output_param_type == 'float'</filter>
+        </output>
+        <output type="boolean" name="output_param_boolean" from="output">
+            <filter>output_param_type == 'boolean'</filter>
+        </output>
     </outputs>
     <help><![CDATA[
-Maps a text parameter value to another value. If the value is not found in the mapping the unmodified value is returned by default. Set "Fail if parameter not found in mappings?" to true to fail the job if the input value has not been mapped to another value.
+Maps a text parameter value to another value. If the value is not found in the mapping the unmodified value is returned by default. Select "Fail if input parameter value not found in mappings" if you wish the job to fail if an input could not be mapped, or select "Provide a default value to use if input parameter value not found in mappings" to provide a default value to use in case the input parameter value could not be mapped.
     ]]></help>
     <tests>
         <test expect_num_outputs="1">
-            <param name="input_text_param" value="A" />
-            <repeat name="mappings">
-                <param name="from" value="A" />
-                <param name="to" value="B" />
-            </repeat>
-            <output name="output_text_param" value_json="&quot;B&quot;" />
+            <conditional name="input_param_type">
+                <param name="type" value="text"/>
+                <param name="input_param" value="A" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+            </conditional>
+            <output name="output_param_text" value_json="&quot;B&quot;" />
         </test>
         <test expect_num_outputs="1">
-            <param name="input_text_param" value="C" />
-            <repeat name="mappings">
-                <param name="from" value="A" />
-                <param name="to" value="B" />
-            </repeat>
-            <output name="output_text_param" value_json="&quot;C&quot;" />
+            <conditional name="input_param_type">
+                <param name="input_param" value="C" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+            </conditional>
+            <output name="output_param_text" value_json="&quot;C&quot;" />
         </test>
         <test expect_num_outputs="1" expect_failure="true">
-            <param name="input_text_param" value="C" />
-            <repeat name="mappings">
-                <param name="from" value="A" />
-                <param name="to" value="B" />
-            </repeat>
-            <param name="fail_unmapped" value="true" />
+            <conditional name="input_param_type">
+                <param name="input_param" value="C" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+            </conditional>
+            <conditional name="unmapped">
+                <param name="on_unmapped" value="fail"/>
+            </conditional>
         </test>
         <test expect_num_outputs="1">
-            <param name="input_text_param" value="C" />
-            <repeat name="mappings">
-                <param name="from" value="A" />
-                <param name="to" value="B" />
-            </repeat>
-            <repeat name="mappings">
-                <param name="from" value="C" />
-                <param name="to" value="D" />
-            </repeat>
-            <param name="output_text_param" value_json="&quot;D&quot;" />
+            <conditional name="input_param_type">
+                <param name="input_param" value="C" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+            </conditional>
+            <conditional name="unmapped">
+                <param name="on_unmapped" value="default"/>
+                <param name="default_value" value="D"/>
+            </conditional>
+            <param name="output_param_text" value_json="&quot;D&quot;" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="input_param" value="C" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+            </conditional>
+            <conditional name="unmapped">
+                <param name="on_unmapped" value="default"/>
+                <param name="default_value" value="X"/>
+            </conditional>
+            <param name="output_param_text" value_json="&quot;X&quot;" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="input_param" value="C" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="B" />
+                </repeat>
+                <repeat name="mappings">
+                    <param name="from" value="C" />
+                    <param name="to" value="D" />
+                </repeat>
+            </conditional>
+            <param name="output_param_text" value_json="&quot;D&quot;" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="type" value="integer" />
+                <param name="input_param" value="42" />
+                <repeat name="mappings">
+                    <param name="from" value="42" />
+                    <param name="to" value="true" />
+                </repeat>
+            </conditional>
+            <param name="output_param_type" value="boolean"/>
+            <param name="output_param_boolean" value_json="true" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="type" value="float" />
+                <param name="input_param" value="1.2" />
+                <repeat name="mappings">
+                    <param name="from" value="42" />
+                    <param name="to" value="true" />
+                </repeat>
+            </conditional>
+            <conditional name="unmapped">
+                <param name="on_unmapped" value="default"/>
+                <param name="default_value" value="False"/>
+            </conditional>
+            <param name="output_param_type" value="boolean"/>
+            <param name="output_param_boolean" value_json="false" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="type" value="integer" />
+                <param name="input_param" value="1" />
+                <repeat name="mappings">
+                    <param name="from" value="1" />
+                    <param name="to" value="1.1" />
+                </repeat>
+            </conditional>
+            <param name="output_param_type" value="float"/>
+            <param name="output_param_float" value_json="1.1" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="input_param_type">
+                <param name="type" value="string" />
+                <param name="input_param" value="A" />
+                <repeat name="mappings">
+                    <param name="from" value="A" />
+                    <param name="to" value="2" />
+                </repeat>
+            </conditional>
+            <param name="output_param_type" value="integer"/>
+            <param name="output_param_float" value_json="2" />
         </test>
     </tests>
 </tool>


### PR DESCRIPTION
This will be very helpful for the 5th bullet point in https://github.com/galaxyproject/iwc/pull/126:
> Also, if there is a way in galaxy to do a:
if $strandness is 'unstranded' then parameter value is blabla elif $strandess is 'forward' then parameter value is bliblibli else parameter value is blobloblo' This would be better than letting the user choose between 3 awk commands and this would help for the stranded coverage.

I think we will eventually want to allow attaching arbitrary expressions to steps, which have access to a particular steps' jobs object,  closer to what CWL allows, but in the meantime this can be used to have user-friendly text values as workflow inputs.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
