### PR TITLE
Updating tools/bakta from version 1.5.0 to
1.8.1

### DIFF
--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.7.0</token>
+    <token name="@TOOL_VERSION@">1.8.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.5.1</token>
+    <token name="@TOOL_VERSION@">1.6.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.6.1</token>
+    <token name="@TOOL_VERSION@">1.7.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.6.0</token>
+    <token name="@TOOL_VERSION@">1.6.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.5.0</token>
+    <token name="@TOOL_VERSION@">1.5.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bakta**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bakta from version 1.5.0 to 1.5.1.

**Project home page:** https://github.com/oschwengers/bakta/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).