### PR TITLE
Updating tools/bracken from version 2.7 to 2.8

### DIFF
--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.8</token>
+    <token name="@TOOL_VERSION@">2.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="requirements">

--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.8</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bracken**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bracken from version 2.7 to 2.8.

**Project home page:** https://ccb.jhu.edu/software/bracken

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).