### PR TITLE
Updating tools/checkm from version 1.2.0 to 1.2.3

### DIFF
--- a/tools/checkm/macros.xml
+++ b/tools/checkm/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.2.0</token>
+    <token name="@TOOL_VERSION@">1.2.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biotools">

--- a/tools/checkm/plot.xml
+++ b/tools/checkm/plot.xml
@@ -47,7 +47,7 @@ ln -s '$i' 'inputs/bins/${identifier}/genes.gff' &&
     </macros>
     <expand macro="biotools"/>
     <expand macro="requirements">
-        <requirement type="package" version="1.15.1">samtools</requirement>
+        <requirement type="package" version="1.20">samtools</requirement>
     </expand>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/checkm/plot.xml
+++ b/tools/checkm/plot.xml
@@ -304,7 +304,7 @@ checkm gc_bias_plot
             <output_collection name="gc_plot" count="1">
                 <element name="637000110" ftype="eps">
                     <assert_contents>
-                        <has_size value="46633" delta="10"/>
+                        <has_size value="46343" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -337,7 +337,7 @@ checkm gc_bias_plot
             <output_collection name="coding_plot" count="1">
                 <element name="637000110" ftype="png">
                     <assert_contents>
-                        <has_size value="224295" delta="10"/>
+                        <has_size value="224229" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -409,7 +409,7 @@ checkm gc_bias_plot
             <output_collection name="dist_plot" count="1">
                 <element name="637000110" ftype="png">
                     <assert_contents>
-                        <has_size value="387707" delta="10"/>
+                        <has_size value="375137" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -435,7 +435,7 @@ checkm gc_bias_plot
             <output_collection name="nx_plot" count="1">
                 <element name="637000110" ftype="ps">
                     <assert_contents>
-                        <has_size value="18835" delta="10"/>
+                        <has_size value="18700" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -461,7 +461,7 @@ checkm gc_bias_plot
             <output_collection name="len_hist" count="1">
                 <element name="637000110" ftype="svg">
                     <assert_contents>
-                        <has_size value="9075" delta="10"/>
+                        <has_size value="11147" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -494,7 +494,7 @@ checkm gc_bias_plot
             <output_collection name="marker_plot" count="1">
                 <element name="637000110" ftype="png">
                     <assert_contents>
-                        <has_size value="137394" delta="10"/>
+                        <has_size value="137320" delta="100"/>
                     </assert_contents>
                 </element>
             </output_collection>

--- a/tools/checkm/taxonomy_wf.xml
+++ b/tools/checkm/taxonomy_wf.xml
@@ -76,9 +76,6 @@ checkm taxonomy_wf
             <filter>extra_outputs and 'bin_stats_ext' in extra_outputs</filter>
         </data>
         <expand macro="qa_extra_outputs" />
-        <data name="marker_gene_stats" format="tabular" from_work_dir="output/storage/marker_gene_stats.tsv"  label="${tool.name} on ${on_string}: Marker gene statistics">
-            <filter>extra_outputs and 'marker_gene_stats' in extra_outputs</filter>
-        </data>
     </outputs>
     <tests>
         <test expect_num_outputs="1">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/checkm**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/checkm from version 1.2.0 to 1.2.1.

**Project home page:** https://github.com/Ecogenomics/CheckM/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).