### PR TITLE
Updating tools/miniprot from version 0.3 to
0.11

### DIFF
--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.3</token>
+    <token name="@TOOL_VERSION@">0.4</token>
 </macros>

--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.9</token>
+    <token name="@TOOL_VERSION@">0.11</token>
 </macros>

--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7</token>
+    <token name="@TOOL_VERSION@">0.9</token>
 </macros>

--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.4</token>
+    <token name="@TOOL_VERSION@">0.5</token>
 </macros>

--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.5</token>
+    <token name="@TOOL_VERSION@">0.6</token>
 </macros>

--- a/tools/miniprot/macros.xml
+++ b/tools/miniprot/macros.xml
@@ -1,3 +1,3 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.6</token>
+    <token name="@TOOL_VERSION@">0.7</token>
 </macros>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/miniprot**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/miniprot from version 0.3 to 0.4.

**Project home page:** https://github.com/lh3/miniprot/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).