### PR TITLE
Updating tools/ncbi_entrez_direct from version 13.3 to 16.2

### DIFF
--- a/tools/ncbi_entrez_direct/macros.xml
+++ b/tools/ncbi_entrez_direct/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">13.3</token>
+    <token name="@TOOL_VERSION@">16.2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">entrez-direct</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ncbi_entrez_direct**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ncbi_entrez_direct from version 13.3 to 16.2.

**Project home page:** http://www.ncbi.nlm.nih.gov/books/NBK179288

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).