### PR TITLE
Updating tools/pangolin from version 4.1.2 to 4.1.3

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,7 +1,7 @@
 <tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.1.2</token>
+        <token name="@TOOL_VERSION@">4.1.3</token>
         <token name="@PANGOLIN_DATA_VERSION@">1.12</token>
         <token name="@CONSTELLATIONS_VERSION@">0.1.10</token>
         <token name="@MIN_COMPATIBLE_PANGOLIN_DATA_FORMAT@">4</token>
@@ -71,8 +71,8 @@
         versions become available. Also, please check for updated dependencies
         when updating the wrapper for other reasons. -->
         <requirement type="package" version="0.3.17">scorpio</requirement>
-        <requirement type="package" version="@PANGOLIN_DATA_VERSION@">pangolin-data</requirement>
-        <requirement type="package" version="@CONSTELLATIONS_VERSION@">constellations</requirement>
+        <requirement type="package" version="1.15.1">pangolin-data</requirement>
+        <requirement type="package" version="0.1.10">constellations</requirement>
         <requirement type="package" version="0.5.6">usher</requirement>
         <requirement type="package" version="1.1.0">gofasta</requirement>
         <requirement type="package" version="426">ucsc-fatovcf</requirement>
@@ -80,7 +80,7 @@
         <!-- wrapper-specific requirements to turn pangolin's native
         comma-separated output into tab-separated one and to truncate
         pangolin's all-versions output. -->
-        <requirement type="package" version="0.23.0">csvtk</requirement>
+        <requirement type="package" version="0.25.0">csvtk</requirement>
         <requirement type="package" version="3.4">grep</requirement>
     </requirements>
     <version_command><![CDATA[pangolin --version]]></version_command>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pangolin**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pangolin from version 4.1.2 to 4.1.3.

**Project home page:** https://github.com/cov-lineages/pangolin/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).