### PR TITLE
Updating tools/semibin from version 1.1.1 to 1.2.0

### DIFF
--- a/tools/semibin/macros.xml
+++ b/tools/semibin/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.1.1</token>
+    <token name="@TOOL_VERSION@">1.2.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biotools">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/semibin**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/semibin from version 1.1.1 to 1.2.0.

**Project home page:** https://semibin.readthedocs.io/en/latest

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).