### PR TITLE
Updating tools/seqkit from version 2.2.0 to 2.3.1

### DIFF
--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.0</token>
+    <token name="@TOOL_VERSION@">2.3.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/test-data/stats_output1.tabular
+++ b/tools/seqkit/test-data/stats_output1.tabular
@@ -1,2 +1,2 @@
-file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)
-input1_fastq_gz	FASTQ	DNA	5	505	101	101.0	101	50.5	101.0	50.5	0	101	98.02	89.31
+file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)	GC(%)
+input1_fastq_gz	FASTQ	DNA	5	505	101	101.0	101	50.5	101.0	50.5	0	101	98.02	89.31	35.45

--- a/tools/seqkit/test-data/stats_output2.tabular
+++ b/tools/seqkit/test-data/stats_output2.tabular
@@ -1,2 +1,2 @@
-file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)
-input1_fasta_gz	FASTA	DNA	3	10732	1213	3577.3	4796	2968.0	4723.0	4759.5	0	4723	0.00	0.00
+file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)	GC(%)
+input1_fasta_gz	FASTA	DNA	3	10732	1213	3577.3	4796	2968.0	4723.0	4759.5	0	4723	0.00	0.00	48.15


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/seqkit**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/seqkit from version 2.2.0 to 2.3.1.

**Project home page:** https://bioinf.shenwei.me/seqkit

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).