### PR TITLE
Updating tools/spades from version 3.15.4 to 3.15.5

### DIFF
--- a/tools/spades/macros.xml
+++ b/tools/spades/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.15.4</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">3.15.5</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">spades</requirement>

--- a/tools/spades/spades.xml
+++ b/tools/spades/spades.xml
@@ -1,4 +1,4 @@
-<tool id="spades" name="SPAdes" version="@TOOL_VERSION@+galaxy1" profile="20.01">
+<tool id="spades" name="SPAdes" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>genome assembler for genomes of regular and single-cell projects</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/spades**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/spades from version 3.15.4 to 3.15.5.

**Project home page:** https://github.com/ablab/spades/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).