### PR TITLE
Updating tools/tn93 from version 1.0.6 to 1.0.14

### DIFF
--- a/tools/tn93/macros.xml
+++ b/tools/tn93/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.0.6</token>
+    <token name="@TOOL_VERSION@">1.0.14</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tn93</requirement>

--- a/tools/tn93/readreduce.xml
+++ b/tools/tn93/readreduce.xml
@@ -1,4 +1,4 @@
-<tool id="tn93_readreduce" name="Merge matching reads" version="@TOOL_VERSION@+galaxy1">
+<tool id="tn93_readreduce" name="Merge matching reads" version="@TOOL_VERSION@+galaxy0">
     <description>into clusters with TN-93</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tn93/tn93.xml
+++ b/tools/tn93/tn93.xml
@@ -1,4 +1,4 @@
-<tool id="tn93" name="TN93" version="@TOOL_VERSION@+galaxy1">
+<tool id="tn93" name="TN93" version="@TOOL_VERSION@+galaxy0">
     <description>compute distances between aligned sequences</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tn93/tn93_cluster.xml
+++ b/tools/tn93/tn93_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="tn93_cluster" name="TN93 Cluster" version="@TOOL_VERSION@+galaxy1">
+<tool id="tn93_cluster" name="TN93 Cluster" version="@TOOL_VERSION@+galaxy0">
     <description>sequences that lie within a specific distance of each other</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tn93/tn93_filter.xml
+++ b/tools/tn93/tn93_filter.xml
@@ -1,10 +1,10 @@
-<tool id="tn93_filter" name="TN93 Filter" version="@TOOL_VERSION@+galaxy1">
+<tool id="tn93_filter" name="TN93 Filter" version="@TOOL_VERSION@+galaxy0">
     <description>- remove sequences from a reference that are within a given distance of of a cluster</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.70">biopython</requirement>
+        <requirement type="package" version="1.84">biopython</requirement>
     </expand>
     <version_command><![CDATA[tn93 --version]]></version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/tn93**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/tn93 from version 1.0.6 to 1.0.9.

**Project home page:** https://github.com/veg/tn93/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).