### PR TITLE
add CLIP-seq toolshed category

### DIFF
--- a/tools/pureclip/.shed.yml
+++ b/tools/pureclip/.shed.yml
@@ -23,3 +23,4 @@ type: unrestricted
 categories:
 - Sequence Analysis
 - RNA
+- CLIP-seq


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

This just adds the "CLIP-seq" toolshed category. There are a number of CLIP-seq related tools on Galaxy, so a CLIP-seq category will be useful to better categorize them.
