### PR TITLE
Updating tools/blast from version 1.6.0 to 1.7.0

### DIFF
--- a/tools/blast/macros.xml
+++ b/tools/blast/macros.xml
@@ -1,11 +1,11 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.6.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">1.7.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">magicblast</requirement>
-            <requirement type="package" version="1.15">samtools</requirement>
+            <requirement type="package" version="1.16.1">samtools</requirement>
         </requirements>
     </xml>
     <xml name="output_sort_param">

--- a/tools/blast/magicblast.xml
+++ b/tools/blast/magicblast.xml
@@ -317,7 +317,7 @@ $output_options.no_discordant
             <param name="subject" value="subject1.fasta.gz" ftype="fasta.gz"/>
             <output name="output" ftype="bam">
                 <assert_contents>
-                    <has_size value="62080" delta="50"/>
+                    <has_size value="61454" delta="50"/>
                 </assert_contents>
             </output>
         </test>
@@ -329,7 +329,7 @@ $output_options.no_discordant
             <param name="database" value="phiX174"/>
             <output name="output" ftype="bam">
                 <assert_contents>
-                    <has_size value="62079" delta="50"/>
+                    <has_size value="61457" delta="50"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/blast**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/blast from version 1.6.0 to 1.7.0.

**Project home page:** https://ncbi.github.io/magicblast

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).