### PR TITLE
Updating tools/optdoe from version 2.0.2 to v2.0.2

### DIFF
--- a/tools/optdoe/optdoe.xml
+++ b/tools/optdoe/optdoe.xml
@@ -2,7 +2,7 @@
     <description>Combine selected genetic parts and enzyme variants for the desired pathways</description>
     <macros>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@TOOL_VERSION@">2.0.2</token>
+        <token name="@TOOL_VERSION@">v2.0.2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">doebase</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/optdoe**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/optdoe from version 2.0.2 to v2.0.2.

**Project home page:** https://github.com/pablocarb/doebase/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).