### PR TITLE
remove deprecated set-output syntax and update create-or-update-comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Add reaction
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v2.1.0
+      uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -173,7 +173,7 @@ jobs:
 
     - name: Create comment
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v2.1.0
+      uses: peter-evans/create-or-update-comment@v2
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Add reaction
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2.1.0
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -173,7 +173,7 @@ jobs:
 
     - name: Create comment
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2.1.0
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,12 @@ jobs:
       id: get-fork-branch
       run: |
         TMP="${{ github.event.client_payload.slash_command.args.named.fork }}"
-        echo "::set-output name=fork::${TMP:-$GALAXY_FORK}"
+        echo "fork=${TMP:-$GALAXY_FORK}" >> $GITHUB_OUTPUT
         TMP="${{ github.event.client_payload.slash_command.args.named.branch }}"
-        echo "::set-output name=branch::${TMP:-$GALAXY_BRANCH}"
+        echo "branch=${TMP:-$GALAXY_BRANCH}" >> $GITHUB_OUTPUT
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
-      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)"
+      run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -169,7 +169,7 @@ jobs:
     - name: Create URL to the run output
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
       id: vars
-      run: echo "::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
 
     - name: Create comment
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,7 +43,7 @@ jobs:
         echo 'event.after: ${{ github.event.after }}'
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
-      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
+      run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         if: github.repository_owner == 'galaxyproject'
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: peter-evans/slash-command-dispatch@v3.0.1
         with:
           token: ${{ secrets.PAT }}
           commands: |

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         if: github.repository_owner == 'galaxyproject'
-        uses: peter-evans/slash-command-dispatch@v3.0.1
+        uses: peter-evans/slash-command-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
           commands: |


### PR DESCRIPTION
This PR only change the github workflow yaml to avoid the deprecation warnings and use the new syntax: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/