### PR TITLE
Updating tools/annotatemyids from version 3.14.0 to 3.16.0

### DIFF
--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -4,8 +4,8 @@
         <xref type="bio.tools">annotatemyids</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">3.14.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">3.16.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-org.hs.eg.db</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/annotatemyids**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/annotatemyids from version 3.14.0 to 3.16.0.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).