### PR TITLE
Fix python linting errors for table_compute

### DIFF
--- a/tools/table_compute/scripts/table_compute.py
+++ b/tools/table_compute/scripts/table_compute.py
@@ -57,7 +57,7 @@ class Utils:
                         for col in data.columns]
         data.index = [row.strip() if type(row) is str else row
                       for row in data.index]
-        return(data)
+        return data
 
     @staticmethod
     def rangemaker(tab):
@@ -106,8 +106,8 @@ class Utils:
                     err_mess = "%s should not be equal or contain a zero" % nums
             if err_mess:
                 print(err_mess)
-                return(None)
-        return(out)
+                return None
+        return out
 
 
 # Set decimal precision
@@ -318,7 +318,7 @@ if user_mode == "single":
             pivot_values = params["PIVOT"]["pivot_values"]
             pivot_aggfunc = params["PIVOT"]["pivot_aggfunc"]
 
-            if not(pivot_aggfunc):
+            if not pivot_aggfunc:
                 out_table = data.pivot(
                     index=pivot_index, columns=pivot_column, values=pivot_values
                 )

--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -2,7 +2,7 @@
     <description>computes operations on table data</description>
     <macros>
         <token name="@VERSION@">1.2.4</token>
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
         <token name="@COPEN@"><![CDATA[<code>]]></token>
         <token name="@CCLOSE@"><![CDATA[</code>]]></token>
         <import>allowed_functions.xml</import>
@@ -24,7 +24,7 @@
             <sanitizer sanitize="false" />
         </macro>
         <macro name="validator_functiondef">
-            <validator type="regex" message="An expression is required and is allowed to contain only letters, numbers and the characters _ !-+=/*%.&lt;&gt;()">^[\w !\-+=/*%,.&lt;&gt;()]+$</validator>
+            <validator type="regex" message="An expression is required and is allowed to contain only letters, numbers and the characters _ !-+=/*%.&lt;&gt;()">^[\w !\-+=/*%,.&lt;&gt;()\[\]:]+$</validator>
             <sanitizer sanitize="false" />
         </macro>
         <!-- macro for main input tests -->

--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -2,7 +2,7 @@
     <description>computes operations on table data</description>
     <macros>
         <token name="@VERSION@">1.2.4</token>
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <token name="@COPEN@"><![CDATA[<code>]]></token>
         <token name="@CCLOSE@"><![CDATA[</code>]]></token>
         <import>allowed_functions.xml</import>
@@ -24,7 +24,7 @@
             <sanitizer sanitize="false" />
         </macro>
         <macro name="validator_functiondef">
-            <validator type="regex" message="An expression is required and is allowed to contain only letters, numbers and the characters _ !-+=/*%.&lt;&gt;()">^[\w !\-+=/*%,.&lt;&gt;()\[\]:]+$</validator>
+            <validator type="regex" message="An expression is required and is allowed to contain only letters, numbers and the characters _ !-+=/*%.&lt;&gt;()">^[\w !\-+=/*%,.&lt;&gt;()]+$</validator>
             <sanitizer sanitize="false" />
         </macro>
         <!-- macro for main input tests -->


### PR DESCRIPTION
- tests 20 and 21 were suddenly failing in CI 
  - failure is legit, but I don't know which galaxy change triggered it
- not sure what triggers the failing test 41 (it appears that the test is supposed to fail, but it is not recognized)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
