### PR TITLE
Updating tools/ampvis2 from version 2.7.22 to 2.8.9

### DIFF
--- a/tools/ampvis2/macros.xml
+++ b/tools/ampvis2/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7.22</token>
+    <token name="@TOOL_VERSION@">2.7.32</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="header">
@@ -8,7 +8,7 @@
         </xrefs>
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-ampvis2</requirement>
-            <requirement type="package" version="2.1.1">r-readr</requirement>
+            <requirement type="package" version="2.1.3">r-readr</requirement>
         </requirements>
         <version_command><![CDATA[
 echo $(R --version | grep "R version")", ampvis2 version" $(R --vanilla --slave -e "library(ampvis2, quietly = TRUE); sessionInfo()\$otherPkgs\$ampvis2\$Version" 2> /dev/null | grep -v -i "WARNING: ")

--- a/tools/ampvis2/macros.xml
+++ b/tools/ampvis2/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.8.6</token>
+    <token name="@TOOL_VERSION@">2.8.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="header">

--- a/tools/ampvis2/macros.xml
+++ b/tools/ampvis2/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7.32</token>
+    <token name="@TOOL_VERSION@">2.8.6</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="header">
@@ -8,7 +8,7 @@
         </xrefs>
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-ampvis2</requirement>
-            <requirement type="package" version="2.1.3">r-readr</requirement>
+            <requirement type="package" version="2.1.5">r-readr</requirement>
         </requirements>
         <version_command><![CDATA[
 echo $(R --version | grep "R version")", ampvis2 version" $(R --vanilla --slave -e "library(ampvis2, quietly = TRUE); sessionInfo()\$otherPkgs\$ampvis2\$Version" 2> /dev/null | grep -v -i "WARNING: ")


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ampvis2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ampvis2 from version 2.7.22 to 2.7.32.

**Project home page:** https://github.com/MadsAlbertsen/ampvis2/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).