### PR TITLE
Updating tools/ancombc from version 1.4.0 to 2.4.0

### DIFF
--- a/tools/ancombc/macros.xml
+++ b/tools/ancombc/macros.xml
@@ -1,11 +1,11 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.1</token>
+    <token name="@TOOL_VERSION@">2.2.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-ancombc</requirement>
-            <requirement type="package" version="1.14.4">r-data.table</requirement>
+            <requirement type="package" version="1.14.8">r-data.table</requirement>
             <requirement type="package" version="1.7.3">r-optparse</requirement>
         </requirements>
     </xml>

--- a/tools/ancombc/macros.xml
+++ b/tools/ancombc/macros.xml
@@ -1,12 +1,12 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.4.0</token>
+    <token name="@TOOL_VERSION@">2.0.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-ancombc</requirement>
-            <requirement type="package" version="1.14.2">r-data.table</requirement>
-            <requirement type="package" version="1.7.1">r-optparse</requirement>
+            <requirement type="package" version="1.14.4">r-data.table</requirement>
+            <requirement type="package" version="1.7.3">r-optparse</requirement>
         </requirements>
     </xml>
     <xml name="sanitize_query" token_validinitial="string.printable">

--- a/tools/ancombc/macros.xml
+++ b/tools/ancombc/macros.xml
@@ -1,12 +1,12 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.0</token>
+    <token name="@TOOL_VERSION@">2.4.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-ancombc</requirement>
-            <requirement type="package" version="1.14.8">r-data.table</requirement>
-            <requirement type="package" version="1.7.3">r-optparse</requirement>
+            <requirement type="package" version="1.14.10">r-data.table</requirement>
+            <requirement type="package" version="1.7.4">r-optparse</requirement>
         </requirements>
     </xml>
     <xml name="sanitize_query" token_validinitial="string.printable">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ancombc**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ancombc from version 1.4.0 to 2.0.1.

**Project home page:** https://github.com/FrederickHuangLin/ANCOMBC/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).