### PR TITLE
Updating tools/cemitool from version 1.18.1 to 1.26.0

### DIFF
--- a/tools/cemitool/macros.xml
+++ b/tools/cemitool/macros.xml
@@ -1,11 +1,11 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.18.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">1.26.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-cemitool</requirement>
-            <requirement type="package" version="3.3.6">r-ggplot2</requirement>
-            <requirement type="package" version="1.20.3">r-getopt</requirement>
+            <requirement type="package" version="3.5.1">r-ggplot2</requirement>
+            <requirement type="package" version="1.20.4">r-getopt</requirement>
         </requirements>
     </xml>
     <xml name="xrefs">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cemitool**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cemitool from version 1.18.1 to 1.22.0.

**Project home page:** https://www.bioconductor.org/packages/release/bioc/html/CEMiTool.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).