### PR TITLE
Updating tools/hapog from version 1.3.3 to 1.3.4

### DIFF
--- a/tools/hapog/hapog.xml
+++ b/tools/hapog/hapog.xml
@@ -1,7 +1,7 @@
 <tool id="hapog" name="Hapo-G" profile="21.05" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>genome polishing</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.3.3</token>
+        <token name="@TOOL_VERSION@">1.3.4</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/hapog**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/hapog from version 1.3.3 to 1.3.4.

**Project home page:** https://github.com/institut-de-genomique/HAPO-G/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).