### PR TITLE
proteinortho: use recent blat package

### DIFF
--- a/tools/proteinortho/proteinortho_grab_proteins.xml
+++ b/tools/proteinortho/proteinortho_grab_proteins.xml
@@ -18,11 +18,9 @@
         proteinortho_grab_proteins.pl 
             --tofiles
             #if $regex:
-                $regex
+                '$regex'
             #end if
-            #if $source:
-                $source
-            #end if
+            $source
             #if $query.querytype == "string":
                 '$query.querystring'
             #else:
@@ -41,6 +39,7 @@
             </param>
             <when value="string">
                 <param name="querystring" type="text" label="A string of the protein/gene name/identifier that you want to search">
+                    <validator type="expression" message="Identifier must not end with a backslash">len(value) == 0 or value[-1] != '\\'</validator>
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="!"/>

--- a/tools/proteinortho/proteinortho_grab_proteins.xml
+++ b/tools/proteinortho/proteinortho_grab_proteins.xml
@@ -39,7 +39,7 @@
             </param>
             <when value="string">
                 <param name="querystring" type="text" label="A string of the protein/gene name/identifier that you want to search">
-                    <validator type="expression" message="Identifier must not end with a backslash">len(value) == 0 or value[-1] != '\\'</validator>
+                    <validator type="regex" negate="true" message="Identifier must not end with a backslash">.*\\$</validator>
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="!"/>

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
    <token name="@TOOL_VERSION@">6.1.2</token>
-   <token name="@WRAPPER_VERSION@">0</token>
+   <token name="@WRAPPER_VERSION@">1</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
         <citations>
@@ -16,7 +16,7 @@
                  diamond is, but latest version does not work: https://gitlab.com/paulklemm_PHD/proteinortho/-/issues/55 -->
             <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.13.0">blast</requirement>
-            <requirement type="package" version="36">blat</requirement>
+            <requirement type="package" version="377">ucsc-blat</requirement>
             <requirement type="package" version="1418">last</requirement>
         </requirements>
     </xml>

--- a/tools/proteinortho/proteinortho_summary.xml
+++ b/tools/proteinortho/proteinortho_summary.xml
@@ -13,10 +13,10 @@
             #end if
             2>&1 | awk '/^$/ && !f{f=1;next}1' | awk -v RS= '{print > ("output" NR ".tsv")}' 
         &&
-        mv output1.tsv adjacencyMat.tsv &&
-        mv output2.tsv average1paths.tsv &&
-        mv output3.tsv adjacencyMatSquared.tsv &&
-        mv output4.tsv average2paths.tsv
+        mv output2.tsv adjacencyMat.tsv &&
+        mv output3.tsv average1paths.tsv &&
+        mv output4.tsv adjacencyMatSquared.tsv &&
+        mv output5.tsv average2paths.tsv
     ]]></command>
     <inputs>
         <param name="queryfile" type="data" format="tabular" label="A orthology-pairs / RBH file"/>

--- a/tools/proteinortho/proteinortho_summary.xml
+++ b/tools/proteinortho/proteinortho_summary.xml
@@ -6,30 +6,33 @@
     <expand macro="requirements"/>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[
+        export TERM=dumb &&
         ## TODOs:
         ## - check if 2>&1 can be removed https://gitlab.com/paulklemm_PHD/proteinortho/-/merge_requests/9
-        ## - include output1.tsv as Galaxy output?
+        ## - include output0.tsv as Galaxy output?
         proteinortho_summary.pl 
             $queryfile
             #if $queryfile2:
                 '$queryfile2'
             #end if
-            2>&1 | awk '/^$/ && !f{f=1;next}1' | awk -v RS= '{print > ("output" NR ".tsv")}' 
+            2>&1 
+            | awk '/^$/ && !f{f=1;next}1' ## remove potentially present 1st empty line
+            | awk 'BEGIN{i=0} /^$/{i+=1}{print > ("output" i ".tsv")}' ## split file at empty lines
         &&
-        mv output2.tsv adjacencyMat.tsv &&
-        mv output3.tsv average1paths.tsv &&
-        mv output4.tsv adjacencyMatSquared.tsv &&
-        mv output5.tsv average2paths.tsv
+        mv output1.tsv '$adjacencyMat' &&
+        mv output2.tsv '$average1paths' &&
+        mv output3.tsv '$adjacencyMatSquared' &&
+        mv output4.tsv '$average2paths'
     ]]></command>
     <inputs>
         <param name="queryfile" type="data" format="tabular" label="A orthology-pairs / RBH file"/>
         <param name="queryfile2" type="data" format="tabular" optional="true" label="(optional) A second orthology-pairs / RBH file" help="If you provide a second file, then difference is calculated (GRAPH - second GRAPH)"/>
     </inputs>
     <outputs>
-        <data name="adjacencyMat" format="tabular" label="${tool.name} on ${on_string}: Adjacency Matrix" from_work_dir="adjacencyMat.tsv"/>
-        <data name="average1paths" format="tabular" label="${tool.name} on ${on_string}: Average number of Edges" from_work_dir="average1paths.tsv"/>
-        <data name="adjacencyMatSquared" format="tabular" label="${tool.name} on ${on_string}: Matrix of 2-paths" from_work_dir="adjacencyMatSquared.tsv"/>
-        <data name="average2paths" format="tabular" label="${tool.name} on ${on_string}: Average number of 2-paths" from_work_dir="average2paths.tsv"/>
+        <data name="adjacencyMat" format="tabular" label="${tool.name} on ${on_string}: Adjacency Matrix"/>
+        <data name="average1paths" format="tabular" label="${tool.name} on ${on_string}: Average number of Edges"/>
+        <data name="adjacencyMatSquared" format="tabular" label="${tool.name} on ${on_string}: Matrix of 2-paths"/>
+        <data name="average2paths" format="tabular" label="${tool.name} on ${on_string}: Average number of 2-paths"/>
     </outputs>
     <tests>
         <test expect_num_outputs="4">

--- a/tools/proteinortho/proteinortho_summary.xml
+++ b/tools/proteinortho/proteinortho_summary.xml
@@ -6,6 +6,9 @@
     <expand macro="requirements"/>
     <expand macro="version_command"/>
     <command detect_errors="exit_code"><![CDATA[
+        ## TODOs:
+        ## - check if 2>&1 can be removed https://gitlab.com/paulklemm_PHD/proteinortho/-/merge_requests/9
+        ## - include output1.tsv as Galaxy output?
         proteinortho_summary.pl 
             $queryfile
             #if $queryfile2:
@@ -35,24 +38,28 @@
                 <assert_contents>
                     <has_text text="18"/>
                     <has_text text="14"/>
+                    <has_text text="TERM" negate="true"/>
                 </assert_contents>
             </output>
             <output name="average1paths">
                 <assert_contents>
                     <has_text text="9.6"/>
                     <has_text text="15"/>
+                    <has_text text="TERM" negate="true"/>
                 </assert_contents>
             </output>
             <output name="adjacencyMatSquared">
                 <assert_contents>
                     <has_text text="750"/>
                     <has_text text="74"/>
+                    <has_text text="TERM" negate="true"/>
                 </assert_contents>
             </output>
             <output name="average2paths">
                 <assert_contents>
                     <has_text text="1088.8"/>
                     <has_text text="1374.2"/>
+                    <has_text text="TERM" negate="true"/>
                 </assert_contents>
             </output>
         </test>
@@ -63,6 +70,7 @@
                 <assert_contents>
                     <has_text text="49.6"/>
                     <has_text text="59.8"/>
+                    <has_text text="TERM" negate="true"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
the bioconda blat package seems outdated (last update ~ 4 years ago). seems now in ucsc-blat

might also be the reason for
https://github.com/BioContainers/multi-package-containers/pull/2378/checks failing

also CI is failing since the last update of proteinortho .. but it's a wild guess that this is related.


see also https://github.com/galaxyproject/tools-iuc/pull/4928

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
