### PR TITLE
Updating tools/ensembl_vep from version 108.0 to 108.2

### DIFF
--- a/tools/ensembl_vep/ensembl_vep.xml
+++ b/tools/ensembl_vep/ensembl_vep.xml
@@ -1,7 +1,7 @@
 <tool id="ensembl_vep" name="Predict variant effects" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>with VEP</description>
     <macros>
-        <token name="@TOOL_VERSION@">108.0</token>
+        <token name="@TOOL_VERSION@">108.2</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <token name="@DB_VERSION@">108</token>
         <xml name="vcf_input">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ensembl_vep**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ensembl_vep from version 108.0 to 108.2.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).