### PR TITLE
Small fix for shape option in ggplot2

### DIFF
--- a/tools/ggplot2/ggplot_point.xml
+++ b/tools/ggplot2/ggplot_point.xml
@@ -52,8 +52,8 @@ names(input)[$yplot] <- "ycol"
         gg_point = geom_point(size=1, alpha=1, gg_factor)
         gg_line = geom_line(size=1, alpha=1, gg_factor)
     #else
-        gg_point = geom_point(size=$adv.type_conditional.points.size, alpha=$adv.type_conditional.points.alpha, gg_factor)
-        gg_line = geom_line(size=$adv.type_conditional.points.size, alpha=$adv.type_conditional.points.alpha, gg_factor)
+        gg_point = geom_point(size=$adv.type_conditional.points.size, alpha=$adv.type_conditional.points.alpha, gg_factor, shape=as.numeric('$adv.type_conditional.points.shape')
+        gg_line = geom_line(size=$adv.type_conditional.points.size, alpha=$adv.type_conditional.points.alpha, gg_factor, shape=as.numeric('$adv.type_conditional.points.shape')
     #end if
 
     #if $adv.factor.colororder == 1

--- a/tools/ggplot2/ggplot_point.xml
+++ b/tools/ggplot2/ggplot_point.xml
@@ -220,7 +220,7 @@ plot_out <- ggplot(input, aes(xcol, ycol)) + gg_point + gg_line + gg_facet +
             <param name="additional_output_format" value="pdf" />
             <output name="output2" file="ggplot_point_result2.pdf" compare="sim_size" />
         </test>
-         <!-- Test defined point options options-->
+         <!-- Test defined point options options -->
         <test>
             <param name="input1" value="mtcars.txt" ftype="tabular" />
             <section name="adv">

--- a/tools/ggplot2/ggplot_point.xml
+++ b/tools/ggplot2/ggplot_point.xml
@@ -1,4 +1,4 @@
-<tool id="ggplot2_point" name="Scatterplot with ggplot2" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
+<tool id="ggplot2_point" name="Scatterplot with ggplot2" version="@TOOL_VERSION@+galaxy2" profile="20.01">
     <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Just a small fix for ggplot2. When selecting "Plot multiple groups of data on one plot" at "Plotting multiple groups" in the advanced options the shape selection was ignored.