### PR TITLE
Update InterProScan to 5.59-91.0

### DIFF
--- a/data_managers/data_manager_interproscan/data_manager/interproscan.py
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.py
@@ -81,11 +81,11 @@ def main():
 
     setup_script = 'initial_setup.py'
     sub_version = re.match(r"^[0-9]\.([0-9]{2})-[0-9]{2}\.[0-9]$", tag)
-    if sub_version and len(sub_version.groups()) == 1 and int(sub_version.group(1)) >= 59:
-        # The setup script was renamed in 5.59
+    if sub_version and len(sub_version.groups()) == 1 and int(sub_version.group(1)) >= 58:
+        # The setup script was renamed in 5.58
         setup_script = 'setup.py'
     else:
-        raise RuntimeError("Sorry, this data manager can only download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan.")
+        raise RuntimeError("Sorry, this data manager can only download data for InterProScan >= 5.58-91.0. Use the 0.0.2 version for older versions of InterProScan.")
 
     print("Will download data for InterProScan version: %s" % tag)
 

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.py
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.py
@@ -81,11 +81,11 @@ def main():
 
     setup_script = 'initial_setup.py'
     sub_version = re.match(r"^[0-9]\.([0-9]{2})-[0-9]{2}\.[0-9]$", tag)
-    if sub_version and sub_version.groups() == 2 and int(sub_version.group(1)) < 59:
+    if sub_version and len(sub_version.groups()) == 1 and int(sub_version.group(1)) >= 59:
         # The setup script was renamed in 5.59
         setup_script = 'setup.py'
     else:
-        raise RuntimeError("Sorry, this data manager can ony download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan.")
+        raise RuntimeError("Sorry, this data manager can only download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan.")
 
     print("Will download data for InterProScan version: %s" % tag)
 
@@ -142,7 +142,7 @@ def main():
     with open('interproscan.properties', 'w') as prop:
         prop.write(prop_content)
     # Run the index command
-    cmd_args = [os.path.join(os.path.dirname(os.path.realpath(shutil.which("interproscan.sh"))), setup_script)]
+    cmd_args = [os.path.join(os.path.dirname(os.path.realpath(shutil.which("interproscan.sh"))), setup_script), 'interproscan.properties']
     proc = subprocess.Popen(args=cmd_args, shell=False)
     out, err = proc.communicate()
     print(out)

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.py
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.py
@@ -79,6 +79,14 @@ def main():
     else:
         tag = all_tags[-1]
 
+    setup_script = 'initial_setup.py'
+    sub_version = re.match(r"^[0-9]\.([0-9]{2})-[0-9]{2}\.[0-9]$", tag)
+    if sub_version and sub_version.groups() == 2 and int(sub_version.group(1)) < 59:
+        # The setup script was renamed in 5.59
+        setup_script = 'setup.py'
+    else:
+        raise RuntimeError("Sorry, this data manager can ony download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan.")
+
     print("Will download data for InterProScan version: %s" % tag)
 
     print("Getting MD5 checksum:")
@@ -125,7 +133,7 @@ def main():
     os.remove(dest_tar)
     shutil.rmtree(os.path.join(output_directory, 'interproscan-%s' % tag))
 
-    print("Running initial_setup.py (index hmm models)...")
+    print("Running {} (index hmm models)...".format(setup_script))
     # Write a temp properties file in work dir
     prop_file_src = os.path.join(os.path.dirname(os.path.realpath(shutil.which("interproscan.sh"))), 'interproscan.properties')
     with open(prop_file_src, 'r') as prop:
@@ -134,14 +142,14 @@ def main():
     with open('interproscan.properties', 'w') as prop:
         prop.write(prop_content)
     # Run the index command
-    cmd_args = [os.path.join(os.path.dirname(os.path.realpath(shutil.which("interproscan.sh"))), 'initial_setup.py')]
+    cmd_args = [os.path.join(os.path.dirname(os.path.realpath(shutil.which("interproscan.sh"))), setup_script)]
     proc = subprocess.Popen(args=cmd_args, shell=False)
     out, err = proc.communicate()
     print(out)
     print(err, file=sys.stderr)
     return_code = proc.wait()
     if return_code:
-        print("Error running initial_setup.py.", file=sys.stderr)
+        print("Error running {}.".format(setup_script), file=sys.stderr)
         sys.exit(return_code)
 
     data_manager_dict["data_tables"][args.datatable_name].append(

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.xml
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.xml
@@ -36,11 +36,11 @@ $partial_data
         </test>
         <test>
             <param name="partial_data" value="--partial"/>
-            <param name="version" value="5.59-91.0"/>
+            <param name="version" value="5.58-91.0"/>
             <output name="output_file">
                 <assert_contents>
-                    <has_text text="InterProScan 5.59-91.0"/>
-                    <has_text text='"interproscan_version": "5.59-91.0'/>
+                    <has_text text="InterProScan 5.58-91.0"/>
+                    <has_text text='"interproscan_version": "5.58-91.0'/>
                 </assert_contents>
             </output>
             <assert_stdout>
@@ -51,7 +51,7 @@ $partial_data
             <param name="partial_data" value="--partial"/>
             <param name="version" value="5.51-85.0"/>
             <assert_stderr>
-                <has_text text="Sorry, this data manager can only download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan." />
+                <has_text text="Sorry, this data manager can only download data for InterProScan >= 5.58-91.0. Use the 0.0.2 version for older versions of InterProScan." />
             </assert_stderr>
         </test>
         <test expect_failure="true">

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.xml
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.xml
@@ -31,8 +31,7 @@ $partial_data
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text="Pressed and indexed" />
-                <has_text text="Completed indexing the hmm models" />
+                <has_text text="Finished." />
             </assert_stdout>
         </test>
         <test>
@@ -45,15 +44,14 @@ $partial_data
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text="Pressed and indexed" />
-                <has_text text="Completed indexing the hmm models" />
+                <has_text text="Finished." />
             </assert_stdout>
         </test>
         <test expect_failure="true">
             <param name="partial_data" value="--partial"/>
             <param name="version" value="5.51-85.0"/>
             <assert_stderr>
-                <has_text text="Sorry, this data manager can ony download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan." />
+                <has_text text="Sorry, this data manager can only download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan." />
             </assert_stderr>
         </test>
         <test expect_failure="true">

--- a/data_managers/data_manager_interproscan/data_manager/interproscan.xml
+++ b/data_managers/data_manager_interproscan/data_manager/interproscan.xml
@@ -1,6 +1,6 @@
-<tool id="data_manager_interproscan" name="InterProScan data manager" version="0.0.2" tool_type="manage_data" profile="20.01">
+<tool id="data_manager_interproscan" name="InterProScan data manager" version="0.0.3" tool_type="manage_data" profile="20.01">
     <requirements>
-        <requirement type="package" version="5.54-87.0">interproscan</requirement>
+        <requirement type="package" version="5.59-91.0">interproscan</requirement>
         <requirement type="package" version="2.26.0">requests</requirement>
         <!-- Forcing an old hmmer version for indexing due to https://github.com/ebi-pf-team/interproscan/issues/232 -->
         <requirement type="package" version="3.1b2">hmmer</requirement>
@@ -15,7 +15,7 @@ $partial_data
     <inputs>
         <param name="partial_data" type="hidden" value="" help="Used for testing"/>
         <param name="version" type="text" value="" label="Version to download" help="Leave empty to download the latest version">
-            <validator type="regex" message="Version must be a valid InterProScan version (e.g. 5.52-86.0)">^([0-9]+\.[0-9]+-[0-9]+\.[0-9]+)?$</validator>
+            <validator type="regex" message="Version must be a valid InterProScan version (e.g. 5.59-91.0)">^([0-9]+\.[0-9]+-[0-9]+\.[0-9]+)?$</validator>
         </param>
     </inputs>
     <outputs>
@@ -37,17 +37,24 @@ $partial_data
         </test>
         <test>
             <param name="partial_data" value="--partial"/>
-            <param name="version" value="5.51-85.0"/>
+            <param name="version" value="5.59-91.0"/>
             <output name="output_file">
                 <assert_contents>
-                    <has_text text="InterProScan 5.51-85.0"/>
-                    <has_text text='"interproscan_version": "5.51-85.0'/>
+                    <has_text text="InterProScan 5.59-91.0"/>
+                    <has_text text='"interproscan_version": "5.59-91.0'/>
                 </assert_contents>
             </output>
             <assert_stdout>
                 <has_text text="Pressed and indexed" />
                 <has_text text="Completed indexing the hmm models" />
             </assert_stdout>
+        </test>
+        <test expect_failure="true">
+            <param name="partial_data" value="--partial"/>
+            <param name="version" value="5.51-85.0"/>
+            <assert_stderr>
+                <has_text text="Sorry, this data manager can ony download data for InterProScan >= 5.59-91.0. Use the 0.0.2 version for older versions of InterProScan." />
+            </assert_stderr>
         </test>
         <test expect_failure="true">
             <param name="partial_data" value="--partial"/>

--- a/tools/interproscan/README.md
+++ b/tools/interproscan/README.md
@@ -17,7 +17,7 @@ All the following steps assume that:
 
 - You agree with each software license
 - InterProScan was installed using Conda in the `IPRSCAN_DIR` directory
-- You have run the InterProScan data manager which placed the data files in the `IPRSCAN_DATA_DIR` directory (e.g. `/data/db/data_managers/interproscan/5.55-88.0/`)
+- You have run the InterProScan data manager which placed the data files in the `IPRSCAN_DATA_DIR` directory (e.g. `/data/db/data_managers/interproscan/5.59-91.0/`)
 
 Everytime you upgrade InterProScan, you'll need to do the same things: modify the `${IPRSCAN_DIR}/share/InterProScan/interproscan.properties` file + add the SMART file.
 

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -64,6 +64,7 @@ $iprlookup
 
         <param name="applications" type="select" multiple="True" label="Applications to run" help="Select your program">
             <option value="TIGRFAM" selected="true">TIGRFAM: protein families based on hidden Markov models (HMMs)</option>
+            <option value="FunFam" selected="true">FunFam: Prediction of functional annotations for novel, uncharacterized sequences.</option>
             <option value="SFLD" selected="true">SFLD: a database of protein families based on hidden Markov models (HMMs)</option>
             <option value="SUPERFAMILY" selected="true">SUPERFAMILY: database of structural and functional annotation for all proteins and genomes</option>
             <option value="PANTHER" selected="true">PANTHER: Protein ANalysis THrough Evolutionary Relationships</option>

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -4,7 +4,7 @@
         <import>macros.xml</import>
     </macros>
     <xrefs>
-        <xref type="bio.tools">interproscan_4</xref>
+        <xref type="bio.tools">interproscan_ebi</xref>
     </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">interproscan</requirement>

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -5,7 +5,7 @@
         Conda understands both notations, but the Galaxy tool requires the use of "-".
         The version should also be bumped in test-data/interproscan.loc
     -->
-    <token name="@TOOL_VERSION@">5.55-88.0</token>
+    <token name="@TOOL_VERSION@">5.59-91.0</token>
     <token name="@VERSION_SUFFIX@">3</token>
 
     <xml name="citations">

--- a/tools/interproscan/test-data/interproscan.loc
+++ b/tools/interproscan/test-data/interproscan.loc
@@ -5,4 +5,4 @@
 # value	description	interproscan_version	path
 #
 # for example
-5.55-88.0	InterProScan 5.55-88.0	5.55-88.0	${__HERE__}/fake_db/
+5.59-91.0	InterProScan 5.59-91.0	5.59-91.0	${__HERE__}/fake_db/


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Here's the interproscan update following https://github.com/bioconda/bioconda-recipes/pull/38043
I had to update the DM too as the data indexing script has a new name in this version, and is not indexing exactly the same way as in previous versions.

I hope we won't get too much surprises with this update :crossed_fingers: 

ping @pvanheus 