### PR TITLE
Updating tools/proteinortho from version 6.1.2 to 6.1.5

### DIFF
--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.2</token>
-   <token name="@WRAPPER_VERSION@">1</token>
+   <token name="@TOOL_VERSION@">6.1.5</token>
+   <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
         <citations>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/proteinortho**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/proteinortho from version 6.1.2 to 6.1.5.

**Project home page:** https://gitlab.com/paulklemm_PHD/proteinortho

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).