### PR TITLE
fix arriba test

### DIFF
--- a/tools/arriba/arriba.xml
+++ b/tools/arriba/arriba.xml
@@ -154,7 +154,7 @@
     $options.duplicate_marking
     $options.fill_discarded_columns
     $options.fill_the_gaps
-#if str($visualization.do_viz) == "yes"
+#if $output_fusion_bams or str($visualization.do_viz) == "yes"
     && samtools sort -@ \${GALAXY_SLOTS:-1} -m 4G -T tmp -O bam '$input' > Aligned.sortedByCoord.out.bam
     && samtools index Aligned.sortedByCoord.out.bam
 #end if
@@ -441,16 +441,13 @@
             <discover_datasets pattern="(?P&lt;name&gt;fusion_\d+\.bam)$" format="bam" directory="fusion_bams" visible="false"/>
             <filter>output_fusion_bams == True</filter>
         </collection>
-        <data name="aligned_bam" format="bam" label="${tool.name} on ${on_string}: Aligned.bam" from_work_dir="Aligned.sortedByCoord.out.bam">
-            <filter>input_params['input_source'] == "use_fastq"</filter>
-        </data> 
         <data name="fusions_pdf" format="pdf" label="${tool.name} on ${on_string}: fusions.pdf" from_work_dir="fusions.pdf">
             <filter>visualization['do_viz'] == "yes"</filter>
         </data> 
     </outputs>
     <tests>
         <!-- Test 1 - From exisitng BAM -->
-        <test> 
+        <test expect_num_outputs="3"> 
             <param name="input" ftype="sam" value="Aligned.out.sam"/>
             <conditional name="genome">
                 <param name="genome_source" value="history"/>
@@ -472,7 +469,7 @@
             </output>
         </test>
         <!-- Test 2 - From exisitng BAM with protein_domains and visualization -->
-        <test> 
+        <test expect_num_outputs="4"> 
             <param name="input" ftype="sam" value="Aligned.out.sam"/>
             <conditional name="genome">
                 <param name="genome_source" value="history"/>

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.3.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">arriba</requirement>


### PR DESCRIPTION
the filter of output `aligned_bam` was broken (the used variables just do not exist). this led to an error because Galaxy tried to set metadata for and empty or non-existent file.

the output was removed because its not needed (its essentially the same as the input). it probably stems from an earlier version that included the alignment step.

also the alignment seems to be used if

- `$output_fusion_bams` and
- `str($visualization.do_viz)=="yes"`

so it needs to be generated in both

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
