### PR TITLE
Updating tools/dram from version 1.3.5 to 1.5.0

### DIFF
--- a/tools/dram/dram_annotate.xml
+++ b/tools/dram/dram_annotate.xml
@@ -54,7 +54,7 @@ $skip_trnascan
     <inputs>
         <param argument="--input_fasta" type="data" format="fasta,fasta.gz" label="FASTA file"/>
         <param argument="--min_contig_size" type="integer" value="2500" min="0" label="Minimum contig size to be used for gene prediction"/>
-        <param argument="--prodigal_mode" type="select" label="Select mode of prodigal to use for gene calling" help="Single mode requires genomes which are high quality with low contamination and long contigs (average length >3 Kbp)">
+        <param argument="--prodigal_mode" type="select" label="Select mode of prodigal to use for gene calling" help="Single mode requires genomes which are high quality with low contamination and long contigs (average length &gt;3 Kbp)">
             <option value="single" selected="true">single</option>
             <option value="meta">meta</option>
             <option value="train">train</option>

--- a/tools/dram/dram_annotate.xml
+++ b/tools/dram/dram_annotate.xml
@@ -4,7 +4,8 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-    <expand macro="requirements"/>
+    <expand macro="requirements">
+    </expand>   
     <expand macro="stdio"/>
     <command detect_errors="exit_code"><![CDATA[
 #import os
@@ -12,6 +13,13 @@
 ## DRAM names the genbank output based on the input_fasta file name
 #set input_fasta_file_name = $os.path.splitext($os.path.basename(str($input_fasta)))[0]
 #set output_gbk_file_name = $input_fasta_file_name + '.gbk'
+
+#if str($custom_hmm_dbs_cond.custom_dbs_hmm) == 'yes':
+    #for count, additional_db in enumerate($custom_hmm_dbs_cond.custom_hmm_dbs):
+        ln -s '$additional_db.custom_hmm_loc' ${count}.hmm &&
+    #end for
+#end if
+
 
 DRAM.py annotate
 --input_fasta '$input_fasta'
@@ -29,9 +37,9 @@ $kofam_use_dbcan2_thresholds
     #end for
 #end if
 #if str($custom_hmm_dbs_cond.custom_dbs_hmm) == 'yes':
-    #for additional_db in $custom_hmm_dbs_cond.custom_hmm_dbs:
+    #for count, additional_db in enumerate($custom_hmm_dbs_cond.custom_hmm_dbs):
         --custom_hmm_name '$additional_db.custom_hmm_name'
-        --custom_hmm_loc '$additional_db.custom_hmm_loc'
+        --custom_hmm_loc ${count}.hmm
         #if $additional_db.custom_hmm_cutoffs_loc:
             --custom_hmm_cutoffs_loc '$additional_db.custom_hmm_cutoffs_loc'
         #end if
@@ -53,15 +61,15 @@ $skip_trnascan
     ]]></command>
     <inputs>
         <param argument="--input_fasta" type="data" format="fasta,fasta.gz" label="FASTA file"/>
-        <param argument="--min_contig_size" type="integer" value="2500" min="0" label="Minimum contig size to be used for gene prediction"/>
+        <param argument="--min_contig_size" type="integer" min="0" value="2500" label="Minimum contig size to be used for gene prediction"/>
         <param argument="--prodigal_mode" type="select" label="Select mode of prodigal to use for gene calling" help="Single mode requires genomes which are high quality with low contamination and long contigs (average length &gt;3 Kbp)">
             <option value="single" selected="true">single</option>
             <option value="meta">meta</option>
             <option value="train">train</option>
         </param>
-        <param argument="--trans_table" type="integer" value="11" min="1" max="25" label="Translation table for prodigal to use for gene calling"/>
-        <param argument="--bit_score_threshold" type="integer" value="60" min="1" label="Minimum bitScore of search to retain hits"/>
-        <param argument="--rbh_bit_score_threshold" type="integer" value="350" min="1" label="Minimum bitScore of reverse best hits to retain hits"/>
+        <param argument="--trans_table" type="integer" min="1" max="25" value="11" label="Translation table for prodigal to use for gene calling"/>
+        <param argument="--bit_score_threshold" type="integer" min="1" value="60" label="Minimum bitScore of search to retain hits"/>
+        <param argument="--rbh_bit_score_threshold" type="integer" min="1" value="350" label="Minimum bitScore of reverse best hits to retain hits"/>
         <param argument="--kofam_use_dbcan2_thresholds" type="boolean" truevalue="--kofam_use_dbcan2_thresholds" falsevalue="" checked="false" label="Use dbcan2 suggested HMM cutoffs for KOfam annotation instead of KOfam recommended cutoffs?"/>
         <conditional name="custom_fasta_dbs_cond">
             <param name="custom_dbs_fasta" type="select" label="Specify additional fasta files against which to annotate?">
@@ -156,8 +164,7 @@ $skip_trnascan
                 </assert_contents>
             </output>
         </test>
-        <!-- These settings require a db which doesn't exist in the test environment -->
-        <test expect_failure="true">
+        <test>
             <param name="input_fasta" value="input_annotate1.fasta.gz" ftype="fasta.gz"/>
             <param name="custom_dbs_fasta" value="yes"/>
             <repeat name="custom_fasta_dbs">
@@ -170,9 +177,19 @@ $skip_trnascan
                 <param name="custom_hmm_loc" value="annotate_custom.hmm" ftype="hmm3"/>
             </repeat>
             <param name="prodigal_mode" value="meta"/>
-            <assert_stderr>
-                <has_text text="returned non-zero exit status"/>
-            </assert_stderr>
+            <output name="output_genbank">
+                <assert_contents>
+                    <has_text text="LOCUS"/>
+                    <has_text text="gc_cont"/>
+                </assert_contents>
+            </output>
+            <output name="output_annotations">
+                <assert_contents>
+                    <has_text text="fasta"/>
+                    <has_text text="gene_position"/>
+                    <has_n_columns n="9"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/tools/dram/dram_annotate.xml
+++ b/tools/dram/dram_annotate.xml
@@ -1,4 +1,4 @@
-<tool id="dram_annotate" name="DRAM annotate" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="dram_annotate" name="DRAM annotate" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>metagenome-assembled-genomes (MAGs)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/dram/dram_distill.xml
+++ b/tools/dram/dram_distill.xml
@@ -1,4 +1,4 @@
-<tool id="dram_distill" name="DRAM distill" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="dram_distill" name="DRAM distill" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>metagenome-assembled-genomes (MAGs)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/dram/dram_merge_annotations.xml
+++ b/tools/dram/dram_merge_annotations.xml
@@ -1,4 +1,4 @@
-<tool id="dram_merge_annotations" name="DRAM merge multiple annotations" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="dram_merge_annotations" name="DRAM merge multiple annotations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>into a single set</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/dram/dram_neighborhoods.xml
+++ b/tools/dram/dram_neighborhoods.xml
@@ -1,4 +1,4 @@
-<tool id="dram_neighborhoods" name="DRAM find neighborhoods" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="dram_neighborhoods" name="DRAM find neighborhoods" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>around genes of interest</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/dram/dram_strainer.xml
+++ b/tools/dram/dram_strainer.xml
@@ -7,7 +7,7 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
 DRAM.py strainer
---input_annotations '$input_annotations'
+--input_tsv '$input_tsv'
 --input_fasta '$input_fasta'
 --output_fasta '$output_fasta'
 #if $advanced.fastas:
@@ -22,16 +22,15 @@ DRAM.py strainer
 #if $advanced.identifiers:
     --identifiers '$advanced.identifiers'
 #end if
-## Broken in 3.5.1 - https://github.com/WrightonLabCSU/DRAM/issues/194
-##if $advanced.categories:
-##    --categories '$advanced.categories'
-##end if
+#if $advanced.categories:
+    --categories '$advanced.categories'
+#end if
 #if $advanced.custom_distillate:
     --custom_distillate '$advanced.custom_distillate'
 #end if
     ]]></command>
     <inputs>
-        <param argument="--input_annotations" type="data" format="tabular" label="Annotations file" help="Produced by the DRAM annotate tool"/>
+        <param argument="--input_tsv" type="data" format="tabular" label="Annotations file" help="Produced by the DRAM annotate tool"/>
         <param argument="--input_fasta" type="data" format="fasta,fasta.gz" label="FASTA file to filter"/>
         <section name="advanced" title="Advanced options" expanded="false">
             <param argument="--fastas" type="text" value="" label="Space-separated list of fastas to keep" help="Optional, leave blank to ignore">
@@ -43,8 +42,7 @@ DRAM.py strainer
             <expand macro="genes_param"/>
             <expand macro="identifiers_param"/>
             <expand macro="custom_distillate_param"/>
-            <!-- Broken in 3.5.1, see above -->
-            <!-- <expand macro="categories_param"/> -->
+            <expand macro="categories_param"/>
         </section>
     </inputs>
     <outputs>
@@ -52,12 +50,12 @@ DRAM.py strainer
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name="input_annotations" ftype="tabular" value="annotated1.tabular"/>
-            <param name="input_fasta" ftype="fasta.gz" value="strainer_input_fasta1.fasta.gz"/>
+            <param name="input_tsv" value="annotated1.tabular" ftype="tabular"/>
+            <param name="input_fasta" value="strainer_input_fasta1.fasta.gz" ftype="fasta.gz"/>
             <param name="fastas" value="dataset_"/>
             <param name="scaffolds" value="scaffold_"/>
             <param name="identifiers" value="K15023"/>
-            <param name="custom_distillate" ftype="tabular" value="distill_custom.tabular"/>
+            <param name="custom_distillate" value="distill_custom.tabular" ftype="tabular"/>
             <output name="output_fasta" ftype="fasta" value="strainer_output1.fasta"/>
        </test>
     </tests>

--- a/tools/dram/macros.xml
+++ b/tools/dram/macros.xml
@@ -10,6 +10,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">dram</requirement>
+            <yield/>
         </requirements>
     </xml>
     <xml name="stdio">

--- a/tools/dram/macros.xml
+++ b/tools/dram/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.3.5</token>
+    <token name="@TOOL_VERSION@">1.5.0</token>
     <!-- token name="@VERSION_SUFFIX@">0</token -->
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/dram**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/dram from version 1.3.5 to 1.4.1.

**Project home page:** https://github.com/WrightonLabCSU/DRAM/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).