### PR TITLE
Updating tools/biom_format from version 2.1.12 to 2.1.13

### DIFF
--- a/tools/biom_format/macros.xml
+++ b/tools/biom_format/macros.xml
@@ -5,8 +5,8 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">2.1.12</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.1.13</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">
         <version_command>biom --version</version_command>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/biom_format**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/biom_format from version 2.1.12 to 2.1.13.

**Project home page:** https://github.com/biocore/biom-format/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).