### PR TITLE
Updating tools/gtdbtk from version 1.7.0 to 2.4.0

### DIFF
--- a/tools/gtdbtk/gtdbtk_classify_wf.xml
+++ b/tools/gtdbtk/gtdbtk_classify_wf.xml
@@ -39,7 +39,7 @@ $advanced.force
         <param name="input" type="data" format="fasta,fasta.gz" multiple="true" label="Fasta (Genome) files"/>
         <param name="gtdbtk_db" type="select" label="GTDB-Tk database" help="This version of GTDB-Tk requires GTDB version 207 or 214. Please contact your service administrator if this version is not available to select.">
             <options from_data_table="gtdbtk_database_versioned">
-                <filter type="regexp" column="version" value="^2(07|14)$"/>
+                <filter type="regexp" column="version" value="^220$"/>
                 <validator type="no_options" message="No locally cached GTDB-Tk database is available"/>
             </options>
         </param>

--- a/tools/gtdbtk/macros.xml
+++ b/tools/gtdbtk/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.3.2</token>
-    <token name="@VERSION_SUFFIX@">5</token>
+    <token name="@TOOL_VERSION@">2.4.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.05</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/gtdbtk**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/gtdbtk from version 1.7.0 to 2.1.1.

**Project home page:** https://github.com/Ecogenomics/GTDBTk/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).