### PR TITLE
Updating tools/proteinortho from version 6.1.5 to
6.2.3

### DIFF
--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.7</token>
+   <token name="@TOOL_VERSION@">6.2.3</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -14,10 +14,10 @@
             <requirement type="package" version="@TOOL_VERSION@">proteinortho</requirement>
             <!-- blast, blat, and last are not in the biopython requirements
                  diamond is, but latest version does not work: https://gitlab.com/paulklemm_PHD/proteinortho/-/issues/55 -->
-            <requirement type="package" version="2.0.15">diamond</requirement>
+            <requirement type="package" version="2.1.6">diamond</requirement>
             <requirement type="package" version="2.13.0">blast</requirement>
             <requirement type="package" version="377">ucsc-blat</requirement>
-            <requirement type="package" version="1422">last</requirement>
+            <requirement type="package" version="1453">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.6</token>
+   <token name="@TOOL_VERSION@">6.1.7</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -17,7 +17,7 @@
             <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.13.0">blast</requirement>
             <requirement type="package" version="377">ucsc-blat</requirement>
-            <requirement type="package" version="1420">last</requirement>
+            <requirement type="package" version="1422">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/proteinortho/proteinortho_macros.xml
+++ b/tools/proteinortho/proteinortho_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@TOOL_VERSION@">6.1.5</token>
+   <token name="@TOOL_VERSION@">6.1.6</token>
    <token name="@WRAPPER_VERSION@">0</token>
    <token name="@PROFILE@">20.09</token>
    <xml name="citations">
@@ -17,7 +17,7 @@
             <requirement type="package" version="2.0.15">diamond</requirement>
             <requirement type="package" version="2.13.0">blast</requirement>
             <requirement type="package" version="377">ucsc-blat</requirement>
-            <requirement type="package" version="1418">last</requirement>
+            <requirement type="package" version="1420">last</requirement>
         </requirements>
     </xml>
     <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/proteinortho**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/proteinortho from version 6.1.5 to 6.1.6.

**Project home page:** https://gitlab.com/paulklemm_PHD/proteinortho

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).