### PR TITLE
Fix GTDB default URL

### DIFF
--- a/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
+++ b/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
@@ -19,8 +19,14 @@
     </command>
     <inputs>
 	    <param name="database_name" type="text" value="" label="Database name or description" help="This value will be displayed in the GTDB-Tk Database select list"/>
-        <param name="database_id" type="text" value="" label="Database id" help="This value must be unique with nNo whitespace allowed-use underscores"/>
-        <param name="url" type="text" value="https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_data.tar.gz" label="URL for downloading the selected version of the GTDB-Tk database"/>
+        <param name="database_id" type="text" value="" label="Database id" help="This value must be unique with no whitespace allowed - use underscores"/>
+        <param
+            name="url"
+            type="text"
+            value="https://data.gtdb.ecogenomic.org/releases/release202/202.0/auxillary_files/gtdbtk_r202_data.tar.gz"
+            label="URL for GTDB release"
+            help="This should point to a GTDB release tarball. A table of available databases and their version compatability can be found at https://ecogenomics.github.io/GTDBTk/installing/index.html#gtdb-tk-reference-data."
+        />
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>


### PR DESCRIPTION
Update the GTDB data manager default URL to match the current version of the tool.

GTDB-Tk versions are tightly linked to the GTDB version. The default version offered by the data manager does not match the currently released GTDB-Tk tool version.

- [x] Set default DB URL to `R202`, which matches GTDB-Tk v1.7.0 (the currently existing version)
- [x] Add some help text and link to version matching table to help admins install the appropriate DB

---

An additional comment - should the DB URL field be a `select` field, with hard-coded values? That way admins will easily be able to select the appropriate version to download, and we can hard-code the correct DB ID into the GTDB-Tk tool wrapper so that users don't need to figure out which DB is appropriate for the current tool version (I picture lots of failed jobs). Something like:

```yml
Select:
  - R207_v2: matches GTDB-Tk v2.1.0+
  - R207: matches GTDB-Tk v2.0.0
  - R202: matches GTDB-Tk v1.5.0 - v1.7.0
```

I'll create a separate issue for this if someone agrees.
