### PR TITLE
Fix use of alternative COMBAT-TB NeoDB

### DIFF
--- a/tools/tbvcfreport/tbvcfreport.xml
+++ b/tools/tbvcfreport/tbvcfreport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<tool id="tbvcfreport" name="TB Variant Report" version="@TOOL_VERSION@+galaxy0">
+<tool id="tbvcfreport" name="TB Variant Report" version="@TOOL_VERSION@+galaxy1">
   <description>- generate HTML report from SnpEff annotated M.tb VCF(s)</description>
   <macros>
     <token name="@TOOL_VERSION@">0.1.10</token>
@@ -9,10 +9,6 @@
   </requirements>
   <command detect_errors="exit_code">
     <![CDATA[
-    #if $adv.database_uri
-        export DATABASE_URI='${adv.database_uri}' &&
-    #end if
-    
     #if not '.vcf' in str($input_vcf.element_identifier)
         #set $input_vcf_filename = str($input_vcf.element_identifier).replace(' ', '') + '.vcf'
     #else
@@ -34,6 +30,9 @@
 
     tbvcfreport generate
 
+    #if $adv.database_host
+      --db_url bolt://'${adv.database_host}':7687
+    #end if
     $filter_udi
     
     #if $tbprofiler_json
@@ -64,7 +63,7 @@
     <param name="tbprofiler_json" type="data" format="json" optional="true" label="TBProfiler Drug Resistance Report (Optional)" help="--tbprofiler-report" />
     <param name="filter_udi" argument="--filter-udi" type="boolean" truevalue="--filter-udi" falsevalue="--no-filter-udi" checked="true" label="Filter UPSTREAM, DOWNSTREAM and INTERGENIC variants" />
     <section name="adv" title="Advanced options" expanded="false">
-      <param name="database_uri" type="text" optional="true" value="neodb.sanbi.ac.za" label="Specify COMBAT-TB-NeoDB URI" help="For people with their own deployment of COMBAT-TB-NeoDB" />
+      <param name="database_host" type="text" optional="true" value="neodb.sanbi.ac.za" label="Specify COMBAT-TB-NeoDB URI" help="For people with their own deployment of COMBAT-TB-NeoDB" />
     </section>
   </inputs>
   <outputs>
@@ -97,6 +96,12 @@
       <output name="variants_report_html" compare="diff" lines_diff="2" file="vcf_with_no_protein_report.html" ftype="html" />
       <output name="variants_report_txt" compare="diff" lines_diff="2" file="vcf_with_no_protein_report.txt" ftype="txt" />      
     </test>
+    <test expect_failure="true">
+      <param name="input_vcf" value="rif_resistant.vcf" ftype="vcf" />
+      <section name="adv">
+        <param name="database_host" value="nosuch.nowhere" />
+      </section>
+    </test>
   </tests>
   <help>
     <![CDATA[
@@ -124,7 +129,7 @@
         
     **Advanced options**:
 
-        - database_uri - String - Use an on-premise COMBAT-TB-NeoDB (default 'neodb.sanbi.ac.za') - **optional**
+        - database_host - String - Hostname of COMBAT-TB-NeoDB (default 'neodb.sanbi.ac.za') - **optional**
 
     **Further information**
     


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
