### PR TITLE
PR workflow: report deployment failure

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -382,6 +382,24 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         shed-target: toolshed
         shed-key: ${{ secrets.TS_API_KEY }}
+    # report to the PR if deployment failed
+    - name: get PR number
+      uses: 8BitJonny/gh-get-current-pr@2.2.0
+      id: getpr
+      if: ${{ failure() }}
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        sha: ${{ github.event.after }}
+    - name: Create comment
+      uses: peter-evans/create-or-update-comment@v2
+      if: ${{ failure() }}
+      with:
+        token: ${{ secrets.PAT }}
+        issue-number: ${{ steps.getpr.outputs.number }}
+        body: |
+          Attention: deployment failed!
+
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   determine-success:
     name: Check workflow success

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -383,12 +383,11 @@ jobs:
         shed-target: toolshed
         shed-key: ${{ secrets.TS_API_KEY }}
     # report to the PR if deployment failed
-    - name: get PR number
+    - name: Get PR object
       uses: 8BitJonny/gh-get-current-pr@2.2.0
       id: getpr
       if: ${{ failure() }}
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
         sha: ${{ github.event.after }}
     - name: Create comment
       uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
I have tested this successfully  with 

- the standard merge and
- squash merge

Note, **rebase merge does not work** .. so we would need to disable this in the settings. This might be a limitation of the action used to get the PR number, but I guess its difficult / impossible because SHAs don't match to the SHAs of the commits in the PR. 

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
