### PR TITLE
Update pangolin to 4.1.3 with latest dependencies

### DIFF
--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -262,14 +262,13 @@ $query
         </data>
     </outputs>
     <tests>
+        <!-- Test only the default UShER mode for now since the
+        pangolearn random forest model uses too much memory
+        see https://github.com/cov-lineages/pangolin/issues/395
         <test expect_num_outputs="1">
             <param name="input1" value="test1.fasta"/>
             <conditional name="engine">
-                <!-- Test only the default UShER mode for now since the
-                pangolearn random forest model uses too much memory
-                see https://github.com/cov-lineages/pangolin/issues/395
                 <param name="analysis_mode" value="pangolearn" />
-                -->
                 <conditional name="pangolin_data">
                     <param name="source" value="default" />
                 </conditional>
@@ -282,11 +281,12 @@ $query
                 </assert_contents>
             </output>
         </test>
+        -->
         <test expect_num_outputs="1">
             <param name="input1" value="test1.fasta"/>
             <conditional name="engine">
                 <conditional name="pangolin_data">
-                    <param name="source" value="download" />
+                    <param name="source" value="default" />
                 </conditional>
             </conditional>
             <output name="output1" ftype="tabular">
@@ -297,6 +297,7 @@ $query
                 </assert_contents>
             </output>
         </test>
+        <!-- test download and alignment options -->
         <test expect_num_outputs="2">
             <param name="input1" value="test1.fasta" />
             <conditional name="engine">

--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -1,8 +1,8 @@
 <tool id="pangolin" name="Pangolin" version="@TOOL_VERSION@+galaxy0" profile="20.01">
     <description>Phylogenetic Assignment of Outbreak Lineages</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.1.2</token>
-        <token name="@PANGOLIN_DATA_VERSION@">1.12</token>
+        <token name="@TOOL_VERSION@">4.1.3</token>
+        <token name="@PANGOLIN_DATA_VERSION@">1.17</token>
         <token name="@CONSTELLATIONS_VERSION@">0.1.10</token>
         <token name="@MIN_COMPATIBLE_PANGOLIN_DATA_FORMAT@">4</token>
         <!-- a regex describing the scorpio versions that this wrapper version
@@ -73,14 +73,14 @@
         <requirement type="package" version="0.3.17">scorpio</requirement>
         <requirement type="package" version="@PANGOLIN_DATA_VERSION@">pangolin-data</requirement>
         <requirement type="package" version="@CONSTELLATIONS_VERSION@">constellations</requirement>
-        <requirement type="package" version="0.5.6">usher</requirement>
+        <requirement type="package" version="0.6.2">usher</requirement>
         <requirement type="package" version="1.1.0">gofasta</requirement>
         <requirement type="package" version="426">ucsc-fatovcf</requirement>
         <requirement type="package" version="2.24">minimap2</requirement>
         <!-- wrapper-specific requirements to turn pangolin's native
         comma-separated output into tab-separated one and to truncate
         pangolin's all-versions output. -->
-        <requirement type="package" version="0.23.0">csvtk</requirement>
+        <requirement type="package" version="0.25.0">csvtk</requirement>
         <requirement type="package" version="3.4">grep</requirement>
     </requirements>
     <version_command><![CDATA[pangolin --version]]></version_command>
@@ -196,7 +196,7 @@ $query
         <param type="data" name="input1" format="fasta,fasta.gz" label="Input FASTA File(s)" />
         <conditional name="engine">
             <param argument="--analysis-mode" type="select" label="Analysis mode"
-            help="The analysis engine to use for lineage assignment. UShER is considered more accurate, but pangoLEARN is faster">
+            help="The analysis engine to use for lineage assignment. UShER is considered more accurate; pangoLEARN typically requires more memory, but might be faster in some cases.">
                 <option value="usher">UShER</option>
                 <option value="pangolearn">pangoLEARN</option>
             </param>

--- a/tools/pangolin/pangolin.xml
+++ b/tools/pangolin/pangolin.xml
@@ -291,7 +291,7 @@ $query
             </conditional>
             <output name="output1" ftype="tabular">
                 <assert_contents>
-                    <has_text_matching expression="B\.1\.1.*\t\d\.\d\t*PUSHER" />
+                    <has_text_matching expression="B\.1\.1.*\t\d\.\d+\t*PUSHER" />
                     <has_text text="pass" />
                     <has_n_lines n="1" />
                 </assert_contents>


### PR DESCRIPTION
The freshly released pangolin 4.2 brings a change to the implementation (usher-sampled) of the tool's UShER mode.
This final wrapper 4.1 series update bumps all dependencies to the versions that will be used for 4.2 to enable direct comparison between the old usher and the new usher-sampled implementation.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
