### PR TITLE
trigger deployment message on anything but success

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -382,21 +382,26 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         shed-target: toolshed
         shed-key: ${{ secrets.TS_API_KEY }}
+
+  deploy-report:
+    name: Report deploy status
+    needs: [deploy]
+    if: ${{ always() && needs.deploy.result != 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    runs-on: ubuntu-latest
+    steps:
     # report to the PR if deployment failed
     - name: Get PR object
       uses: 8BitJonny/gh-get-current-pr@2.2.0
       id: getpr
-      if: ${{ failure() }}
       with:
         sha: ${{ github.event.after }}
     - name: Create comment
       uses: peter-evans/create-or-update-comment@v2
-      if: ${{ failure() }}
       with:
         token: ${{ secrets.PAT }}
         issue-number: ${{ steps.getpr.outputs.number }}
         body: |
-          Attention: deployment failed!
+          Attention: deployment ${{ needs.deploy.result }}!
 
           https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
If any of jobs needed for deployment fails, the deployment job is skipped and no message is triggered. 

Now a message should be triggered.

Just wondering if people subscribed to a PR still get the notification once the PR is closed .. guess so - but not sure.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
