### PR TITLE
Updating tools/kleborate from version 2.2.0 to 2.3.0

### DIFF
--- a/tools/kleborate/kleborate.xml
+++ b/tools/kleborate/kleborate.xml
@@ -1,12 +1,12 @@
 <tool id="kleborate" name="Kleborate" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <description>screen genome assemblies of Klebsiella pneumoniae</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.2.0</token>
+        <token name="@TOOL_VERSION@">2.3.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">kleborate</requirement>
-        <requirement type="package" version="2.0.0">kaptive</requirement>
+        <requirement type="package" version="2.0.4">kaptive</requirement>
     </requirements>
     <version_command>kleborate --version</version_command>
     <command detect_errors="aggressive"><![CDATA[


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/kleborate**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/kleborate from version 2.2.0 to 2.3.0.

**Project home page:** https://github.com/katholt/Kleborate/wiki/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).