### PR TITLE
Updating tools/ncbi_datasets from version 14.6.0 to 16.41.0

### DIFF
--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">16.20.0</token>
+    <token name="@TOOL_VERSION@">16.41.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">23.0</token>
     <token name="@LICENSE@">MIT</token>
@@ -11,7 +11,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">ncbi-datasets-cli</requirement>
-            <requirement type="package" version="2024.2.2">ca-certificates</requirement>
+            <requirement type="package" version="2025.1.31">ca-certificates</requirement>
             <requirement type="package" version="16.02">p7zip</requirement>
         </requirements>
     </xml>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ncbi_datasets**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ncbi_datasets from version 14.6.0 to 14.7.0.

**Project home page:** https://github.com/ncbi/datasets/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).