### PR TITLE
Updating tools/pyega3 from version 4.0.5 to
5.0.2

### DIFF
--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,7 +1,7 @@
 <tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.01" >
     <macros>
-        <token name="@TOOL_VERSION@">4.0.5</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">5.0.1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pyega3</requirement>

--- a/tools/pyega3/pyega3.xml
+++ b/tools/pyega3/pyega3.xml
@@ -1,6 +1,6 @@
 <tool id="pyega3" name="EGA Download Client" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.01" >
     <macros>
-        <token name="@TOOL_VERSION@">5.0.1</token>
+        <token name="@TOOL_VERSION@">5.0.2</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pyega3**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pyega3 from version 4.0.5 to 5.0.1.

**Project home page:** https://github.com/EGA-archive/ega-download-client/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).