### PR TITLE
Updating tools/straindesign from version 3.1.0 to
3.2.2

### DIFF
--- a/tools/straindesign/macros.xml
+++ b/tools/straindesign/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <!--  GLOBAL  -->
-    <token name="@TOOL_VERSION@">3.2.0</token>
+    <token name="@TOOL_VERSION@">3.2.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@LICENSE@">MIT</token>
     <xml name="requirements">

--- a/tools/straindesign/macros.xml
+++ b/tools/straindesign/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <!--  GLOBAL  -->
-    <token name="@TOOL_VERSION@">3.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">3.2.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@LICENSE@">MIT</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/straindesign**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/straindesign from version 3.1.0 to 3.2.0.

**Project home page:** https://github.com/brsynth/straindesign/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).