### PR TITLE
beagle: fix tests

### DIFF
--- a/tools/beagle/beagle.xml
+++ b/tools/beagle/beagle.xml
@@ -7,15 +7,14 @@
     <expand macro='requirements' />
     <command detect_errors='exit_code'><![CDATA[
         #set out_prefix='out'
-        #if $optional_inputs.ref.ext == 'bref3'
-            ln -s '${optional_inputs.ref}' ref.bref3 &&
+        #if $optional_inputs.ref
+            ln -s '${optional_inputs.ref}' ref.$optional_inputs.ref.ext &&
         #end if
+
         beagle
         gt='${gt}'
-        #if $optional_inputs.ref and $optional_inputs.ref.ext == 'bref3'
-            ref=ref.bref3
-        #else if $optional_inputs.ref
-            ref='${optional_inputs.ref}'
+        #if $optional_inputs.ref
+            ref=ref.$optional_inputs.ref.ext
         #end if
         #if $optional_inputs.map
             map='${optional_inputs.map}'
@@ -146,7 +145,7 @@
     <tests>
         <!-- Test default values -->
         <test expect_num_outputs="2">
-            <param name="gt" value="test.vcf.gz"/>
+            <param name="gt" value="test.vcf.gz" ftype="vcf"/>
             <param name="chrom" value="22:100-"/>
             <param name="ne" value="1000000"/>
             <param name="window" value="40.0"/>
@@ -160,11 +159,15 @@
                 <param name="phase_states" value="280"/>
             </section>
             <output name="vcf_file" file="test_output.vcf" ftype="vcf" lines_diff="3"/>
-            <output name="log_file" file="test_output.log" ftype="txt" lines_diff="16"/>
+            <output name="log_file" file="test_output.log" ftype="txt" lines_diff="16">
+                <assert_contents>
+                    <has_text text="WARNING" negate="true"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- Test plink file-->
         <test expect_num_outputs="2">
-            <param name="gt" value="test.vcf.gz"/>
+            <param name="gt" value="test.vcf.gz" ftype="vcf"/>
             <param name="ne" value="1000000"/>
             <param name="window" value="30.0"/>
             <param name="overlap" value="3.0"/>
@@ -186,19 +189,21 @@
             <output name="log_file" ftype="txt">
                 <assert_contents>
                     <has_text text="Reference markers:                  223"/>
-                    <has_size value="1586" delta="10"/>
+                    <has_size value="1586" delta="100"/>
+                    <has_text text="WARNING" negate="true"/>
+                    <has_text_matching expression="beagle.*jar finished"/>
                 </assert_contents>
             </output>
         </test>
         <!-- Test ref VCF input -->
         <test expect_num_outputs="2">
-            <param name="gt" value="target.vcf.gz"/>
+            <param name="gt" value="target.vcf.gz" ftype="vcf"/>
             <param name="ne" value="1000000"/>
             <param name="window" value="40.0"/>
             <param name="overlap" value="2.0"/>
             <param name="output_log" value="true"/>
             <section name="optional_inputs">
-                <param name="ref" value="ref.vcf.gz"/>
+                <param name="ref" value="ref.vcf.gz" ftype="vcf"/>
             </section>
             <section name="imputation_parameters">
                 <param name="impute" value="true"/>
@@ -218,18 +223,20 @@
             <output name="log_file" ftype="txt">
                 <assert_contents>
                     <has_text text="Reference markers:                  223"/>
-                    <has_size value="1801" delta="10"/>
+                    <has_size value="1600" delta="100"/>
+                    <has_text text="WARNING" negate="true"/>
+                    <has_text_matching expression="beagle.*jar finished"/>
                 </assert_contents>
             </output>
         </test>
         <!-- Test ref bref3 input -->
         <test expect_num_outputs="1">
-            <param name="gt" value="target.vcf.gz"/>
+            <param name="gt" value="target.vcf.gz" ftype="vcf"/>
             <param name="ne" value="1000000"/>
             <param name="window" value="40.0"/>
             <param name="overlap" value="2.0"/>
             <section name="optional_inputs">
-                <param name="ref" value="ref.bref3"/>
+                <param name="ref" value="ref.bref3" ftype="bref3"/>
             </section>
             <section name="imputation_parameters">
                 <param name="impute" value="true"/>

--- a/tools/beagle/beagle.xml
+++ b/tools/beagle/beagle.xml
@@ -276,7 +276,7 @@ Beagle versions 4.0 and 4.1 have this capability.
 **HapMap genetic maps**
 
 HapMap genetic maps in PLINK format for GRCh36, GRCh37, and GRCh38 are available 
-in `this link <http://bochet.gcc.biostat.washington.edu/beagle/genetic_maps/>`_
+in `this links <https://bochet.gcc.biostat.washington.edu/beagle/genetic_maps/>`_
 
 ----
 

--- a/tools/beagle/macros.xml
+++ b/tools/beagle/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">5.2_21Apr21.304</token>
-    <token name="@SUFFIX_VERSION@">0</token>
+    <token name="@SUFFIX_VERSION@">1</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0196</edam_topic>


### PR DESCRIPTION
and always set input extension for ext to avoid WARNING in log (which might be meaningful)

tool currently fails CI



FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
