### PR TITLE
fix mirnature tests

### DIFF
--- a/tools/mirnature/macros.xml
+++ b/tools/mirnature/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">mirnature</requirement>

--- a/tools/mirnature/mirnature.xml
+++ b/tools/mirnature/mirnature.xml
@@ -168,7 +168,7 @@
         <param name="speT" value="Unsg"/>
         <param name="homology_mode" value="hmm"/>
         <param name="repeat_filter" value="relax"/>
-        <output name="std_output" file="test_hmm.txt" ftype="txt"/>
+        <output name="std_output" file="test_hmm.txt" ftype="txt" lines_diff="8"/>
         <output_collection name="gff3_files_h" count="1"/>
         <output_collection name="yaml_files_h" count="1"/>
         <output_collection name="tab_files_h" count="1"/>
@@ -185,7 +185,7 @@
         <param name="speT" value="Unsp"/>
         <param name="homology_mode" value="rfam"/>
         <param name="repeat_filter" value="relax"/>
-        <output name="std_output" file="test_rfam.txt" ftype="txt"/>
+        <output name="std_output" file="test_rfam.txt" ftype="txt" lines_diff="8"/>
         <output_collection name="gff3_files_h" count="1"/>
         <output_collection name="yaml_files_h" count="1"/>
         <output_collection name="tab_files_h" count="1"/>
@@ -202,7 +202,7 @@
         <param name="speT" value="Unsd"/>
         <param name="homology_mode" value="mirbase"/>
         <param name="repeat_filter" value="relax"/>
-        <output name="std_output" file="test_mirbase.txt" ftype="txt"/>
+        <output name="std_output" file="test_mirbase.txt" ftype="txt" lines_diff="8"/>
         <output_collection name="gff3_files_h" count="1"/>
         <output_collection name="yaml_files_h" count="1"/>
         <output_collection name="tab_files_h" count="1"/>
@@ -221,7 +221,7 @@
         <param name="blast_strategy" value="8,9"/>
         <param name="queries_to_blast" value="test.fasta"/>
         <param name="repeat_filter" value="relax"/>
-        <output name="std_output" file="test_all_homology.txt" ftype="txt"/>
+        <output name="std_output" file="test_all_homology.txt" ftype="txt" lines_diff="20"/>
         <output_collection name="gff3_files_h" count="1"/>
         <output_collection name="yaml_files_h" count="1"/>
         <output_collection name="tab_files_h" count="1"/>


### PR DESCRIPTION
stdout contains dataset IDs which are different in weekly CI tests

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
