### PR TITLE
rename bioinf cafe suite

### DIFF
--- a/tools/bioinformatics_cafe/.shed.yml
+++ b/tools/bioinformatics_cafe/.shed.yml
@@ -1,4 +1,4 @@
-name: bioinformatics-cafe
+name: bioinformatics_cafe
 owner: mbernt
 description: Miscellanea of scripts for bioinformatics
 long_description: |
@@ -10,9 +10,9 @@ homepage_url: https://github.com/dariober/bioinformatics-cafe/
 type: unrestricted
 auto_tool_repositories:
   name_template: "{{ tool_id }}"
-  description_template: "bioinformatics-cafe {{ tool_name }}."
+  description_template: "bioinformatics_cafe {{ tool_name }}."
 suite:
-  name: "suite_bioinformatics-cafe"
+  name: "suite_bioinformatics_cafe"
   description: Miscellanea of scripts for bioinformatics
   long_description: |
     Miscellanea of scripts for bioinformatics


### PR DESCRIPTION
because TS does not allow dash
followup for https://github.com/galaxyproject/tools-iuc/pull/5094

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
