### PR TITLE
samtools view use new arguments

### DIFF
--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_view" name="Samtools view" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="samtools_view" name="Samtools view" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>- reformat, filter, or subsample SAM, BAM or CRAM</description>
     <macros>
         <import>macros.xml</import>
@@ -154,11 +154,11 @@
                         ## not dealing with all of the reads in the indexed
                         ## file. We have to do an extra pass over the input to
                         ## count the reads to subsample.
-                        sample_fragment=`samtools view -c $std_filters infile $reg_filters | awk '{s=\$1} END {frac=s/${mode.subsample_config.subsampling_mode.target}; printf("%.8f\n", frac > 1 ? $seed+1/frac : ".0")}'` &&
+                        sample_fragment=`samtools view -c $std_filters infile $reg_filters | awk '{s=\$1} END {fac=s/${mode.subsample_config.subsampling_mode.target}; printf("%f\n", fac > 1 ? 1/fac : 1)}'` &&
                     #else:
                         ## We can get the count of reads to subsample using
                         ## an inexpensive call to idxstats.
-                        sample_fragment=`samtools idxstats infile | awk '{s+=\$4+\$3} END {frac=s/${mode.subsample_config.subsampling_mode.target}; printf("%.8f\n", frac > 1 ? $seed+1/frac : ".0")}'` &&
+                        sample_fragment=`samtools idxstats infile | awk '{s+=\$4+\$3} END {fac=s/${mode.subsample_config.subsampling_mode.target}; printf("%f\n", fac > 1 ? 1/fac : 1)}'` &&
                     #end if
                 #end if
             #end if
@@ -172,12 +172,13 @@
             $std_filters
 
             #if $with_subsampling:
+                --subsample-seed $seed
                 #if str($mode.subsample_config.subsampling_mode.select_subsample) == "target":
                     ##this is calculated at execution time before the main samtools command
-                    -s \${sample_fragment}
+                    --subsample \${sample_fragment}
                 #else:
-                    #set $fraction = $seed + 1 / float($mode.subsample_config.subsampling_mode.factor)
-                    -s $fraction
+                    #set $fraction = 1 / float($mode.subsample_config.subsampling_mode.factor)
+                    --subsample $fraction
                 #end if
             #end if
 
@@ -398,7 +399,7 @@
         </data>
     </outputs>
     <tests>
-<!-- 1) sam to bam (copied from the sam_to_bam tool) -->
+        <!-- 1) sam to bam (copied from the sam_to_bam tool) -->
         <test>
             <param name="input" ftype="sam" value="in_test_1.sam" />
             <output name="outputsam" ftype="bam" file="test_1.bam" lines_diff="4" />


### PR DESCRIPTION
`--subsample-seed SEED --subsample FRACTION`

instead of the awkward difficult to read

`-s SEED.FRACTION

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
