### PR TITLE
Fix ivar trim use of autogenerated amplicon info

### DIFF
--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_trim" name="ivar trim" version="@TOOL_VERSION@+galaxy5" profile="@PROFILE@">
+<tool id="ivar_trim" name="ivar trim" version="@TOOL_VERSION@+galaxy6" profile="@PROFILE@">
     <description>Trim reads in aligned BAM</description>
     <macros>
         <import>macros.xml</import>
@@ -26,7 +26,7 @@
         ivar trim
         -i sorted.bam
         -b bed.bed
-        #if $amplicons.filter_by == 'yes'
+        #if $amplicons.filter_by == 'yes' or $amplicons.filter_by == 'yes_compute'
             -f amplicon_info.tsv
         #end if
         -x $primer_pos_wiggle

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -75,8 +75,8 @@
         help="Reads that occur at the specified offset positions relative to primer positions (as annotated in the primer information dataset) will also be trimmed (default: 0)" />
         <param name="inc_primers" argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Include reads not ending in any primer binding sites?"/>
         <param name="min_len" argument="-m" type="integer" min="0" value="30" label="Minimum length of read to retain after trimming"/>
-        <param name="min_qual" argument="-q" type="integer" min="0" value="20" label="Minimum quality threshold for sliding window to pass"/>
-        <param name="window_width" argument="-s" type="integer" min="0" value="4" label="Width of sliding window"/>
+        <param name="min_qual" argument="-q" type="integer" min="0" max="255" value="20" label="Minimum quality threshold for sliding window to pass"/>
+        <param name="window_width" argument="-s" type="integer" min="0" max="255" value="4" label="Width of sliding window"/>
     </inputs>
     <outputs>
         <data name="output_bam" format="bam" label="${tool.name} on ${on_string} Trimmed bam" from_work_dir="trimmed.sorted.bam"/>


### PR DESCRIPTION
... for real this time after an insufficient previous attempt in [27f076c].

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
