### PR TITLE
Updating tools/busco from version 5.4.4 to 5.4.5

### DIFF
--- a/tools/busco/busco.xml
+++ b/tools/busco/busco.xml
@@ -173,7 +173,7 @@ busco
                 </conditional>
             </conditional>
             <param name="outputs" value="short_summary,missing,gff" />
-            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="4" />
+            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="6" />
             <output name="busco_table" file="genome_results/full_table" compare="diff" lines_diff="4" />
             <output name="busco_gff">
                 <assert_contents>
@@ -197,7 +197,7 @@ busco
                 <param name="mode" value="prot" />
             </conditional>
             <param name="outputs" value="short_summary,missing,image,gff" />
-            <output name="busco_sum" file="proteome_results/short_summary" compare="diff" lines_diff="4" />
+            <output name="busco_sum" file="proteome_results/short_summary" compare="diff" lines_diff="6" />
             <output name="busco_table" file="proteome_results/full_table" compare="diff" lines_diff="4" />
             <output name="busco_missing" file="proteome_results/missing_buscos_list" compare="diff" lines_diff="4" />
             <output name="summary_image" file="proteome_results/summary.png" compare="sim_size" />
@@ -241,7 +241,7 @@ busco
                 </conditional>
             </conditional>
             <param name="outputs" value="short_summary,gff" />
-            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="4" />
+            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="6" />
             <output name="busco_table" file="genome_results/full_table" compare="diff" lines_diff="4" />
             <output name="busco_gff">
                 <assert_contents>
@@ -267,7 +267,7 @@ busco
                 </conditional>
             </conditional>
             <param name="outputs" value="short_summary,missing" />
-            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="4" />
+            <output name="busco_sum" file="genome_results/short_summary" compare="diff" lines_diff="6" />
             <output name="busco_table" file="genome_results/full_table" compare="diff" lines_diff="4" />
             <output name="busco_missing" file="genome_results/missing_buscos_list" compare="diff" lines_diff="4" />
         </test>

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.4.4</token>
+    <token name="@TOOL_VERSION@">5.4.5</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/busco**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/busco from version 5.4.4 to 5.4.5.

**Project home page:** https://gitlab.com/ezlab/busco/-/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).