### PR TITLE
Updating tools/ivar from version 1.3.1 to 1.3.2

### DIFF
--- a/tools/ivar/ivar_consensus.xml
+++ b/tools/ivar/ivar_consensus.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_consensus" name="ivar consensus" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="ivar_consensus" name="ivar consensus" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Call consensus from aligned BAM file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ivar/ivar_filtervariants.xml
+++ b/tools/ivar/ivar_filtervariants.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_filtervariants" name="ivar filtervariants" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="ivar_filtervariants" name="ivar filtervariants" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Filter variants across replicates or multiple samples aligned using the same reference</description>
         <macros>
         <import>macros.xml</import>

--- a/tools/ivar/ivar_removereads.xml
+++ b/tools/ivar/ivar_removereads.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_removereads" name="ivar removereads" version="@TOOL_VERSION@+galaxy4" profile="@PROFILE@">
+<tool id="ivar_removereads" name="ivar removereads" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Remove reads from trimmed BAM file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_trim" name="ivar trim" version="@TOOL_VERSION@+galaxy6" profile="@PROFILE@">
+<tool id="ivar_trim" name="ivar trim" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Trim reads in aligned BAM</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ivar/ivar_variants.xml
+++ b/tools/ivar/ivar_variants.xml
@@ -1,4 +1,4 @@
-<tool id="ivar_variants" name="ivar variants" version="@TOOL_VERSION@+galaxy3" profile="@PROFILE@">
+<tool id="ivar_variants" name="ivar variants" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Call variants from aligned BAM file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ivar/macros.xml
+++ b/tools/ivar/macros.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.3.1</token>
+  <token name="@TOOL_VERSION@">1.3.2</token>
   <token name="@PROFILE@">21.01</token>
   <xml name="requirements">
   <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ivar</requirement>
       <requirement type="package" version="3.10.8">python</requirement>
-      <requirement type="package" version="1.16">samtools</requirement>
+      <requirement type="package" version="1.16.1">samtools</requirement>
       <yield/>
   </requirements>
   </xml>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ivar**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ivar from version 1.3.1 to 1.3.2.

**Project home page:** https://github.com/andersen-lab/ivar/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).