### PR TITLE
Add a safe guard to integron 

### DIFF
--- a/tools/integron_finder/integron_finder.xml
+++ b/tools/integron_finder/integron_finder.xml
@@ -35,7 +35,9 @@
         && mv Results_Integron_Finder_* Results_Integron_Finder
     ]]></command>
     <inputs>
-        <param type="data" name="sequence" format="fasta" label="Replicon file" help="Replicon can be entire chromosome, contif, PCR fragments..." />
+        <param type="data" name="sequence" format="fasta" label="Replicon file" help="Replicon can be entire chromosome, contif, PCR fragments...">
+             <validator type="expression" message="Integron Finder has problems with large multi FASTA files. Please assembly your sequences or split them up into files smaller 10.000 sequences."><![CDATA[value is not None and value.metadata.sequences <= 10000]]></validator>
+        </param>
         <param name="local_max" argument="--local-max" type="boolean" checked="false" truevalue="--local-max" falsevalue="" label="Thorough local detection" help="This option allows a more sensitive search. I will be slower (dependant on the number of hits) if integrons are found, but will be as fast if nothing is detected and will not increase the false positive rate." />
 	      <param name="type_replicon" type="select" optional="true" label="Default replicons topology" help="Set the default topology for replicons, linear, circular (deault: no topology)">
 	          <option value="--linear">linear (--linear)</option>

--- a/tools/integron_finder/macro.xml
+++ b/tools/integron_finder/macro.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.0.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.05</token>
     <token name="@THREADS@">\${GALAXY_SLOTS:-2}</token>
     <xml name="requirements">


### PR DESCRIPTION
This is needed because of https://github.com/gem-pasteur/Integron_Finder/issues/90 which results in a directory with multi-million of files.
