### PR TITLE
Updating tools/tb-profiler from version 4.4.1 to 4.4.2

### DIFF
--- a/tools/tb-profiler/tb_profiler_profile.xml
+++ b/tools/tb-profiler/tb_profiler_profile.xml
@@ -1,7 +1,7 @@
 <tool id="tb_profiler_profile" name="TB-Profiler Profile" version="@TOOL_VERSION@+galaxy0" profile="20.09">
     <description>Infer strain types and drug resistance markers from sequences</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.4.1</token>
+        <token name="@TOOL_VERSION@">4.4.2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">tb-profiler</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/tb-profiler**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/tb-profiler from version 4.4.1 to 4.4.2.

**Project home page:** https://github.com/jodyphelan/TBProfiler/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).