### PR TITLE
bedtool add mean option to calculate mean depth of specific bed regions

### DIFF
--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -14,6 +14,7 @@ $d
 $hist
 $split
 $strandedness
+$mean
 #if str($overlap_a):
     -f $overlap_a
 #end if
@@ -64,6 +65,8 @@ $a_or_b
         <param argument="-hist" type="boolean" truevalue="-hist" falsevalue="" checked="false"
             label="Report a histogram of coverage for each feature in A as well as a summary histogram for all features in A"
             help="Additional columns after each feature in A: 1) depth 2) # bases at depth 3) size of A 4) % of A at depth" />
+        <param name="mean" argument="-mean" type="boolean" label="Mean depth" truevalue="-mean" falsevalue="" checked="false"
+            help="Report the mean depth of all positions in each A feature."/>
         <expand macro="overlap" name="overlap_a" />
         <expand macro="overlap" name="overlap_b" argument="-F" fracof="B" />
         <param name="reciprocal_overlap" argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false"
@@ -121,6 +124,12 @@ $a_or_b
             <param name="inputA" value="coverageBedA2.bed" ftype="bed" />
             <param name="inputB" value="coverageBed.bam" ftype="bam" />
             <output name="output" file="coverageBed_result5_unsorted.bed" ftype="bed" />
+        </test>
+        <test>
+            <param name="inputA" value="coverageBedA2.bed" ftype="bed" />
+            <param name="inputB" value="coverageBed.bam" ftype="bam" />
+            <param name="mean" value="true"/>
+            <output name="output" file="mean_coverage.bed" ftype="bed" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_coveragebed" name="bedtools Compute both the depth and breadth of coverage" version="@TOOL_VERSION@" profile="@PROFILE@">
+<tool id="bedtools_coveragebed" name="bedtools Compute both the depth and breadth of coverage" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>of features in file B on the features in file A (bedtools coverage)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/test-data/mean_coverage.bed
+++ b/tools/bedtools/test-data/mean_coverage.bed
@@ -1,0 +1,3 @@
+dummy_chr	1	100	0.0000000
+dummy_chr	1000	1000000	0.0001522
+super_dummy_chr	1	100	0.0000000


### PR DESCRIPTION
Just add the `-mean options` which simplify the output to extract the mean depth of specific regions 