### PR TITLE
Quast: support assemby (individual or co) modes

### DIFF
--- a/tools/quast/macros.xml
+++ b/tools/quast/macros.xml
@@ -15,7 +15,7 @@
         </xrefs>
     </xml>
     <xml name="gene_thresholds">
-        <param name="gene_thresholds" argument="--gene-thresholds" type="text" value="0,300,1500,3000" label="Comma-separated list of thresholds (in bp) for gene lengths to find with a finding tool"/>
+        <param argument="--gene-thresholds" type="text" value="0,300,1500,3000" label="Comma-separated list of thresholds (in bp) for gene lengths to find with a finding tool"/>
     </xml>
     <xml name="citations">
         <citations>

--- a/tools/quast/macros.xml
+++ b/tools/quast/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">5.2.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/quast/macros.xml
+++ b/tools/quast/macros.xml
@@ -26,7 +26,28 @@
         </citations>
     </xml>
     <xml name="min_identity_macros" token_value="">
-        <param argument="--min-identity" type="float" value="@VALUE@" min="80" max="100" label="Minimum IDY% considered as proper alignment" help="Alignments with IDY% worse than this value will be filtered. Note that all alignments
-            with IDY% less than 80.0% will be filtered regardless of this threshold. "/>
+        <param argument="--min-identity" type="float" value="@VALUE@" min="80" max="100" label="Minimum IDY% considered as proper alignment" help="Alignments with IDY% worse than this value will be filtered. Note that all alignments with IDY% less than 80.0% will be filtered regardless of this threshold. "/>
+    </xml>
+    <xml name="custom">
+        <param name="custom" type="select" label="Use customized names for the input files?" help="They will be used in reports, plots and logs">
+            <option value="true">Yes, specify custom names</option>
+            <option value="false" selected="true">No, use dataset names</option>
+        </param>
+    </xml>
+    <xml name="labelled_input">
+        <param name="input" type="data" format="fasta" label="Contigs/scaffolds file"/>
+        <param argument="--labels" type="text" value="" label="Name"/>
+    </xml>
+    <xml name="reads_option">
+        <param name="reads_option" type="select" label="Reads options" help="Currently, the supported read types are Illumina unpaired, paired-end and mate-pair reads, PacBio SMRT, and Oxford Nanopore long reads.">
+            <option value="disabled">Disabled</option>
+            <option value="single">Illumina single-end reads</option>
+            <option value="paired">Illumina paired-end reads</option>
+            <option value="paired_collection">Illumina paired-end reads in paired collection</option>
+            <option value="paired_interlaced">Illumina interlaced paired-end reads</option>
+            <option value="mate_paired">Illumina mate-pair reads</option>
+            <option value="pacbio">Pacbio SMRT reads</option>
+            <option value="nanopore">Nanopore reads</option>
+        </param>
     </xml>
 </macros>

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -265,9 +265,9 @@ metaquast
     ]]></command>
     <inputs>
         <conditional name="mode">
-            <param name="mode" type="select" label="Assembly mode?" help="Useful to know if QUAST should be run on all samples together on on each sample individually">
-                <option value="individual" selected="true">Individual assembly</option>
-                <option value="co">Co-assembly</option>
+            <param name="mode" type="select" label="Assembly mode?" help="Useful to know if contigs have been generated all samples together (co-assembly) or on each sample individually (individual assembly)">
+                <option value="individual">Individual assembly (1 contig file per sample)</option>
+                <option value="co" selected="true">Co-assembly (1 contig file for several samples)</option>
             </param>
             <when value="individual">
                 <conditional name="in">

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -483,7 +483,7 @@ metaquast
         <data name="log" format="txt" label="${tool.name} on ${on_string}: Log" from_work_dir="outputdir/quast.log">
             <filter>assembly['type'] == 'genome' and 'log' in output_files</filter>
         </data>
-        <data name="log_meta" format="txt" label="${tool.name} on ${on_string}: Log" from_work_dir="outputdir/metaquast.log">
+        <data name="log_meta" format="txt" label="${tool.name} on ${on_string}: Log Meta" from_work_dir="outputdir/metaquast.log">
             <filter>assembly['type'] == 'metagenome' and 'log' in output_files</filter>
         </data>
         <data name="mis_ass" format="tabular" label="${tool.name} on ${on_string}: Misassemblies report" from_work_dir="outputdir/contigs_reports/misassemblies_report.txt">

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -369,7 +369,7 @@ metaquast
                                 <option value="" selected="true">No</option>
                             </param>
                             <when value="--k-mer-stats">
-                                <param name="k_mer_size" argument="--k-mer-size" type="integer" value="101" label="Size of k" />
+                                <param argument="--k-mer-size" type="integer" value="101" label="Size of k" />
                             </when>
                             <when value=""/>
                         </conditional>
@@ -1053,12 +1053,16 @@ metaquast
                     <param name="input_1">
                         <collection type="list:paired">
                             <element name="s1">
-                                <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
-                                <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                                <collection type="paired">
+                                    <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                                    <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                                </collection>
                             </element>
                             <element name="s2">
-                                <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
-                                <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                                <collection type="paired">
+                                    <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                                    <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                                </collection>
                             </element>
                         </collection>
                     </param>
@@ -1074,9 +1078,9 @@ metaquast
             <output name="report_tabular" ftype="tabular">
                 <assert_contents>
                     <has_text text="# contigs (>= 0 bp)"/>
-                    <has_text text="contig1"/>
+                    <has_text text="contigs1"/>
                     <has_text text="# N's per 100 kbp"/>
-                    <has_n_lines n="15"/>
+                    <has_n_lines n="22"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -288,22 +288,20 @@ metaquast
             </when>
             <when value="metagenome">
                 <conditional name="ref">
-                    <param name="origin" type="select" label="Reference genome" help="Many metrics can't be evaluated without a reference. If this is omitted, QUAST will only report the metrics that can be evaluated without a reference.">
+                    <param name="origin" type="select" label="Reference genome" help="If no reference genomes is provided, the tool will try to identify genome content of the metagenome. By default, it will align contigs to SILVA 16S rRNA database, i.e. FASTA file containing small subunit ribosomal RNA sequences to identify genomes. The reference genomes for the chosen genomes are downloaded from the NCBI database. After that, Quast is run on all of them. Reference genomes with low genome fraction (less than 10%) are removed. The usual MetaQUAST analysis continues with the remaining references.">
+                        <option value="silva" selected="true">From SILVA database</option>
                         <option value="history">From history</option>
-                        <option value="list">From list</option>
-                        <option value="silva">From SILVA database</option>
-                        <option value="none" selected="true">None</option>
+                        <option value="list">From a list</option>
                     </param>
+                    <when value="silva">
+                        <param argument="--max-ref-num" type="integer" value="50" label="Maximum number of reference genomes (per each assembly) to download after searching in the SILVA databa" />
+                    </when>
                     <when value="history">
                         <param argument="-r" type="data" format="fasta" multiple="true" label="Reference genome" />
                     </when>
                     <when value="list">
-                        <param name="references_list" argument="references-list" type="text" value="" label="Comma-separated list of reference genomes" help="MetaQUAST will search for these references in the NCBI database and will download the found ones"/>
+                        <param argument="--references-list" type="text" value="" label="Comma-separated list of reference genomes" help="MetaQUAST will search for these references in the NCBI database and will download the found ones"/>
                     </when>
-                    <when value="silva">
-                        <param name="max_ref_num" argument="-max-ref-num" type="integer" value="50" label="Maximum number of reference genomes (per each assembly) to download after searching in the SILVA databa" />
-                    </when>
-                    <when value="none"/>
                 </conditional>
                 <param argument="--reuse-combined-alignments" type="boolean" truevalue="--reuse-combined-alignments" falsevalue="" checked="false" label="Reuse the alignments on the combined reference" help="Reuse the alignments on the combined reference in the subsequent runs per separate references. That is, the alignment procedure is performed only once (for all assemblies against the combined reference) and does NOT executed for each subgroups of contigs against the corresponding separate reference genomes. In each separate reference run, all precomputed assembly alignments for other references are simply ignored" />
                 <expand macro="min_identity_macros" value="90"/>
@@ -564,7 +562,8 @@ metaquast
             <conditional name="assembly">
                 <param name="type" value="metagenome"/>
                 <conditional name="ref">
-                    <param name="origin" value="none"/>
+                    <param name="origin" value="silva"/>
+                    <param name="max_ref_num" value="50"/>
                 </conditional>
             </conditional>
             <param name="min_contig" value="500"/>

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -10,19 +10,31 @@
 #import re
 #import os
 
-#if str($in.custom) == 'false'
-    #set $labels = ','.join( [re.sub('[^\w\-_]', '_', str($x.element_identifier)) for $x in $in.inputs])
+#if str($mode.in.custom) == 'false'
+    #if $mode.mode == 'individual'
+        #set $labels = re.sub('[^\w\-_]', '_', str($mode.in.inputs.element_identifier))
+    #else
+        #set $labels = ','.join( [re.sub('[^\w\-_]', '_', str($x.element_identifier)) for $x in $mode.in.inputs])
+    #end if
 echo $labels &&
 #else
-    #set $labels = []
-    #for $x in $in.inputs
-        #if str($x.labels) != ''
-            #silent $labels.append(re.sub('[^\w\-_]', '_', str($x.labels)))
+    #if $mode.mode == 'individual'
+        #if str($mode.in.labels) != ''
+            #set $labels = re.sub('[^\w\-_]', '_', str($mode.in.labels))
         #else
-            #silent $labels.append(re.sub('[^\w\-_]', '_', str($x.input.element_identifier)))
+            #set $labels = re.sub('[^\w\-_]', '_', str($mode.in.input.element_identifier))
         #end if
-    #end for
-    #set $labels = ','.join($labels)
+    #else
+        #set $labels = []
+        #for $x in $mode.in.inputs
+            #if str($x.labels) != ''
+                #silent $labels.append(re.sub('[^\w\-_]', '_', str($x.labels)))
+            #else
+                #silent $labels.append(re.sub('[^\w\-_]', '_', str($x.input.element_identifier)))
+            #end if
+        #end for
+        #set $labels = ','.join($labels)
+    #end if
 #end if
 
 #if $assembly.type == 'metagenome' and $assembly.ref.origin == 'list'
@@ -32,19 +44,34 @@ echo $labels &&
     #end for
 #end if
 
-#if $reads.reads_option == 'paired'
-    #for $read in $reads.input_1
-        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+#if $mode.reads.reads_option == 'paired'
+    #if $mode.mode == 'individual'
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_1.element_identifier))
+ln -s '$mode.reads.input_1' 'pe1-${identifier}.${mode.reads.input_1.ext}' &&
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_2.element_identifier))
+ln -s '$mode.reads.input_2' 'pe2-${identifier}.${mode.reads.input_2.ext}' &&
+    #else
+        #for $read in $mode.reads.input_1
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
 ln -s '$read' 'pe1-${identifier}.${read.ext}' &&
-    #end for
-    #for $read in $reads.input_2
-        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+        #end for
+        #for $read in $mode.reads.input_2
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
 ln -s '$read' 'pe2-${identifier}.${read.ext}' &&
-    #end for
-#else if $reads.reads_option == 'paired_collection'
-    #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($reads.input_1.element_identifier))
-ln -s '$reads.input_1.forward' 'pe1-${identifier}.${reads.input_1.forward.ext}' &&
-ln -s '$reads.input_1.reverse' 'pe2-${identifier}.${reads.input_1.reverse.ext}' &&
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'paired_collection'
+    #if $mode.mode == 'individual'
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_1.element_identifier))
+ln -s '$mode.reads.input_1.forward' 'pe1-${identifier}.${mode.reads.input_1.forward.ext}' &&
+ln -s '$mode.reads.input_1.reverse' 'pe2-${identifier}.${mode.reads.input_1.reverse.ext}' &&
+    #else
+        #for $read in $mode.reads.input_1
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+ln -s '$read.forward' 'pe1-${identifier}.${read.forward.ext}' &&
+ln -s '$read.reverse' 'pe2-${identifier}.${read.reverse.ext}' &&
+        #end for
+    #end if
 #end if
 
 #if $assembly.type == 'genome'
@@ -53,44 +80,79 @@ quast
 metaquast
 #end if
 
-#if $reads.reads_option == 'single'
-    #for $read in $reads.input_1
+#if $mode.reads.reads_option == 'single'
+    #if $mode.mode == 'individual'
+    --single '$mode.reads.input_1'
+    #else
+        #for $read in $mode.reads.input_1
     --single '$read'
-    #end for
-#else if $reads.reads_option == 'paired'
-    #for $read in $reads.input_1
-        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'paired'
+    #if $mode.mode == 'individual'
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_1.element_identifier))
+    --pe1 'pe1-${identifier}.${mode.reads.input_1.ext}'
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_2.element_identifier))
+    --pe2 'pe2-${identifier}.${mode.reads.input_2.ext}'
+    #else
+        #for $read in $mode.reads.input_1
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
     --pe1 'pe1-${identifier}.${read.ext}'
-    #end for
-    #for $read in $reads.input_2
-        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+        #end for
+        #for $read in $mode.reads.input_2
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
     --pe2 'pe2-${identifier}.${read.ext}'
-    #end for
-#else if $reads.reads_option == 'paired_collection'
-    #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($reads.input_1.element_identifier))
-    --pe1 'pe1-${identifier}.${reads.input_1.forward.ext}'
-    --pe2 'pe2-${identifier}.${reads.input_1.reverse.ext}'
-#else if $reads.reads_option == 'paired_interlaced'
-    #for $read in $reads.input_1
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'paired_collection'
+    #if $mode.mode == 'individual'
+        #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($mode.reads.input_1.element_identifier))
+    --pe1 'pe1-${identifier}.${mode.reads.input_1.forward.ext}'
+    --pe2 'pe2-${identifier}.${mode.reads.input_1.reverse.ext}'
+    #else
+        #for $read in $mode.reads.input_1
+            #set $identifier = re.sub('[^\s\w\-\\.]', '_', str($read.element_identifier))
+    --pe1 'pe1-${identifier}.${read.forward.ext}'
+    --pe2 'pe2-${identifier}.${read.reverse.ext}'
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'paired_interlaced'
+    #if $mode.mode == 'individual'
+    --pe12 '$mode.reads.input_1'
+    #else
+        #for $read in $mode.reads.input_1
     --pe12 '$read'
-    #end for
-#else if $reads.reads_option == 'mate_paired'
-    #for $read in $reads.input_1
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'mate_paired'
+    #if $mode.mode == 'individual'
+    --mp1 '$mode.reads.input_1'
+    --mp2 '$mode.reads.input_2'
+    #else
+        #for $read in $mode.reads.input_1
     --mp1 '$read'
-    #end for
-    #for $read in $reads.input_2
+        #end for
+        #for $read in $mode.reads.input_2
     --mp2 '$read'
-    #end for
-#else if $reads.reads_option == 'pacbio'
-    #for $read in $reads.input_1
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'pacbio'
+    #if $mode.mode == 'individual'
+    --pacbio '$mode.reads.input_1'
+    #else
+        #for $read in $mode.reads.input_1
     --pacbio '$read'
-    #end for
-#else if $reads.reads_option == 'nanopore'
-    #for $read in $reads.input_1
+        #end for
+    #end if
+#else if $mode.reads.reads_option == 'nanopore'
+    #if $mode.mode == 'individual'
+    --nanopore '$mode.reads.input_1'
+    #else
+        #for $read in $mode.reads.input_1
     --nanopore '$read'
-    #end for
+        #end for
+    #end if
 #end if
-
     --labels '$labels'
     -o 'outputdir'
 
@@ -118,14 +180,11 @@ metaquast
     #else if $assembly.ref.origin == 'list'
     --references-list '$temp_ref_list_fp'
     #else if $assembly.ref.origin == 'silva'
-    --test-no-ref
     --max-ref-num $assembly.ref.max_ref_num
     #end if
     $assembly.reuse_combined_alignments
 #end if
-
     --min-identity $assembly.min_identity
-
     --min-contig $min_contig
     $split_scaffolds
     $large
@@ -169,14 +228,22 @@ metaquast
     $advanced.report_all_metrics
     --x-for-Nx $advanced.x_for_Nx
 
-#if str($in.custom) == 'false'
-    #for $k in $in.inputs
+#if str($mode.in.custom) == 'false'
+    #if $mode.mode == 'individual'
+    '$mode.in.inputs'
+    #else
+        #for $k in $mode.in.inputs
     '$k'
-    #end for
+        #end for
+    #end if
 #else
-    #for $k in $in.inputs
+    #if $mode.mode == 'individual'
+    '$mode.in.input'
+    #else
+        #for $k in $mode.in.inputs
     '$k.input'
-    #end for
+        #end for
+    #end if
 #end if
     --threads \${GALAXY_SLOTS:-1}
 
@@ -197,55 +264,88 @@ metaquast
 #end if
     ]]></command>
     <inputs>
-        <conditional name="in">
-            <param name="custom" type="select" label="Use customized names for the input files?" help="They will be used in reports, plots and logs">
-                <option value="true">Yes, specify custom names</option>
-                <option value="false" selected="true">No, use dataset names</option>
+        <conditional name="mode">
+            <param name="mode" type="select" label="Assembly mode?" help="Useful to know if QUAST should be run on all samples together on on each sample individually">
+                <option value="individual" selected="true">Individual assembly</option>
+                <option value="co">Co-assembly</option>
             </param>
-            <when value="true">
-                <repeat name="inputs" title="Contigs/scaffolds" min="1">
-                    <param name="input" type="data" format="fasta" label="Contigs/scaffolds file"/>
-                    <param argument="--labels" type="text" value="" label="Name"/>
-                </repeat>
+            <when value="individual">
+                <conditional name="in">
+                    <expand macro="custom"/>
+                    <when value="true">
+                        <expand macro="labelled_input"/>
+                    </when>
+                    <when value="false">
+                        <param name="inputs" type="data" format="fasta" label="Contigs/scaffolds file"/>
+                    </when>
+                </conditional>
+                <conditional name="reads">
+                    <expand macro="reads_option"/>
+                    <when value="disabled"/>
+                    <when value="single">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="paired">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file #1" />
+                        <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file #2" />
+                    </when>
+                    <when value="paired_collection">
+                        <param name="input_1" type="data_collection" collection_type="paired" format="fastq,fastq.gz,fasta,fasta.gz" label="FASTQ/FASTA files" />
+                    </when>
+                    <when value="paired_interlaced">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="mate_paired">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file #1" />
+                        <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file #2" />
+                    </when>
+                    <when value="pacbio">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="nanopore">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" label="FASTQ/FASTA file" />
+                    </when>
+                </conditional>
             </when>
-            <when value="false">
-                <param name="inputs" type="data" format="fasta" multiple="true" label="Contigs/scaffolds file"/>
-            </when>
-        </conditional>
-        <conditional name="reads">
-            <param name="reads_option" type="select" label="Reads options" help="Currently, the supported read types are Illumina unpaired, paired-end and mate-pair reads, PacBio SMRT, and Oxford Nanopore long reads.">
-                <option value="disabled">Disabled</option>
-                <option value="single">Illumina single-end reads</option>
-                <option value="paired">Illumina paired-end reads</option>
-                <option value="paired_collection">Illumina paired-end reads in paired collection</option>
-                <option value="paired_interlaced">Illumina interlaced paired-end reads</option>
-                <option value="mate_paired">Illumina mate-pair reads</option>
-                <option value="pacbio">Pacbio SMRT reads</option>
-                <option value="nanopore">Nanopore reads</option>
-            </param>
-            <when value="disabled"/>
-            <when value="single">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
-            </when>
-            <when value="paired">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #1" />
-                <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #2" />
-            </when>
-            <when value="paired_collection">
-                <param name="input_1" type="data_collection" collection_type="paired" format="fastq,fastq.gz,fasta,fasta.gz" label="FASTQ/FASTA files" />
-            </when>
-            <when value="paired_interlaced">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
-            </when>
-            <when value="mate_paired">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #1" />
-                <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #2" />
-            </when>
-            <when value="pacbio">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
-            </when>
-            <when value="nanopore">
-                <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
+            <when value="co">
+                <conditional name="in">
+                    <expand macro="custom"/>
+                    <when value="true">
+                        <repeat name="inputs" title="Contigs/scaffolds" min="1">
+                            <expand macro="labelled_input"/>
+                        </repeat>
+                    </when>
+                    <when value="false">
+                        <param name="inputs" type="data" format="fasta" multiple="true" label="Contigs/scaffolds file"/>
+                    </when>
+                </conditional>
+                <conditional name="reads">
+                    <expand macro="reads_option"/>
+                    <when value="disabled"/>
+                    <when value="single">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="paired">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #1" />
+                        <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #2" />
+                    </when>
+                    <when value="paired_collection">
+                        <param name="input_1" type="data_collection" collection_type="list:paired" format="fastq,fastq.gz,fasta,fasta.gz" label="FASTQ/FASTA files" />
+                    </when>
+                    <when value="paired_interlaced">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="mate_paired">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #1" />
+                        <param name="input_2" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file #2" />
+                    </when>
+                    <when value="pacbio">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
+                    </when>
+                    <when value="nanopore">
+                        <param name="input_1" format="fastq,fastq.gz,fasta,fasta.gz" type="data" multiple="true" label="FASTQ/FASTA file" />
+                    </when>
+                </conditional>
             </when>
         </conditional>
         <conditional name="assembly">
@@ -416,16 +516,19 @@ metaquast
     <tests>
         <!-- Test 01: reference, genes annotations and operon coordinates -->
         <test expect_num_outputs="2">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>
@@ -474,16 +577,19 @@ metaquast
         </test>
         <!-- Test 02: all outputs -->
         <test expect_num_outputs="8">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>
@@ -511,9 +617,12 @@ metaquast
         </test>
         <!-- Test 03: without reference -->
         <test expect_num_outputs="3">
-            <conditional name="in">
-                <param name="custom" value="false"/>
-                <param name="inputs" value="contigs1.fna,contigs2.fna"/>
+            <conditional name="mode">
+                <param name="mode" value="individual"/>
+                <conditional name="in">
+                    <param name="custom" value="false"/>
+                    <param name="inputs" value="contigs1.fna"/>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>
@@ -555,9 +664,12 @@ metaquast
         </test>
         <!-- Test 04: metagenomics -->
         <test expect_num_outputs="3">
-            <conditional name="in">
-                <param name="custom" value="false"/>
-                <param name="inputs" value="contigs3.fasta"/>
+            <conditional name="mode">
+                <param name="mode" value="individual"/>
+                <conditional name="in">
+                    <param name="custom" value="false"/>
+                    <param name="inputs" value="contigs3.fasta"/>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="metagenome"/>
@@ -616,20 +728,23 @@ metaquast
         </test>
         <!-- Test 05: FASTQ read files -->
         <test expect_num_outputs="3">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
-            </conditional>
-            <conditional name="reads">
-                <param name="reads_option" value="pacbio"/>
-                <param name="input_1" value="pacbio_01.fastq,pacbio_02.fastq,pacbio_03.fastq,pacbio_04.fastq"/>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="pacbio"/>
+                    <param name="input_1" value="pacbio_01.fastq,pacbio_02.fastq,pacbio_03.fastq,pacbio_04.fastq"/>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>
@@ -660,55 +775,64 @@ metaquast
         </test>
         <!-- Test 06: FASTQ.gz read files -->
         <test expect_num_outputs="1">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
-            </conditional>
-            <conditional name="reads">
-                <param name="reads_option" value="single"/>
-                <param name="input_1" value="pacbio_01.fastq.gz,pacbio_02.fastq.gz"/>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="single"/>
+                    <param name="input_1" value="pacbio_01.fastq.gz,pacbio_02.fastq.gz"/>
+                </conditional>
             </conditional>
             <param name="output_files" value="tabular"/>
             <output name="report_tabular" file="test6.tab" ftype="tabular"/>
         </test>
         <!-- Test 07: FASTA.gz read files -->
         <test expect_num_outputs="1">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
-            </conditional>
-            <conditional name="reads">
-                <param name="reads_option" value="single"/>
-                <param name="input_1" value="pacbio_01.fasta.gz,pacbio_02.fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="single"/>
+                    <param name="input_1" value="pacbio_01.fasta.gz,pacbio_02.fasta.gz"/>
+                </conditional>
             </conditional>
             <param name="output_files" value="tabular"/>
             <output name="report_tabular" file="test7.tab" ftype="tabular"/>
         </test>
         <!-- Test 08: metagenomics all tab outputs-->
         <test expect_num_outputs="3">
-            <conditional name="in">
-                <repeat name="inputs">
-                    <param name="input" value="meta_contigs_1.fasta"/>
-                    <param name="labels" value="meta_contigs_1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="meta_contigs_2.fasta"/>
-                    <param name="labels" value="meta_contigs_2"/>
-                </repeat>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <repeat name="inputs">
+                        <param name="input" value="meta_contigs_1.fasta"/>
+                        <param name="labels" value="meta_contigs_1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="meta_contigs_2.fasta"/>
+                        <param name="labels" value="meta_contigs_2"/>
+                    </repeat>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="metagenome"/>
@@ -757,15 +881,18 @@ metaquast
         </test>
         <!-- Test 09: metagenomics log, html and krona outputs-->
         <test expect_num_outputs="2">
-            <conditional name="in">
-                <repeat name="inputs">
-                    <param name="input" value="meta_contigs_1.fasta"/>
-                    <param name="labels" value="meta_contigs_1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="meta_contigs_2.fasta"/>
-                    <param name="labels" value="meta_contigs_2"/>
-                </repeat>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <repeat name="inputs">
+                        <param name="input" value="meta_contigs_1.fasta"/>
+                        <param name="labels" value="meta_contigs_1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="meta_contigs_2.fasta"/>
+                        <param name="labels" value="meta_contigs_2"/>
+                    </repeat>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="metagenome"/>
@@ -817,16 +944,19 @@ metaquast
         </test>
         <!-- Test 10: Test new options -->
         <test expect_num_outputs="1">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
-                    <param name="input" value="contigs1.fna"/>
-                    <param name="labels" value="contig1"/>
-                </repeat>
-                <repeat name="inputs">
-                    <param name="input" value="contigs2.fna"/>
-                    <param name="labels" value="contig2"/>
-                </repeat>
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs1.fna"/>
+                        <param name="labels" value="contig1"/>
+                    </repeat>
+                    <repeat name="inputs">
+                        <param name="input" value="contigs2.fna"/>
+                        <param name="labels" value="contig2"/>
+                    </repeat>
+                </conditional>
             </conditional>
             <section name="alignments">
                 <param name="local_mis_size" value="210"/>
@@ -846,17 +976,18 @@ metaquast
         </test>
         <!-- Test 11: Test paired fastq.gz inputs -->
         <test expect_num_outputs="1">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
+            <conditional name="mode">
+                <param name="mode" value="individual"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
                     <param name="input" value="contigs1.fna"/>
                     <param name="labels" value="contig1"/>
-                </repeat>
-            </conditional>
-            <conditional name="reads">
-                <param name="reads_option" value="paired"/>
-                <param name="input_1" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
-                <param name="input_2" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="paired"/>
+                    <param name="input_1" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                    <param name="input_2" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>
@@ -876,21 +1007,62 @@ metaquast
         </test>
         <!-- Test 12: Test paired-collection fastq.gz inputs -->
         <test expect_num_outputs="1">
-            <conditional name="in">
-                <param name="custom" value="true"/>
-                <repeat name="inputs">
+            <conditional name="mode">
+                <param name="mode" value="individual"/>
+                <conditional name="in">
+                    <param name="custom" value="true"/>
                     <param name="input" value="contigs1.fna"/>
                     <param name="labels" value="contig1"/>
-                </repeat>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="paired_collection"/>
+                    <param name="input_1">
+                        <collection type="paired">
+                            <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                            <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                        </collection>
+                    </param>
+                </conditional>
             </conditional>
-            <conditional name="reads">
-                <param name="reads_option" value="paired_collection"/>
-                <param name="input_1">
-                    <collection type="paired">
-                        <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
-                        <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
-                    </collection>
-                </param>
+            <conditional name="assembly">
+                <param name="type" value="genome"/>
+                <conditional name="ref">
+                    <param name="use_ref" value="false"/>
+                </conditional>
+            </conditional>
+            <param name="output_files" value="tabular"/>
+            <output name="report_tabular" ftype="tabular">
+                <assert_contents>
+                    <has_text text="# contigs (>= 0 bp)"/>
+                    <has_text text="contig1"/>
+                    <has_text text="# N's per 100 kbp"/>
+                    <has_n_lines n="15"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Test 13: Test co-assembly with paired-collection fastq.gz inputs -->
+        <test expect_num_outputs="1">
+            <conditional name="mode">
+                <param name="mode" value="co"/>
+                <conditional name="in">
+                    <param name="custom" value="false"/>
+                    <param name="inputs" value="contigs1.fna,contigs2.fna"/>
+                </conditional>
+                <conditional name="reads">
+                    <param name="reads_option" value="paired_collection"/>
+                    <param name="input_1">
+                        <collection type="list:paired">
+                            <element name="s1">
+                                <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                                <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                            </element>
+                            <element name="s2">
+                                <element name="forward" value="reads1.fastq.gz" ftype="fastqsanger.gz"/>
+                                <element name="reverse" value="reads2.fastq.gz" ftype="fastqsanger.gz"/>
+                            </element>
+                        </collection>
+                    </param>
+                </conditional>
             </conditional>
             <conditional name="assembly">
                 <param name="type" value="genome"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X]  I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ]  License permits unrestricted use (educational + commercial)
* [ ]  This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ]  This PR does something else (explain below)

---

With the current implementation of QUAST, we do not support the mapping  (when reads are given) of raw data on contigs generated by assembly run on individual samples (because of the `multiple=True` and loops on inputs)

It should work like this: 
![image](https://user-images.githubusercontent.com/1842467/220958696-023502aa-4f55-4484-bf94-062aef096763.png)

But in reality, currently, we have 2 use cases with individual assembly:
- With raw reads in paired collection:
     
    ![image](https://user-images.githubusercontent.com/1842467/220959069-94912ccf-0c82-45e4-91a8-df6845bc554b.png)

     This case was really computational expensive as raw reads were mapped on each contig files in the collection

- With reads in forward and reverse collections:

     ![image](https://user-images.githubusercontent.com/1842467/220959381-f844e1d7-9684-4fae-b0fb-a60eafa0458b.png)

To solve this, I added a conditional for the assembly mode:
- If individual assembly, I removed all `multiple=True` and for loops on inputs, so QUAST runs several times in each element in collection
- If co-assembly, I kept the `multiple=True` and put loops on inputs, so QUAST runs once on all elements together
