### PR TITLE
Updating tools/arriba from version 2.3.0 to 2.4.0

### DIFF
--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -80,7 +80,7 @@
                              Transcript isoforms tagged with appris_principal, appris_candidate, or CCDS are considered canonical.
                         </help>
                         <option value="coverage">coverage</option>
-                        <option value="provided">provided</option>
+                        <option value="provided" selected="true">provided</option>
                         <option value="canonical">canonical</option>
                     </param>
                     <param argument="--minConfidenceForCircosPlot" type="select" optional="true" label="Transcript selection">

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.3.0</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@TOOL_VERSION@">2.4.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">arriba</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/arriba**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/arriba from version 2.3.0 to 2.4.0.

**Project home page:** https://github.com/suhrig/arriba/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).