### PR TITLE
Updating tools/codeml from version 4.9 to 4.10.6

### DIFF
--- a/tools/codeml/codeml.xml
+++ b/tools/codeml/codeml.xml
@@ -1,4 +1,4 @@
-<tool name="codeML" id="codeml" version="@TOOL_VERSION@+galaxy2" profile="18.01">
+<tool name="codeML" id="codeml" version="@TOOL_VERSION@+galaxy0" profile="18.01">
     <description>
         Detects positive selection (paml package)
     </description>

--- a/tools/codeml/macros.xml
+++ b/tools/codeml/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">4.9</token>
+    <token name="@TOOL_VERSION@">4.10.6</token>
     <xml name="FSsites_br0" >
         <param argument="NSsites" type="select" label="Site model ; fix_alpha !=1 and alpha !=0 are not compatible with NSsites !=0" >
             <option value="0" selected="true">0 : e.g. basic model if model=0</option>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/codeml**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/codeml from version 4.9 to 4.10.6.

**Project home page:** http://abacus.gene.ucl.ac.uk/software/paml.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).