### PR TITLE
Updating tools/diamond from version 2.0.15 to 2.1.11

### DIFF
--- a/tools/diamond/macros.xml
+++ b/tools/diamond/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.15</token>
+    <token name="@TOOL_VERSION@">2.1.11</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/diamond**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/diamond from version 2.0.15 to 2.1.3.

**Project home page:** https://github.com/bbuchfink/diamond/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).