### PR TITLE
Updating tools/pysradb from version 1.4.2 to
2.1.0

### DIFF
--- a/tools/pysradb/macros.xml
+++ b/tools/pysradb/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.1</token>
+    <token name="@TOOL_VERSION@">2.0.2</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="bio_tools">
         <xrefs>

--- a/tools/pysradb/macros.xml
+++ b/tools/pysradb/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.2</token>
+    <token name="@TOOL_VERSION@">2.1.0</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="bio_tools">
         <xrefs>

--- a/tools/pysradb/macros.xml
+++ b/tools/pysradb/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.4.2</token>
-    <token name="@SUFFIX_VERSION@">2</token>
+    <token name="@TOOL_VERSION@">2.0.0</token>
+    <token name="@SUFFIX_VERSION@">0</token>
     <xml name="bio_tools">
         <xrefs>
             <xref type="bio.tools">pysradb</xref>
@@ -9,8 +9,8 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">pysradb</requirement>
-            <requirement type="package" version="3.6.2">matplotlib</requirement>
-            <requirement type="package" version="7.1.0_52">imagemagick</requirement>
+            <requirement type="package" version="3.7.0">matplotlib</requirement>
+            <requirement type="package" version="7.1.0.43">imagemagick</requirement>
             <requirement type="package" version="5.1.0">gawk</requirement>
         </requirements>
     </xml>

--- a/tools/pysradb/macros.xml
+++ b/tools/pysradb/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.0</token>
+    <token name="@TOOL_VERSION@">2.0.1</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="bio_tools">
         <xrefs>
@@ -9,7 +9,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">pysradb</requirement>
-            <requirement type="package" version="3.7.0">matplotlib</requirement>
+            <requirement type="package" version="3.7.1">matplotlib</requirement>
             <requirement type="package" version="7.1.0.43">imagemagick</requirement>
             <requirement type="package" version="5.1.0">gawk</requirement>
         </requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pysradb**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pysradb from version 1.4.2 to 2.0.0.

**Project home page:** https://github.com/saketkc/pysradb/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).