### PR TITLE
Updating tools/transdecoder from version 5.5.0 to 5.7.0

### DIFF
--- a/tools/transdecoder/transdecoder.xml
+++ b/tools/transdecoder/transdecoder.xml
@@ -4,8 +4,8 @@
         <xref type="bio.tools">TransDecoder</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">5.5.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">5.7.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">transdecoder</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/transdecoder**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/transdecoder from version 5.5.0 to 5.7.0.

**Project home page:** https://transdecoder.github.io

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).