### PR TITLE
Update ivar suite of tools to v1.4

### DIFF
--- a/tools/ivar/ivar_consensus.xml
+++ b/tools/ivar/ivar_consensus.xml
@@ -21,8 +21,6 @@
     ]]></command>
     <inputs>
         <param name="input_bam" type="data" format="bam" label="Bam file" help="Aligned reads, to trim primers and quality"/>
-        <!-- Warning: integer params in the following define a max of 255 intentionally
-        because the underlying C++ code of ivar defines them as uint8 and does not check for overflow! -->
         <param name="min_qual" argument="-q" type="integer" min="0" max="255" value="20" label="Minimum quality score threshold to count base"/>
         <param name="min_freq" argument="-t" type="float" min="0" max="1" value="0.0" label="Minimum frequency threshold">
             <help>
@@ -36,7 +34,7 @@
             </help>
         </param>
         <param name="min_indel_freq" argument="-c" type="float" min="0" max="1" value="0.8" label="Minimum indel frequency threshold" help="Same meaning as the &quot;Minimum frequency threshold&quot; above, but applied to indels."/>
-        <param name="min_depth" argument="-m" type="integer" min="1" max="255" value="10" label="Minimum depth to call consensus"/>
+        <param name="min_depth" argument="-m" type="integer" min="1" value="10" label="Minimum depth to call consensus"/>
         <param name="depth_action" type="select" label="How to represent positions with coverage less than the minimum depth threshold">
             <option value="-k">Drop from output (-k)</option>
             <option value="-n N" selected="true">Represent as N (-n N)</option>

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -151,13 +151,11 @@
                     <has_size value="4023965" delta="1000"/>
                 </assert_contents>
             </output>
-            <assert_stdout>
+            <assert_stderr>
                 <has_text text="Found 68 primers in BED file"/>
-                <has_text text="Using Region: PRV"/>
-                <has_text text="Found 40964 mapped reads"/>
                 <has_text text="reads were quality trimmed below the minimum length of 30 bp and were not written to file"/>
                 <has_text text="reads that started outside of primer regions were not written to file"/>
-            </assert_stdout>
+            </assert_stderr>
         </test>
         <test>
             <conditional name="primer">

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -31,7 +31,13 @@
         #end if
         -x $primer_pos_wiggle
         $inc_primers
-        -m $trimmed_length.min_len
+        #if $trimmed_length.filter == 'off':
+            -m 0
+        #elif $trimmed_length.filter == 'auto':
+            -m -1
+        #else:
+            -m $trimmed_length.min_len
+        #end if
         -q $min_qual
         -s $window_width
         ## since v1.4 ivar trim *almost* supports piping its output, but
@@ -86,12 +92,8 @@
                 <option value="auto" selected="true">Yes, and determine required length threshold automatically from input (-m -1)</option>
                 <option value="custom">Yes, and provide a custom threshold</option>
             </param>
-            <when value="off">
-                <param name="min_len" argument="-m" type="hidden" value="0" />
-            </when>
-            <when value="auto">
-                <param name="min_len" argument="-m" type="hidden" value="-1" />
-            </when>
+            <when value="off" />
+            <when value="auto" />
             <when value="custom">
                 <param name="min_len" argument="-m" type="integer" min="1" value="30" label="Minimum trimmed length threshold" help="Reads with a trimmed length shorter than this value will be discarded."/>
             </when>
@@ -143,17 +145,16 @@
             </conditional>
             <param name="input_bam" value="zika/Z52_b.sorted.bam" />
             <conditional name="trimmed_length">
-                <param name="filter" value="custom" />
-                <param name="min_len" value="30" />
+                <param name="filter" value="auto" />
             </conditional>
             <output name="output_bam" ftype="bam">
                 <assert_contents>
-                    <has_size value="4023965" delta="1000"/>
+                    <has_size value="3373924" delta="1000"/>
                 </assert_contents>
             </output>
             <assert_stderr>
                 <has_text text="Found 68 primers in BED file"/>
-                <has_text text="reads were quality trimmed below the minimum length of 30 bp and were not written to file"/>
+                <has_text text="reads were quality trimmed below the minimum length of 125 bp and were not written to file"/>
                 <has_text text="reads that started outside of primer regions were not written to file"/>
             </assert_stderr>
         </test>

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -106,6 +106,10 @@
             <param name="input_bam" value="covid19/PC00101P_sub.sorted.bam" />
             <param name="input_bed" value="covid19/ARTIC-V1.bed" />
             <param name="inc_primers" value="true" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <output name="output_bam" file="covid19/PC00101P_sub.sorted.bam" compare="sim_size" delta="300000"/>
         </test>
         <test>
@@ -113,6 +117,10 @@
             <param name="input_bam" value="covid19/PC00101P_sub.sorted.bam" />
             <param name="input_bed" value="covid19/ARTIC-V1-bad.bed" />
             <param name="inc_primers" value="true" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <output name="output_bam" file="covid19/PC00101P_sub.sorted.bam" compare="sim_size" delta="300000"/>
         </test>
         <!-- #1: Zika data-->
@@ -122,6 +130,10 @@
                 <param name="input_bed" value="zika/db/zika_primers.bed" />
             </conditional>
             <param name="input_bam" value="zika/Z52_a.sorted.bam" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <output name="output_bam" file="zika/Z52_a.trimmed.sorted.bam" compare="sim_size" delta="100000"/>
         </test>
         <test>
@@ -130,6 +142,10 @@
                 <param name="input_bed" value="zika/db/zika_primers.bed" />
             </conditional>
             <param name="input_bam" value="zika/Z52_b.sorted.bam" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <output name="output_bam" ftype="bam">
                 <assert_contents>
                     <has_size value="4023965" delta="1000"/>
@@ -149,6 +165,10 @@
                 <param name="cached_bed" value="SARS-CoV-2-ARTICv1" />
             </conditional>
             <param name="input_bam" value="sars-cov-2/sars_cov2_untrimmed.bam" ftype="bam" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <output name="output_bam" file="sars-cov-2/sars_cov2_trimmed.bam" compare="sim_size" delta="100000"/>
         </test>
         <test>
@@ -160,6 +180,10 @@
                 <param name="filter_by" value="yes_compute" />
             </conditional>
             <param name="input_bam" value="sars-cov-2/sars_cov2_untrimmed.bam" ftype="bam" />
+            <conditional name="trimmed_length">
+                <param name="filter" value="custom" />
+                <param name="min_len" value="30" />
+            </conditional>
             <assert_command>
                 <has_text text="write_amplicon_info_file" />
             </assert_command>

--- a/tools/ivar/ivar_trim.xml
+++ b/tools/ivar/ivar_trim.xml
@@ -31,12 +31,16 @@
         #end if
         -x $primer_pos_wiggle
         $inc_primers
-        -m $min_len
+        -m $trimmed_length.min_len
         -q $min_qual
         -s $window_width
-        -p trimmed &&
-        samtools sort -@ \${GALAXY_SLOTS:-1} -o trimmed.sorted.bam trimmed.bam
-    ]]>    </command>
+        ## since v1.4 ivar trim *almost* supports piping its output, but
+        ## unfortunately still writes *some* regular messages to stdout,
+        ## so we need to stick writing to an intermediate file for now and
+        ## want to unify the output stream
+        -p trimmed 1>&2 &&
+        samtools sort -@ \${GALAXY_SLOTS:-1} -T "\${TMPDIR:-.}" -o trimmed.sorted.bam trimmed.bam
+    ]]></command>
     <inputs>
         <param name="input_bam" argument="-i" type="data" format="bam" label="Bam file" help="Aligned reads, to trim primers and quality"/>
         <conditional name="primer">
@@ -74,9 +78,24 @@
         label="Wiggling room for read ends relative to primer binding sites"
         help="Reads that occur at the specified offset positions relative to primer positions (as annotated in the primer information dataset) will also be trimmed (default: 0)" />
         <param name="inc_primers" argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Include reads not ending in any primer binding sites?"/>
-        <param name="min_len" argument="-m" type="integer" min="0" value="30" label="Minimum length of read to retain after trimming"/>
         <param name="min_qual" argument="-q" type="integer" min="0" max="255" value="20" label="Minimum quality threshold for sliding window to pass"/>
         <param name="window_width" argument="-s" type="integer" min="0" max="255" value="4" label="Width of sliding window"/>
+        <conditional name="trimmed_length">
+            <param name="filter" type="select" label="Require a minimum length for reads to retain them after any trimming?" help="The default automatic setting will determine the threshold as 50% of the mean length of the first 1000 raw input reads, which may or may not be adequate for your data. You can always make the outcome of filtering more predictable by specifying the threshold explicitly. You can also opt to retain reads independently of their trimmed length, but typically this only makes sense if you are performing additional read filtering with additional tools in your analysis pipeline.">
+                <option value="off">No, keep reads independently of their trimmed length (-m 0)</option>
+                <option value="auto" selected="true">Yes, and determine required length threshold automatically from input (-m -1)</option>
+                <option value="custom">Yes, and provide a custom threshold</option>
+            </param>
+            <when value="off">
+                <param name="min_len" argument="-m" type="hidden" value="0" />
+            </when>
+            <when value="auto">
+                <param name="min_len" argument="-m" type="hidden" value="-1" />
+            </when>
+            <when value="custom">
+                <param name="min_len" argument="-m" type="integer" min="1" value="30" label="Minimum trimmed length threshold" help="Reads with a trimmed length shorter than this value will be discarded."/>
+            </when>
+        </conditional>
     </inputs>
     <outputs>
         <data name="output_bam" format="bam" label="${tool.name} on ${on_string} Trimmed bam" from_work_dir="trimmed.sorted.bam"/>
@@ -186,13 +205,15 @@ If the primer scheme has more than two primers contributing to a given amplicon
 specify all of them on one line and the tool will calculate the maximum extent
 of the amplicon.
 
-**Quality trimming details**
+**Quality trimming details and final length filtering**
 
 To do the quality trimming, iVar uses a sliding window approach. The window
 slides from the 5' end to the 3' end and if at any point the average base
 quality in the window falls below the threshold, the remaining read is soft
-clipped. If after trimming, the length of the read is greater than the minimum
-length specified, the read is written to the new trimmed BAM file.
+clipped.
+
+Finally, the trimmed length threshold gets applied if specified, and fully
+trimmed surviving reads are written to the BAM output.
 
 Documentation can be found at `<https://andersen-lab.github.io/ivar/html/manualpage.html>`_.
     ]]></help>

--- a/tools/ivar/macros.xml
+++ b/tools/ivar/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.4</token>
+  <token name="@TOOL_VERSION@">1.4.1</token>
   <token name="@PROFILE@">21.01</token>
   <xml name="requirements">
   <requirements>

--- a/tools/ivar/macros.xml
+++ b/tools/ivar/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.4.1</token>
+  <token name="@TOOL_VERSION@">1.4</token>
   <token name="@PROFILE@">21.01</token>
   <xml name="requirements">
   <requirements>

--- a/tools/ivar/macros.xml
+++ b/tools/ivar/macros.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.3.2</token>
+  <token name="@TOOL_VERSION@">1.4</token>
   <token name="@PROFILE@">21.01</token>
   <xml name="requirements">
   <requirements>
       <requirement type="package" version="@TOOL_VERSION@">ivar</requirement>
-      <requirement type="package" version="3.10.8">python</requirement>
+      <requirement type="package" version="3.11.0">python</requirement>
       <requirement type="package" version="1.16.1">samtools</requirement>
       <yield/>
   </requirements>

--- a/tools/ivar/macros.xml
+++ b/tools/ivar/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.4</token>
+  <token name="@TOOL_VERSION@">1.4.0</token>
   <token name="@PROFILE@">21.01</token>
   <xml name="requirements">
   <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

- implements new -m default in ivar trim
- removes max value restriction on -m option in ivar consensus after upstream fix
- works around messed up ivar trim stdout/stderr in new version