### PR TITLE
Updating tools/umi_tools from version 1.1.2 to 1.1.5

### DIFF
--- a/tools/umi_tools/macros.xml
+++ b/tools/umi_tools/macros.xml
@@ -3,8 +3,8 @@
 
     <!-- macros applying to all umi_tools -->
 
-    <token name="@TOOL_VERSION@">1.1.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">1.1.5</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/umi_tools/umi-tools_dedup.xml
+++ b/tools/umi_tools/umi-tools_dedup.xml
@@ -5,7 +5,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.12">samtools</requirement>
+        <requirement type="package" version="1.21">samtools</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         @LINK_SAM_BAM_INPUT@

--- a/tools/umi_tools/umi-tools_group.xml
+++ b/tools/umi_tools/umi-tools_group.xml
@@ -5,7 +5,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="1.12">samtools</requirement>
+        <requirement type="package" version="1.21">samtools</requirement>
     </expand>
     <command detect_errors="exit_code"><![CDATA[
         @LINK_SAM_BAM_INPUT@


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/umi_tools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/umi_tools from version 1.1.2 to 1.1.4.

**Project home page:** https://github.com/CGATOxford/UMI-tools/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).