### PR TITLE
yahs: added option for Omni-C enzyme-free prep

### DIFF
--- a/tools/yahs/yahs.xml
+++ b/tools/yahs/yahs.xml
@@ -259,7 +259,10 @@
                 <param name="bfile" value="test.bed"/>
             </conditional>
             <conditional name="enzyme_conditional">
-                <param name="enzyme_options" value="omnic"/>
+                <param name="enzyme_options" value="preconfigured"/>
+                <conditional name="enzyme_conditional">
+                    <param name="enzyme_options" value="omnic"/>
+                </conditional>
             </conditional>
             <param name="log_out" value="yes"/>
             <output name="log_file" ftype="txt">

--- a/tools/yahs/yahs.xml
+++ b/tools/yahs/yahs.xml
@@ -39,8 +39,10 @@
                     -e 'GATC'
                 #else if $function.enzyme_conditional.preconfigured_enzymes == 'arima1'
                     -e 'GATC,GANTC'
-                #else
+                #else if $function.enzyme_conditional.preconfigured_enzymes == 'arima2'
                     -e 'GATC,GANTC,CTNAG,TTAA'
+                #else if $function.enzyme_conditional.preconfigured_enzymes == 'omnic'
+
                 #end if
             #else if $function.enzyme_conditional.enzyme_options == 'specific':
                 -e '${function.enzyme_conditional.manual_enzyme}'
@@ -101,6 +103,7 @@
                             <option value="dovetail">Dovetail Chicago, Dovetail Hi-C or Phase: GATC</option>
                             <option value="arima1">Arima Hi-C 1.0: GATC, GANTC</option>
                             <option value="arima2">Arima Hi-C 2.0: GATC, GANTC, CTNAG, TTAA</option>
+                            <option value="omnic">Dovetail Omni-C: enzyme-free prep</option>
                         </param>
                     </when>
                     <when value="specific">
@@ -247,6 +250,20 @@
                 </assert_contents>
             </output>
             <!-- COMMAND:   yahs test.fasta test.bed -r 50000,100000,150000,2000000,1000000 -a test.agp -o test_1 -->
+        </test>
+        <!-- TEST 7: omnic prep -->
+        <test expect_num_outputs="6">
+            <conditional name="function">
+                <param name="function_select" value="yahs"/>
+                <param name="fasta" value="test.fasta"/>
+                <param name="bfile" value="test.bed"/>
+            </conditional>
+            <param name="log_out" value="yes"/>
+            <output name="log_file" ftype="txt">
+                <assert_contents>
+                    <not_has_text text="-e"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/yahs/yahs.xml
+++ b/tools/yahs/yahs.xml
@@ -258,6 +258,9 @@
                 <param name="fasta" value="test.fasta"/>
                 <param name="bfile" value="test.bed"/>
             </conditional>
+            <conditional name="enzyme_conditional">
+                <param name="enzyme_options" value="omnic"/>
+            </conditional>
             <param name="log_out" value="yes"/>
             <output name="log_file" ftype="txt">
                 <assert_contents>

--- a/tools/yahs/yahs.xml
+++ b/tools/yahs/yahs.xml
@@ -2,7 +2,7 @@
     <description>yet another HI-C scaffolding tool</description>
     <macros>
         <token name="@VERSION@">1.2a.2</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@VERSION@">yahs</requirement>

--- a/tools/yahs/yahs.xml
+++ b/tools/yahs/yahs.xml
@@ -260,9 +260,7 @@
             </conditional>
             <conditional name="enzyme_conditional">
                 <param name="enzyme_options" value="preconfigured"/>
-                <conditional name="enzyme_conditional">
-                    <param name="enzyme_options" value="omnic"/>
-                </conditional>
+                <param name="preconfigured_enzymes" value="omnic"/>
             </conditional>
             <param name="log_out" value="yes"/>
             <output name="log_file" ftype="txt">


### PR DESCRIPTION
hello! 👋🏼 

added an option to the yahs tools under the "preconfigured enzymes" to select Dovetail Omni-C, which is an enzyme-free prep, which means just running yahs without the restriction enzyme argument

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
