### PR TITLE
Datamash 1.1.0->1.8 and fix

### DIFF
--- a/tools/datamash/datamash-ops.xml
+++ b/tools/datamash/datamash-ops.xml
@@ -211,4 +211,5 @@ This sample file is available at http://www.gnu.org/software/datamash .
 @HELP_FOOTER@
 ]]>
     </help>
+    <expand macro="citation"/>
 </tool>

--- a/tools/datamash/datamash-reverse.xml
+++ b/tools/datamash/datamash-reverse.xml
@@ -46,4 +46,5 @@ Output file::
 @HELP_FOOTER@
 ]]>
     </help>
+    <expand macro="citation"/>
 </tool>

--- a/tools/datamash/datamash-transpose.xml
+++ b/tools/datamash/datamash-transpose.xml
@@ -3,19 +3,57 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="requirements" />
-    <expand macro="stdio" />
+    <edam_topics>
+        <edam_topic>topic_3570</edam_topic> <!-- Pure math / linear algebra -->
+    </edam_topics>
+    <edam_operations>
+         <!-- <edam_operation>operation_1234</edam_operation> -->
+    </edam_operations>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <command><![CDATA[
-        datamash transpose
-        @FIELD_SEPARATOR@
-        < $in_file > $out_file
+        #set size_threshold_MB = 1024
+        file_size_MB=\$(du -m $in_file | cut -f 1) &&
+        if [ \$file_size_MB -le $size_threshold_MB ]; then
+            datamash transpose @FIELD_SEPARATOR@ < $in_file > $out_file;
+        else
+            ## Input matrix is very big: divide and conquer
+            ## If the input file is very big, datamash runs out of memory (much earlier than file size ~ available RAM.
+            ## Split into managable chunks of row vectors, transpose the chunks and juxtapose column vector chunks.
+            echo Huge matrix detected &&
+            num_lines=\$(wc -l $in_file | cut -d " " -f 1) &&
+            lines_per_chunk=\$(( $size_threshold_MB * \$num_lines / \$file_size_MB )) &&
+            split -l \${lines_per_chunk} $in_file split_input_ &&
+            for chunk in \$(ls split_input*); do
+                datamash transpose @FIELD_SEPARATOR@ < \$chunk > \${chunk}_transposed;
+            done &&
+            paste split_input_*_transposed > $out_file;
+        fi
     ]]></command>
-    <expand macro="inputs_outputs" />
+    <expand macro="inputs_outputs"/>
     <tests>
-        <test>
-            <param name="in_file" value="datamash_transpose_input.txt" />
-            <output file="datamash_transpose_output.txt" name="out_file" />
+        <test expect_num_outputs="1">
+            <param name="in_file" value="datamash_transpose_input.txt"/>
+            <output file="datamash_transpose_output.txt" name="out_file"/>
         </test>
+        <!-- Test for transposing an extremely big input matrix
+         Disabled to keep the repository size reasonable.
+        For testing, manually download a pathological in- and output from:
+        https://usegalaxy.eu/u/tunc/h/very-big-scrna-matrix
+        -->
+        <!--
+        <test>
+            <param name="in_file" value="big.tabular"/>
+            <output file="transposed_big.tabular" name="out_file"/>
+        </test>
+        -->
+        <!-- transpose(transpose(A)) = A -->
+        <!--
+        <test>
+            <param name="in_file" value="transposed_big.tabular"/>
+            <output file="big.tabular" name="out_file"/>
+        </test>
+        -->
     </tests>
     <help>
 <![CDATA[

--- a/tools/datamash/datamash-transpose.xml
+++ b/tools/datamash/datamash-transpose.xml
@@ -45,4 +45,5 @@ Output file::
 @HELP_FOOTER@
 ]]>
     </help>
+    <expand macro="citation"/>
 </tool>

--- a/tools/datamash/macros.xml
+++ b/tools/datamash/macros.xml
@@ -1,7 +1,7 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.1.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
-    <token name="@PROFILE@">21.01</token>
+    <token name="@TOOL_VERSION@">1.8</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">22.01</token>
     <xml name="inputs_outputs">
         <inputs>
             <param name="in_file" type="data" format="tabular,csv,tsv" label="Input tabular dataset" help="" />
@@ -44,4 +44,14 @@ For more details about supported statistical operations, see Datamash_ website.
 
 -----
     </token>
+    <xml name="citation">
+        <citations>
+            <citation type="bibtex">
+                @ONLINE{datamash,
+                    title = {GNU Datamash},
+                    url = {https://www.gnu.org/software/datamash/}
+                }
+            </citation>
+        </citations>
+    </xml>
 </macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

1) Updated datamash 1.1.0 -> 1.9
2) Current tool errors out if the input matrix is too big. This seems to be inherent to datamash itself and can happen even if 1 << input size < RAM (`tool_script.sh: line 27: 1772740 Bus error (core dumped) datamash`) I propose splitting the matrix into chunks, transposing the chunks and then combining the results, if the input is big.