### PR TITLE
Reduce number of github action runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,10 @@
 name: Galaxy Tool Linting and Tests for push and PR
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05
@@ -21,6 +26,7 @@ jobs:
   setup:
     name: Setup cache and determine changed repositories
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     outputs:
       galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
       repository-list: ${{ steps.discover.outputs.repository-list }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, review_requested]
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Wonder what you think about this and whether you'd see unwanted side effects:
The idea here is to run the pr workflow only on PRs that are ready for review or on pushes to the main branch.

This has the following effects:
- when a draft PR gets opened, all tests will be skipped until the PR is marked as ready for review, which will then directly trigger runs of all of them
- when a PR gets converted to a draft, this will stop any tests to run on any new commits to it
- tests will not run in duplicate anymore for pushes to PRs

Taken from: https://engineering.leanix.net/blog/halve-your-github-actions-bill/