### PR TITLE
Updating tools/rnaquast from version 2.2.1 to 2.2.3

### DIFF
--- a/tools/rnaquast/rna_quast.xml
+++ b/tools/rnaquast/rna_quast.xml
@@ -4,8 +4,8 @@
         <xref type="bio.tools">rnaQUAST</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">2.2.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">2.2.3</token>
+        <token name="@VERSION_SUFFIX@">0</token>
         <xml name="element_matching_line" token_name="" token_expression="">
             <element name="@NAME@">
                 <assert_contents>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rnaquast**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rnaquast from version 2.2.1 to 2.2.3.

**Project home page:** https://github.com/ablab/rnaquast/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).