### PR TITLE
Updating tools/seqkit from version 2.3.1 to 2.8.1

### DIFF
--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.3.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.4.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">
         <xrefs>

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.6.0</token>
+    <token name="@TOOL_VERSION@">2.6.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.5.1</token>
+    <token name="@TOOL_VERSION@">2.6.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7.0</token>
+    <token name="@TOOL_VERSION@">2.8.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.6.1</token>
+    <token name="@TOOL_VERSION@">2.7.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4.0</token>
+    <token name="@TOOL_VERSION@">2.5.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.5.0</token>
+    <token name="@TOOL_VERSION@">2.5.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/macros.xml
+++ b/tools/seqkit/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.8.0</token>
+    <token name="@TOOL_VERSION@">2.8.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="bio_tools">

--- a/tools/seqkit/seqkit_fx2tab.xml
+++ b/tools/seqkit/seqkit_fx2tab.xml
@@ -86,4 +86,3 @@ qualities is selected or additional columns (e.g., md5 sequence hash) are reques
     </help>
     <expand macro="citations"/>
 </tool>
-

--- a/tools/seqkit/seqkit_locate.xml
+++ b/tools/seqkit/seqkit_locate.xml
@@ -39,9 +39,7 @@ $advanced_options.id_ncbi
     <inputs>
         <param name="input" type="data" format="fasta,fasta.gz" label="Input file"/>
         <conditional name="conditional_pattern">
-            <param name="mode" type="select" label="Pattern mode" 
-                help="Specify a pattern/motif sequence or a FASTA file with the motif of interest. Motifs could be EITHER plain sequence containing 'ACTGN' OR regular
-                    expression like 'A[TU]G(?:.{3})+?[TU](?:AG|AA|GA)' for ORFs">
+            <param name="mode" type="select" label="Pattern mode" help="Specify a pattern/motif sequence or a FASTA file with the motif of interest. Motifs could be EITHER plain sequence containing 'ACTGN' OR regular                     expression like 'A[TU]G(?:.{3})+?[TU](?:AG|AA|GA)' for ORFs">
                 <option value="expression">Pattern/motif sequence</option>
                 <option value="file">FASTA file with the pattern/motif of interest</option>
             </param>
@@ -49,21 +47,21 @@ $advanced_options.id_ncbi
                 <param argument="--pattern" type="text" value="" label="Pattern/motif sequence" help="Perl regular expressions are allowed">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
-                        <add value="^"/>
-                        <add value="$"/>
-                        <add value="("/>
-                        <add value=")"/>
-                        <add value="|"/>
-                        <add value="?"/>
-                        <add value="*"/>
-                        <add value="+"/>
-                        <add value="{"/>
-                        <add value="}"/>
-                        <add value="\"/>
-                        <add value="["/>
-                        <add value="]"/>
-                        <add value="."/>
-                        <add value=","/>
+                            <add value="^"/>
+                            <add value="$"/>
+                            <add value="("/>
+                            <add value=")"/>
+                            <add value="|"/>
+                            <add value="?"/>
+                            <add value="*"/>
+                            <add value="+"/>
+                            <add value="{"/>
+                            <add value="}"/>
+                            <add value="\"/>
+                            <add value="["/>
+                            <add value="]"/>
+                            <add value="."/>
+                            <add value=","/>
                         </valid>
                     </sanitizer>
                     <validator type="regex" message="Pattern must not end with backslash.">.*[^\\]$</validator>
@@ -86,19 +84,16 @@ $advanced_options.id_ncbi
             <option value="--bed">BED6</option>
         </param>
         <section name="advanced_options" title="Advanced options">
-            <param argument="--validate-seq-length" type="integer" min="0" value="10000" label="Lenth of the sequence to validate" help="Default: 10000" />
-            <param argument="--circular" type="boolean" truevalue="--circular" falsevalue="" checked="false" label="Circular genome" 
-                help="When using flag --circular, end position of matched subsequence that crossing genome sequence end would be greater than sequence length" />
-            <param argument="--degenerate" type="boolean" truevalue="--degenerate" falsevalue="" checked="false" label="Pattern/motif contains degenerate bases"
-                help="Do not use degenerate bases/residues in regular expression, you need convert them to regular expression, e.g., change 'N' or 'X'  to '.'"/>
+            <param argument="--validate-seq-length" type="integer" min="0" value="10000" label="Lenth of the sequence to validate" help="Default: 10000"/>
+            <param argument="--circular" type="boolean" truevalue="--circular" falsevalue="" checked="false" label="Circular genome" help="When using flag --circular, end position of matched subsequence that crossing genome sequence end would be greater than sequence length"/>
+            <param argument="--degenerate" type="boolean" truevalue="--degenerate" falsevalue="" checked="false" label="Pattern/motif contains degenerate bases" help="Do not use degenerate bases/residues in regular expression, you need convert them to regular expression, e.g., change 'N' or 'X'  to '.'"/>
             <param argument="--hide-matched" type="boolean" truevalue="--hide-matched" falsevalue="" checked="false" label="Do not show matched sequences"/>
             <param argument="--ignore-case" type="boolean" truevalue="--ignore-case" falsevalue="" checked="false" label="Ignore case"/>
-            <param argument="--max-mismatch" type="integer" min="0" value="0" label="Maximum mismatch" help="For large genomes like human genome, using mapping/alignment tools would be faster" />
-            <param argument="--non-greedy" type="boolean" truevalue="--non-greedy" falsevalue="" checked="false" label="Non-greedy mode" help="Faster, but muy miss motifs overlapping with others" />
+            <param argument="--max-mismatch" type="integer" min="0" value="0" label="Maximum mismatch" help="For large genomes like human genome, using mapping/alignment tools would be faster"/>
+            <param argument="--non-greedy" type="boolean" truevalue="--non-greedy" falsevalue="" checked="false" label="Non-greedy mode" help="Faster, but muy miss motifs overlapping with others"/>
             <param argument="--only-positive-strand" type="boolean" truevalue="--only-positive-strand" falsevalue="" checked="false" label="Only search on positive strand"/>
-            <param argument="--use-fmi" type="boolean" truevalue="--use-fmi" falsevalue="" checked="false" label="FM-index" 
-                help="Use FM-index for much faster search of lots of sequence patterns. This option is not compatible with the --degenerate option"/>
-            <param argument="--id-ncbi" type="boolean" truevalue="--id-ncbi" falsevalue="" checked="false" label="FASTA head is NCBI stype" help="Example: >gi|110645304|ref|NC_002516.2| Pseud..." />
+            <param argument="--use-fmi" type="boolean" truevalue="--use-fmi" falsevalue="" checked="false" label="FM-index" help="Use FM-index for much faster search of lots of sequence patterns. This option is not compatible with the --degenerate option"/>
+            <param argument="--id-ncbi" type="boolean" truevalue="--id-ncbi" falsevalue="" checked="false" label="FASTA head is NCBI stype" help="Example: &gt;gi|110645304|ref|NC_002516.2| Pseud..."/>
         </section>
     </inputs>
     <outputs>
@@ -193,4 +188,3 @@ Locate subsequences/motifs, mismatch allowed.
     </help>
     <expand macro="citations"/>
 </tool>
-

--- a/tools/seqkit/seqkit_locate.xml
+++ b/tools/seqkit/seqkit_locate.xml
@@ -20,7 +20,6 @@ seqkit locate
     --pattern-file '$conditional_pattern.pattern_file'
 #end if
 $output_mode
---validate-seq-length $advanced_options.validate_seq_length
 $advanced_options.circular
 $advanced_options.degenerate
 $advanced_options.hide_matched
@@ -84,7 +83,6 @@ $advanced_options.id_ncbi
             <option value="--bed">BED6</option>
         </param>
         <section name="advanced_options" title="Advanced options">
-            <param argument="--validate-seq-length" type="integer" min="0" value="10000" label="Lenth of the sequence to validate" help="Default: 10000"/>
             <param argument="--circular" type="boolean" truevalue="--circular" falsevalue="" checked="false" label="Circular genome" help="When using flag --circular, end position of matched subsequence that crossing genome sequence end would be greater than sequence length"/>
             <param argument="--degenerate" type="boolean" truevalue="--degenerate" falsevalue="" checked="false" label="Pattern/motif contains degenerate bases" help="Do not use degenerate bases/residues in regular expression, you need convert them to regular expression, e.g., change 'N' or 'X'  to '.'"/>
             <param argument="--hide-matched" type="boolean" truevalue="--hide-matched" falsevalue="" checked="false" label="Do not show matched sequences"/>

--- a/tools/seqkit/seqkit_stats.xml
+++ b/tools/seqkit/seqkit_stats.xml
@@ -56,4 +56,3 @@ sum gap, N50, Q20(%), and Q30(%).
     </help>
     <expand macro="citations"/>
 </tool>
-

--- a/tools/seqkit/test-data/stats_output1.tabular
+++ b/tools/seqkit/test-data/stats_output1.tabular
@@ -1,2 +1,2 @@
-file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)	GC(%)
-input1_fastq_gz	FASTQ	DNA	5	505	101	101.0	101	50.5	101.0	50.5	0	101	98.02	89.31	35.45
+file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	N50_num	Q20(%)	Q30(%)	AvgQual	GC(%)
+input1_fastq_gz	FASTQ	DNA	5	505	101	101.0	101	101.0	101.0	101.0	0	101	1	98.02	89.31	25.93	35.45

--- a/tools/seqkit/test-data/stats_output2.tabular
+++ b/tools/seqkit/test-data/stats_output2.tabular
@@ -1,2 +1,2 @@
-file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	Q20(%)	Q30(%)	GC(%)
-input1_fasta_gz	FASTA	DNA	3	10732	1213	3577.3	4796	2968.0	4723.0	4759.5	0	4723	0.00	0.00	48.15
+file	format	type	num_seqs	sum_len	min_len	avg_len	max_len	Q1	Q2	Q3	sum_gap	N50	N50_num	Q20(%)	Q30(%)	AvgQual	GC(%)
+input1_fasta_gz	FASTA	DNA	3	10732	1213	3577.3	4796	2968.0	4723.0	4759.5	0	4723	2	0.00	0.00	0.00	48.15


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/seqkit**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/seqkit from version 2.3.1 to 2.4.0.

**Project home page:** https://bioinf.shenwei.me/seqkit

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).