### PR TITLE
Updating tools/trycycler from version 0.5.3 to 0.5.4

### DIFF
--- a/tools/trycycler/macros.xml
+++ b/tools/trycycler/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.5.3</token>
+    <token name="@TOOL_VERSION@">0.5.4</token>
     <token name="@PIPELINE@">                                                                                
 **Trycycler pipeline**                                                                                  
                                                                                                         


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/trycycler**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/trycycler from version 0.5.3 to 0.5.4.

**Project home page:** https://github.com/rrwick/Trycycler/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).