### PR TITLE
Fix coverm test

### DIFF
--- a/tools/coverm/coverm_contig.xml
+++ b/tools/coverm/coverm_contig.xml
@@ -272,7 +272,7 @@
                 </param>
                 <param name="ref_fasta_history" value="7seqs.fna"/>
             </conditional>
-            <output name="output1" file="contig_test1.tsv" ftype="tsv"/>
+            <output name="output1" file="contig_test1.tsv" ftype="tsv" sort="true"/>
         </test> 
         <test>
             <conditional name="reads">
@@ -286,7 +286,7 @@
             <section name="out">
                 <param name="output_format" value="sparse"/>
             </section>            
-            <output name="output1" file="contig_test2.tsv" ftype="tsv"/>
+            <output name="output1" file="contig_test2.tsv" ftype="tsv" sort="true"/>
         </test> 
         <test>
             <conditional name="reads">
@@ -304,7 +304,7 @@
             <section name="out">
                 <param name="output_format" value="sparse"/>
             </section>            
-            <output name="output1" file="contig_test3.tsv" ftype="tsv"/>
+            <output name="output1" file="contig_test3.tsv" ftype="tsv" sort="true"/>
         </test> 
         <test>
             <conditional name="reads">
@@ -334,7 +334,7 @@
             <section name="mapping">
                 <param name="--min-read-percent-identity" value="0.95"/>
             </section>
-            <output name="output1" file="contig_test4.tsv" ftype="tsv"/>
+            <output name="output1" file="contig_test4.tsv" ftype="tsv" sort="true"/>
         </test> 
         <test>
             <conditional name="reads">
@@ -348,7 +348,7 @@
             <section name="out">
                 <param name="output_format" value="sparse"/>
             </section>            
-            <output name="output1" file="contig_test5.tsv" ftype="tsv"/>
+            <output name="output1" file="contig_test5.tsv" ftype="tsv" sort="true"/>
         </test> 
         </tests>
     <help><![CDATA[

--- a/tools/coverm/coverm_genome.xml
+++ b/tools/coverm/coverm_genome.xml
@@ -443,7 +443,7 @@
             <section name="out">
                 <param name="output_format" value="sparse"/>
             </section>
-            <output name="output1" file="test1.tsv" ftype="tsv"/>
+            <output name="output1" file="test1.tsv" ftype="tsv" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <conditional name="reads">
@@ -469,7 +469,7 @@
             <section name="out">
                 <param name="output_format" value="sparse"/>
             </section>
-            <output name="output1" file="test2.tsv" ftype="tsv"/>
+            <output name="output1" file="test2.tsv" ftype="tsv" sort="true"/>
         </test>
         <test expect_num_outputs="1">
             <section name="derep">
@@ -528,7 +528,7 @@
                 <param name="dereplication_output_cluster_definition" value="true"/>
                 <param name="dereplication_output_representative_fasta_directory_copy" value="true"/>
             </section>
-            <output name="output1" file="test3.tsv" ftype="tsv"/>
+            <output name="output1" file="test3.tsv" ftype="tsv" sort="true"/>
             <output name="cluster_definition" ftype="tsv" value="test4_cluster.tsv"/>
             <output_collection name="representative_fasta" type="list" count="3">
                 <element name="genome1" file="test4_rep1.fa" ftype="fasta" />
@@ -549,7 +549,7 @@
                 <param name="count" value="true"/>
                 <param name="min_covered_fraction" value="0"/>
             </section>
-            <output name="output1" file="test5.tsv" ftype="tsv"/>
+            <output name="output1" file="test5.tsv" ftype="tsv" sort="true"/>
         </test>
         </tests>
     <help><![CDATA[

--- a/tools/coverm/coverm_genome.xml
+++ b/tools/coverm/coverm_genome.xml
@@ -529,7 +529,7 @@
                 <param name="dereplication_output_representative_fasta_directory_copy" value="true"/>
             </section>
             <output name="output1" file="test3.tsv" ftype="tsv" sort="true"/>
-            <output name="cluster_definition" ftype="tsv" value="test4_cluster.tsv"/>
+            <output name="cluster_definition" ftype="tsv" value="test4_cluster.tsv" sort="true"/>
             <output_collection name="representative_fasta" type="list" count="3">
                 <element name="genome1" file="test4_rep1.fa" ftype="fasta" />
                 <element name="genome2" file="test4_rep2.fa" ftype="fasta" />


### PR DESCRIPTION
weekly CI failing with:

```
Output output1:  different than expected, difference (using diff):
( /tmp/tmpiesiezo1test3.tsv v. /tmp/tmpjejgm78btest3.tsv )
--- local_file
+++ history_data
@@ -1,4 +1,4 @@
 Genome	fw0 Mean
+genome2	4.8142858
 genome1	0
-genome2	4.8142858
 genome3	0
```

just applied it to all tests

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
