### PR TITLE
Test commits pushed to main, not other branches

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,9 @@
 name: Galaxy Tool Linting and Tests for push and PR
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    - main
+    - master
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,8 +2,9 @@ name: Galaxy Tool Linting and Tests for push and PR
 on:
   pull_request:
   push:
-    - main
-    - master
+    branches:
+      - main
+      - master
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05


### PR DESCRIPTION
... but keep testing PR commits as before.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Includes only the uncontroversial part of #5199.
Regarding planemo-autoupdate, this will already cut the number of tests run down to half (since push tests are currently running on the autoupdate bots branches, while those same commits get tested also as part of the PRs).