### PR TITLE
Do not initiate tool tests if no tool was touched

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,20 @@
 name: Galaxy Tool Linting and Tests for push and PR
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'deprecated/**'
+      - 'docs/**'
+      - '*'
   push:
     branches:
       - main
       - master
+    paths-ignore:
+      - '.github/**'
+      - 'deprecated/**'
+      - 'docs/**'
+      - '*'
 env:
   GALAXY_FORK: galaxyproject
   GALAXY_BRANCH: release_22.05

--- a/.github/workflows/pr_without_tool_change.yaml
+++ b/.github/workflows/pr_without_tool_change.yaml
@@ -14,4 +14,4 @@ jobs:
     name: Check workflow success
     runs-on: ubuntu-latest
     steps:
-      -  run: 'echo "No tool tests required for this PR"
+      -  run: 'echo "No tool tests required for this PR"'

--- a/.github/workflows/pr_without_tool_change.yaml
+++ b/.github/workflows/pr_without_tool_change.yaml
@@ -1,0 +1,17 @@
+name: Galaxy Tool Linting and Tests for push and PR
+  # Fallback workflow that provides a succeeding "Check workflow success" job
+  # as this is a requirement for being able to merge a PR
+  # see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+on:
+  pull_request:
+concurrency:
+  # Group runs by PR, but keep runs on the default branch separate
+  # because we do not want to cancel ToolShed uploads
+  group: pr-${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.run_number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  determine-success:
+    name: Check workflow success
+    runs-on: ubuntu-latest
+    steps:
+      -  run: 'echo "No tool tests required for this PR"

--- a/.github/workflows/pr_without_tool_change.yaml
+++ b/.github/workflows/pr_without_tool_change.yaml
@@ -1,7 +1,7 @@
 name: Galaxy Tool Linting and Tests for push and PR
-  # Fallback workflow that provides a succeeding "Check workflow success" job
-  # as this is a requirement for being able to merge a PR
-  # see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+# Fallback workflow that provides a succeeding "Check workflow success" job
+# as this is a requirement for being able to merge a PR
+# see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 on:
   pull_request:
 concurrency:


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

The intention here is to prevent the entire tool linting and tests workflow from running if the only files changed in a PR or a merge commit are in folders that do not contain tool-associated files.

This is kind of straightforward using paths-ignore, but needs a bit of extra work because of the repo's required status check (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore and the note on status checks therein).