### PR TITLE
Update metaphlan: Toy db added

### DIFF
--- a/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
+++ b/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
@@ -5,7 +5,7 @@
     </requirements>
     <macros>
         <token name="@TOOL_VERSION@">4.0.6</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <stdio>
         <exit_code range=":-1" level="fatal" description="Error: Cannot open file"/>

--- a/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
+++ b/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
@@ -18,25 +18,24 @@ python '$__tool_directory__/data_manager_metaphlan_download.py'
     ]]></command>
     <inputs>
         <param name="index" type="select" label="Version">
-            <option value="mpa_vOct22_CHOCOPhlAnSGB_202212" selected="true">mpa_vOct22_CHOCOPhlAnSGB_202212</option>
-            <option value="mpa_vJan21_CHOCOPhlAnSGB_202103">mpa_vJan21_CHOCOPhlAnSGB_202103</option>
+            <option value="mpa_vOct22_CHOCOPhlAnSGB_202212" selected="true">FULL: mpa_vOct22_CHOCOPhlAnSGB_202212</option>
+            <option value="mpa_vJan21_CHOCOPhlAnSGB_202103">FULL: mpa_vJan21_CHOCOPhlAnSGB_202103</option>
+            <option value="mpa_vJan21_TOY_CHOCOPhlAnSGB_202103">DEMO: mpa_vJan21_TOY_CHOCOPhlAnSGB_202103</option>
         </param>
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json" label="${tool.name}"/>
     </outputs>
     <tests>
-        <!--
         <test expect_num_outputs="1">
-            <param name="index" value="mpa_vOct22_CHOCOPhlAnSGB_202212"/>
+            <param name="index" value="mpa_vJan21_TOY_CHOCOPhlAnSGB_202103"/>
             <output name="out_file">
                 <assert_contents>
-                    <has_text text="mpa_vOct22_CHOCOPhlAnSGB_202212"/>
-                    <has_text text="MetaPhlAn clade-specific marker genes (mpa_vOct22_CHOCOPhlAnSGB_202212)"/>
+                    <has_text text="mpa_vJan21_TOY_CHOCOPhlAnSGB_202103"/>
+                    <has_text text="MetaPhlAn clade-specific marker genes (mpa_vJan21_TOY_CHOCOPhlAnSGB_202103)"/>
                 </assert_contents>
             </output>
         </test>
-        -->
     </tests>
     <help><![CDATA[
 This tool downloads and builds the MetaPhlAn databases.


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Segata lab kindly re-organised their FTP server upon our request, so now we have a toy DB for tests.