### PR TITLE
remove deprecated `version` attribute from data_manager_conf.xml

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/data_manager_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <data_managers>
 
-    <data_manager tool_file="data_manager/bowtie2_index_builder.xml" id="bowtie2_index_builder" version="2.2.6">
+    <data_manager tool_file="data_manager/bowtie2_index_builder.xml" id="bowtie2_index_builder">
         <data_table name="bowtie2_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_bowtie_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_bowtie_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/bowtie_index_builder.xml" id="bowtie_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/bowtie_index_builder.xml" id="bowtie_index_builder">
         <data_table name="bowtie_indexes">
             <output>
                 <column name="value" />
@@ -17,7 +17,7 @@
             </output>
         </data_table>
     </data_manager>
-    <data_manager tool_file="data_manager/bowtie_color_space_index_builder.xml" id="bowtie_color_space_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/bowtie_color_space_index_builder.xml" id="bowtie_color_space_index_builder">
         <data_table name="bowtie_indexes_color">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
@@ -69,7 +69,13 @@
         <!-- Test_1 DB latest -->
         <test expect_num_outputs="1">
             <param name="test_data_manager" value="--test"/>
-            <output name="output_file" value="amrfinderplus_test_data_manager_1.json"/>
+            <output name="output_file">
+                <assert_contents>
+                    <has_n_lines n="1"/>
+                    <has_text text="{&quot;data_tables&quot;"/>
+                    <has_text text="amrfinderplus_database"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- Test_2 DB 3.2 -->
         <test expect_num_outputs="1">

--- a/data_managers/data_manager_build_amrfinderplus/data_manager_conf.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/data_manager_build_amrfinderplus.xml" id="data_manager_build_amrfinderplus" version="@TOOL_VERSION@">
+    <data_manager tool_file="data_manager/data_manager_build_amrfinderplus.xml" id="data_manager_build_amrfinderplus">
         <data_table name="amrfinderplus_database">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_build_amrfinderplus/test-data/amrfinderplus_test_data_manager_1.json
+++ b/data_managers/data_manager_build_amrfinderplus/test-data/amrfinderplus_test_data_manager_1.json
@@ -1,1 +1,0 @@
-{"data_tables": {"amrfinderplus_database": [{"name": "V3.11-2022-12-19.1", "path": "amrfinderplus-db", "value": "amrfinderplus_V3.11_2022-12-19.1"}]}}

--- a/data_managers/data_manager_build_bakta_database/data_manager_conf.xml
+++ b/data_managers/data_manager_build_bakta_database/data_manager_conf.xml
@@ -1,5 +1,5 @@
 <data_managers>
-    <data_manager tool_file="data_manager/bakta_build_database.xml" id="bakta_build_database" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <data_manager tool_file="data_manager/bakta_build_database.xml" id="bakta_build_database">
         <data_table name="bakta_database">
             <output>
                 <column name="value"/>

--- a/data_managers/data_manager_build_bracken_database/data_manager_conf.xml
+++ b/data_managers/data_manager_build_bracken_database/data_manager_conf.xml
@@ -1,5 +1,5 @@
 <data_managers>
-    <data_manager tool_file="data_manager/bracken_build_database.xml" id="bracken_build_database" version="2.6+galaxy0">
+    <data_manager tool_file="data_manager/bracken_build_database.xml" id="bracken_build_database">
         <data_table name="bracken_databases">
             <output>
                 <column name="value"/>

--- a/data_managers/data_manager_build_kraken2_database/data_manager_conf.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager_conf.xml
@@ -1,5 +1,5 @@
 <data_managers>
-    <data_manager tool_file="data_manager/kraken2_build_database.xml" id="kraken2_build_database" version="2.1.1+galaxy0">
+    <data_manager tool_file="data_manager/kraken2_build_database.xml" id="kraken2_build_database">
         <data_table name="kraken2_databases">
             <output>
                 <column name="value"/>

--- a/data_managers/data_manager_build_kraken_database/data_manager_conf.xml
+++ b/data_managers/data_manager_build_kraken_database/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/kraken_database_builder.xml" id="kraken_database_builder" version="1.1">
+    <data_manager tool_file="data_manager/kraken_database_builder.xml" id="kraken_database_builder">
         <data_table name="kraken_databases">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_bwa_mem_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_bwa_mem_index_builder/data_manager_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <data_managers>
 
-    <data_manager tool_file="data_manager/bwa_mem_index_builder.xml" id="bwa_mem_index_builder" version="0.0.2">
+    <data_manager tool_file="data_manager/bwa_mem_index_builder.xml" id="bwa_mem_index_builder">
         <data_table name="bwa_mem_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_gatk_picard_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_gatk_picard_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/data_manager_gatk_picard_index_builder.xml" id="gatk_picard_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/data_manager_gatk_picard_index_builder.xml" id="gatk_picard_index_builder">
         <data_table name="gatk_picard_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_hisat2_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_hisat2_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/hisat2_index_builder.xml" id="hisat2_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/hisat2_index_builder.xml" id="hisat2_index_builder">
         <data_table name="hisat2_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_homer_preparsed/data_manager_conf.xml
+++ b/data_managers/data_manager_homer_preparsed/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/homer_genome_preparse.xml" id="homer_genome_preparse" version="4.11">
+    <data_manager tool_file="data_manager/homer_genome_preparse.xml" id="homer_genome_preparse">
         <data_table name="homer_preparse">
             <output>
                 <column name="value" />
@@ -20,7 +20,7 @@
             </output>
         </data_table>
     </data_manager>
-    <data_manager tool_file="data_manager/homer_install_promoters.xml" id="homer_install_promoters" version="4.11">
+    <data_manager tool_file="data_manager/homer_install_promoters.xml" id="homer_install_promoters">
         <data_table name="homer_promoters">
             <output>
                 <column name="value"/>

--- a/data_managers/data_manager_kallisto_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_kallisto_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/kallisto_index_builder.xml" id="kallisto_index_builder" version="0.43.1">
+    <data_manager tool_file="data_manager/kallisto_index_builder.xml" id="kallisto_index_builder">
         <data_table name="kallisto_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_manual/data_manager_conf.xml
+++ b/data_managers/data_manager_manual/data_manager_conf.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/data_manager_manual.xml" id="data_manager_manual" version="0.0.1" undeclared_tables="True" />
+    <data_manager tool_file="data_manager/data_manager_manual.xml" id="data_manager_manual" undeclared_tables="True" />
 </data_managers>

--- a/data_managers/data_manager_mash_sketch_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_mash_sketch_builder/data_manager_conf.xml
@@ -1,5 +1,5 @@
 <data_managers>
-    <data_manager tool_file="data_manager/mash_sketch_builder.xml" id="mash_sketch_builder" version="2.1+galaxy0">
+    <data_manager tool_file="data_manager/mash_sketch_builder.xml" id="mash_sketch_builder">
         <data_table name="mash_sketches">
             <output>
                 <column name="value"/>

--- a/data_managers/data_manager_mitos/data_manager_conf.xml
+++ b/data_managers/data_manager_mitos/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/data_manager_mitos.xml" id="mitos_fetcher" version="0.0.1">
+    <data_manager tool_file="data_manager/data_manager_mitos.xml" id="mitos_fetcher">
         <data_table name="mitos">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_ncbi_taxonomy_sqlite/data_manager_conf.xml
+++ b/data_managers/data_manager_ncbi_taxonomy_sqlite/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/data_manager_ncbi_taxonomy_sqlite.xml" id="data_manager_ncbi_taxonomy_sqlite" version="0.0.1">
+    <data_manager tool_file="data_manager/data_manager_ncbi_taxonomy_sqlite.xml" id="data_manager_ncbi_taxonomy_sqlite">
         <data_table name="ncbi_taxonomy_sqlite">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_picard_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_picard_index_builder/data_manager_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <data_managers>
 
-    <data_manager tool_file="data_manager/picard_index_builder.xml" id="picard_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/picard_index_builder.xml" id="picard_index_builder">
         <data_table name="picard_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_salmon_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_salmon_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/salmon_index_builder.xml" id="salmon_index_builder" version="0.1">
+    <data_manager tool_file="data_manager/salmon_index_builder.xml" id="salmon_index_builder">
         <data_table name="salmon_indexes_versioned">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_sam_fasta_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_sam_fasta_index_builder/data_manager_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <data_managers>
     
-    <data_manager tool_file="data_manager/data_manager_sam_fasta_index_builder.xml" id="sam_fasta_index_builder" version="0.0.1">
+    <data_manager tool_file="data_manager/data_manager_sam_fasta_index_builder.xml" id="sam_fasta_index_builder">
         <data_table name="fasta_indexes">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_star_index_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_star_index_builder/data_manager_conf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <data_managers>
-    <data_manager tool_file="data_manager/rna_star_index_builder.xml" id="rna_star_index_builder" version="0.0.7">
+    <data_manager tool_file="data_manager/rna_star_index_builder.xml" id="rna_star_index_builder">
         <data_table name="rnastar_index2x_versioned">
             <output>
                 <column name="value" />

--- a/data_managers/data_manager_twobit_builder/data_manager_conf.xml
+++ b/data_managers/data_manager_twobit_builder/data_manager_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <data_managers>
     
-    <data_manager tool_file="data_manager/twobit_builder.xml" id="twobit_builder" version="0.0.2">
+    <data_manager tool_file="data_manager/twobit_builder.xml" id="twobit_builder">
         <data_table name="lastz_seqs">
             <output>
                 <column name="value" />


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/pull/12255

I suggest to skip deployment, ie.. [skip-ci]

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
