### PR TITLE
fix PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -334,12 +334,6 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-    - name: Check if all test chunks succeeded
-      run: |
-        NFILES=$(ls artifacts/ | wc -l)
-        if [[ "${{ needs.setup.outputs.chunk-count }}" != "$NFILES" ]]; then
-          exit 1
-        fi
     - name: Combine outputs
       uses: galaxyproject/planemo-ci-action@v1
       id: combine
@@ -355,6 +349,12 @@ jobs:
       id: check
       with:
         mode: check
+    - name: Check if all test chunks succeeded
+      run: |
+        NFILES=$(ls artifacts/ | grep "Tool test output" | wc -l)
+        if [[ "${{ needs.setup.outputs.chunk-count }}" != "$NFILES" ]]; then
+          exit 1
+        fi
 
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:


### PR DESCRIPTION
- do not count tool linting artifact
- and move test to the end such that the combined tool test output artifact is uploaded in any case

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
