### PR TITLE
Sinto fragment: correct the duplicated labels

### DIFF
--- a/tools/sinto/sinto_fragments.xml
+++ b/tools/sinto/sinto_fragments.xml
@@ -36,9 +36,9 @@
             </sanitizer>
         </param>
         <param argument="--max_distance" type="integer" value="5000" min="0" label="Maximum distance between integration sites for the fragment to be retained" 
-            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions. Default is 5000 bp."/>
+            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions."/>
         <param argument="--min_distance" type="integer" value="10" min="0" label="Minimum distance between integration sites for the fragment to be retained" 
-            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions. Default is 10 bp. (--min_distance)."/>
+            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions."/>
         <param argument="--shift_plus" type="integer" value="4" label=" Number of bases to shift Tn5 insertion position by on the forward strand" />
         <param argument="--shift_minus" type="integer" value="-5" label="Number of bases to shift Tn5 insertion position by on the reverse strand" />
         <param argument="--collapse_within" type="boolean" truevalue="--collapse_within" falsevalue="" label="Take cell barcode into account 

--- a/tools/sinto/sinto_fragments.xml
+++ b/tools/sinto/sinto_fragments.xml
@@ -27,7 +27,7 @@
         <param argument="--bam" type="data" format="bam" label="Input BAM file" />
         <param argument="--min_mapq" type="integer" value="30" min="0" label="Minimum MAPQ required to retain fragment" />
         <param argument="--barcodetag" type="text" value="CB" label="Read tag storing cell barcode information" />
-        <param argument="--barcode_regex" type="text" value="[^:]*" label="Read tag storing cell barcode information" 
+        <param argument="--barcode_regex" type="text" value="[^:]*" label="Regular expression used to extract cell barcode from read name" 
             help="[^:]* matches all characters up to the first colon" >
             <sanitizer>
                 <valid initial="string.printable">
@@ -38,15 +38,15 @@
         <param argument="--max_distance" type="integer" value="5000" min="0" label="Maximum distance between integration sites for the fragment to be retained" 
             help="Allows filtering of implausible fragments that likely result from incorrect mapping positions. Default is 5000 bp."/>
         <param argument="--min_distance" type="integer" value="10" min="0" label="Minimum distance between integration sites for the fragment to be retained" 
-            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions. Default is 5000 bp."/>
-        <param argument="--shift_plus" type="integer" value="4" label="Minimum MAPQ required to retain fragment" />
-        <param argument="--shift_minus" type="integer" value="-5" label="Minimum MAPQ required to retain fragment" />
+            help="Allows filtering of implausible fragments that likely result from incorrect mapping positions. Default is 10 bp. (--min_distance)."/>
+        <param argument="--shift_plus" type="integer" value="4" label=" Number of bases to shift Tn5 insertion position by on the forward strand" />
+        <param argument="--shift_minus" type="integer" value="-5" label="Number of bases to shift Tn5 insertion position by on the reverse strand" />
         <param argument="--collapse_within" type="boolean" truevalue="--collapse_within" falsevalue="" label="Take cell barcode into account 
             when collapsing duplicate fragments" help="Setting this flag means that fragments with the same coordinates can be identified 
             provided they originate from a different cell barcode." />
     </inputs>
     <outputs>
-        <data name='fragments' format='bed' label="${tool.name} on ${on_string}: fragments" />
+        <data name='fragments' format='bed' label="${tool.name} on ${on_string}: fragments BED" />
     </outputs>
     <tests>
         <test expect_num_outputs="1">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
