### PR TITLE
Update metaphlan: error on alternative analysis types

### DIFF
--- a/tools/metaphlan/macros.xml
+++ b/tools/metaphlan/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">4.0.6</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.05</token>
     <!-- Metaphlan DB compatible with this version of Metaphlan
     v4 introduced single genome level bins (SGB) and the index syntax differs from previous versions --> 

--- a/tools/metaphlan/metaphlan.xml
+++ b/tools/metaphlan/metaphlan.xml
@@ -192,16 +192,18 @@ metaphlan
 mv 'bowtie2out' '$bowtie2out'
 #end if
 
-#if $analysis.analysis_type.tax_lev.tax_lev == 'a' and $analysis.analysis_type.tax_lev.split_levels
-&&
-mkdir 'split_levels'
-&&
-python '$__tool_directory__/formatoutput.py'
-    split_levels
-    --metaphlan_output '$output_file'
-    --outdir 'split_levels'
-    $out.legacy_output
 
+#if $analysis.analysis_type.t in ['rel_ab', 'rel_ab_w_read_stats']
+    #if $analysis.analysis_type.tax_lev.tax_lev == 'a' and $analysis.analysis_type.tax_lev.split_levels
+        &&
+        mkdir 'split_levels'
+        &&
+        python '$__tool_directory__/formatoutput.py'
+            split_levels
+            --metaphlan_output '$output_file'
+            --outdir 'split_levels'
+            $out.legacy_output
+    #end if
 #end if
 
 #if $out.krona_output
@@ -368,6 +370,7 @@ python '$__tool_directory__/formatoutput.py'
         </data>
     </outputs>
     <tests>
+
         <test expect_num_outputs="6">
             <section name="inputs">
                 <conditional name="in">
@@ -1051,6 +1054,34 @@ python '$__tool_directory__/formatoutput.py'
                     <not_has_text text="k__Bacteria"/>
                     <has_text text="Corynebacterium accolens"/>
                     <has_n_columns n="9"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Check a non-default analysis mode -->
+        <test expect_num_outputs="5">
+            <section name="inputs">
+                <conditional name="in">
+                    <param name="selector" value="raw"/>
+                    <conditional name="raw_in">
+                        <param name="selector" value="single"/>
+                        <param name="in" value="SRS014464-Anterior_nares.fasta"/>
+                    </conditional>
+                </conditional>
+                <conditional name="db">
+                    <param name="db_selector" value="cached"/>
+                    <param name="cached_db" value="test-db-20210409"/>
+                </conditional>
+            </section>
+            <section name="analysis">
+                <conditional name="analysis_type">
+                    <param name="t" value="marker_ab_table"/>
+                </conditional>
+            </section>
+            <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-legacy-abundances.tabular" compare="sim_size">
+                <assert_contents>
+                    <has_text text="29394__H3NC06__B8A41_08715"/>
+                    <has_text text="SampleID"/>
+                    <has_text text="Metaphlan_Analysis"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/metaphlan/metaphlan.xml
+++ b/tools/metaphlan/metaphlan.xml
@@ -363,14 +363,13 @@ python '$__tool_directory__/formatoutput.py'
         <data name="biom_output_file" format="biom1" label="${tool.name} on ${on_string}: BIOM file" />
         <collection name="levels" type="list" label="${tool.name} on ${on_string}: Predicted taxon relative abundances at each taxonomic levels" >
             <discover_datasets pattern="(?P&lt;designation&gt;.+)" directory="split_levels/" format="tabular"/>
-            <filter>analysis['analysis_type']['tax_lev']['tax_lev'] == "a" and analysis['analysis_type']['tax_lev']['split_levels']</filter>
+            <filter>analysis['analysis_type']['t'] in ['rel_ab', 'rel_ab_w_read_stats'] and analysis['analysis_type']['tax_lev']['tax_lev'] == "a" and analysis['analysis_type']['tax_lev']['split_levels']</filter>
         </collection>
         <data name="krona_output_file" format="tabular" label="${tool.name} on ${on_string}: Predicted taxon relative abundances for Krona">
             <filter>out['krona_output']</filter>
         </data>
     </outputs>
     <tests>
-
         <test expect_num_outputs="6">
             <section name="inputs">
                 <conditional name="in">
@@ -438,8 +437,7 @@ python '$__tool_directory__/formatoutput.py'
                     <not_has_text text="p__Actinobacteria"/>
                 </assert_contents>
             </output>
-            <output_collection name="levels" type="list" >
-            
+            <output_collection name="levels" type="list">
                 <element name="all" ftype="tabular">
                     <assert_contents>
                         <has_text text="class"/>
@@ -1058,7 +1056,7 @@ python '$__tool_directory__/formatoutput.py'
             </output>
         </test>
         <!-- Check a non-default analysis mode -->
-        <test expect_num_outputs="5">
+        <test expect_num_outputs="4">
             <section name="inputs">
                 <conditional name="in">
                     <param name="selector" value="raw"/>


### PR DESCRIPTION
Addresses the Cheetah error encountered if a non-default analysis type is chosen:

...
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1681888750_8410845_53299.py", line 401, in respond
NameMapper.NotFound: cannot find 'tax_lev' while searching for 'analysis.analysis_type.tax_lev.tax_lev'



FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
