### PR TITLE
Ruvseq add normcounts

### DIFF
--- a/tools/ruvseq/ruvseq.R
+++ b/tools/ruvseq/ruvseq.R
@@ -17,7 +17,8 @@ setup_cmdline_options <- function() {
     "plots", "p", 1, "character",
     "header", "H", 0, "logical",
     "txtype", "y", 1, "character",
-    "tx2gene", "x", 1, "character"), # a space-sep tx-to-gene map or GTF file (auto detect .gtf/.GTF)
+    "tx2gene", "x", 1, "character", # a space-sep tx-to-gene map or GTF file (auto detect .gtf/.GTF)
+    "ruv_ncounts","ruv_ncounts",0,"logical"),
     byrow = TRUE, ncol = 4)
 
   opt <- getopt(spec)
@@ -155,6 +156,7 @@ alpha <- opt$alpha
 min_k <- opt$min_k
 max_k <- opt$max_k
 min_c <- opt$min_mean_count
+ruv_ncounts <- ifelse ( is.null(opt$ruv_ncounts ) , FALSE, TRUE )
 sample_json <- fromJSON(opt$sample_json)
 sample_paths <- sample_json$path
 sample_names <- sample_json$label
@@ -185,6 +187,12 @@ for (name in names(result)) {
     colnames(df)[2] <- "condition"
     write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = F, row.names = F)
   }
+  if(ruv_ncounts){
+    ruvnorm_counts <- normCounts(set)
+    ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)
+    write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = F, row.names = F)
+  }
+
 }
 
 # close the plot device

--- a/tools/ruvseq/ruvseq.R
+++ b/tools/ruvseq/ruvseq.R
@@ -1,7 +1,8 @@
 # setup R error handling to go to stderr
 library("getopt")
 options(show.error.messages = F, error = function() {
-  cat(geterrmessage(), file = stderr()); q("no", 1, F)
+  cat(geterrmessage(), file = stderr())
+  q("no", 1, FALSE)
 })
 options(stringAsFactors = FALSE, useFancyQuotes = FALSE)
 
@@ -18,7 +19,7 @@ setup_cmdline_options <- function() {
     "header", "H", 0, "logical",
     "txtype", "y", 1, "character",
     "tx2gene", "x", 1, "character", # a space-sep tx-to-gene map or GTF file (auto detect .gtf/.GTF)
-    "ruv_ncounts","ruv_ncounts",0,"logical"),
+    "ruv_ncounts", "ruv_ncounts", 0, "logical"),
     byrow = TRUE, ncol = 4)
 
   opt <- getopt(spec)
@@ -156,7 +157,7 @@ alpha <- opt$alpha
 min_k <- opt$min_k
 max_k <- opt$max_k
 min_c <- opt$min_mean_count
-ruv_ncounts <- ifelse ( is.null(opt$ruv_ncounts ) , FALSE, TRUE )
+ruv_ncounts <- ifelse (is.null(opt$ruv_ncounts), FALSE, TRUE)
 sample_json <- fromJSON(opt$sample_json)
 sample_paths <- sample_json$path
 sample_names <- sample_json$label
@@ -185,12 +186,12 @@ for (name in names(result)) {
     df <- data.frame(identifier = rownames(unwanted_variation))
     df <- cbind(df, unwanted_variation)
     colnames(df)[2] <- "condition"
-    write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = F, row.names = F)
+    write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
   }
-  if(ruv_ncounts){
+  if(ruv_ncounts) {
     ruvnorm_counts <- normCounts(set)
     ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)
-    write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = F, row.names = F)
+    write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
   }
 
 }

--- a/tools/ruvseq/ruvseq.R
+++ b/tools/ruvseq/ruvseq.R
@@ -1,6 +1,6 @@
 # setup R error handling to go to stderr
 library("getopt")
-options(show.error.messages = F, error = function() {
+options(show.error.messages = FALSE, error = function() {
   cat(geterrmessage(), file = stderr())
   q("no", 1, FALSE)
 })
@@ -157,7 +157,7 @@ alpha <- opt$alpha
 min_k <- opt$min_k
 max_k <- opt$max_k
 min_c <- opt$min_mean_count
-ruv_ncounts <- ifelse (is.null(opt$ruv_ncounts), FALSE, TRUE)
+ruv_ncounts <- ifelse(is.null(opt$ruv_ncounts), FALSE, TRUE)
 sample_json <- fromJSON(opt$sample_json)
 sample_paths <- sample_json$path
 sample_names <- sample_json$label
@@ -188,7 +188,7 @@ for (name in names(result)) {
     colnames(df)[2] <- "condition"
     write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
   }
-  if(ruv_ncounts) {
+  if (ruv_ncounts) {
     ruvnorm_counts <- normCounts(set)
     ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)
     write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)

--- a/tools/ruvseq/ruvseq.R
+++ b/tools/ruvseq/ruvseq.R
@@ -186,7 +186,7 @@ for (name in names(result)) {
     df <- data.frame(identifier = rownames(unwanted_variation))
     df <- cbind(df, unwanted_variation)
     colnames(df)[2] <- "condition"
-    write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
+    write.table(df, file = paste0("uv_batch_effects_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
     if (ruv_ncounts) {
       ruvnorm_counts <- normCounts(set)
       ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)

--- a/tools/ruvseq/ruvseq.R
+++ b/tools/ruvseq/ruvseq.R
@@ -187,11 +187,11 @@ for (name in names(result)) {
     df <- cbind(df, unwanted_variation)
     colnames(df)[2] <- "condition"
     write.table(df, file = paste0("batch_effects_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
-  }
-  if (ruv_ncounts) {
-    ruvnorm_counts <- normCounts(set)
-    ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)
-    write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
+    if (ruv_ncounts) {
+      ruvnorm_counts <- normCounts(set)
+      ruvnorm_df <- data.frame(geneID = rownames(ruvnorm_counts), ruvnorm_counts)
+      write.table(ruvnorm_df, file = paste0("ruv_norm_counts_", name, ".tabular"),  sep = "\t", quote = FALSE, row.names = FALSE)
+    }
   }
 
 }

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -297,7 +297,7 @@ $header
             <param name="ruv_ncounts" value="true"/>
             <output name="plots" file="ruvseq_diag_sailfish.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="ruv_normcounts" type="list">
-                <element name="counts_control_method_k1">
+                <element name="norm_counts_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
                     </assert_contents>

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -127,15 +127,15 @@ $header
             help="output an additional PDF files" />
         <param name="ruv_ncounts" type="boolean" truevalue="1" falsevalue="0" checked="false"
             label="Output RUVSeq normalized count tables"
-            help="CAREFUL RUVSeq normalized count tables are not to use for Statistical Analysis with DESeq2, edger or limma -- Only for Visualisation" />
+            help="If this option is set to Yes, the tool will generate RUVseq normalized count files. Default: No" />
     </inputs>
     <outputs>
         <collection name="unwanted_variation" type="list" label="RUVSeq covariate files on ${on_string}">
-            <discover_datasets pattern="batch_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
+            <discover_datasets pattern="uv_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
         </collection>
         <collection name="ruv_normcounts" type="list" label="RUVSeq normalized counts on ${on_string}">
             <filter>ruv_ncounts == True</filter>
-            <discover_datasets pattern="ruv_norm_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
+            <discover_datasets pattern="ruv_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
         </collection>
         <data format="pdf" name="plots" label="RUVSeq diagonstic plots on ${on_string}">
             <filter>pdf == True</filter>
@@ -155,19 +155,19 @@ $header
             <param name="pdf" value="true"/>
             <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="effects_control_method_k1">
+                <element name="batch_effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="effects_replicate_method_k1">
+                <element name="batch_effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="effects_residual_method_k1">
+                <element name="batch_effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
@@ -189,19 +189,19 @@ $header
             <param name="header" value="false"/>
             <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="effects_control_method_k1">
+                <element name="batch_effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="effects_replicate_method_k1">
+                <element name="batch_effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="effects_residual_method_k1">
+                <element name="batch_effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
@@ -227,19 +227,19 @@ $header
             <param name="min_mean_count" value="0"/>
             <output name="plots" file="ruvseq_diag_sailfish.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="effects_control_method_k1">
+                <element name="batch_effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 
                     </assert_contents>
                 </element>
-                <element name="effects_replicate_method_k1">
+                <element name="batch_effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 
                     </assert_contents>
                 </element>
-                <element name="effects_residual_method_k1">
+                <element name="batch_effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 
@@ -261,17 +261,17 @@ $header
             <param name="ruv_ncounts" value="true"/>
             <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="ruv_normcounts" type="list">
-                <element name="counts_control_method_k1">
+                <element name="norm_counts_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
                     </assert_contents>
                 </element>
-                <element name="counts_replicate_method_k1">
+                <element name="norm_counts_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
                     </assert_contents>
                 </element>
-                <element name="counts_residual_method_k1">
+                <element name="norm_counts_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
                     </assert_contents>
@@ -302,12 +302,12 @@ $header
                         <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
                     </assert_contents>
                 </element>
-                <element name="counts_replicate_method_k1">
+                <element name="norm_counts_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
                     </assert_contents>
                 </element>
-                <element name="counts_residual_method_k1">
+                <element name="norm_counts_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
                     </assert_contents>
@@ -387,6 +387,9 @@ NM_014576    9267       7714.88         8.37255     0.0481114
 **Output**
 
 RUVSeq_ generates a tabular file for each method and each k of variation as well as a summary PDF.
+
+RUVSeq can also generate RUVSeq normalized count tables. However, *these counts should be used only for exploration. It is important that subsequent DE analysis be done on the original counts (accessible through the counts method), as removing the unwanted factors from the counts can also remove part of a factor of interest*. 
+
 
 .. _RUVSeq: http://master.bioconductor.org/packages/release/bioc/html/RUVSeq.html
 .. _tximport: https://bioconductor.org/packages/devel/bioc/vignettes/tximport/inst/doc/tximport.html

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -388,7 +388,7 @@ NM_014576    9267       7714.88         8.37255     0.0481114
 
 RUVSeq_ generates a tabular file for each method and each k of variation as well as a summary PDF.
 
-RUVSeq can also generate RUVSeq normalized count tables. However, *these counts should be used only for exploration. It is important that subsequent DE analysis be done on the original counts (accessible through the counts method), as removing the unwanted factors from the counts can also remove part of a factor of interest*. 
+RUVSeq can also generate RUVSeq normalized count tables. However, *these counts should be used only for exploration. It is important that subsequent DE analysis be done on the original counts, as removing the unwanted factors from the counts can also remove part of a factor of interest*. 
 
 
 .. _RUVSeq: http://master.bioconductor.org/packages/release/bioc/html/RUVSeq.html

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -6,7 +6,7 @@
     </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">1.26.0</token>
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-ruvseq</requirement>

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -131,7 +131,11 @@ $header
     </inputs>
     <outputs>
         <collection name="unwanted_variation" type="list" label="RUVSeq covariate files on ${on_string}">
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
+            <discover_datasets pattern="batch_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
+        </collection>
+        <collection name="ruv_normcounts" type="list" label="RUVSeq normalized counts on ${on_string}">
+            <filter>ruv_ncounts == True</filter>
+            <discover_datasets pattern="ruv_norm_(?P&lt;designation&gt;.+)\.tabular" format="tabular" directory="." visible="false"/>
         </collection>
         <data format="pdf" name="plots" label="RUVSeq diagonstic plots on ${on_string}">
             <filter>pdf == True</filter>
@@ -151,19 +155,19 @@ $header
             <param name="pdf" value="true"/>
             <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="batch_effects_control_method_k1">
+                <element name="effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="batch_effects_replicate_method_k1">
+                <element name="effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="batch_effects_residual_method_k1">
+                <element name="effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
@@ -185,19 +189,19 @@ $header
             <param name="header" value="false"/>
             <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="batch_effects_control_method_k1">
+                <element name="effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="batch_effects_replicate_method_k1">
+                <element name="effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
                     </assert_contents>
                 </element>
-                <element name="batch_effects_residual_method_k1">
+                <element name="effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression="GSM461179.*\tTreated\t\-.+"/>
@@ -223,19 +227,19 @@ $header
             <param name="min_mean_count" value="0"/>
             <output name="plots" file="ruvseq_diag_sailfish.pdf" ftype="pdf" compare="sim_size"/>
             <output_collection name="unwanted_variation" type="list">
-                <element name="batch_effects_control_method_k1">
+                <element name="effects_control_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 
                     </assert_contents>
                 </element>
-                <element name="batch_effects_replicate_method_k1">
+                <element name="effects_replicate_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 
                     </assert_contents>
                 </element>
-                <element name="batch_effects_residual_method_k1">
+                <element name="effects_residual_method_k1">
                     <assert_contents>
                         <has_text_matching expression="identifier\tcondition\tW_1"/>
                         <has_text_matching expression=".*sailfish_quant.sf1.tab\tTreated\t.+"/> 

--- a/tools/ruvseq/ruvseq.xml
+++ b/tools/ruvseq/ruvseq.xml
@@ -64,6 +64,10 @@ $header
         --tx2gene mapping.txt
     #end if
 #end if
+
+#if $ruv_ncounts == 1:
+    --ruv_ncounts 
+#end if
 ]]></command>
     <configfiles>
         <configfile name="sampleTable">
@@ -121,6 +125,9 @@ $header
         <param name="pdf" type="boolean" truevalue="1" falsevalue="0" checked="true"
             label="Visualising the analysis results"
             help="output an additional PDF files" />
+        <param name="ruv_ncounts" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            label="Output RUVSeq normalized count tables"
+            help="CAREFUL RUVSeq normalized count tables are not to use for Statistical Analysis with DESeq2, edger or limma -- Only for Visualisation" />
     </inputs>
     <outputs>
         <collection name="unwanted_variation" type="list" label="RUVSeq covariate files on ${on_string}">
@@ -236,6 +243,73 @@ $header
                 </element>
             </output_collection>
         </test>
+                <!--Ensure Normalized counts files are generated -->
+        <test>
+            <repeat name="rep_factorLevel">
+                <param name="factorLevel" value="Treated"/>
+                <param name="countsFile" value="GSM461179_treat_single.counts,GSM461180_treat_paired.counts,GSM461181_treat_paired.counts"/>
+            </repeat>
+            <repeat name="rep_factorLevel">
+                <param name="factorLevel" value="Untreated"/>
+                <param name="countsFile" value="GSM461176_untreat_single.counts,GSM461177_untreat_paired.counts,GSM461178_untreat_paired.counts,GSM461182_untreat_single.counts"/>
+            </repeat>
+            <param name="pdf" value="true"/>
+            <param name="ruv_ncounts" value="true"/>
+            <output name="plots" file="ruvseq_diag.pdf" ftype="pdf" compare="sim_size"/>
+            <output_collection name="ruv_normcounts" type="list">
+                <element name="counts_control_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
+                    </assert_contents>
+                </element>
+                <element name="counts_replicate_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
+                    </assert_contents>
+                </element>
+                <element name="counts_residual_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\t.+"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+        <!--Ensure Normalized counts are generated with sailfish files  -->
+        <test>
+            <repeat name="rep_factorLevel">
+                <param name="factorLevel" value="Treated"/>
+                <param name="countsFile" value="sailfish/sailfish_quant.sf1.tab,sailfish/sailfish_quant.sf2.tab,sailfish/sailfish_quant.sf3.tab"/>
+            </repeat>
+            <repeat name="rep_factorLevel">
+                <param name="factorLevel" value="Untreated"/>
+                    <param name="countsFile" value="sailfish/sailfish_quant.sf4.tab,sailfish/sailfish_quant.sf5.tab,sailfish/sailfish_quant.sf6.tab"/>
+            </repeat>
+            <param name="pdf" value="true"/>
+            <param name="tximport_selector" value="tximport"/>
+            <param name="txtype" value="sailfish"/>
+            <param name="mapping_format_selector" value="tabular"/>
+            <param name="tabular_file" value="tx2gene.tab"/>
+            <param name="min_mean_count" value="0"/>
+            <param name="ruv_ncounts" value="true"/>
+            <output name="plots" file="ruvseq_diag_sailfish.pdf" ftype="pdf" compare="sim_size"/>
+            <output_collection name="ruv_normcounts" type="list">
+                <element name="counts_control_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
+                    </assert_contents>
+                </element>
+                <element name="counts_replicate_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
+                    </assert_contents>
+                </element>
+                <element name="counts_residual_method_k1">
+                    <assert_contents>
+                        <has_text_matching expression="geneID\tsailfish_quant.sf1.tab\tsailfish_quant.sf2.tab\t.+"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test> 
     </tests>
     <help><![CDATA[
 .. class:: infomark


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Changes in ruvseq wrapper and script to add Ruvseq Normalized counts output

Be aware that this normalized counts CANNOT be utilized for statistical purposes and further DESeq2, edgeR or limma analysis.
It can ONLY be used for vizualisation purposes