### PR TITLE
Updating tools/cojac from version 0.2 to
0.9.1

### DIFF
--- a/tools/cojac/cooc_pubmut.xml
+++ b/tools/cojac/cooc_pubmut.xml
@@ -8,7 +8,7 @@
     </macros>
     <expand macro="biotools"/>
     <expand macro="requirements">
-        <requirement type="package" version="3.1.1">pandoc</requirement>
+        <requirement type="package" version="3.1.3">pandoc</requirement>
     </expand>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/cojac/cooc_pubmut.xml
+++ b/tools/cojac/cooc_pubmut.xml
@@ -8,7 +8,7 @@
     </macros>
     <expand macro="biotools"/>
     <expand macro="requirements">
-        <requirement type="package" version="2.12">pandoc</requirement>
+        <requirement type="package" version="3.1.1">pandoc</requirement>
     </expand>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/cojac/macros.xml
+++ b/tools/cojac/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">0.2</token>
+    <token name="@TOOL_VERSION@">0.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biotools">

--- a/tools/cojac/macros.xml
+++ b/tools/cojac/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">0.9</token>
+    <token name="@TOOL_VERSION@">0.9.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biotools">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cojac**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cojac from version 0.2 to 0.9.

**Project home page:** https://github.com/cbg-ethz/cojac/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).