### PR TITLE
Updating tools/humann from version 3.6.1 to 3.7

### DIFF
--- a/tools/humann/macros.xml
+++ b/tools/humann/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">3.6.1</token>
+    <token name="@TOOL_VERSION@">3.7</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/humann**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/humann from version 3.6.1 to 3.7.

**Project home page:** http://huttenhower.sph.harvard.edu/humann

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).