### PR TITLE
Updating tools/iqtree from version 2.1.2 to 2.3.3

### DIFF
--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.5</token>
+    <token name="@TOOL_VERSION@">2.2.6</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.2.3</token>
+    <token name="@TOOL_VERSION@">2.2.2.7</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.2.7</token>
+    <token name="@TOOL_VERSION@">2.2.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.3</token>
+    <token name="@TOOL_VERSION@">2.2.5</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.1.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.2.2.3</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">
         <requirements>

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.6</token>
+    <token name="@TOOL_VERSION@">2.3.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.3.0</token>
+    <token name="@TOOL_VERSION@">2.3.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/iqtree**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/iqtree from version 2.1.2 to 2.2.2.3.

**Project home page:** http://www.iqtree.org

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).