### PR TITLE
Updating tools/picrust2 from version 2.5.1 to 2.5.2

### DIFF
--- a/tools/picrust2/macros.xml
+++ b/tools/picrust2/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.5.1</token>
+    <token name="@TOOL_VERSION@">2.5.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="bio_tool">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/picrust2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/picrust2 from version 2.5.1 to 2.5.2.

**Project home page:** https://github.com/picrust/picrust2/wiki/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).