### PR TITLE
Updating tools/trinotate from version 3.2.2 to 4.0.0

### DIFF
--- a/tools/trinotate/trinotate.xml
+++ b/tools/trinotate/trinotate.xml
@@ -1,7 +1,7 @@
 <tool id="trinotate" name="Trinotate" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05">
     <description>functional transcript annotation</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.2.2</token>
+        <token name="@TOOL_VERSION@">4.0.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/trinotate**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/trinotate from version 3.2.2 to 4.0.0.

**Project home page:** https://trinotate.github.io

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).