### PR TITLE
Funannotate: fix for missing env var

### DIFF
--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -9,6 +9,7 @@
     <version_command>funannotate check --show-versions</version_command>
     <command><![CDATA[
 ## Needed by some subprocess invoked internally
+## https://github.com/nextgenusfs/funannotate/issues/905
 export FUNANNOTATE_DB='$database.fields.path'
 
 &&

--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -8,6 +8,11 @@
     </requirements>
     <version_command>funannotate check --show-versions</version_command>
     <command><![CDATA[
+## Needed by some subprocess invoked internally
+export FUNANNOTATE_DB='$database.fields.path'
+
+&&
+
 funannotate annotate
 
 #if $input.input_type == 'gbk'

--- a/tools/funannotate/macros.xml
+++ b/tools/funannotate/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.8.15</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="requirements">
         <requirement type="package" version="@TOOL_VERSION@">funannotate</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Fill an env var needed by some subprocess. Problem reported upstream in https://github.com/nextgenusfs/funannotate/issues/905