### PR TITLE
Updating tools/busco from version 5.4.6 to
5.5.0

### DIFF
--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.4.6</token>
+    <token name="@TOOL_VERSION@">5.4.7</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">

--- a/tools/busco/macros.xml
+++ b/tools/busco/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">5.4.7</token>
+    <token name="@TOOL_VERSION@">5.5.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/busco**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/busco from version 5.4.6 to 5.4.7.

**Project home page:** https://gitlab.com/ezlab/busco/-/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).