### PR TITLE
Updating tools/minimap2 from version 2.24 to 2.26

### DIFF
--- a/tools/minimap2/macros.xml
+++ b/tools/minimap2/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.24</token>
+    <token name="@TOOL_VERSION@">2.26</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
@@ -12,7 +12,7 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">minimap2</requirement>
-            <requirement type="package" version="1.14">samtools</requirement>
+            <requirement type="package" version="1.17">samtools</requirement>
         </requirements>
     </xml>
     <xml name="pe_anaylsis_fixed_selector">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/minimap2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/minimap2 from version 2.24 to 2.26.

**Project home page:** https://github.com/lh3/minimap2/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).