### PR TITLE
Updating tools/recentrifuge from version 1.10.0 to 1.12.1

### DIFF
--- a/tools/recentrifuge/macro.xml
+++ b/tools/recentrifuge/macro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.10.0</token>
+  <token name="@TOOL_VERSION@">1.12.1</token>
   <token name="@VERSION_SUFFIX@">0</token>
   <token name="@PROFILE@">21.05</token>
   <xml name="version_command">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/recentrifuge**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/recentrifuge from version 1.10.0 to 1.12.1.

**Project home page:** https://github.com/khyox/recentrifuge/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).