### PR TITLE
RepeatModeler: adapt to new thread count option

### DIFF
--- a/tools/repeatmodeler/macros.xml
+++ b/tools/repeatmodeler/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">2.0.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="requirements">
         <requirement type="package" version="@TOOL_VERSION@">repeatmodeler</requirement>

--- a/tools/repeatmodeler/repeatmodeler.xml
+++ b/tools/repeatmodeler/repeatmodeler.xml
@@ -11,12 +11,7 @@ BuildDatabase -name 'rmdb' '$input_file'
 
 &&
 
-## "RMBlast jobs will use 4 cores each"
-pa=\$(( (\${GALAXY_SLOTS:-1}+3)/4 ))
-
-&&
-
-RepeatModeler -database 'rmdb' -threads \$pa
+RepeatModeler -database 'rmdb' -threads \${GALAXY_SLOTS:-1}
     ]]></command>
     <inputs>
         <param type="data" name="input_file" format="fasta" label="Input genome fasta"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

The thread count option has changed in 2.0.4, it's simpler now:
https://github.com/Dfam-consortium/RepeatModeler/blob/master/RELEASE-NOTES#LL7C39-L7C39