### PR TITLE
Updating tools/abyss from version 2.3.4 to 2.3.6

### DIFF
--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -1,8 +1,5 @@
 <tool id="abyss-pe" name="ABySS" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>de novo sequence assembler</description>
-    <xrefs>
-        <xref type="bio.tools">abyss</xref>
-    </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">2.3.6</token>
         <token name="@VERSION_SUFFIX@">0</token>
@@ -26,6 +23,9 @@
             </conditional>
         </xml>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">abyss</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">abyss</requirement>
         <requirement type="package" version="0.7.17">bwa</requirement>
@@ -219,7 +219,7 @@ k=$k
         <data name="scaffolds" format="fasta" label="${tool.name} on ${on_string}: scaffolds" from_work_dir="abyss-scaffolds.fa">
             <filter>lib_repeat or mp_repeat</filter>
         </data>
-        <data name="long_scaffolds" format="fasta" label="${tool.name} on ${on_string}: scaffolds" from_work_dir="abyss-long-scaffs.fa">
+        <data name="long_scaffolds" format="fasta" label="${tool.name} on ${on_string}: long scaffolds" from_work_dir="abyss-long-scaffs.fa">
             <filter>long_seqs</filter>
         </data>
         <data name="indels" format="fasta" label="${tool.name} on ${on_string}: indels" from_work_dir="abyss-indel.fa" />

--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -4,8 +4,8 @@
         <xref type="bio.tools">abyss</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">2.3.4</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">2.3.6</token>
+        <token name="@VERSION_SUFFIX@">0</token>
         <xml name="reads_conditional">
             <conditional name="reads">
                 <param name="reads_selector" type="select" label="Type of paired-end datasets">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/abyss**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/abyss from version 2.3.4 to 2.3.6.

**Project home page:** http://www.bcgsc.ca/platform/bioinfo/software/abyss

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).