### PR TITLE
Updating tools/verkko from version 1.2 to 1.3.1

### DIFF
--- a/tools/verkko/verkko.xml
+++ b/tools/verkko/verkko.xml
@@ -1,8 +1,8 @@
 <tool id="verkko" name="verkko" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <description>hybrid genome assembly pipeline</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.2</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">1.3.1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">verkko</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/verkko**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/verkko from version 1.2 to 1.3.1.

**Project home page:** https://github.com/marbl/verkko/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).