### PR TITLE
Update Deseq2 to v. 1.38

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -36,12 +36,6 @@ options(show.error.messages = FALSE, error = function() {
   q("no", 1, FALSE)
 })
 
-# we need that to not crash galaxy with an UTF8 error on German LC settings.
-# As if "loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")" is not needed anymore.
-# Sometimes some tests break, but not 100% reproducible.
-#loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
-
-
 library("getopt")
 library("tools")
 options(stringAsFactors = FALSE, useFancyQuotes = FALSE)

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -37,8 +37,7 @@ options(show.error.messages = FALSE, error = function() {
 })
 
 # we need that to not crash galaxy with an UTF8 error on German LC settings.
-# The line below breaks test #11 and as if not needed anymore?
-# loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
+# As if "loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")" is not needed anymore breaks test #11
 
 
 library("getopt")

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -37,7 +37,9 @@ options(show.error.messages = FALSE, error = function() {
 })
 
 # we need that to not crash galaxy with an UTF8 error on German LC settings.
-loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
+# The line below breaks test #11 and as if not needed anymore?
+# loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
+
 
 library("getopt")
 library("tools")
@@ -69,7 +71,7 @@ spec <- matrix(c(
   "outlier_replace_off", "a", 0, "logical",
   "outlier_filter_off", "b", 0, "logical",
   "auto_mean_filter_off", "c", 0, "logical",
-  "beta_prior_off", "d", 0, "logical",
+  "use_beta_priors", "d", 0, "logical",
   "alpha_ma", "A", 1, "numeric",
   "prefilter", "P", 0, "logical",
   "prefilter_value", "V", 1, "numeric"
@@ -312,12 +314,15 @@ if (is.null(opt$auto_mean_filter_off)) {
 }
 
 # shrinkage of LFCs
-if (is.null(opt$beta_prior_off)) {
-  beta_prior <- TRUE
-} else {
+if (is.null(opt$use_beta_priors)) {
   beta_prior <- FALSE
-  if (verbose) cat("beta prior off\n")
+  if (verbose)
+    cat("Applied default - beta prior off\n")
+} else {
+  beta_prior <- opt$use_beta_priors
 }
+sprintf("use_beta_prior is set to %s", beta_prior)
+
 
 # dispersion fit type
 if (is.null(opt$fit_type)) {

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -229,7 +229,7 @@ if (!is.null(opt$esf)) {
     } else {
         sf_table <- read.table(opt$esf)
         # Sort the provided size factors just in case the order differs from the input file order.
-        merged_table <- merge(sample_table, sf_table, by.x=0, by.y=1, sort=F)
+        merged_table <- merge(sample_table, sf_table, by.x = 0, by.y = 1, sort = FALSE)
         sf_values <- as.numeric(unlist(merged_table[5]))
         "sizeFactors"(dds) <- sf_values
 

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -39,7 +39,7 @@ options(show.error.messages = FALSE, error = function() {
 # we need that to not crash galaxy with an UTF8 error on German LC settings.
 # As if "loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")" is not needed anymore.
 # Sometimes some tests break, but not 100% reproducible.
-loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
+#loc <- Sys.setlocale("LC_MESSAGES", "en_US.UTF-8")
 
 
 library("getopt")

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -100,18 +100,12 @@ Rscript '${__tool_directory__}/deseq2.R'
         $advanced_options.prefilter_conditional.prefilter
         -V $advanced_options.prefilter_conditional.prefilter_value
     #end if
-    #if $advanced_options.outlier_replace_off:
-        -a
-    #end if
-    #if $advanced_options.outlier_filter_off:
-        -b
-    #end if
-    #if $advanced_options.auto_mean_filter_off:
-        -c
-    #end if
-    #if $advanced_options.use_beta_priors:
-        -d
-    #end if
+    
+    $advanced_options.outlier_replace_off
+    $advanced_options.outlier_filter_off
+    $advanced_options.auto_mean_filter_off
+    $advanced_options.use_beta_priors
+
     #if 'many_contrasts' in $output_options.output_selector
         -m
     #end if
@@ -123,7 +117,6 @@ Rscript '${__tool_directory__}/deseq2.R'
         #else:
             -x mapping.txt
         #end if
-
     #end if
 ]]></command>
     <inputs>
@@ -203,16 +196,16 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <option value="2">local</option>
                 <option value="3">mean</option>
             </param>
-            <param name="outlier_replace_off" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            <param name="outlier_replace_off" type="boolean" truevalue="-a" falsevalue="" checked="false"
                 label="Turn off outliers replacement (only affects with >6 replicates)"
                 help="When there are more than 6 replicates for a given sample, the DESeq2 will automatically replace
                     counts with large Cook’s distance with the trimmed mean over all samples, scaled up by the size factor
                     or normalization factor for that sample"/>
-            <param name="outlier_filter_off" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            <param name="outlier_filter_off" type="boolean" truevalue="-b" falsevalue="" checked="false"
                 label="Turn off outliers filtering (only affects with >2 replicates)"
                 help="When there are more than 2 replicates for a given sample, the DESeq2 will automatically
                     filter genes which contain a Cook’s distance above a cutoff"/>
-            <param name="auto_mean_filter_off" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            <param name="auto_mean_filter_off" type="boolean" truevalue="-c" falsevalue="" checked="false"
                 label="Turn off independent filtering"
                 help=" DESeq2 performs independent filtering by default using the mean of normalized counts as a filter statistic"/>
             <conditional name="prefilter_conditional">
@@ -228,7 +221,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </when>
                 <when value=""/>
             </conditional>
-            <param name="use_beta_priors" type="boolean" truevalue="1" falsevalue="0" checked="false"
+            <param name="use_beta_priors" type="boolean" truevalue="-d" falsevalue="" checked="false"
                 label="Use beta priors"
                 help="Whether or not to put a zero-mean normal prior on the non-intercept coefficients"/>
         </section>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -85,8 +85,12 @@ Rscript '${__tool_directory__}/deseq2.R'
 
     -f '#echo json.dumps(temp_factor_names)#'
     -l '#echo json.dumps(filename_to_element_identifiers)#'
-    #if $advanced_options.esf:
-        -e $advanced_options.esf
+    #if $advanced_options.esf_cond.esf:
+        #if $advanced_options.esf_cond.esf == "user":
+            -e $advanced_options.esf_cond.size_factor_input
+        #else:
+            -e $advanced_options.esf_cond.esf
+        #end if
     #end if
     -t $advanced_options.fit_type
     #if $batch_factors:
@@ -171,19 +175,29 @@ Rscript '${__tool_directory__}/deseq2.R'
             <when value="count"/>
         </conditional>
         <section name="advanced_options" title="Advanced options">
-            <param name="esf" type="select" label="Method for estimateSizeFactors" 
-                help="Method for estimation: either 'ratio', 'poscounts', or 'iterate'. 'ratio' uses the standard median ratio method introduced in DESeq. 
-                    The size factor is the median ratio of the sample over a 'pseudosample': for each gene, the geometric mean of all samples. 
-                    'poscounts' and 'iterate' offer alternative estimators, which can be used even when all genes contain a sample with a zero (a problem 
-                    for the default method, as the geometric mean becomes zero, and the ratio undefined). The 'poscounts' estimator deals with a gene with 
-                    some zeros, by calculating a modified geometric mean by taking the n-th root of the product of the non-zero counts. This evolved out of 
-                    use cases with Paul McMurdie's phyloseq package for metagenomic samples. The 'iterate' estimator iterates between estimating the dispersion 
-                    with a design of ~1, and finding a size factor vector by numerically optimizing the likelihood of the ~1 model.">
-                <option value="" selected="true">No Selection (use default)</option>
-                <option value="ratio">ratio</option>
-                <option value="poscounts">poscounts</option>
-                <option value="iterate">iterate</option>
-            </param>
+            <conditional name="esf_cond">
+                <param name="esf" type="select" label="Method for estimateSizeFactors"
+                    help="Method for estimation: either 'ratio', 'poscounts', or 'iterate'. 'ratio' uses the standard median ratio method introduced in DESeq.
+                        The size factor is the median ratio of the sample over a 'pseudosample': for each gene, the geometric mean of all samples.
+                        'poscounts' and 'iterate' offer alternative estimators, which can be used even when all genes contain a sample with a zero (a problem
+                        for the default method, as the geometric mean becomes zero, and the ratio undefined). The 'poscounts' estimator deals with a gene with
+                        some zeros, by calculating a modified geometric mean by taking the n-th root of the product of the non-zero counts. This evolved out of
+                        use cases with Paul McMurdie's phyloseq package for metagenomic samples. The 'iterate' estimator iterates between estimating the dispersion
+                        with a design of ~1, and finding a size factor vector by numerically optimizing the likelihood of the ~1 model.">
+                    <option value="" selected="true">No Selection (use default)</option>
+                    <option value="ratio">ratio</option>
+                    <option value="poscounts">poscounts</option>
+                    <option value="iterate">iterate</option>
+                    <option value="user">User-provided</option>
+                </param>
+                <when value=""/>
+                <when value="ratio"/>
+                <when value="poscounts"/>
+                <when value="iterate"/>
+                <when value="user">
+                    <param name="size_factor_input" type="data" format="tabular" label="File with custom size factors" help="The input must be a 2-column file: col1 should have the input file names. Col2 should contain your custom size factors."/>
+                </when>
+            </conditional>
             <param name="fit_type" type="select" label="Fit type">
                 <option value="1" selected="true">parametric</option>
                 <option value="2">local</option>
@@ -354,7 +368,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </assert_contents>
             </output>
         </test>
-         <!--Ensure counts files without header works -->
+        <!--Ensure counts files without header works -->
         <test expect_num_outputs="4">
             <repeat name="rep_factorName">
                 <param name="factorName" value="Treatment"/>
@@ -622,6 +636,40 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <assert_contents>
                     <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+" />
                     <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+" />
+                </assert_contents>
+            </output>
+        </test>
+        <!--Test alpha_ma option, but with user-provided size factors -->
+        <test expect_num_outputs="1">
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment"/>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf1.tab,sailfish_ensembl/sailfish_quant.sf2.tab,sailfish_ensembl/sailfish_quant.sf3.tab"/>
+                </repeat>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Untreated"/>
+                    <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf4.tab,sailfish_ensembl/sailfish_quant.sf5.tab,sailfish_ensembl/sailfish_quant.sf6.tab"/>
+                </repeat>
+            </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+                <conditional name="esf_cond">
+                    <param name="esf" value="user"/>
+                    <param name="size_factor_input" value="size_factors_out.tsv"/>
+                </conditional>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value=""/>
+                <param name="alpha_ma" value="0.05"/>
+            </section>
+            <param name="tximport_selector" value="tximport"/>
+            <param name="txtype" value="sailfish"/>
+            <param name="mapping_format_selector" value="gtf"/>
+            <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
+            <output name="deseq_out">
+                <assert_contents>
+                    <has_text_matching expression="ENSG00000168671\t1.90.*\t-0.05.*\t0.75.*\t-0.07.*\t0.94.*\t0.95.*"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -1,11 +1,11 @@
-<tool id="deseq2" name="DESeq2" version="@TOOL_VERSION@+galaxy@SUFFIX_VERSION@">
+<tool id="deseq2" name="DESeq2" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Determines differentially expressed features from count tables</description>
     <macros>
-        <import>deseq2_macros.xml</import>
+        <import>macros.xml</import>
     </macros>
-    <expand macro='requirements'/>
-    <expand macro='edam_ontology' />
+    <expand macro='edam_ontology'/>
     <expand macro='xrefs'/>
+    <expand macro='requirements'/>
     <stdio>
         <regex match="Execution halted"
            source="both"

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -10,15 +10,15 @@
         <regex match="Execution halted"
            source="both"
            level="fatal"
-           description="Execution halted." />
+           description="Execution halted."/>
         <regex match="Error in"
            source="both"
            level="fatal"
-           description="An undefined error occurred, please check your input carefully and contact your administrator." />
+           description="An undefined error occurred, please check your input carefully and contact your administrator."/>
         <regex match="Fatal error"
            source="both"
            level="fatal"
-           description="An undefined error occurred, please check your input carefully and contact your administrator." />
+           description="An undefined error occurred, please check your input carefully and contact your administrator."/>
     </stdio>
     <version_command><![CDATA[
 echo $(R --version | grep version | grep -v GNU)", DESeq2 version" $(R --vanilla --slave -e "library(DESeq2); cat(sessionInfo()\$otherPkgs\$DESeq2\$Version)" 2> /dev/null | grep -v -i "WARNING: ")
@@ -105,6 +105,9 @@ Rscript '${__tool_directory__}/deseq2.R'
     #if $advanced_options.auto_mean_filter_off:
         -c
     #end if
+    #if $advanced_options.use_beta_priors:
+        -d
+    #end if
     #if 'many_contrasts' in $output_options.output_selector
         -m
     #end if
@@ -139,7 +142,7 @@ Rscript '${__tool_directory__}/deseq2.R'
         </conditional>
 
         <param name="batch_factors" type="data" format="tabular" optional="true" label="(Optional) provide a tabular file with additional batch factors to include in the model." help="You can produce this file using RUVSeq or svaseq."/>
-        <param name="header" type="boolean" truevalue="-H" falsevalue="" checked="true" label="Files have header?" help="If this option is set to Yes, the tool will assume that the count files have column headers in the first row. Default: Yes" />
+        <param name="header" type="boolean" truevalue="-H" falsevalue="" checked="true" label="Files have header?" help="If this option is set to Yes, the tool will assume that the count files have column headers in the first row. Default: Yes"/>
 
         <conditional name="tximport">
             <param name="tximport_selector" type="select" label="Choice of Input data">
@@ -165,7 +168,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                     </when>
                 </conditional>
             </when>
-            <when value="count" />
+            <when value="count"/>
         </conditional>
         <section name="advanced_options" title="Advanced options">
             <param name="esf" type="select" label="Method for estimateSizeFactors" 
@@ -190,14 +193,14 @@ Rscript '${__tool_directory__}/deseq2.R'
                 label="Turn off outliers replacement (only affects with >6 replicates)"
                 help="When there are more than 6 replicates for a given sample, the DESeq2 will automatically replace
                     counts with large Cook’s distance with the trimmed mean over all samples, scaled up by the size factor
-                    or normalization factor for that sample" />
+                    or normalization factor for that sample"/>
             <param name="outlier_filter_off" type="boolean" truevalue="1" falsevalue="0" checked="false"
                 label="Turn off outliers filtering (only affects with >2 replicates)"
                 help="When there are more than 2 replicates for a given sample, the DESeq2 will automatically
-                    filter genes which contain a Cook’s distance above a cutoff" />
+                    filter genes which contain a Cook’s distance above a cutoff"/>
             <param name="auto_mean_filter_off" type="boolean" truevalue="1" falsevalue="0" checked="false"
                 label="Turn off independent filtering"
-                help=" DESeq2 performs independent filtering by default using the mean of normalized counts as a filter statistic" />
+                help=" DESeq2 performs independent filtering by default using the mean of normalized counts as a filter statistic"/>
             <conditional name="prefilter_conditional">
                 <param name="prefilter" type="select" label="Perform pre-filtering" help="While it is not necessary to pre-filter 
                     low count genes before running the DESeq2 functions, there are two reasons which make pre-filtering useful: 
@@ -207,28 +210,31 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <option value="" selected="true">Disabled</option>
                 </param>
                 <when value="-P">
-                    <param name="prefilter_value" type="integer" min="0" value="10" label="Pre-filter value" help="Keep only rows that have at least N reads total." />
+                    <param name="prefilter_value" type="integer" min="0" value="10" label="Pre-filter value" help="Keep only rows that have at least N reads total."/>
                 </when>
                 <when value=""/>
             </conditional>
+            <param name="use_beta_priors" type="boolean" truevalue="1" falsevalue="0" checked="true"
+                label="Use beta priors"
+                help="Whether or not to put a zero-mean normal prior on the non-intercept coefficients"/>
         </section>
         <section name="output_options" title="Output options">
             <param name="output_selector" type="select" multiple="True" optional="true" display="checkboxes" label="Output selector">
                 <option value="pdf" selected="True">Generate plots for visualizing the analysis results</option>
-                <option value="sizefactors" >Output sample size factors</option>
+                <option value="sizefactors">Output sample size factors</option>
                 <option value="normCounts">Output normalised counts</option>
                 <option value="normVST">Output VST normalized table</option>
                 <option value="normRLog">Output rLog normalized table</option>
                 <option value="many_contrasts">Output all levels vs all levels of primary factor (use when you have >2 levels for primary factor)</option>
             </param>
-            <param name="alpha_ma" type="float" min="0" max="0.5" value="0.1" label="Alpha value for MA-plot" help="Default value is 0.1. This option is only meaninful when plots are generated" />
+            <param name="alpha_ma" type="float" min="0" max="0.5" value="0.1" label="Alpha value for MA-plot" help="Default value is 0.1. This option is only meaninful when plots are generated"/>
         </section>
     </inputs>
     <outputs>
         <data name="deseq_out" format="tabular" label="DESeq2 result file on ${on_string}">
             <filter>'many_contrasts' not in output_options['output_selector']</filter>
             <actions>
-                <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),StdErr,Wald-Stats,P-value,P-adj" />
+                <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),StdErr,Wald-Stats,P-value,P-adj"/>
             </actions>
         </data>
         <collection name="split_output" type="list" label="DESeq2 result files on ${on_string}">
@@ -307,16 +313,45 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </repeat>
             </repeat>
             <param name="batch_factors" value="batch_factors.tab"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value="normCounts"/>
             </section>
             <output name="deseq_out">
                 <assert_contents>
-                    <has_text_matching expression="FBgn0003360\t1933.*\t-2.9.*\t0.1.*\t-26.*\t1.*-152\t4.*-149" />
+                    <has_text_matching expression="FBgn0003360\t1933.*\t-2.9.*\t0.1.*\t-26.*\t1.*-152\t4.*-149"/>
                 </assert_contents>
             </output>
         </test>
-        <!--Ensure counts files without header works -->
+        <!-- Same as above, but without beta priors -->
+        <test expect_num_outputs="2">
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment"/>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated"/>
+                    <param name="countsFile" value="GSM461179_treat_single.counts,GSM461180_treat_paired.counts,GSM461181_treat_paired.counts"/>
+                </repeat>
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Untreated"/>
+                    <param name="countsFile" value="GSM461176_untreat_single.counts,GSM461177_untreat_paired.counts,GSM461178_untreat_paired.counts,GSM461182_untreat_single.counts"/>
+                </repeat>
+            </repeat>
+            <param name="batch_factors" value="batch_factors.tab"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="0"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="deseq_out">
+                <assert_contents>
+                    <has_text_matching expression="FBgn0003360\t1933.*\t-3.*\t0.1.*\t-26.*\t6.*-151\t1.*-147"/>
+                </assert_contents>
+            </output>
+        </test>
+         <!--Ensure counts files without header works -->
         <test expect_num_outputs="4">
             <repeat name="rep_factorName">
                 <param name="factorName" value="Treatment"/>
@@ -732,5 +767,5 @@ be output as a tabular file.
 .. _DESeq2: http://master.bioconductor.org/packages/release/bioc/html/DESeq2.html
 .. _tximport: https://bioconductor.org/packages/devel/bioc/vignettes/tximport/inst/doc/tximport.html
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -214,7 +214,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </when>
                 <when value=""/>
             </conditional>
-            <param name="use_beta_priors" type="boolean" truevalue="1" falsevalue="0" checked="true"
+            <param name="use_beta_priors" type="boolean" truevalue="1" falsevalue="0" checked="false"
                 label="Use beta priors"
                 help="Whether or not to put a zero-mean normal prior on the non-intercept coefficients"/>
         </section>
@@ -271,6 +271,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="countsFile" value="GSM461176_untreat_single.counts,GSM461177_untreat_paired.counts,GSM461178_untreat_paired.counts,GSM461182_untreat_single.counts"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value="normCounts,normRLog,normVST"/>
             </section>
@@ -365,6 +368,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </repeat>
             </repeat>
             <param name="header" value="False"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value="normCounts,normRLog,normVST"/>
             </section>        
@@ -405,6 +411,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="countsFile" value="sailfish/sailfish_quant.sf4.tab,sailfish/sailfish_quant.sf5.tab,sailfish/sailfish_quant.sf6.tab"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value=""/>
             </section>            
@@ -431,6 +440,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="countsFile" value="sailfish/sailfish_quant.sf4.tab,sailfish/sailfish_quant.sf5.tab,sailfish/sailfish_quant.sf6.tab"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value=""/>
             </section>            
@@ -457,6 +469,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf4.tab,sailfish_ensembl/sailfish_quant.sf5.tab,sailfish_ensembl/sailfish_quant.sf6.tab"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value=""/>
             </section>            
@@ -494,6 +509,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="groups" value="primary:untreated"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value=""/>
             </section>            
@@ -531,6 +549,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="groups" value="primary:untreated"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value="many_contrasts"/>
             </section>            
@@ -559,6 +580,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <param name="countsFile" value="sailfish_ensembl/sailfish_quant.sf4.tab,sailfish_ensembl/sailfish_quant.sf5.tab,sailfish_ensembl/sailfish_quant.sf6.tab"/>
                 </repeat>
             </repeat>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
             <section name="output_options">
                 <param name="output_selector" value=""/>
                 <param name="alpha_ma" value="0.05"/>
@@ -569,7 +593,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="ENSG00000168671\t1.8841.*\t-0.1180.*\t0.7429.*\t-0.1589.*\t0.8737.*\t0.9999.*" />
+                    <has_text_matching expression="ENSG00000168671\t1.8841.*\t-0.1180.*\t0.7429.*\t-0.1589.*\t0.8737.*\t0.9999.*"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -636,7 +636,7 @@ Rscript '${__tool_directory__}/deseq2.R'
 
 **What it does**
 
-Estimate variance-mean dependence in count data from high-throughput sequencing assays and test for differential expression based on a model using the negative binomial distribution
+Uses DESeq2 version @DESEQ2_VERSION@ to estimate variance-mean dependence in count data from high-throughput sequencing assays and test for differential expression based on a model using the negative binomial distribution.
 
 -----
 

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -293,25 +293,25 @@ Rscript '${__tool_directory__}/deseq2.R'
             </section>
             <output name="counts_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts"/>
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0"/>
                 </assert_contents>
             </output>
             <output name="rlog_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts"/>
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0"/>
                 </assert_contents>
             </output>
             <output name="vst_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts" />
-                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts\tGSM461177_untreat_paired.counts\tGSM461178_untreat_paired.counts\tGSM461182_untreat_single.counts\tGSM461179_treat_single.counts\tGSM461180_treat_paired.counts\tGSM461181_treat_paired.counts"/>
+                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*"/>
                 </assert_contents>
             </output>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.8399.*\t0\.1309.*\t-21\.68.*\t.*e-104\t.*e-101" />
+                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.8399.*\t0\.1309.*\t-21\.68.*\t.*e-104\t.*e-101"/>
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
@@ -390,25 +390,25 @@ Rscript '${__tool_directory__}/deseq2.R'
             </section>        
             <output name="counts_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader"/>
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0"/>
                 </assert_contents>
             </output>
             <output name="rlog_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
-                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader"/>
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0"/>
                 </assert_contents>
             </output>
             <output name="vst_out">
                 <assert_contents>
-                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader" />
-                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*" />
+                    <has_text_matching expression="GSM461176_untreat_single.counts.noheader\tGSM461177_untreat_paired.counts.noheader\tGSM461178_untreat_paired.counts.noheader\tGSM461182_untreat_single.counts.noheader\tGSM461179_treat_single.counts.noheader\tGSM461180_treat_paired.counts.noheader\tGSM461181_treat_paired.counts.noheader"/>
+                    <has_text_matching expression="FBgn0000003\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*\t5.*"/>
                 </assert_contents>
             </output>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.8399.*\t0\.1309.*\t-21\.68.*\t.*e-104\t.*e-101" />
+                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.8399.*\t0\.1309.*\t-21\.68.*\t.*e-104\t.*e-101"/>
                 </assert_contents>
             </output>
         </test>
@@ -437,7 +437,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="tabular_file" value="tx2gene.tab"/>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="UGT3A2\t1.8841.*\t-0.1329.*\t0.6936.*\t-0.1917.*\t0.8479.*\t0.9999.*" />
+                    <has_text_matching expression="UGT3A2\t1.8841.*\t-0.1329.*\t0.6936.*\t-0.1917.*\t0.8479.*\t0.9999.*"/>
                 </assert_contents>
             </output>
         </test>
@@ -466,7 +466,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="gtf_file" value="GRCh38_latest_genomic.gff"/>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="UGT3A2\t1.8841.*\t-0.1329.*\t0.6936.*\t-0.1917.*\t0.8479.*\t0.9999.*" />
+                    <has_text_matching expression="UGT3A2\t1.8841.*\t-0.1329.*\t0.6936.*\t-0.1917.*\t0.8479.*\t0.9999.*"/>
                 </assert_contents>
             </output>
         </test>
@@ -495,7 +495,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
             <output name="deseq_out" >
                 <assert_contents>
-                    <has_text_matching expression="ENSG00000168671\t1.8841.*\t-0.1180.*\t0.7429.*\t-0.1589.*\t0.8737.*\t0.9999.*" />
+                    <has_text_matching expression="ENSG00000168671\t1.8841.*\t-0.1180.*\t0.7429.*\t-0.1589.*\t0.8737.*\t0.9999.*"/>
                 </assert_contents>
             </output>
         </test>
@@ -634,8 +634,8 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
             <output name="sizefactors_out">
                 <assert_contents>
-                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+" />
-                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+" />
+                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+"/>
+                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+"/>
                 </assert_contents>
             </output>
         </test>
@@ -687,7 +687,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </repeat>
             </repeat>
             <section name="advanced_options">
-                <param name="esf" value="poscounts" />
+                <param name="esf" value="poscounts"/>
             </section>
             <section name="output_options">
                 <param name="output_selector" value="sizefactors"/>
@@ -699,8 +699,8 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="gtf_file" value="Homo_sapiens.GRCh38.94.gtf" ftype="gtf"/>
             <output name="sizefactors_out" >
                 <assert_contents>
-                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+" />
-                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+" />
+                    <has_text_matching expression="sailfish_quant\.sf4\.tab\t0\.8\d+"/>
+                    <has_text_matching expression="sailfish_quant\.sf3\.tab\t1\.0\d+"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/deseq2/macros.xml
+++ b/tools/deseq2/macros.xml
@@ -20,20 +20,21 @@
     </xml>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="1.34.0">bioconductor-deseq2</requirement>
+            <requirement type="package" version="@DESEQ2_VERSION@">bioconductor-deseq2</requirement>
             <!-- Optional dependency of tximport, needed to import kallisto results https://github.com/galaxyproject/usegalaxy-playbook/issues/161 -->
-            <requirement type="package" version="2.38.0">bioconductor-rhdf5</requirement>
-            <requirement type="package" version="1.22.0">bioconductor-tximport</requirement>
-            <requirement type="package" version="1.46.1">bioconductor-genomicfeatures</requirement>
+            <requirement type="package" version="2.42.0">bioconductor-rhdf5</requirement>
+            <requirement type="package" version="1.26.0">bioconductor-tximport</requirement>
+            <requirement type="package" version="1.50.2">bioconductor-genomicfeatures</requirement>
             <requirement type="package" version="1.20.3">r-getopt</requirement>
-            <requirement type="package" version="0.9.1">r-ggrepel</requirement>
-            <requirement type="package" version="3.1.1">r-gplots</requirement>
+            <requirement type="package" version="0.9.3">r-ggrepel</requirement>
+            <requirement type="package" version="3.1.3">r-gplots</requirement>
             <requirement type="package" version="1.0.12">r-pheatmap</requirement>
-            <requirement type="package" version="0.2.20">r-rjson</requirement>
+            <requirement type="package" version="0.2.21">r-rjson</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">2.11.40.7</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.11.40.8</token>
+    <token name="@DESEQ2_VERSION@">1.38.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  

--- a/tools/deseq2/macros.xml
+++ b/tools/deseq2/macros.xml
@@ -33,7 +33,8 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">2.11.40.7</token>
-    <token name="@SUFFIX_VERSION@">2</token>
+    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_3308</edam_topic>

--- a/tools/deseq2/macros.xml
+++ b/tools/deseq2/macros.xml
@@ -22,9 +22,9 @@
         <requirements>
             <requirement type="package" version="@DESEQ2_VERSION@">bioconductor-deseq2</requirement>
             <!-- Optional dependency of tximport, needed to import kallisto results https://github.com/galaxyproject/usegalaxy-playbook/issues/161 -->
-            <requirement type="package" version="2.42.0">bioconductor-rhdf5</requirement>
-            <requirement type="package" version="1.26.0">bioconductor-tximport</requirement>
-            <requirement type="package" version="1.50.2">bioconductor-genomicfeatures</requirement>
+            <requirement type="package" version="2.44.0">bioconductor-rhdf5</requirement>
+            <requirement type="package" version="1.28.0">bioconductor-tximport</requirement>
+            <requirement type="package" version="1.52.1">bioconductor-genomicfeatures</requirement>
             <requirement type="package" version="1.20.3">r-getopt</requirement>
             <requirement type="package" version="0.9.3">r-ggrepel</requirement>
             <requirement type="package" version="3.1.3">r-gplots</requirement>
@@ -33,11 +33,11 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">2.11.40.8</token>
-    <token name="@DESEQ2_VERSION@">1.38.0</token>
+    <token name="@DESEQ2_VERSION@">1.40.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
-        <edam_topics>                                                                                  
+        <edam_topics>
             <edam_topic>topic_3308</edam_topic>
         </edam_topics>
         <edam_operations>

--- a/tools/deseq2/test-data/size_factors_out.tsv
+++ b/tools/deseq2/test-data/size_factors_out.tsv
@@ -1,0 +1,6 @@
+sailfish_quant.sf4.tab	0.84800690799672
+sailfish_quant.sf5.tab	1.10790786350701
+sailfish_quant.sf6.tab	1.21319523337605
+sailfish_quant.sf1.tab	1.19061589081921
+sailfish_quant.sf2.tab	0.712203801356132
+sailfish_quant.sf3.tab	1.03464248515867


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

I  wish there would be a way to fix the displayed version numbers to something that follows the version of deseq2 itself. Displaying "2.11.40.8" is misleading.