### PR TITLE
bakta: update tool_data_table_conf.xml.sample

### DIFF
--- a/tools/bakta/tool_data_table_conf.xml.sample
+++ b/tools/bakta/tool_data_table_conf.xml.sample
@@ -2,6 +2,6 @@
 <tables>
     <table name="bakta_database" comment_char="#">
         <columns>value, dbkey, bakta_version, path</columns>
-        <file path="tool-data/bakta_database.loc.sample" />
+        <file path="tool-data/bakta_database.loc" />
     </table>
 </tables>


### PR DESCRIPTION
Removed `.sample` in the line 5, otherwise Galaxy will claim it cannot find that file and fail to install Bakta

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
