### PR TITLE
Update get_organelle_from_reads.xml to handle paired collections correctly 

### DIFF
--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -249,14 +249,14 @@
                 </assert_contents>
             </output>
             <output_collection name="path_sequence_list" type="list" count="2">
-                <element name="a" ftype="fasta">
+                <element name="embplant_pt.K115.complete.graph1.1" ftype="fasta">
                     <assert_contents>
-                        <has_n_lines n="100"/>
+                        <has_n_lines n="2"/>
                     </assert_contents>
                 </element>
-                <element name="b" ftype="fasta">
+                <element name="embplant_pt.K115.complete.graph1.2" ftype="fasta">
                     <assert_contents>
-                        <has_n_lines n="100"/>
+                        <has_n_lines n="2"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -292,7 +292,7 @@
             </output>
         </test>
         <!-- Ensure paired collection works; also check output filters -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="config_dir" value="getorganelle_refdata"/>
             <conditional name="fastq_input">
                 <param name="fastq_input_selector" value="paired_collection"/>
@@ -304,7 +304,7 @@
                 </param>
             </conditional>
             <param name="F" value="embplant_pt" />
-            <param name="advanced" value="advanced" />
+	    <param name="advanced" value="simple" />
             <assert_stdout>
                 <has_text text="Thank you!" />
             </assert_stdout>

--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -278,6 +278,59 @@
                 </assert_contents>
             </output>
         </test>
+        <!-- Ensure paired collection works -->
+        <test expect_num_outputs="8">
+            <param name="config_dir" value="getorganelle_refdata"/>
+            <param name="fastq_input_selector" value="paired_collection"/>
+            <param name="paired_input">
+                <collection type="paired">
+                    <element name="forward" value="Arabidopsis_simulated.10k.1.fq.gz" ftype="fastqsanger.gz" />
+                    <element name="reverse" value="Arabidopsis_simulated.10k.2.fq.gz" ftype="fastqsanger.gz" />
+                </collection>
+            </param>
+            <param name="F" value="embplant_pt" />
+            <param name="advanced" value="advanced" />
+            <param name="out" value="raw_assembly_graph,simplified_graph,contig_labels,seed_fastq,seed_sam" />
+            <assert_stdout>
+                <has_text text="Thank you!" />
+            </assert_stdout>
+            <output name="logfile" >
+                <assert_contents>
+                    <has_text text="Thank you!" />
+                </assert_contents>
+            </output>
+            <output_collection name="path_sequence_list" type="list" count="2" />
+            <output name="selected_graph" >
+                <assert_contents>
+                    <has_n_lines n="7" />
+                </assert_contents>
+            </output>
+            <output name="raw_assembly_graph" >
+                <assert_contents>
+                    <has_text text=">EDGE" />
+                </assert_contents>
+            </output>
+            <output name="simplified_graph" >
+                <assert_contents>
+                    <has_text text=">EDGE" />
+                </assert_contents>
+            </output>
+            <output name="assembly_csv" >
+                <assert_contents>
+                    <has_text text="EDGE" />
+                </assert_contents>
+            </output>
+            <output name="seed_fastq" >
+                <assert_contents>
+                    <has_text text="@" />
+                </assert_contents>
+            </output>
+            <output name="seed_sam" >
+                <assert_contents>
+                    <has_text text="@HD" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
         GetOrganelle assembles organelle genomes from genome skimming data.

--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -1,4 +1,4 @@
-<tool id="get_organelle_from_reads" name="Get organelle from reads" version="@TOOL_VERSION@">
+<tool id="get_organelle_from_reads" name="Get organelle from reads" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <macros>
         <import>macros.xml</import>
         <xml name="seed_and_genes" tokens="optional">

--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -16,47 +16,47 @@
         ## Link input files
         #import re
         #set ext = '.fastq'
-        #if str($fastq_input.fastq_input_selector) == 'single':
+        #if $fastq_input.fastq_input_selector == 'single':
             #if $fastq_input.fastq_input1.ext.endswith('.gz'):
                 #set ext = '.fastq.gz'
             #end if
             #set $in1 = $fastq_input.fastq_input1
-            #set $in1_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input1.name)) + $ext
+            #set $in1_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input1.element_identifier)) + $ext
             ln -s '$in1' '$in1_name' &&
-        #else if str($fastq_input.fastq_input_selector) == 'paired':
+        #else if $fastq_input.fastq_input_selector == 'paired':
             #if $fastq_input.fastq_input1.ext.endswith('.gz'):
                 #set ext = '.fastq.gz'
             #end if
             #set $in1 = $fastq_input.fastq_input1
             #set $in2 = $fastq_input.fastq_input2
-            #set $in1_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input1.name)) + $ext
-            #set $in2_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input2.name)) + $ext
+            #set $in1_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input1.element_identifier)) + $ext
+            #set $in2_name = re.sub('[^\w\-\.]', '_', str($fastq_input.fastq_input2.element_identifier)) + $ext
             ln -s '$in1' '$in1_name' &&
             ln -s '$in2' '$in2_name' &&
-        #else if str($fastq_input.fastq_input_selector) == 'paired_collection':
+        #else if $fastq_input.fastq_input_selector == 'paired_collection':
             #if $fastq_input.paired_input.forward.ext.endswith('.gz'):
                 #set ext = '.fastq.gz'
             #end if
             #set $in1 = $fastq_input.paired_input.forward
             #set $in2 = $fastq_input.paired_input.reverse
-            #set $in1_name = re.sub('[^\w\-\.]', '_', str($fastq_input.paired_input.name)) + $ext
-            #set $in2_name = re.sub('[^\w\-\.]', '_', str("%s_%s" % ($fastq_input.paired_input.name, "R2"))) + $ext
+            #set $in1_name = "%s_R1%s" % (re.sub('[^\w\-\.]', '_', str($fastq_input.paired_input.element_identifier)),$ext)
+            #set $in2_name = "%s_R2%s" % (re.sub('[^\w\-\.]', '_', str($fastq_input.paired_input.element_identifier)),$ext)
             ln -s '$in1' '$in1_name' &&
             ln -s '$in2' '$in2_name' &&
         #end if
         ## GetOrganelle cmd
         get_organelle_from_reads.py
         #if str($fastq_input.fastq_input_selector) == "single":
-            -u '${$in1_name}'
+            -u '$in1_name'
         #end if
         #if str($fastq_input.fastq_input_selector) == "paired":
-            -1 '${$in1_name}' -2 '${$in2_name}'
+            -1 '$in1_name' -2 '$in2_name'
         #end if
         #if str($fastq_input.fastq_input_selector) == "paired_collection":
-            -1 '${$in1_name}' -2 '${$in2_name}'
+            -1 '$in1_name' -2 '$in2_name'
         #end if
         -o results_directory
-        #if str($organelle_type_input.F) == "anonym":
+        #if $organelle_type_input.F == "anonym":
             -F '$organelle_type_input.F'
             -s '$organelle_type_input.s'
             --genes '$organelle_type_input.genes'
@@ -232,9 +232,11 @@
     <tests>
         <test expect_num_outputs="8">
             <param name="config_dir" value="getorganelle_refdata"/>
-            <param name="fastq_input_selector" value="paired"/>
-            <param name="fastq_input1" value="Arabidopsis_simulated.10k.1.fq.gz" ftype="fastqsanger.gz"/>
-            <param name="fastq_input2" value="Arabidopsis_simulated.10k.2.fq.gz" ftype="fastqsanger.gz"/>
+            <conditional name="fastq_input">
+                <param name="fastq_input_selector" value="paired"/>
+                <param name="fastq_input1" value="Arabidopsis_simulated.10k.1.fq.gz" ftype="fastqsanger.gz"/>
+                <param name="fastq_input2" value="Arabidopsis_simulated.10k.2.fq.gz" ftype="fastqsanger.gz"/>
+            </conditional>
             <param name="F" value="embplant_pt" />
             <param name="advanced" value="advanced" />
             <param name="out" value="raw_assembly_graph,simplified_graph,contig_labels,seed_fastq,seed_sam" />
@@ -246,7 +248,18 @@
                     <has_text text="Thank you!" />
                 </assert_contents>
             </output>
-            <output_collection name="path_sequence_list" type="list" count="2" />
+            <output_collection name="path_sequence_list" type="list" count="2">
+                <element name="a" ftype="fasta">
+                    <assert_contents>
+                        <has_n_lines n="100"/>
+                    </assert_contents>
+                </element>
+                <element name="b" ftype="fasta">
+                    <assert_contents>
+                        <has_n_lines n="100"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
             <output name="selected_graph" >
                 <assert_contents>
                     <has_n_lines n="7" />
@@ -278,19 +291,20 @@
                 </assert_contents>
             </output>
         </test>
-        <!-- Ensure paired collection works -->
-        <test expect_num_outputs="8">
+        <!-- Ensure paired collection works; also check output filters -->
+        <test expect_num_outputs="2">
             <param name="config_dir" value="getorganelle_refdata"/>
-            <param name="fastq_input_selector" value="paired_collection"/>
-            <param name="paired_input">
-                <collection type="paired">
-                    <element name="forward" value="Arabidopsis_simulated.10k.1.fq.gz" ftype="fastqsanger.gz" />
-                    <element name="reverse" value="Arabidopsis_simulated.10k.2.fq.gz" ftype="fastqsanger.gz" />
-                </collection>
-            </param>
+            <conditional name="fastq_input">
+                <param name="fastq_input_selector" value="paired_collection"/>
+                <param name="paired_input">
+                    <collection type="paired">
+                        <element name="forward" value="Arabidopsis_simulated.10k.1.fq.gz" ftype="fastqsanger.gz" />
+                        <element name="reverse" value="Arabidopsis_simulated.10k.2.fq.gz" ftype="fastqsanger.gz" />
+                    </collection>
+                </param>
+            </conditional>
             <param name="F" value="embplant_pt" />
             <param name="advanced" value="advanced" />
-            <param name="out" value="raw_assembly_graph,simplified_graph,contig_labels,seed_fastq,seed_sam" />
             <assert_stdout>
                 <has_text text="Thank you!" />
             </assert_stdout>
@@ -300,36 +314,6 @@
                 </assert_contents>
             </output>
             <output_collection name="path_sequence_list" type="list" count="2" />
-            <output name="selected_graph" >
-                <assert_contents>
-                    <has_n_lines n="7" />
-                </assert_contents>
-            </output>
-            <output name="raw_assembly_graph" >
-                <assert_contents>
-                    <has_text text=">EDGE" />
-                </assert_contents>
-            </output>
-            <output name="simplified_graph" >
-                <assert_contents>
-                    <has_text text=">EDGE" />
-                </assert_contents>
-            </output>
-            <output name="assembly_csv" >
-                <assert_contents>
-                    <has_text text="EDGE" />
-                </assert_contents>
-            </output>
-            <output name="seed_fastq" >
-                <assert_contents>
-                    <has_text text="@" />
-                </assert_contents>
-            </output>
-            <output name="seed_sam" >
-                <assert_contents>
-                    <has_text text="@HD" />
-                </assert_contents>
-            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -313,7 +313,23 @@
                     <has_text text="Thank you!" />
                 </assert_contents>
             </output>
-            <output_collection name="path_sequence_list" type="list" count="2" />
+            <output_collection name="path_sequence_list" type="list" count="2">
+                <element name="embplant_pt.K115.complete.graph1.1" ftype="fasta">
+                    <assert_contents>
+                        <has_n_lines n="2"/>
+                    </assert_contents>
+                </element>
+                <element name="embplant_pt.K115.complete.graph1.2" ftype="fasta">
+                    <assert_contents>
+                        <has_n_lines n="2"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
+            <output name="selected_graph" >
+                <assert_contents>
+                    <has_n_lines n="7" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/getorganelle/get_organelle_from_reads.xml
+++ b/tools/getorganelle/get_organelle_from_reads.xml
@@ -53,7 +53,7 @@
             -1 '${$in1_name}' -2 '${$in2_name}'
         #end if
         #if str($fastq_input.fastq_input_selector) == "paired_collection":
-            -1 '${$in1_name1}' -2 '${$in2_name}'
+            -1 '${$in1_name}' -2 '${$in2_name}'
         #end if
         -o results_directory
         #if str($organelle_type_input.F) == "anonym":
@@ -130,7 +130,7 @@
                 <param type="data" name="fastq_input2" format="fastqsanger,fastqsanger.gz" label="Reverse fastq"/>
             </when>
             <when value="paired_collection">
-                <param type="data_collection" collection_type="paired" name="fastq_input1" format="fastqsanger,fastqsanger.gz" label="Paired collection fastq"/>
+                <param type="data_collection" collection_type="paired" name="paired_input" format="fastqsanger,fastqsanger.gz" label="Paired collection fastq"/>
             </when>
         </conditional>
         <conditional name="organelle_type_input">

--- a/tools/getorganelle/macros.xml
+++ b/tools/getorganelle/macros.xml
@@ -1,4 +1,5 @@
 <macros>
     <token name="@TOOL_VERSION@">1.7.7.0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@BIOPYTHON_VERSION@">1.79</token>
 </macros>


### PR DESCRIPTION
Hello, 

Today I found that get_organelle_from_reads.xml was not able to work with "paired_collections" as input. 

I was able to find a couple of potential issues: 
- spelling of "in1_name1" 
- the paired_collection paramter name "fastq_input1" did not match the name used in the command block "paired_input".  

I thought this might fix my issue but I still get the error below: 

```
NameMapper.NotFound: cannot find 'paired_input' while searching for 'fastq_input.paired_input.forward.ext'
```

@bernt-matthias can you see where i might have gone wrong here? 

Fix errors with paired collection parameters

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
