### PR TITLE
Updating tools/bedtools from version 2.30.0 to 2.31.1

### DIFF
--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -1,11 +1,11 @@
-<tool id="bedtools_bamtobed" name="bedtools BAM to BED" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="bedtools_bamtobed" name="bedtools BAM to BED" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>converter</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
+        <requirement type="package" version="1.17">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bamToBed.xml
+++ b/tools/bedtools/bamToBed.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="1.17">samtools</requirement>
+        <requirement type="package" version="1.18">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bedToBam.xml
+++ b/tools/bedtools/bedToBam.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_bedtobam" name="bedtools BED to BAM" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_bedtobam" name="bedtools BED to BAM" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>converter</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/bedpeToBam.xml
+++ b/tools/bedtools/bedpeToBam.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_bedpetobam" name="bedtools BEDPE to BAM" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_bedpetobam" name="bedtools BEDPE to BAM" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>converter</description>
     <macros>
         <import>macros.xml</import>
@@ -6,7 +6,7 @@
     <expand macro="bio_tools" />
     <!-- bedtobam broken in 2.29.0 <expand macro="requirements" /> -->
     <requirements>
-        <requirement type="package" version="2.27.1">bedtools</requirement>
+        <requirement type="package" version="2.31.0">bedtools</requirement>
     </requirements>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/bedpeToBam.xml
+++ b/tools/bedtools/bedpeToBam.xml
@@ -6,7 +6,7 @@
     <expand macro="bio_tools" />
     <!-- bedtobam broken in 2.29.0 <expand macro="requirements" /> -->
     <requirements>
-        <requirement type="package" version="2.31.0">bedtools</requirement>
+        <requirement type="package" version="2.31.1">bedtools</requirement>
     </requirements>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/complementBed.xml
+++ b/tools/bedtools/complementBed.xml
@@ -3,9 +3,9 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="bio_tools" />
-    <expand macro="requirements" />
-    <expand macro="stdio" />
+    <expand macro="bio_tools"/>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <command><![CDATA[
 complementBed
 -i '$input'
@@ -14,17 +14,17 @@ complementBed
     ]]></command>
     <inputs>
         <param name="input" argument="-i" type="data" format="@STD_BEDTOOLS_INPUTS@" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
-        <expand macro="input_conditional_genome_file" />
+        <expand macro="input_conditional_genome_file"/>
     </inputs>
     <outputs>
         <data name="output" format_source="input" metadata_source="input" label="Complement of ${input.name}"/>
     </outputs>
     <tests>
         <test>
-            <param name="input" value="a.bed" ftype="bed" />
-            <param name="genome_file_opts_selector" value="hist" />
-            <param name="genome" value="mm9_chr1.len" ftype="tabular" />
-            <output name="output" file="complementBed_result1.bed" ftype="bed" />
+            <param name="input" value="a.bed" ftype="bed"/>
+            <param name="genome_file_opts_selector" value="hist"/>
+            <param name="genome" value="mm9_chr1.len" ftype="tabular"/>
+            <output name="output" file="complementBed_result1.bed" ftype="bed"/>
         </test>
     </tests>
     <help><![CDATA[
@@ -36,5 +36,5 @@ bedtools complement returns all intervals in a genome that are not covered by at
 
 @REFERENCES@
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/bedtools/complementBed.xml
+++ b/tools/bedtools/complementBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_complementbed" name="bedtools ComplementBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_complementbed" name="bedtools ComplementBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Extract intervals not represented by an interval file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -3,11 +3,11 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="bio_tools" />
+    <expand macro="bio_tools"/>
     <expand macro="requirements">
         <requirement type="package" version="1.18">samtools</requirement>
     </expand>
-    <expand macro="stdio" />
+    <expand macro="stdio"/>
     <command><![CDATA[
 bedtools coverage
 $d
@@ -41,95 +41,83 @@ $a_or_b
 > '$output'
     ]]></command>
     <inputs>
-        <param name="inputA" argument="-a" type="data" format="bam,@STD_BEDTOOLS_INPUTS@" label="File A (on which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format" />
+        <param name="inputA" argument="-a" type="data" format="bam,@STD_BEDTOOLS_INPUTS@" label="File A (on which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
         <conditional name="reduce_or_iterate">
             <param name="reduce_or_iterate_selector" type="select" label="Combined or separate output files">
                 <option value="iterate" selected="true">One output file per 'input B' file</option>
                 <option value="reduce">Single output containing results for all 'input B' files</option>
             </param>
             <when value="iterate">
-                <param name="inputB" argument="-b" type="data" format="bam,@STD_BEDTOOLS_INPUTS@"
-                       label="File B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
+                <param name="inputB" argument="-b" type="data" format="bam,@STD_BEDTOOLS_INPUTS@" label="File B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
             </when>
             <when value="reduce">
-                <param name="inputB" argument="-b" type="data" format="bam,@STD_BEDTOOLS_INPUTS@" multiple="true"
-                       label="File(s) B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format"/>
+                <param name="inputB" argument="-b" type="data" format="bam,@STD_BEDTOOLS_INPUTS@" label="File(s) B (for which coverage is calculated)" help="BAM/@STD_BEDTOOLS_INPUT_LABEL@ format" multiple="true"/>
             </when>
         </conditional>
-        <expand macro="split" />
-        <param name="strandedness" argument="-s" type="boolean" label="Force strandedness" truevalue="-s" falsevalue="" checked="false"
-            help="Only report hits in B that overlap A on the same strand. By default, overlaps are reported without respect to strand"/>
-        <param argument="-d" type="boolean" truevalue="-d" falsevalue="" checked="false"
-            label="Report the depth at each position in each A feature"
-            help="Positions reported are one based. Each position and depth follow the complete B feature" />
-        <param argument="-hist" type="boolean" truevalue="-hist" falsevalue="" checked="false"
-            label="Report a histogram of coverage for each feature in A as well as a summary histogram for all features in A"
-            help="Additional columns after each feature in A: 1) depth 2) # bases at depth 3) size of A 4) % of A at depth" />
-        <param name="mean" argument="-mean" type="boolean" label="Mean depth" truevalue="-mean" falsevalue="" checked="false"
-            help="Report the mean depth of all positions in each A feature."/>
-        <expand macro="overlap" name="overlap_a" />
-        <expand macro="overlap" name="overlap_b" argument="-F" fracof="B" />
-        <param name="reciprocal_overlap" argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false"
-            label="Require that the fraction overlap be reciprocal for A AND B."
-            help="if -f is 0.90 and -r is used, this requires that B overlap 90% of A and A _also_ overlaps 90% of B" />
-        <param name="a_or_b" argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false"
-            label="Require that the minimum fraction be satisfied for A OR B."
-            help="If -e is used with -f 0.90 and -F 0.10 this requires that either 90% of A is covered OR 10% of  B is covered. Without -e, both fractions would have to be satisfied" />
+        <expand macro="split"/>
+        <param name="strandedness" argument="-s" type="boolean" truevalue="-s" falsevalue="" checked="false" label="Force strandedness" help="Only report hits in B that overlap A on the same strand. By default, overlaps are reported without respect to strand"/>
+        <param argument="-d" type="boolean" truevalue="-d" falsevalue="" checked="false" label="Report the depth at each position in each A feature" help="Positions reported are one based. Each position and depth follow the complete B feature"/>
+        <param argument="-hist" type="boolean" truevalue="-hist" falsevalue="" checked="false" label="Report a histogram of coverage for each feature in A as well as a summary histogram for all features in A" help="Additional columns after each feature in A: 1) depth 2) # bases at depth 3) size of A 4) % of A at depth"/>
+        <param argument="-mean" type="boolean" truevalue="-mean" falsevalue="" checked="false" label="Mean depth" help="Report the mean depth of all positions in each A feature."/>
+        <expand macro="overlap" name="overlap_a"/>
+        <expand macro="overlap" name="overlap_b" argument="-F" fracof="B"/>
+        <param name="reciprocal_overlap" argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false" label="Require that the fraction overlap be reciprocal for A AND B." help="if -f is 0.90 and -r is used, this requires that B overlap 90% of A and A _also_ overlaps 90% of B"/>
+        <param name="a_or_b" argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Require that the minimum fraction be satisfied for A OR B." help="If -e is used with -f 0.90 and -F 0.10 this requires that either 90% of A is covered OR 10% of  B is covered. Without -e, both fractions would have to be satisfied"/>
         <!-- -sorted -g  -->
-        <expand macro="sorted" />
+        <expand macro="sorted"/>
     </inputs>
     <outputs>
         <data name="output" format="bed" metadata_source="inputA" label="Count of overlaps on ${inputA.name}"/>
     </outputs>
     <tests>
         <test>
-            <param name="inputA" value="coverageBedA.bed" ftype="bed" />
-            <param name="inputB" value="coverageBedB.bed" ftype="bed" />
-            <output name="output" file="coverageBed_result1.bed" ftype="bed" />
+            <param name="inputA" value="coverageBedA.bed" ftype="bed"/>
+            <param name="inputB" value="coverageBedB.bed" ftype="bed"/>
+            <output name="output" file="coverageBed_result1.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="multiCov1.bed" ftype="bed" />
-            <param name="inputB" value="srma_in3.bam" ftype="bam" />
+            <param name="inputA" value="multiCov1.bed" ftype="bed"/>
+            <param name="inputB" value="srma_in3.bam" ftype="bam"/>
             <param name="sorted" value="true"/>
-            <output name="output" file="multicov1_by_srma_in3.cov.bed" ftype="bed" />
+            <output name="output" file="multicov1_by_srma_in3.cov.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="multiCov1.bed" ftype="bed" />
-            <param name="reduce_or_iterate_selector" value="reduce" />
-            <param name="inputB" value="srma_in3.bam" ftype="bam" />
+            <param name="inputA" value="multiCov1.bed" ftype="bed"/>
+            <param name="reduce_or_iterate_selector" value="reduce"/>
+            <param name="inputB" value="srma_in3.bam" ftype="bam"/>
             <param name="sorted" value="true"/>
-            <output name="output" file="multicov1_by_srma_in3.cov.bed" ftype="bed" />
+            <output name="output" file="multicov1_by_srma_in3.cov.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="coverageBedA.bed" ftype="bed" />
-            <param name="inputB" value="coverageBedB.bed" ftype="bed" />
-            <param name="overlap_b" value="1"  />
-            <output name="output" file="coverageBed_result2_F1.bed" ftype="bed" />
+            <param name="inputA" value="coverageBedA.bed" ftype="bed"/>
+            <param name="inputB" value="coverageBedB.bed" ftype="bed"/>
+            <param name="overlap_b" value="1"/>
+            <output name="output" file="coverageBed_result2_F1.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="coverageBedA.bed" ftype="bed" />
-            <param name="inputB" value="coverageBedB.bed" ftype="bed" />
-            <param name="overlap_a" value="1E-5"  />
-            <param name="reciprocal_overlap" value="true"  />
-            <output name="output" file="coverageBed_result3_f1r.bed" ftype="bed" />
+            <param name="inputA" value="coverageBedA.bed" ftype="bed"/>
+            <param name="inputB" value="coverageBedB.bed" ftype="bed"/>
+            <param name="overlap_a" value="1E-5"/>
+            <param name="reciprocal_overlap" value="true"/>
+            <output name="output" file="coverageBed_result3_f1r.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="multiCov1.bed" ftype="bed" />
-            <param name="reduce_or_iterate_selector" value="reduce" />
-            <param name="inputB" value="srma_in3.bam,coverageBed.bam" ftype="bam" />
+            <param name="inputA" value="multiCov1.bed" ftype="bed"/>
+            <param name="reduce_or_iterate_selector" value="reduce"/>
+            <param name="inputB" value="srma_in3.bam,coverageBed.bam" ftype="bam"/>
             <param name="sorted" value="true"/>
-            <output name="output" file="coverageBed_result4_2bam.bed" ftype="bed" />
+            <output name="output" file="coverageBed_result4_2bam.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="coverageBedA2.bed" ftype="bed" />
-            <param name="inputB" value="coverageBed.bam" ftype="bam" />
-            <output name="output" file="coverageBed_result5_unsorted.bed" ftype="bed" />
+            <param name="inputA" value="coverageBedA2.bed" ftype="bed"/>
+            <param name="inputB" value="coverageBed.bam" ftype="bam"/>
+            <output name="output" file="coverageBed_result5_unsorted.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="coverageBedA2.bed" ftype="bed" />
-            <param name="inputB" value="coverageBed.bam" ftype="bam" />
+            <param name="inputA" value="coverageBedA2.bed" ftype="bed"/>
+            <param name="inputB" value="coverageBed.bam" ftype="bam"/>
             <param name="mean" value="true"/>
-            <output name="output" file="mean_coverage.bed" ftype="bed" />
+            <output name="output" file="mean_coverage.bed" ftype="bed"/>
         </test>
     </tests>
     <help><![CDATA[
@@ -155,5 +143,5 @@ The lines in the output will be comprised of each interval in A, followed by:
 
 @REFERENCES@
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -1,11 +1,11 @@
-<tool id="bedtools_coveragebed" name="bedtools Compute both the depth and breadth of coverage" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_coveragebed" name="bedtools Compute both the depth and breadth of coverage" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>of features in file B on the features in file A (bedtools coverage)</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
+        <requirement type="package" version="1.17">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/coverageBed.xml
+++ b/tools/bedtools/coverageBed.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="1.17">samtools</requirement>
+        <requirement type="package" version="1.18">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/fisherBed.xml
+++ b/tools/bedtools/fisherBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_fisher" name="bedtools FisherBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_fisher" name="bedtools FisherBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>calculate Fisher statistic between two feature files</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/flankBed.xml
+++ b/tools/bedtools/flankBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_flankbed" name="bedtools FlankBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_flankbed" name="bedtools FlankBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>create new intervals from the flanks of existing intervals</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/getfastaBed.xml
+++ b/tools/bedtools/getfastaBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_getfastabed" name="bedtools getfasta" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_getfastabed" name="bedtools getfasta" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>use intervals to extract sequences from a FASTA file</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -1,11 +1,11 @@
-<tool id="bedtools_intersectbed" name="bedtools Intersect intervals" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_intersectbed" name="bedtools Intersect intervals" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>find overlapping intervals in various ways</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="@SAMTOOLS_VERSION@">samtools</requirement>
+        <requirement type="package" version="1.17">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/intersectBed.xml
+++ b/tools/bedtools/intersectBed.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="bio_tools" />
     <expand macro="requirements">
-        <requirement type="package" version="1.17">samtools</requirement>
+        <requirement type="package" version="1.18">samtools</requirement>
     </expand>
     <expand macro="stdio" />
     <command><![CDATA[

--- a/tools/bedtools/jaccardBed.xml
+++ b/tools/bedtools/jaccardBed.xml
@@ -3,9 +3,9 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="bio_tools" />
-    <expand macro="requirements" />
-    <expand macro="stdio" />
+    <expand macro="bio_tools"/>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <command><![CDATA[
 bedtools jaccard
 $strand
@@ -22,29 +22,33 @@ $reciprocal
     <inputs>
         <param name="inputA" argument="-a" type="data" format="@STD_BEDTOOLS_INPUTS@" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
         <param name="inputB" argument="-b" type="data" format="@STD_BEDTOOLS_INPUTS@" label="@STD_BEDTOOLS_INPUT_LABEL@ file"/>
-        <expand macro="overlap" />
+        <expand macro="overlap"/>
         <expand macro="overlap" name="overlapB" argument="-F" fracof="B"/>
-        <expand macro="reciprocal" />
-        <param name="strand" argument="-s" type="boolean" truevalue="-s" falsevalue="" checked="false"
-            label="Force strandedness"
-            help="That is, only report hits in B that overlap A on the same strand. By default, overlaps are reported without respect to strand." />
-        <expand macro="strand2" />
-        <expand macro="split" />
+        <expand macro="reciprocal"/>
+        <param name="strand" argument="-s" type="boolean" truevalue="-s" falsevalue="" checked="false" label="Force strandedness" help="That is, only report hits in B that overlap A on the same strand. By default, overlaps are reported without respect to strand."/>
+        <expand macro="split"/>
     </inputs>
     <outputs>
-        <data name="output" format_source="inputA" metadata_source="inputA" label="Intersection of ${inputA.name} and ${inputB.name}" />
+        <data name="output" format_source="inputA" metadata_source="inputA" label="Intersection of ${inputA.name} and ${inputB.name}"/>
     </outputs>
     <tests>
         <test>
-            <param name="inputA" value="jaccardBed1.bed" ftype="bed" />
-            <param name="inputB" value="jaccardBed2.bed" ftype="bed" />
-            <output name="output" file="jaccardBed_result1.bed" ftype="bed" />
+            <param name="inputA" value="jaccardBed1.bed" ftype="bed"/>
+            <param name="inputB" value="jaccardBed2.bed" ftype="bed"/>
+            <output name="output" file="jaccardBed_result1.bed" ftype="bed"/>
         </test>
         <test>
-            <param name="inputA" value="jaccardBed1.bed" ftype="bed" />
-            <param name="inputB" value="jaccardBed2.bed" ftype="bed" />
-            <param name="overlap" value="0.1" />
-            <output name="output" file="jaccardBed_result2.bed" ftype="bed" />
+            <param name="inputA" value="jaccardBed1.bed" ftype="bed"/>
+            <param name="inputB" value="jaccardBed2.bed" ftype="bed"/>
+            <param name="overlap" value="0.1"/>
+            <output name="output" file="jaccardBed_result2.bed" ftype="bed"/>
+        </test>
+        <test>
+            <param name="inputA" value="jaccardBed1.bed" ftype="bed"/>
+            <param name="inputB" value="jaccardBed2.bed" ftype="bed"/>
+            <param name="overlap" value="0.1"/>
+            <param name="strand" value="true"/>
+            <output name="output" file="jaccardBed_strand_result2.bed" ftype="bed"/>
         </test>
     </tests>
     <help><![CDATA[
@@ -61,5 +65,5 @@ The jaccard tool requires that your data is pre-sorted by chromosome and then by
 
 @REFERENCES@
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -10,7 +10,7 @@
             <xref type="bio.tools">bedtools</xref>
         </xrefs>
     </xml>
-    <token name="@TOOL_VERSION@">2.31.0</token>
+    <token name="@TOOL_VERSION@">2.31.1</token>
     <token name="@SAMTOOLS_VERSION@">1.9</token>
     <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf,encodepeak</token>
     <token name="@STD_BEDTOOLS_INPUT_LABEL@">BED/bedGraph/GFF/VCF/EncodePeak</token>

--- a/tools/bedtools/macros.xml
+++ b/tools/bedtools/macros.xml
@@ -10,7 +10,7 @@
             <xref type="bio.tools">bedtools</xref>
         </xrefs>
     </xml>
-    <token name="@TOOL_VERSION@">2.30.0</token>
+    <token name="@TOOL_VERSION@">2.31.0</token>
     <token name="@SAMTOOLS_VERSION@">1.9</token>
     <token name="@STD_BEDTOOLS_INPUTS@">bed,bedgraph,gff,vcf,encodepeak</token>
     <token name="@STD_BEDTOOLS_INPUT_LABEL@">BED/bedGraph/GFF/VCF/EncodePeak</token>

--- a/tools/bedtools/randomBed.xml
+++ b/tools/bedtools/randomBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_randombed" name="bedtools RandomBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_randombed" name="bedtools RandomBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>generate random intervals in a genome</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/shuffleBed.xml
+++ b/tools/bedtools/shuffleBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_shufflebed" name="bedtools ShuffleBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_shufflebed" name="bedtools ShuffleBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>randomly redistrubute intervals in a genome</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/slopBed.xml
+++ b/tools/bedtools/slopBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_slopbed" name="bedtools SlopBed" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="bedtools_slopbed" name="bedtools SlopBed" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>adjust the size of intervals</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/sortBed.xml
+++ b/tools/bedtools/sortBed.xml
@@ -1,4 +1,4 @@
-<tool id="bedtools_sortbed" name="bedtools SortBED" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="bedtools_sortbed" name="bedtools SortBED" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>order the intervals</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/bedtools/test-data/jaccardBed_strand_result2.bed
+++ b/tools/bedtools/test-data/jaccardBed_strand_result2.bed
@@ -1,0 +1,2 @@
+intersection	union	jaccard	n_intersections
+0	0	-nan	0


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bedtools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bedtools from version 2.30.0 to 2.31.0.

**Project home page:** https://github.com/arq5x/bedtools2/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).