### PR TITLE
Updating tools/spyboat from version 0.1.2 to 0.1.1

### DIFF
--- a/tools/spyboat/spyboat.xml
+++ b/tools/spyboat/spyboat.xml
@@ -1,8 +1,8 @@
 <tool id="spyboat" name="SpyBOAT" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01" license="MIT">
 <description>wavelet analyzes image stacks</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.1.2</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">0.1.1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">spyboat</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/spyboat**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/spyboat from version 0.1.2 to 0.1.1.

**Project home page:** http://github.com/tensionhead/spyboat/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).