### PR TITLE
Updating tools/orthofinder from version 2.5.4 to 2.5.5

### DIFF
--- a/tools/orthofinder/macros.xml
+++ b/tools/orthofinder/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.5.4</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.5.5</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">
         <citations>

--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -8,7 +8,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">orthofinder</requirement>
-        <requirement type="package" version="2.36">util-linux</requirement>
+        <requirement type="package" version="2.38.1">util-linux</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         #import re


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/orthofinder**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/orthofinder from version 2.5.4 to 2.5.5.

**Project home page:** https://github.com/davidemms/OrthoFinder/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).