### PR TITLE
Updating tools/sra-tools from version 3.0.3 to 3.0.5

### DIFF
--- a/tools/sra-tools/macros.xml
+++ b/tools/sra-tools/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.0.3</token>
+    <token name="@TOOL_VERSION@">3.0.5</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
@@ -16,7 +16,7 @@
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">sra-tools</requirement>
             <requirement type="package" version="2.6">pigz</requirement>
-            <requirement type="package" version="1.16.1">samtools</requirement>
+            <requirement type="package" version="1.17">samtools</requirement>
             <yield/>
         </requirements>
     </macro>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/sra-tools**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/sra-tools from version 3.0.3 to 3.0.5.

**Project home page:** https://github.com/ncbi/sra-tools/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).