### PR TITLE
Updating tools/ucsc_blat from version 377 to 469

### DIFF
--- a/tools/ucsc_blat/blat.xml
+++ b/tools/ucsc_blat/blat.xml
@@ -1,8 +1,8 @@
 <tool id="ucsc_blat" name="UCSC BLAT Alignment Tool" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>BLAST-like sequence alignment tool</description>
     <macros>
-        <token name="@TOOL_VERSION@">377</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">469</token>
+        <token name="@VERSION_SUFFIX@">0</token>
 
         <xml name="mask_cond" tokens="maskarg,label,help">
             <conditional name="@MASKARG@_type">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ucsc_blat**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ucsc_blat from version 377 to 445.

**Project home page:** http://genome.ucsc.edu/goldenPath/help/blatSpec.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).