### PR TITLE
Fix erroneous --empirical-freqs flag

### DIFF
--- a/tools/pear/pear.xml
+++ b/tools/pear/pear.xml
@@ -2,7 +2,7 @@
     <description>Paired-End read merger</description>
     <macros>
         <token name="@TOOL_VERSION@">0.9.6</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">3</token>
         <xml name="format_action">
             <actions>
                 <conditional name="library.type">
@@ -65,11 +65,11 @@
         --quality-theshold $quality_threshold
         --max-uncalled-base $max_uncalled_base
         --test-method $test_method
-        $empirical_freqs
         -j "\${GALAXY_SLOTS:-8}"
         --score-method $score_method
         --cap $cap
         $nbase
+        $empirical_freqs
 ]]>
     </command>
     <inputs>
@@ -121,9 +121,9 @@
             <option value="2">Use the acceptance probability (2)</option>
         </param>
 
-        <param name="empirical_freqs" type="boolean" truevalue="-e" falsevalue="" checked="false"
+        <param argument="empirical_freqs" type="boolean" truevalue="-e" falsevalue="" checked="false"
             label="Disable empirical base frequencies" help="(--empirical-freqs)" />
-        <param name="nbase" type="boolean" truevalue="--nbase" falsevalue="" checked="false"
+        <param argument="nbase" type="boolean" truevalue="--nbase" falsevalue="" checked="false"
             label="Use N base if uncertain" help="When  merging a base-pair that consists of two non-equal bases out of which none is degenerate, set the merged base to N and use the highest quality score of the two bases. (--nbase)" />
 
         <param name="score_method" type="select" label="Scoring method" help="(--score-method)">

--- a/tools/pear/pear.xml
+++ b/tools/pear/pear.xml
@@ -65,7 +65,7 @@
         --quality-theshold $quality_threshold
         --max-uncalled-base $max_uncalled_base
         --test-method $test_method
-        --empirical-freqs $empirical_freqs
+        $empirical_freqs
         -j "\${GALAXY_SLOTS:-8}"
         --score-method $score_method
         --cap $cap


### PR DESCRIPTION
Changes '--empirical-freqs $empirical_freqs' to use only the $empirical_freqs param. 

For two test Pear jobs, one with the default settings and another one with 'Disable empirical base frequencies' set to use, the Tool Standard Output files from both jobs have: Using empirical frequencies........: NO

This seemingly results from the '--empirical-freqs' flag always being present in the tool command.
By modifying to use only the user-selected '-e' flag this issue should be resolved.

FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)