### PR TITLE
Updating tools/rgcca from version 3.0.2 to 3.0.3

### DIFF
--- a/tools/rgcca/macro.xml
+++ b/tools/rgcca/macro.xml
@@ -1,8 +1,8 @@
 <macros>
 
-    <token name="@TOOL_VERSION@">3.0.2</token>
+    <token name="@TOOL_VERSION@">3.0.3</token>
 
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <token name="@BLOCK_RULES@">1 corresponds to the first block, 2 corresponds to the second one, etc. This number should not be greater than the number of blocks selected.</token>
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rgcca**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rgcca from version 3.0.2 to 3.0.3.

**Project home page:** https://github.com/rgcca-factory/RGCCA/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).