### PR TITLE
Updating tools/ucsc_tools/twobittofa from version 377 to 472

### DIFF
--- a/tools/ucsc_tools/twobittofa/twobittofa.xml
+++ b/tools/ucsc_tools/twobittofa/twobittofa.xml
@@ -1,7 +1,7 @@
 <tool id="ucsc-twobittofa" name="twoBitToFa" version="@TOOL_VERSION@" profile="22.05">
     <description>Convert all or part of .2bit file to FASTA</description>
     <macros>
-        <token name="@TOOL_VERSION@">469</token>
+        <token name="@TOOL_VERSION@">472</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">UCSC_Genome_Browser_Utilities</xref>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ucsc_tools/twobittofa**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ucsc_tools/twobittofa from version 377 to 447.

**Project home page:** https://genome.ucsc.edu/goldenpath/help/twoBit.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).