### PR TITLE
Bug fix for deepmicro

### DIFF
--- a/tools/deepmicro/deepmicro.xml
+++ b/tools/deepmicro/deepmicro.xml
@@ -30,7 +30,10 @@
 
             #for $params in $mode.parameter_set:
 
-                #if $params.rl_type.rl_type_choice == "--pca" or $params.rl_type.rl_type_choice == "--rp":
+                ## only train classifier without encoding
+                #if $params.rl_type.rl_type_choice == "no_rl":
+                    DM.py -r 1 -cd features.csv -cl labels.csv --save_rep -m '$params.rl_type.classifier' -t \${GALAXY_SLOTS:-8} &&
+                #elif $params.rl_type.rl_type_choice == "--pca" or $params.rl_type.rl_type_choice == "--rp":
                     DM.py -r 1 -cd features.csv -cl labels.csv '$params.rl_type.rl_type_choice' --save_rep -m '$params.rl_type.classifier' -t \${GALAXY_SLOTS:-8} &&
                 #else: 
                     DM.py -r 1 -cd features.csv -cl labels.csv '$params.rl_type.rl_type_choice' -dm '$params.rl_type.dm' --save_rep -m '$params.rl_type.classifier'  -t \${GALAXY_SLOTS:-8} &&

--- a/tools/deepmicro/deepmicro.xml
+++ b/tools/deepmicro/deepmicro.xml
@@ -218,6 +218,20 @@
 
         </test>
 
+        <test expect_num_outputs="1">
+            <param name="features" value="UserDataExample.csv" />
+            <param name="mode_type" value="e_and_c" />
+            <param name="class_labels" value="UserLabelExample.csv" />
+            <param name="rl_type_choice" value="no_rl" />
+            <param name="classifier" value="rf" /> 
+            <output ftype="tabular" name="results" >
+                <assert_contents>
+                    <has_text text="rf" />
+                </assert_contents>
+            </output>
+
+        </test>
+
         <!-- test multiple parameter sets -->
         <test expect_num_outputs="1">
             <param name="features" value="UserDataExample.csv" />

--- a/tools/deepmicro/macros.xml
+++ b/tools/deepmicro/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.05</token>
     <xml name="biotools">
         <xrefs>


### PR DESCRIPTION
fix `cannot find 'dm' while searching for 'params.rl_type.dm'` bug for train on input option

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
