### PR TITLE
Updating tools/pbmm2 from version 1.10.0 to 1.13.1

### DIFF
--- a/tools/pbmm2/macros.xml
+++ b/tools/pbmm2/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.13.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">20.09</token>
+    <token name="@PROFILE@">22.05</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">pbmm2</requirement>

--- a/tools/pbmm2/pbmm2.xml
+++ b/tools/pbmm2/pbmm2.xml
@@ -42,23 +42,22 @@
             <when value="cached">
                 <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
                     <options from_data_table="all_fasta">
-                        <filter type="sort_by" column="2" />
-                        <validator type="no_options" message="No reference genomes are available" />
+                        <filter type="sort_by" column="2"/>
+                        <validator type="no_options" message="No reference genomes are available"/>
                     </options>
                     <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
                 </param>
             </when>
             <when value="history">
-                <param name="ref_file" type="data" format="fasta" label="Use the following dataset as the reference sequence" help="You can upload a FASTA sequence to the history and use it as reference" />
+                <param name="ref_file" type="data" format="fasta" label="Use the following dataset as the reference sequence" help="You can upload a FASTA sequence to the history and use it as reference"/>
             </when>
         </conditional>
         <param type="data" name="reads" format="fastq,fastq.gz,fasta,fasta.gz,bam" label="reads" help="PacBio reads in BAM or [gzipped] fasta or fastq format"/>
-        <param argument="--preset" type="select"
-                label="Set alignment mode">
-                <option value="CCS">PacBio CCS or HiFi reads</option>
-                <option value="SUBREAD">PacBio CLR or raw subreads</option>
-                <option value="ISOSEQ">PacBio IsoSeq transcripts</option>
-                <option value="UNROLLED">Align entire raw ZMW</option>
+        <param argument="--preset" type="select" label="Set alignment mode">
+            <option value="CCS">PacBio CCS or HiFi reads</option>
+            <option value="SUBREAD">PacBio CLR or raw subreads</option>
+            <option value="ISOSEQ">PacBio IsoSeq transcripts</option>
+            <option value="UNROLLED">Align entire raw ZMW</option>
         </param>
         <section name="output_options" title="Output Options" help="Sets -l, -N, --strip,  --split-by-sample,  --unmapped, --short-sa-cigar" expanded="False">
             <param argument="-l" type="integer" min="0" label="Minimum mapped read length in basepairs" value="50" optional="true"/>
@@ -71,40 +70,40 @@
     <tests>
         <!-- test1: basic test -->
         <test expect_num_outputs="1">
-            <param name="reference_source_selector" value="history" />
+            <param name="reference_source_selector" value="history"/>
             <param name="ref_file" ftype="fasta" value="bnd-ref.fasta"/>
             <param name="reads" value="bnd.bam"/>
             <output name="bam">
                 <assert_contents>
-                    <has_size value="2778" delta="200" />
+                    <has_size value="2778" delta="200"/>
                 </assert_contents>
             </output>
         </test>
         <!-- test2: map some reads for use with pbgcpp -->
         <test expect_num_outputs="1">
-            <param name="reference_source_selector" value="history" />
+            <param name="reference_source_selector" value="history"/>
             <param name="ref_file" ftype="fasta" value="All4mer.V2.01_Insert.fa"/>
             <param name="reads" value="out.aligned_subreads.bam"/>
             <param name="preset" value="SUBREAD"/>
             <output name="bam">
                 <assert_contents>
-                    <has_size value="538329" delta="50000" />
+                    <has_size value="538329" delta="50000"/>
                 </assert_contents>
             </output>
         </test>
         <!-- test3: cached genome -->
         <test>
-            <param name="reference_source_selector" value="cached" />
+            <param name="reference_source_selector" value="cached"/>
             <param name="ref_file" value="bnd-ref"/>
             <param name="reads" value="bnd.bam"/>
             <output name="bam">
                 <assert_contents>
-                    <has_size value="2778" delta="200" />
+                    <has_size value="2778" delta="200"/>
                 </assert_contents>
             </output>
         </test>
     </tests>
-        <help><![CDATA[
+    <help><![CDATA[
 **What it does**
 
 A minimap2 wrapper for PacBio data: native PacBio data in ⇨ native
@@ -127,8 +126,8 @@ but you can’t use the output for pbgcpp (GenomicConsensus).
 pbgcpp (previously known as GenomicConsensus).
 
         ]]></help>
-        <citations>
-            <citation type="bibtex">
+    <citations>
+        <citation type="bibtex">
 @misc{githubpbmm2,
   author = {PacBio},
   year = {2023},


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/pbmm2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/pbmm2 from version 1.10.0 to 1.12.0.

**Project home page:** https://github.com/PacificBiosciences/pbmm2/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).