### PR TITLE
Updating tools/episcanpy from version 0.3.2 to 0.4.0

### DIFF
--- a/tools/episcanpy/macros.xml
+++ b/tools/episcanpy/macros.xml
@@ -1,14 +1,14 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.3.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">0.4.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">episcanpy</requirement>
             <requirement type="package" version="1.0.8">bzip2</requirement>
             <requirement type="package" version="1.11">tabix</requirement>
-            <requirement type="package" version="0.7.5">anndata</requirement>
-            <requirement type="package" version="0.8.3">leidenalg</requirement>
+            <requirement type="package" version="0.9.1">anndata</requirement>
+            <requirement type="package" version="0.9.1">leidenalg</requirement>
             <requirement type="package" version="0.8.0">louvain</requirement>
             <yield />
         </requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/episcanpy**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/episcanpy from version 0.3.2 to 0.4.0.

**Project home page:** https://github.com/colomemaria/epiScanpy/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).