### PR TITLE
Samtool coverage: fix region parameter

### DIFF
--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -17,7 +17,7 @@
         samtools coverage
 
             #if $condition_input.input_pooling == "Yes":
-                ${ ' '.join( [ "'%s'" %  $i for $i in range($condition_input.input_bams)]) }
+                ${ ' '.join( [ "'%s'" %  $i for $i, $x in enumerate($condition_input.input_bams)]) }
             #else
                 infile
             #end if

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -32,12 +32,13 @@
             @FLAGS@
             --ff $flags
 
+            #if $region != "":
+                -r '$region'
+            #end if
+
             #if $condition_histogram.histogram_select == "yes"
                 -m
                 -w $condition_histogram.n_bins
-                #if $condition_histogram.region != "":
-                    -r '$condition_histogram.region'
-                #end if
             #end if
 
             -o '$output'
@@ -68,6 +69,7 @@
             <param name="skipped_flags" argument="--ff" type="select" multiple="True" label="Exclude reads with any of the following flags set">
                 <expand macro="flag_options" s4="true" s256="true" s512="true" s1024="true"/>
             </param>
+            <param name="region" argument="-r" type="text" value="" label="Show specified region" help="Show specified region. Format: chr:start-end." />
         </section>
 
         <conditional name="condition_histogram">
@@ -77,7 +79,6 @@
             </param>
             <when value="yes">
                 <param name="n_bins" argument="-w" type="integer" min="1" value="100" label="Number of bins in histogram" help="Number of bins in histogram" />
-                <param name="region" argument="-r" type="text" value="" label="Show specified region" help="Show specified region. Format: chr:start-end." />
             </when>
             <when value="no" />
         </conditional>
@@ -104,6 +105,11 @@
             <param name="histogram_select" value="yes" />
             <param name="n_bins" value="100" />
             <output name="output" file="results_3.txt" ftype="tabular" />
+        </test>
+        <test><!-- test with a region -->
+            <param name="input" value="test_1.bam" ftype="bam" />
+            <param name="region" value="ref1" />
+            <output name="output" file="results_4.tabular" ftype="tabular" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -8,16 +8,18 @@
     <expand macro="version_command"/>
     <command><![CDATA[
         #if $condition_input.input_pooling == "No":
+            #set $input = $condition_input.input
             @PREPARE_IDX@
         #else:
+            #set $input_bams = $condition_input.input_bams
             @PREPARE_IDX_MULTIPLE@
         #end if
         samtools coverage
 
             #if $condition_input.input_pooling == "Yes":
-                ${ ' '.join( [ "'%s'" %  $x for $x in $condition_input.input_bams] ) }
+                ${ ' '.join( [ "'%s'" %  $i for $i, $x in enumerate($condition_input.input_bams)]) }
             #else
-                '$condition_input.input'
+                infile
             #end if
 
             -l $additional_options.min_read_length
@@ -106,10 +108,16 @@
             <param name="n_bins" value="100" />
             <output name="output" file="results_3.txt" ftype="tabular" />
         </test>
-        <test><!-- test with a region -->
+        <test><!-- test with a region (requires index) -->
             <param name="input" value="test_1.bam" ftype="bam" />
             <param name="region" value="ref1" />
             <output name="output" file="results_4.tabular" ftype="tabular" />
+        </test>
+        <test><!-- test with pooled BAMs and a region -->
+            <param name="input_pooling" value="Yes" />
+            <param name="input_bams" value="test_1.bam,test_2.bam" ftype="bam" />
+            <param name="region" value="ref2" />
+            <output name="output" file="results_5.tabular" ftype="tabular" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -32,8 +32,8 @@
             @FLAGS@
             --ff $flags
 
-            #if $region != "":
-                -r '$region'
+            #if $additional_options.region != "":
+                -r '$additional_options.region'
             #end if
 
             #if $condition_histogram.histogram_select == "yes"

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -17,7 +17,7 @@
         samtools coverage
 
             #if $condition_input.input_pooling == "Yes":
-                ${ ' '.join( [ "'%s'" %  $i for $i, $x in enumerate($condition_input.input_bams)]) }
+                ${ ' '.join( [ "'%s'" %  $i for $i in range($condition_input.input_bams)]) }
             #else
                 infile
             #end if

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_coverage" name="Samtools coverage" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="samtools_coverage" name="Samtools coverage" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>computes the depth at each position or region</description>
     <macros>
         <import>macros.xml</import>

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -76,6 +76,7 @@
                     <valid initial="string.ascii_letters,string.digits">
                         <add value=":" />
                         <add value="-" />
+                        <add value="_" />
                     </valid>
                 </sanitizer>
             </param>

--- a/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
+++ b/tool_collections/samtools/samtools_coverage/samtools_coverage.xml
@@ -71,7 +71,14 @@
             <param name="skipped_flags" argument="--ff" type="select" multiple="True" label="Exclude reads with any of the following flags set">
                 <expand macro="flag_options" s4="true" s256="true" s512="true" s1024="true"/>
             </param>
-            <param name="region" argument="-r" type="text" value="" label="Show specified region" help="Show specified region. Format: chr:start-end." />
+            <param name="region" argument="-r" type="text" value="" label="Show specified region" help="Show specified region. Format: chr:start-end." >
+                <sanitizer invalid_char="">
+                    <valid initial="string.ascii_letters,string.digits">
+                        <add value=":" />
+                        <add value="-" />
+                    </valid>
+                </sanitizer>
+            </param>
         </section>
 
         <conditional name="condition_histogram">

--- a/tool_collections/samtools/samtools_coverage/test-data/results_4.tabular
+++ b/tool_collections/samtools/samtools_coverage/test-data/results_4.tabular
@@ -1,0 +1,2 @@
+#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq
+ref1	1	45	6	31	68.8889	1.24444	255	30

--- a/tool_collections/samtools/samtools_coverage/test-data/results_5.tabular
+++ b/tool_collections/samtools/samtools_coverage/test-data/results_5.tabular
@@ -1,0 +1,2 @@
+#rname	startpos	endpos	numreads	covbases	coverage	meandepth	meanbaseq	meanmapq
+ref2	1	40	12	36	90	6.75	63.3	30


### PR DESCRIPTION
In the samtools coverage tool, fixed 2 issues with the region parameter:
- region parameter is not specific to histogram output option so moved it out of that conditional and into the general additional options section
- region parameter was not working because the macros preparing the index do not work out of the box if the input files are inside a conditional

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
