### PR TITLE
bump dada2 data manager

### DIFF
--- a/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
+++ b/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
@@ -143,7 +143,7 @@ Public Reference databases maintained by the DADA2 project
 The following refrence databases which are describes as maintained by the DADA2 project (https://benjjneb.github.io/dada2/training.html) are available
 
 - Silva (https://www.arb-silva.de/)
-- RDP (http://rdp.cme.msu.edu/)
+- RDP
 - GreenGenes (http://greengenes.secondgenome.com/)
 - UNITE general FASTA (https://unite.ut.ee/repository.php)
 

--- a/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
+++ b/data_managers/data_manager_dada2/data_manager/dada2_fetcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="dada2_fetcher" name="dada2 data manager" tool_type="manage_data" version="0.0.8">
+<tool id="dada2_fetcher" name="dada2 data manager" tool_type="manage_data" version="0.1.0">
     <requirements>
         <requirement type="package" version="3.7">python</requirement>
     </requirements>


### PR DESCRIPTION
Just realized that I messed up the versioning of this datamanager in the past https://github.com/galaxyproject/tools-iuc/pull/3000

xref: https://github.com/galaxyproject/galaxy/issues/16276

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
