### PR TITLE
Updating tools/seurat from version 4.3.0 to 4.3.0.1

### DIFF
--- a/tools/seurat/seurat.xml
+++ b/tools/seurat/seurat.xml
@@ -1,11 +1,11 @@
 <tool id="seurat" name="Seurat" version="@TOOL_VERSION@+galaxy0">
     <description>- toolkit for exploration of single-cell RNA-seq data</description>
     <macros>
-        <token name="@TOOL_VERSION@">4.3.0</token>
+        <token name="@TOOL_VERSION@">4.3.0.1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">r-seurat</requirement>
-        <requirement type="package" version="2.18">r-rmarkdown</requirement>
+        <requirement type="package" version="2.22">r-rmarkdown</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 #if "vln" in $meta.plots:


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/seurat**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/seurat from version 4.3.0 to 4.3.0.1.

**Project home page:** https://github.com/satijalab/seurat/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).