### PR TITLE
Updating tools/ucsc_tools/fatovcf from version 426 to 448

### DIFF
--- a/tools/ucsc_tools/fatovcf/fatovcf.xml
+++ b/tools/ucsc_tools/fatovcf/fatovcf.xml
@@ -3,7 +3,7 @@
         Convert a FASTA alignment file to Variant Call Format (VCF) single-nucleotide diffs
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">426</token>
+        <token name="@TOOL_VERSION@">448</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">UCSC_Genome_Browser_Utilities</xref>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/ucsc_tools/fatovcf**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/ucsc_tools/fatovcf from version 426 to 448.

**Project home page:** http://hgdownload.cse.ucsc.edu/admin/exe

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).