### PR TITLE
Remove VCF as viable format

### DIFF
--- a/tools/geneiobio/geneiobio-iframe.xml
+++ b/tools/geneiobio/geneiobio-iframe.xml
@@ -1,4 +1,4 @@
-<tool id="gene_iobio_display_generation_iframe" name="gene.iobio visualisation" version="4.7.1"+galaxy1>
+<tool id="gene_iobio_display_generation_iframe" name="gene.iobio visualisation" version="4.7.1+galaxy1">
 	<description>analyses VCFs for single and trio analysis to find causative variants using gene.iobio's public server</description>
 	<command>cat '$index' | tr -d '\n' > '$outfile'</command>
 	<configfiles>

--- a/tools/geneiobio/geneiobio-iframe.xml
+++ b/tools/geneiobio/geneiobio-iframe.xml
@@ -56,7 +56,7 @@
             ]]></configfile>
 	</configfiles>
     <inputs>
-        <param name="proband_vcf" type="data" format="vcf,vcf_bgzip" label="Proband VCF file"/>
+        <param name="proband_vcf" type="data" format="vcf_bgzip" label="Proband VCF file"/>
         <param name="proband_bam" type="data" format="bam,cram" label="Proband BAM file" optional="true"/>
         <param name="proband_sex" type="select" display="radio" label="Proband sex">
             <option value="male" selected="true">Male</option>
@@ -71,13 +71,13 @@
             </param>
             <when value="trio">
                 <section name="father" title="Father input">
-                    <param name="vcf" type="data" format="vcf,vcf_bgzip" label="Father VCF file"/>
+                    <param name="vcf" type="data" format="vcf_bgzip" label="Father VCF file"/>
                     <param name="bam" type="data" format="bam,cram" label="Father BAM file" optional="true"/>
                     <param name="affected" type="boolean" truevalue="affected" falsevalue="unaffected" checked="false" label="Is the father affected?"/>
                     <param name="name" type="text" value="F" label="Father sample name" help="The sample names are listed in the columns of the VCF."/>
                 </section>
                 <section name="mother" title="Mother input">
-                    <param name="vcf" type="data" format="vcf,vcf_bgzip" label="Mother VCF file"/>
+                    <param name="vcf" type="data" format="vcf_bgzip" label="Mother VCF file"/>
                     <param name="bam" type="data" format="bam,cram" label="Mother BAM file" optional="true"/>
                     <param name="affected" type="boolean" truevalue="affected" falsevalue="unaffected" checked="false" label="Is the mother affected?"/>
                     <param name="name" type="text" value="M" label="Mother sample name" help="The sample names are listed in the columns of the VCF."/>

--- a/tools/geneiobio/geneiobio-iframe.xml
+++ b/tools/geneiobio/geneiobio-iframe.xml
@@ -1,4 +1,4 @@
-<tool id="gene_iobio_display_generation_iframe" name="gene.iobio visualisation" version="4.7.1">
+<tool id="gene_iobio_display_generation_iframe" name="gene.iobio visualisation" version="4.7.1"+galaxy1>
 	<description>analyses VCFs for single and trio analysis to find causative variants using gene.iobio's public server</description>
 	<command>cat '$index' | tr -d '\n' > '$outfile'</command>
 	<configfiles>


### PR DESCRIPTION
Gene.iobio does not accept `vcf` as it has to find the `tbi` file which is only generated from the `vcf_bgzip` format.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
