### PR TITLE
Fix dram error propagation

### DIFF
--- a/tools/dram/dram_annotate.xml
+++ b/tools/dram/dram_annotate.xml
@@ -1,4 +1,4 @@
-<tool id="dram_annotate" name="DRAM annotate" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="dram_annotate" name="DRAM annotate" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>metagenome-assembled-genomes (MAGs)</description>
     <macros>
         <import>macros.xml</import>
@@ -41,14 +41,14 @@ $use_vogdb
 $low_mem_mode
 $skip_trnascan
 --threads \${GALAXY_SLOTS:-10}
-&& test -f 'output_dir/genes.faa' && mv 'output_dir/genes.faa' '$output_genes_faa' || echo 'No genes.faa output produced'
-&& test -f 'output_dir/genes.fna' && mv 'output_dir/genes.fna' '$output_genes_fna' || echo 'No genes.fna output produced'
-&& test -f 'output_dir/genes.gff' && mv 'output_dir/genes.gff' '$output_genes_gff' || echo 'No genes.gff output produced'
-&& test -f 'output_dir/scaffolds.fna' && mv 'output_dir/scaffolds.fna' '$output_scaffolds_fna' || echo 'No scaffolds.fna output produced'
-&& test -f 'output_dir/rrnas.tsv' && mv 'output_dir/rrnas.tsv' '$output_rrnas' || echo 'No rrnas.tsv output produced'
-&& test -f 'output_dir/trnas.tsv' && mv 'output_dir/trnas.tsv' '$output_trnas' || echo 'No trnas.tsv output produced'
-&& test -f 'output_dir/genbank/$output_gbk_file_name' && mv 'output_dir/genbank/$output_gbk_file_name' '$output_genbank' || echo 'No genbank output produced'
-&& test -f 'output_dir/annotations.tsv' && mv 'output_dir/annotations.tsv' '$output_annotations' || echo 'No annotations.tsv output produced'
+&& (test -f 'output_dir/genes.faa' && mv 'output_dir/genes.faa' '$output_genes_faa' || echo 'No genes.faa output produced')
+&& (test -f 'output_dir/genes.fna' && mv 'output_dir/genes.fna' '$output_genes_fna' || echo 'No genes.fna output produced')
+&& (test -f 'output_dir/genes.gff' && mv 'output_dir/genes.gff' '$output_genes_gff' || echo 'No genes.gff output produced')
+&& (test -f 'output_dir/scaffolds.fna' && mv 'output_dir/scaffolds.fna' '$output_scaffolds_fna' || echo 'No scaffolds.fna output produced')
+&& (test -f 'output_dir/rrnas.tsv' && mv 'output_dir/rrnas.tsv' '$output_rrnas' || echo 'No rrnas.tsv output produced')
+&& (test -f 'output_dir/trnas.tsv' && mv 'output_dir/trnas.tsv' '$output_trnas' || echo 'No trnas.tsv output produced')
+&& (test -f 'output_dir/genbank/$output_gbk_file_name' && mv 'output_dir/genbank/$output_gbk_file_name' '$output_genbank' || echo 'No genbank output produced')
+&& (test -f 'output_dir/annotations.tsv' && mv 'output_dir/annotations.tsv' '$output_annotations' || echo 'No annotations.tsv output produced')
     ]]></command>
     <inputs>
         <param argument="--input_fasta" type="data" format="fasta,fasta.gz" label="FASTA file"/>

--- a/tools/dram/dram_distill.xml
+++ b/tools/dram/dram_distill.xml
@@ -1,4 +1,4 @@
-<tool id="dram_distill" name="DRAM distill" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="dram_distill" name="DRAM distill" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>metagenome-assembled-genomes (MAGs)</description>
     <macros>
         <import>macros.xml</import>
@@ -21,10 +21,10 @@ DRAM.py distill
 #end if
 $distillate_gene_names
 --genomes_per_product $genomes_per_product
-&& test -f 'output_dir/genome_stats.tsv' && mv 'output_dir/genome_stats.tsv' '$output_genome_stats' || echo 'No genome_stats.tsv output produced'
-&& test -f 'output_dir/metabolism_summary.xlsx' && mv 'output_dir/metabolism_summary.xlsx' '$output_metabolism_summary' || echo 'No metabolism_summary.xlsx output produced'
-&& test -f 'output_dir/product.html' && mv 'output_dir/product.html' '$output_product_html' || echo 'No product.html output produced'
-&& test -f 'output_dir/product.tsv' && mv 'output_dir/product.tsv' '$output_product_tsv' || echo 'No product.tsv output produced'
+&& (test -f 'output_dir/genome_stats.tsv' && mv 'output_dir/genome_stats.tsv' '$output_genome_stats' || echo 'No genome_stats.tsv output produced')
+&& (test -f 'output_dir/metabolism_summary.xlsx' && mv 'output_dir/metabolism_summary.xlsx' '$output_metabolism_summary' || echo 'No metabolism_summary.xlsx output produced')
+&& (test -f 'output_dir/product.html' && mv 'output_dir/product.html' '$output_product_html' || echo 'No product.html output produced')
+&& (test -f 'output_dir/product.tsv' && mv 'output_dir/product.tsv' '$output_product_tsv' || echo 'No product.tsv output produced')
     ]]></command>
     <inputs>
         <expand macro="input_file_param"/>

--- a/tools/dram/dram_merge_annotations.xml
+++ b/tools/dram/dram_merge_annotations.xml
@@ -1,4 +1,4 @@
-<tool id="dram_merge_annotations" name="DRAM merge multiple annotations" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="dram_merge_annotations" name="DRAM merge multiple annotations" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>into a single set</description>
     <macros>
         <import>macros.xml</import>
@@ -38,17 +38,17 @@
 DRAM.py merge_annotations
 --input_dirs 'input_dir*'
 --output_dir 'output_dir'
-&& test -f 'output_dir/genes.faa' && mv 'output_dir/genes.faa' '$output_genes_faa' || echo 'No genes.faa output produced'
-&& test -f 'output_dir/genes.fna' && mv 'output_dir/genes.fna' '$output_genes_fna' || echo 'No genes.fna output produced'
-&& test -f 'output_dir/genes.gff' && mv 'output_dir/genes.gff' '$output_genes_gff' || echo 'No genes.gff output produced'
-&& test -f 'output_dir/scaffolds.fna' && mv 'output_dir/scaffolds.fna' '$output_scaffolds_fna' || echo 'No scaffolds.fna output produced'
+&& (test -f 'output_dir/genes.faa' && mv 'output_dir/genes.faa' '$output_genes_faa' || echo 'No genes.faa output produced')
+&& (test -f 'output_dir/genes.fna' && mv 'output_dir/genes.fna' '$output_genes_fna' || echo 'No genes.fna output produced')
+&& (test -f 'output_dir/genes.gff' && mv 'output_dir/genes.gff' '$output_genes_gff' || echo 'No genes.gff output produced')
+&& (test -f 'output_dir/scaffolds.fna' && mv 'output_dir/scaffolds.fna' '$output_scaffolds_fna' || echo 'No scaffolds.fna output produced')
 #if $rrnas_collection:
-    && test -f 'output_dir/rrnas.tsv' && mv 'output_dir/rrnas.tsv' '$output_rrnas' || echo 'No rrnas.tsv output produced'
+    && (test -f 'output_dir/rrnas.tsv' && mv 'output_dir/rrnas.tsv' '$output_rrnas' || echo 'No rrnas.tsv output produced')
 #end if
 #if $trnas_collection:
-    && test -f 'output_dir/trnas.tsv' && mv 'output_dir/trnas.tsv' '$output_trnas' || echo 'No trnas.tsv output produced'
+    && (test -f 'output_dir/trnas.tsv' && mv 'output_dir/trnas.tsv' '$output_trnas' || echo 'No trnas.tsv output produced')
 #end if
-&& test -f 'output_dir/annotations.tsv' && mv 'output_dir/annotations.tsv' '$output_annotations' || echo 'No annotations.tsv output produced'
+&& (test -f 'output_dir/annotations.tsv' && mv 'output_dir/annotations.tsv' '$output_annotations' || echo 'No annotations.tsv output produced')
     ]]></command>
     <inputs>
         <param name="annotations_collection" type="data_collection" format="tabular" collection_type="list" label="Collection of annotation files"/>

--- a/tools/dram/dram_neighborhoods.xml
+++ b/tools/dram/dram_neighborhoods.xml
@@ -1,4 +1,4 @@
-<tool id="dram_neighborhoods" name="DRAM find neighborhoods" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="dram_neighborhoods" name="DRAM find neighborhoods" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>around genes of interest</description>
     <macros>
         <import>macros.xml</import>
@@ -33,12 +33,12 @@ DRAM.py neighborhoods
 #if $advanced.distance_bp > 0:
     --distance_bp $advanced.distance_bp
 #end if
-&& test -f 'output_dir/neighborhood_annotations.tsv' && mv 'output_dir/neighborhood_annotations.tsv' '$output_neighborhood_annotations' || echo 'No neighborhood_annotations.tsv output produced'
+&& (test -f 'output_dir/neighborhood_annotations.tsv' && mv 'output_dir/neighborhood_annotations.tsv' '$output_neighborhood_annotations' || echo 'No neighborhood_annotations.tsv output produced')
 #if $advanced.genes_loc:
-    && test -f 'output_dir/neighborhood_genes.dat' && mv 'output_dir/neighborhood_genes.dat' '$output_neighborhood_genes' || echo 'No neighborhood_genes.dat output produced'
+    && (test -f 'output_dir/neighborhood_genes.dat' && mv 'output_dir/neighborhood_genes.dat' '$output_neighborhood_genes' || echo 'No neighborhood_genes.dat output produced')
 #end if
 #if $advanced.scaffolds_loc:
-    && test -f 'output_dir/neighborhood_scaffolds.fna' && mv 'output_dir/neighborhood_scaffolds.fna' '$output_neighborhood_scaffolds' || echo 'No neighborhood_scaffolds.fna output produced'
+    && (test -f 'output_dir/neighborhood_scaffolds.fna' && mv 'output_dir/neighborhood_scaffolds.fna' '$output_neighborhood_scaffolds' || echo 'No neighborhood_scaffolds.fna output produced')
 #end if
     ]]></command>
     <inputs>

--- a/tools/dram/dram_strainer.xml
+++ b/tools/dram/dram_strainer.xml
@@ -1,4 +1,4 @@
-<tool id="dram_strainer" name="DRAM strain annotations" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="dram_strainer" name="DRAM strain annotations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>down to genes of interest</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/dram/macros.xml
+++ b/tools/dram/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.3.5</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <!-- token name="@VERSION_SUFFIX@">0</token -->
     <token name="@PROFILE@">20.09</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Errors with the original tool execution should not get swallowed by output checks.
