### PR TITLE
Updating tools/annotatemyids from version 3.16.0 to 3.17.0

### DIFF
--- a/tools/annotatemyids/.shed.yml
+++ b/tools/annotatemyids/.shed.yml
@@ -6,6 +6,7 @@ long_description: |
   Supported organisms are human, mouse, fruit fly and zebrafish and supported IDs include Ensembl,
   Entrez ID, RefSeq, Gene Symbol, GO and KEGG.
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/annotatemyids
+homepage_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/annotatemyids
 type: unrestricted
 categories:
   - Genome annotation

--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -1,12 +1,12 @@
 <tool id="annotatemyids" name="annotateMyIDs" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>annotate a generic set of identifiers</description>
-    <xrefs>
-        <xref type="bio.tools">annotatemyids</xref>
-    </xrefs>
     <macros>
         <token name="@TOOL_VERSION@">3.17.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">annotatemyids</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-org.hs.eg.db</requirement>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-org.mm.eg.db</requirement>

--- a/tools/annotatemyids/annotateMyIDs.xml
+++ b/tools/annotatemyids/annotateMyIDs.xml
@@ -4,8 +4,8 @@
         <xref type="bio.tools">annotatemyids</xref>
     </xrefs>
     <macros>
-        <token name="@TOOL_VERSION@">3.16.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">3.17.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-org.hs.eg.db</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/annotatemyids**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/annotatemyids from version 3.16.0 to 3.17.0.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).