### PR TITLE
Updating tools/macs2 from version 2.2.7.1 to 2.2.9.1

### DIFF
--- a/tools/macs2/macs2_bdgbroadcall.xml
+++ b/tools/macs2/macs2_bdgbroadcall.xml
@@ -5,7 +5,7 @@
         <import>macs2_macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="4.1.3">gawk</requirement>
+        <requirement type="package" version="5.1.0">gawk</requirement>
     </expand>
     <expand macro="stdio" />
     <expand macro="version_command" />

--- a/tools/macs2/macs2_bdgdiff.xml
+++ b/tools/macs2/macs2_bdgdiff.xml
@@ -5,7 +5,7 @@
         <import>macs2_macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="4.1.3">gawk</requirement>
+        <requirement type="package" version="5.1.0">gawk</requirement>
     </expand>
     <expand macro="stdio" />
     <expand macro="version_command" />

--- a/tools/macs2/macs2_macros.xml
+++ b/tools/macs2/macs2_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.2.7.1</token>
+    <token name="@TOOL_VERSION@">2.2.9.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/macs2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/macs2 from version 2.2.7.1 to 2.2.9.1.

**Project home page:** https://github.com/taoliu/MACS/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).