### PR TITLE
RNA star: Added custom junction type

### DIFF
--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -5,7 +5,7 @@
     the index versions in sync, but you should manually update @IDX_VERSION_SUFFIX@ -->
     <!-- STAR version to be used -->
     <token name="@TOOL_VERSION@">2.7.10b</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@VERSION_SUFFIX@">4</token>
     <token name="@PROFILE@">21.01</token>
     <!-- STAR index version compatible with this version of STAR
     This is the STAR version that introduced the index structure expected
@@ -60,6 +60,7 @@
     </xml>
     <xml name="SJDBOPTIONS">
          <param argument="--sjdbGTFfile" type="data" format="gff3,gtf" label="Gene model (gff3,gtf) file for splice junctions" optional="false" help="Exon junction information for mapping splices"/>
+         <param argument="--sjdbGTFfeatureExon" type="text" value="exon" label="Elements to use from the gene model to use for splice junctions" help="By default and for almost all cases: 'exon', referring to finding junctions at the RNA splice sites. This can optionally be changed to allow splicing at other levels, such as 'gene', 'transcript', 'CDS'."/>
          <param argument="--sjdbOverhang" type="integer" min="1" value="100" label="Length of the genomic sequence around annotated junctions" help="Used in constructing the splice junctions database. Ideal value is ReadLength-1"/>
     </xml>
     <xml name="dbKeyActions">
@@ -108,7 +109,7 @@
                     #end if
                 #end if
             #else:
-                ## ref genome selection is less complex for STARsolo cause
+                ## ref genome selection is less complex for STARsolo because
                 ## with-gtf is mandatory there
                 --sjdbOverhang '${refGenomeSource.sjdbOverhang}'
                 --sjdbGTFfile '${refGenomeSource.sjdbGTFfile}'
@@ -122,6 +123,12 @@
             --runThreadN \${GALAXY_SLOTS:-4}
             ## in bytes
             --limitGenomeGenerateRAM \$((\${GALAXY_MEMORY_MB:-31000} * 1000000))
+
+            #if $varExists('refGenomeSource.GTFconditional.sjdbGTFfeatureExon'):
+                #if str($refGenomeSource.GTFconditional.sjdbGTFfeatureExon) != "exon":
+                    --sjdbGTFfeatureExon '${refGenomeSource.GTFconditional.sjdbGTFfeatureExon}'
+                #end if
+            #end if
         &&
     #end if
     ]]></token>
@@ -140,6 +147,12 @@
             #if str($refGenomeSource.GTFconditional.sjdbGTFfile.ext) == 'gff3':
                 --sjdbGTFtagExonParentTranscript Parent
             #end if
+        #end if
+    #end if
+
+    #if $varExists('refGenomeSource.GTFconditional.sjdbGTFfeatureExon'):
+        #if str($refGenomeSource.GTFconditional.sjdbGTFfeatureExon) != "exon":
+            --sjdbGTFfeatureExon '${refGenomeSource.GTFconditional.sjdbGTFfeatureExon}'
         #end if
     #end if
     ]]></token>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -628,6 +628,39 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
                 <metadata name="column_names" value="GeneID,Counts_unstrand,Counts_firstStrand,Counts_secondStrand" />
             </output>
         </test>
+        <!-- test splices sites at other features other than exons -->
+        <test expect_num_outputs="4">
+            <conditional name="singlePaired">
+                <param name="sPaired" value="single" />
+                <param name="input1" value="tophat_in2.fastqsanger" ftype="fastqsanger" />
+            </conditional>
+            <conditional name="refGenomeSource">
+                <param name="geneSource" value="history" />
+                <param name="genomeFastaFiles" value="tophat_test.fa" />
+                <param name="genomeSAindexNbases" value="5" />
+                <conditional name="GTFconditional">
+                    <param name="GTFselect" value="with-gtf" />
+                    <param name="sjdbOverhang" value="75"/>
+                    <param name="sjdbGTFfile" value="test1.gtf" ftype="gtf"/>
+                    <param name="sjdbGTFfeatureExon" value="transcript"/>
+                    <conditional name="quantmode_output">
+                        <param name="quantMode" value="GeneCounts"/>
+                    </conditional>
+                </conditional>
+            </conditional>
+            <section name="algo">
+                <conditional name="params">
+                    <param name="settingsType" value="default" />
+                </conditional>
+            </section>
+
+            <output name="output_log" file="rnastar_test.log" compare="re_match_multiline" />
+            <output name="splice_junctions" file="rnastar_test_splicejunctions.bed"/>
+            <output name="mapped_reads" file="rnastar_test_mapped_reads.bam" compare="sim_size" delta="634" />
+            <output name="reads_per_gene" file="tophat_test_reads_per_gene.txt">
+                <metadata name="column_names" value="GeneID,Counts_unstrand,Counts_firstStrand,Counts_secondStrand" />
+            </output>
+        </test>
         <!-- test gtf file and TranscriptomeSAM mode -->
         <test expect_num_outputs="4">
             <conditional name="singlePaired">


### PR DESCRIPTION
In the current setting, STAR RNA errors out if a gtf file is provided without any exons. Some organisms, such as SC2, can have unusual transcription that can split reads across different functional units. I added a button to make provision of the name of the genetic elements to use as junctions possible.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
