### PR TITLE
bwa-mem2: expose the `-K` parameter for batch size

### DIFF
--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -64,7 +64,6 @@ bwa-mem2 mem
     #if str( $analysis_type.io_options.io_options_selector ) == "set":
         -T '${analysis_type.io_options.T}'
         -h '${analysis_type.io_options.h}'
-        -K '${analysis_type.io_options.K}'
         ${analysis_type.io_options.a}
         ${analysis_type.io_options.C}
         ${analysis_type.io_options.V}
@@ -72,6 +71,9 @@ bwa-mem2 mem
         ${analysis_type.io_options.M}
         ${analysis_type.io_options.five}
         ${analysis_type.io_options.q}
+        #if str( $analysis_type.io_options.batch_size_options.batch_size_selector ) == "set_batch_size":
+            -K '${analysis_type.io_options.batch_size_options.K}'
+        #end if
     #end if
 
 #end if
@@ -253,7 +255,18 @@ bwa-mem2 mem
                         <param name="V" type="boolean" truevalue="-V" falsevalue="" label="Output the reference FASTA header in the XR tag" help="-C"/>
                         <param name="Y" type="boolean" truevalue="-Y" falsevalue="" label="Use soft clipping for supplementary alignments" help="-Y; By default, BWA-MEM uses soft clipping for the primary alignment and hard clipping for supplementary alignments" />
                         <param name="M" type="boolean" truevalue="-M" falsevalue="" label="Mark shorter split hits of a chimeric alignment in the FLAG field as 'secondary alignment' instead of 'supplementary alignment'" help="-M; For Picard&lt;1.96 compatibility" />
-                        <param name="K" type="integer" value="" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility) (default is scaled to number of threads)" />
+                        <conditional name="batch_size_options">
+                            <param name="batch_size_selector" type="select" label="Do you want to manually set the batch size? (default is scaled to number of threads given)">
+                                <option value="do_not_set_batch_size" selected="True">No (default)</option>
+                                <option value="set_batch_size">Yes</option>
+                            </param>
+                            <when value="set_batch_size">
+                                <param name="K" type="integer" value="" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility)" />
+                            </when>
+                            <when value="do_not_set_batch_size">
+                                <!-- do nothing -->
+                            </when>
+                        </conditional>
                     </when>
                     <when value="do_not_set">
                         <!-- do nothing -->

--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -255,7 +255,7 @@ bwa-mem2 mem
                         <param name="V" type="boolean" truevalue="-V" falsevalue="" label="Output the reference FASTA header in the XR tag" help="-C"/>
                         <param name="Y" type="boolean" truevalue="-Y" falsevalue="" label="Use soft clipping for supplementary alignments" help="-Y; By default, BWA-MEM uses soft clipping for the primary alignment and hard clipping for supplementary alignments" />
                         <param name="M" type="boolean" truevalue="-M" falsevalue="" label="Mark shorter split hits of a chimeric alignment in the FLAG field as 'secondary alignment' instead of 'supplementary alignment'" help="-M; For Picard&lt;1.96 compatibility" />
-                        <param name="K" type="integer" optional="True" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility)" />
+                        <param name="K" type="integer" optional="True" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility)" help="-K"/>
                     </when>
                     <when value="do_not_set">
                         <!-- do nothing -->

--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -64,6 +64,7 @@ bwa-mem2 mem
     #if str( $analysis_type.io_options.io_options_selector ) == "set":
         -T '${analysis_type.io_options.T}'
         -h '${analysis_type.io_options.h}'
+        -K '${analysis_type.io_options.K}'
         ${analysis_type.io_options.a}
         ${analysis_type.io_options.C}
         ${analysis_type.io_options.V}
@@ -238,7 +239,7 @@ bwa-mem2 mem
                 </conditional>
 
                 <conditional name="io_options">
-                    <param name="io_options_selector" type="select" label="Set input/output options" help="Sets -T, -h, -a, -C, -V, -Y, and -M options.">
+                    <param name="io_options_selector" type="select" label="Set input/output options" help="Sets -T, -h, -a, -C, -V, -Y, -M, and -K options.">
                         <option value="set">Set</option>
                         <option value="do_not_set" selected="True">Do not set</option>
                     </param>
@@ -252,6 +253,7 @@ bwa-mem2 mem
                         <param name="V" type="boolean" truevalue="-V" falsevalue="" label="Output the reference FASTA header in the XR tag" help="-C"/>
                         <param name="Y" type="boolean" truevalue="-Y" falsevalue="" label="Use soft clipping for supplementary alignments" help="-Y; By default, BWA-MEM uses soft clipping for the primary alignment and hard clipping for supplementary alignments" />
                         <param name="M" type="boolean" truevalue="-M" falsevalue="" label="Mark shorter split hits of a chimeric alignment in the FLAG field as 'secondary alignment' instead of 'supplementary alignment'" help="-M; For Picard&lt;1.96 compatibility" />
+                        <param name="K" type="integer" value="" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility) (default is scaled to number of threads)" />
                     </when>
                     <when value="do_not_set">
                         <!-- do nothing -->

--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -71,8 +71,8 @@ bwa-mem2 mem
         ${analysis_type.io_options.M}
         ${analysis_type.io_options.five}
         ${analysis_type.io_options.q}
-        #if str( $analysis_type.io_options.batch_size_options.batch_size_selector ) == "set_batch_size":
-            -K '${analysis_type.io_options.batch_size_options.K}'
+        #if str( $analysis_type.io_options.K ):
+            -K '${analysis_type.io_options.K}'
         #end if
     #end if
 
@@ -255,18 +255,7 @@ bwa-mem2 mem
                         <param name="V" type="boolean" truevalue="-V" falsevalue="" label="Output the reference FASTA header in the XR tag" help="-C"/>
                         <param name="Y" type="boolean" truevalue="-Y" falsevalue="" label="Use soft clipping for supplementary alignments" help="-Y; By default, BWA-MEM uses soft clipping for the primary alignment and hard clipping for supplementary alignments" />
                         <param name="M" type="boolean" truevalue="-M" falsevalue="" label="Mark shorter split hits of a chimeric alignment in the FLAG field as 'secondary alignment' instead of 'supplementary alignment'" help="-M; For Picard&lt;1.96 compatibility" />
-                        <conditional name="batch_size_options">
-                            <param name="batch_size_selector" type="select" label="Do you want to manually set the batch size? (default is scaled to number of threads given)">
-                                <option value="do_not_set_batch_size" selected="True">No (default)</option>
-                                <option value="set_batch_size">Yes</option>
-                            </param>
-                            <when value="set_batch_size">
-                                <param name="K" type="integer" value="" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility)" />
-                            </when>
-                            <when value="do_not_set_batch_size">
-                                <!-- do nothing -->
-                            </when>
-                        </conditional>
+                        <param name="K" type="integer" optional="True" label="Process this number of input bases in each batch regardless of nThreads (for reproducibility)" />
                     </when>
                     <when value="do_not_set">
                         <!-- do nothing -->

--- a/tools/bwa_mem2/macros.xml
+++ b/tools/bwa_mem2/macros.xml
@@ -2,7 +2,7 @@
     <import>read_group_macros.xml</import>
 
     <token name="@TOOL_VERSION@">2.2.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="xrefs">
         <xrefs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

hello! 👋🏼 

this PR exposes the `-K` parameter in bwa-mem2, which is described in the help as: `-K INT        process INT input bases in each batch regardless of nThreads (for reproducibility) []`

normally, the program just sets this parameter scaled to the number of threads given, but we've been having some memory issues on our local infrastructure where we want to still give the program a good amount of cores but not have the memory necessarily scale up, too, so this lets us set it lower