### PR TITLE
multigsea: conda requirements are lower case

### DIFF
--- a/tools/multigsea/macros.xml
+++ b/tools/multigsea/macros.xml
@@ -1,23 +1,23 @@
 <macros>
     <token name="@TOOL_VERSION@">1.8.0</token>
-    <token name="@SUFFIX_VERSION@">0</token>
+    <token name="@SUFFIX_VERSION@">1</token>
     <token name="@PROFILE@">20.05</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-multigsea</requirement>
             <requirement type="package" version="2.2.1">r-argparse</requirement>
             <requirement type="package" version="1.0.0">bioconductor-metaboliteidmapping</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Hs.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Mm.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Rn.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Cf.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Bt.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Ss.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Gg.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Xl.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Dr.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Dm.eg.db</requirement>
-            <requirement type="package" version="3.16.0">bioconductor-org.Ce.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.hs.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.mm.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.rn.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.cf.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.bt.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.ss.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.gg.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.xl.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.dr.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.dm.eg.db</requirement>
+            <requirement type="package" version="3.16.0">bioconductor-org.ce.eg.db</requirement>
         </requirements>
     </xml>
     <xml name="citations">


### PR DESCRIPTION
Otherwise planemo monitor does not build container.  This worked in the tool tests because of a bug in Galaxy https://github.com/galaxyproject/galaxy/issues/16435

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
