### PR TITLE
Add --threads flag to bellerophon command

### DIFF
--- a/tools/bellerophon/bellerophon.xml
+++ b/tools/bellerophon/bellerophon.xml
@@ -2,7 +2,7 @@
     <description>chimeric reads from Arima Genomics</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bellerophon</requirement>

--- a/tools/bellerophon/bellerophon.xml
+++ b/tools/bellerophon/bellerophon.xml
@@ -28,6 +28,7 @@
         --reverse $reverse_input
         --quality $quality
         --output 'merged_out.bam'
+        --threads \${GALAXY_SLOTS:-1}
         && samtools sort --no-PG -O BAM -o '$outfile' -@ \${GALAXY_SLOTS:-1} merged_out.bam
         ]]>
     </command>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

bellephoron  has a [--threads](https://github.com/davebx/bellerophon/blob/main/bellerophon/cli.py#L12) flag but it isn't used. The `GALAXY_SLOTS` variable is only used for the subsequent samtools command.