### PR TITLE
[CONCOCT] Fix total_percentage_pca default value

### DIFF
--- a/tools/concoct/concoct.xml
+++ b/tools/concoct/concoct.xml
@@ -38,7 +38,7 @@ concoct
             <param argument="--kmer_length" type="integer" min="0" value="4" label="Kmer length"/>
             <param argument="--length_threshold" type="integer" min="0" value="1000" label="Sequence length threshold" help="Contigs shorter than this value will not be included"/>
             <param argument="--read_length" type="integer" min="0" value="100" label="Read length for coverage"/>
-            <param argument="--total_percentage_pca" type="integer" min="0" value="100" label="Percentage of variance explained by the principal components for the combined data"/>
+            <param argument="--total_percentage_pca" type="integer" min="0" value="90" label="Percentage of variance explained by the principal components for the combined data"/>
             <param argument="--seed" type="integer" min="0" value="1" label="Seed for clustering" help="Zero value will use random seed"/>
             <param argument="--iterations" type="integer" min="0" value="500" label="Maximum number of iterations for the Variational Bayes Gaussian Mixture Models (VBGMM)"/>
             <param argument="--no_cov_normalization" type="boolean" truevalue="--no_cov_normalization" falsevalue="" checked="false" label="Skip normalization and only do log transorm of the coverage?" help="By default, the coverage is normalized for samples, then normalized for contigs and finally log transformed. By setting this flag you skip the normalization and only do log transorm of the   coverage."/>

--- a/tools/concoct/concoct.xml
+++ b/tools/concoct/concoct.xml
@@ -90,7 +90,7 @@ concoct
             </output>
             <output name="output_pca_transformed" ftype="csv">
                 <assert_contents>
-                    <has_size value="834200" delta="10"/>
+                    <has_size value="834200" delta="50"/>
                     <has_text text="contig-21000001"/>
                 </assert_contents>
             </output>
@@ -127,7 +127,7 @@ concoct
             </output>
             <output name="output_pca_transformed" ftype="csv">
                 <assert_contents>
-                    <has_size value="834200" delta="10"/>
+                    <has_size value="834200" delta="50"/>
                     <has_text text="contig-21000001"/>
                 </assert_contents>
             </output>

--- a/tools/concoct/macros.xml
+++ b/tools/concoct/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Using the default value that is actually in the wrapper leads to error for many datasets. Looking at the tool code, I found out that the default value is different than the one defined in the wrapper. Using the new value fixes the error for the few datasets I tried