### PR TITLE
Import PAPAA (Pan-cancer Aberrant Pathway Activity Analysis) toolsuite to IUC 

### DIFF
--- a/tools/papaa/.shed.yml
+++ b/tools/papaa/.shed.yml
@@ -1,8 +1,8 @@
 name: papaa
-owner: vijay
+owner: iuc
 description: "PAPAA - Pancancer Aberrant Pathway Activity Analysis a toolset for measuring aberrant pathway activity in TCGA."
 homepage_url: http://github.com/nvk747/papaa
-remote_repository_url: http://github.com/nvk747/papaa/galaxy/
+remote_repository_url: http://github.com/galaxyproject/tools-iuc/tree/main/tools/papaa
 type: unrestricted
 auto_tool_repositories:
   name_template: "{{ tool_id }}"

--- a/tools/papaa/.shed.yml
+++ b/tools/papaa/.shed.yml
@@ -1,0 +1,15 @@
+name: papaa
+owner: vijay
+description: "PAPAA - Pancancer Aberrant Pathway Activity Analysis a toolset for measuring aberrant pathway activity in TCGA."
+homepage_url: http://github.com/nvk747/papaa
+remote_repository_url: http://github.com/nvk747/papaa/galaxy/
+type: unrestricted
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "Wrapper for the papaa tool suite: {{ tool_name }}"
+suite:
+  name: "suite_papaa"
+  description: "PAPAA toolset for measuring aberrant pathway activity in TCGA."
+categories:
+- Machine Learning
+- Graphics

--- a/tools/papaa/alternative_genes_pathwaymapper.xml
+++ b/tools/papaa/alternative_genes_pathwaymapper.xml
@@ -1,0 +1,81 @@
+<tool id="pancancer_alternative_genes_pathwaymapper" name="PAPAA: PanCancer alternative genes pathwaymapper" version="@VERSION@">
+    <description>alternative genes pathwaymapper</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_alternative_genes_pathwaymapper.py' --version]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        ln -s '${classifier_decisions}' 'classifier/classifier_decisions.tsv' && 
+        papaa_alternative_genes_pathwaymapper.py
+        --classifier_decisions 'classifier'
+        #if $genes and str($genes):
+        --genes '$genes'
+        #end if
+        #if $path_genes and str($path_genes):
+        --path_genes '$path_genes'
+        #end if
+        #if $filename_mut and $filename_mut is not None:
+        --filename_mut '$filename_mut'
+        #end if
+        #if $filename_sample and $filename_sample is not None:
+        --filename_sample '$filename_sample'
+        #end if
+        @INPUTS_COPY_NUMBER_FILE_CONDITIONAL@
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param argument="--classifier_decisions" label="pancancer decisions" name="classifier_decisions" optional="false" type="data" format="tabular" help="classifier_decisions.tsv"/>
+        <param argument="--genes" label="Comma separated string of HUGO gene symbols" name="genes" optional="False" type="text" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+        <param argument="--path_genes" label="string of the genes to extract or genelist file" name="path_genes" optional="true" type= "data" format="txt"/>
+        <param argument="--filename_mut" label="Filename mutations" name="filename_mut" optional="true" type="data" format="tabular" help="data/pancan_mutation_freeze.tsv"/>
+        <param argument="--filename_sample" label="Filename of sample" name="filename_sample" optional="true" type="data" format="tabular" help="data/sample_freeze.tsv"/>
+        <expand macro="inputs_copy_number_file_conditional" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+        <data format="txt" name="pathway_metrics_pathwaymapper" label="${tool.name} on ${on_string} (pathway_metrics_pathwaymapper.txt)" from_work_dir="classifier/tables/pathway_metrics_pathwaymapper.txt"/>
+        <data format="tabular" name="all_gene_metric_ranks" label="${tool.name} on ${on_string} (all_gene_metric_ranks.tsv)" from_work_dir="classifier/tables/all_gene_metric_ranks.tsv"/>
+    </outputs>
+    <tests>
+        <test>
+          <param name="classifier_decisions" value="classifier_decisions.tsv" ftype="tabular"/>
+          <param name="genes" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+          <param name="path_genes" value="path_genes.txt" ftype="txt"/>
+          <param name="filename_mut" value="pancan_mutation_freeze_t1p.tsv.gz" ftype="tabular"/>
+          <param name="filename_sample" value="sample_freeze.tsv" ftype="tabular"/>
+          <param name="copy_number" value="yes"/>
+          <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular"/>
+          <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular"/>
+          <param name="filename_raw_mut" value="mc3.v0.2.8.PUBLIC_t1p.maf.gz" ftype="tabular"/>
+          <output name="log" file="alternative_genes_pathwaymapper_Log.txt"/>
+          <output name="pathway_metrics_pathwaymapper" file="pathway_metrics_pathwaymapper.txt" />
+          <output name="all_gene_metric_ranks" file="all_gene_metric_ranks.tsv" />
+        </test>
+    </tests>
+    <help><![CDATA[
+
+      **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_alternative_genes_pathwaymapper.py:**
+
+        **Inputs:**
+          --gene  Comma separated string of HUGO symbols for target genes or targenes_list.csv file
+          --path_genes  Comma separated string of HUGO symbols for all genes in the target pathway or path_genes.txt file
+          --classifier_decisions  String of the location of classifier decisions with predictions or scores
+          --filename_mut  Filename of sample/gene mutations to use in model
+          --filename_mut_burden   Filename of sample mutation burden to use in model
+          --filename_sample   Filename of patient/samples to use in model
+          --filename_copy_loss  Filename of copy number loss
+          --filename_copy_gain  Filename of copy number gain
+
+        **Outputs:**
+          Calculate and display metrics for targene classification  
+
+          Calculate and display pathway metrics ("pathway_metrics_pathwaymapper.txt")  
+
+          Visualize Distribution of AUROC and AUPRC for all genes and Get Metrics for All Genes ("all_gene_metric_ranks.tsv)  ]]>
+      </help>
+      <expand macro="citations" />
+</tool>

--- a/tools/papaa/compare_within_models.xml
+++ b/tools/papaa/compare_within_models.xml
@@ -1,0 +1,120 @@
+<tool id="pancancer_compare_within_models" name="PAPAA: PanCancer compare within models" version="@VERSION@">
+    <description>compare within models</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_compare_within_models.R' --version 2>&1 | grep PAPAA]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        mkdir -p 'classifier/figures' &&
+        ln -s '${pancan_classifier_summary}' 'classifier/classifier_summary.txt' &&
+        ln -s '${pancan_classifier_coefficients}' 'classifier/classifier_coefficients.tsv' &&
+        #for $within_summary in $pancan_within_classifier_summary:
+            mkdir -p 'classifier/within_disease/${within_summary.element_identifier}' &&
+            ln -s '${within_summary}' 'classifier/within_disease/${within_summary.element_identifier}/classifier_summary.txt' &&
+        #end for
+        #for $within_coefficient in $pancan_within_classifier_coefficients:
+            mkdir -p 'classifier/within_disease/${within_coefficient.element_identifier}' &&
+            ln -s '${within_coefficient}' 'classifier/within_disease/${within_coefficient.element_identifier}/classifier_coefficients.tsv' &&
+        #end for
+        #if $include_alt.include_alt_select == 'true':
+        mkdir 'alt_classifier' &&
+        ln -s '${include_alt.alt_pancan_classifier_summary}' 'alt_classifier/classifier_summary.txt' &&
+        ln -s '${include_alt.alt_pancan_classifier_coefficients}' 'alt_classifier/classifier_coefficients.tsv' &&
+        #for $within_summary in $include_alt.alt_pancan_within_classifier_summary:
+            mkdir -p 'alt_classifier/within_disease/${within_summary.element_identifier}' &&
+            ln -s '${within_summary}' 'alt_classifier/within_disease/${within_summary.element_identifier}/classifier_summary.txt' &&
+        #end for
+        #for $within_coefficient in $include_alt.alt_pancan_within_classifier_coefficients:
+            mkdir -p 'alt_classifier/within_disease/${within_coefficient.element_identifier}' &&
+            ln -s '${within_coefficient}' 'alt_classifier/within_disease/${within_coefficient.element_identifier}/classifier_coefficients.tsv' &&
+        #end for
+        #end if
+        ls -lahR &&
+        papaa_compare_within_models.R
+        --pancan_model 'classifier'
+        #if $include_alt.include_alt_select == 'true':
+        --alt_model 'alt_classifier'
+        #end if
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param argument="--pancan_model" label="pancancer classifier summary" name="pancan_classifier_summary" optional="false" type="data" format="txt" help="classifier_summary.txt"/>
+        <param label="pancancer classifier coefficients" name="pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="classifier_coefficients.tsv"/>
+        <param label="pan_within classifier summary" name="pancan_within_classifier_summary" optional="false" type="data" format="txt" multiple="true" help="multiple classifier_summary.txt"/>
+        <param label="pan_within classifier coefficients" name="pancan_within_classifier_coefficients" optional="false" type="data" format="tabular" multiple="true" help="multiple classifier_coefficients.tsv"/>
+        <conditional name="include_alt">
+          <param name="include_alt_select" type="select" label="Would you want to compare given model with alt gene model?" help="output of pancancer classifier and pancancer within disease for alt gene">
+            <option value="false" selected="true">do not do alt gene</option>
+            <option value="true">do alt gene</option>
+          </param>
+          <when value="true">
+                <param argument="--alt_model" label="pancancer classifier summary" name="alt_pancan_classifier_summary" optional="false" type="data" format="txt" help="alt classifier_summary.txt"/>
+                <param label="pancancer classifier coefficients" name="alt_pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="alt classifier_coefficients.tsv"/>
+                <param argument="pan_within classifier summary" label="alt_pancan_within_classifier_summary" name="alt_pancan_within_classifier_summary" optional="true" type="data" format="txt" multiple="true" help="multiple alt classifier_summary.txt"/>
+                <param label="alt_pancan_within classifier coefficients" name="alt_pancan_within_classifier_coefficients" optional="true" type="data" format="tabular" multiple="true" help="multiple alt classifier_coefficients.tsv"/>
+            </when>
+            <when value="false">
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)" />
+        <data format="pdf" name="aupr_comparison" label="${tool.name} on ${on_string} (aupr_comparison.pdf)" from_work_dir="classifier/figures/aupr_comparison.pdf"/>
+        <data format="pdf" name="auroc_comparison" label="${tool.name} on ${on_string} (auroc_comparison.pdf)" from_work_dir="classifier/figures/auroc_comparison.pdf"/>
+        <data format="pdf" name="alt_gene_aupr_comparison" label="${tool.name} on ${on_string} (alt_gene_aupr_comparison.pdf)" from_work_dir="classifier/figures/alt_gene_aupr_comparison.pdf" >
+          <filter>include_alt['include_alt_select'] == 'true' </filter> 
+        </data>
+        <data format="pdf" name="alt_gene_auroc_comparison" label="${tool.name} on ${on_string} (alt_gene_auroc_comparison.pdf)" from_work_dir="classifier/figures/alt_gene_auroc_comparison.pdf" >
+          <filter>include_alt['include_alt_select'] == 'true' </filter> 
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="pancan_classifier_summary" value="classifier_summary.txt" ftype="txt"/>
+            <param name="pancan_classifier_coefficients" value="classifier_coefficients.tsv" ftype="tabular"/>
+            <param name="pancan_within_classifier_summary" value="classifier_summary/GBM" > <!--
+                <collection type="list">
+                    <element name="GBM" value="GBM_100.txt" ftype="txt"/>
+                </collection> -->
+            </param>
+            <param name="pancan_within_classifier_coefficients" value="classifier_coefficients/GBM"> <!--
+                <collection type="list">
+                    <element name="GBM" value="GBM_99.tabular" ftype="tabular"/>
+                </collection> -->
+            </param>
+            <param name="include_alt_select" value="false"/>
+            <!--
+            <conditional name="include_alt">
+              <param name="include_alt_select" value="false"/>
+                <param name="alt_pancan_summary" value="alt_pancan_summary.txt" ftype="txt"/>
+                <param name="alt_pancan_classifier_coefficients" value="alt_pancan_classifier_coefficients.tsv" ftype="tabular"/>
+                <param name="alt_pan_within_classifier_summary" value="alt_pan_within_classifier_summary.txt" ftype="txt"/>
+                <param name="alt_pan_within_classifier_coefficients" value="alt_pan_within_classifier_coefficients.tsv" ftype="tabular"/> 
+            </conditional>
+            -->
+            <output name="log" file="compare_within_models_Log.txt"/>
+            <output name="aupr_comparison" file="aupr_comparison.pdf" compare="sim_size" delta="50"/>
+            <output name="auroc_comparison" file="auroc_comparison.pdf" compare="sim_size" delta="50"/>
+
+        </test>
+    </tests>
+    <help><![CDATA[
+
+        **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_compare_within_models.R:**
+            
+            **Inputs:**
+                --pancan_model      String of the Directory: location of Pan classifier summary file
+                --alt_model         String of the Directory: location of Alt gene classifier summary file
+            
+            **Outputs:**
+                Comparison plots for Pan and Pan_within models ("auroc_comparison.pdf" and "aupr_comparison.pdf")  
+
+                Comparison plots for altgene, alt_within, Pan_alt models ("alt_gene_auroc_comparison.pdf" and "alt_gene_aupr_comparison.pdf")  ]]>
+            
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/external_sample_status_prediction.xml
+++ b/tools/papaa/external_sample_status_prediction.xml
@@ -1,0 +1,65 @@
+<tool id="pancancer_external_sample_status_prediction" name="PAPAA: PanCancer external sample status prediction" version="@VERSION@">
+    <description>external sample status</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_external_sample_pred_targene_classifier.py' --version]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        mkdir -p 'classifier/figures' &&
+        ln -s '${classifier_summary}' 'classifier/classifier_summary.txt' &&
+        ln -s '${pancan_classifier_coefficients}' 'classifier/classifier_coefficients.tsv' &&
+        papaa_external_sample_pred_targene_classifier.py
+        --classifier_summary 'classifier'
+        #if $ex_vlog and str($ex_vlog):
+        --expression_file '$ex_vlog'
+        #end if
+        #if $sign and str($sign):
+        --status_sign '$sign'
+        #end if
+        --figure1 '${figure1}'
+        --figure2 '${figure2}'
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param argument="--classifier_summary" label="Classifier data" name="classifier_summary" optional="false" type="data" format="txt" help="classifier_summary.txt"/>
+        <param label="pancancer classifier coefficients" name="pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="classifier_coefficients.tsv"/>
+        <param argument="--expression_file" label="external sample gene expression data" name="ex_vlog" optional="false" type="data" format="csv" help="data/vlog_trans.csv" />
+        <param argument="--status_sign" label="given mutational status" name="sign" optional="false" type="data" format="txt" help="data/sign.txt" />
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)" />
+        <data format="pdf" name="figure1" label="${tool.name} on ${on_string} (Figure 1)" />
+        <data format="pdf" name="figure2" label="${tool.name} on ${on_string} (Figure 2)" />
+    </outputs>
+    <tests>
+        <test>
+          <param name="classifier_summary" value="classifier_summary.txt" ftype="txt"/>
+          <param name="pancan_classifier_coefficients" value="classifier_coefficients.tsv" ftype="tabular"/>
+          <param name="ex_vlog" value="vlog_trans.csv.gz" ftype="csv"/>
+          <param name="sign" value="sign.txt" ftype="txt"/>
+          <output name="log" file="external_sample_status_prediction_Log.txt" />
+          <output name="figure1" file="Figure_1.pdf" compare="sim_size" delta="50"/>
+          <output name="figure2" file="Figure_2.pdf" compare="sim_size" delta="50"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+      **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_external_sample_pred_targene_classifier.py:**
+        
+        **Inputs:**
+          --classifier_summary  String of the location of classifier scores file
+
+          --expression_file   File path for external sample expression data file (fpkm/rpkm/rlog/vlog/nlog values)
+
+          --status_sign   Provide sign for tumor/mutant [1] or normal/WT [-1] along with sorted sample names
+      
+        **Outputs:**
+          Model based classification scores distribution Plots for external normal and tumor samples   ("targene_external_sample_predictions.pdf and targene_external_sample_predictions_1.pdf")  ]]>
+      
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/macros.xml
+++ b/tools/papaa/macros.xml
@@ -1,0 +1,229 @@
+<macros>
+    <token name="@VERSION@">0.1.9</token>
+
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="@VERSION@">papaa</requirement>
+        </requirements>
+    </xml>
+
+    <xml name="stdio">
+        <stdio>
+             <exit_code level="fatal" range="1:"/>
+        </stdio>
+    </xml>
+
+    <xml name="inputs_basic">
+        <param argument="--x_matrix" label="Filename of features to use in model" name="x_matrix" optional="true" type="data" format="tabular" help="data/pancan_rnaseq_freeze.tsv.gz"/>
+        <yield/>
+        <param argument="--filename_mut" label="Filename mutations" name="filename_mut" optional="true" type="data" format="tabular" help="data/pancan_mutation_freeze.tsv.gz"/>
+        <param argument="--filename_mut_burden" label="Filename of mutation burden" name="filename_mut_burden" optional="true" type="data" format="tabular" help="data/mutation_burden_freeze.tsv"/>
+        <param argument="--filename_sample" label="Filename of sample" name="filename_sample" optional="true" type="data" format="tabular" help="data/sample_freeze.tsv"/>
+    </xml>
+
+    <token name="@INPUTS_BASIC@"><![CDATA[
+        #if $x_matrix and $x_matrix is not None:
+        --x_matrix '$x_matrix'
+        #end if
+        #if $filename_mut and $filename_mut is not None:
+        --filename_mut '$filename_mut'
+        #end if
+        #if $filename_mut_burden and $filename_mut_burden is not None:
+        --filename_mut_burden '$filename_mut_burden'
+        #end if
+        #if $filename_sample and $filename_sample is not None:
+        --filename_sample '$filename_sample'
+        #end if
+        ]]>
+    </token>
+
+    <xml name="inputs_genes_diseases">
+        <param argument="--genes" label="Comma separated string of HUGO gene symbols" name="genes" optional="False" type="text" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+        <param argument="--diseases" label="Comma sep string of TCGA disease acronyms. If no arguments are passed, filtering will default to options given in --filter_count and --filter_prop." name="diseases" optional="true" type="text" value="BLCA,BRCA,CESC,COAD,ESCA,LUAD,LUSC,OV,PRAD,READ,STAD,UCEC,UCS"/>
+    </xml>
+
+    <token name="@INPUTS_GENES_DISEASES@"><![CDATA[
+        #if $genes and $genes is not None:
+        --genes '$genes'
+        #end if
+        #if $diseases and str($diseases) != '':
+        --diseases '$diseases'
+        #end if
+        ]]>
+    </token>
+
+
+    <xml name="input_filename_raw_mut">
+        <param argument="--filename_raw_mut" label="Filename of raw mut MAF" name="filename_raw_mut" optional="true" type="data" format="tabular" help="data/raw/mc3.v0.2.8.PUBLIC.maf"/>
+    </xml>
+
+    <token name="@INPUT_FILENAME_RAW_MUT@"><![CDATA[
+        #if $filename_raw_mut and $filename_raw_mut is not None:
+        --filename_raw_mut '$filename_raw_mut'
+        #end if
+        ]]>
+    </token>
+
+
+    <xml name="input_filename_burden">
+        <param argument="--filename_burden" label="Burden file" name="filename_burden" optional="true" type="data" format="tabular" help="data/seg_based_scores.tsv"/>
+    </xml>
+
+    <token name="@INPUT_FILENAME_BURDEN@"><![CDATA[
+        #if $filename_burden and $filename_burden is not None:
+        --filename_burden '$filename_burden'
+        #end if
+        ]]>        
+    </token>
+
+    <xml name="input_filename_snaptron_samples">
+        <param argument="--sample_file" label="SNAPTRON samples" name="sample_file" optional="true" type="data" format="tabular" help="scripts/snaptron/samples.tsv.gz"/>
+    </xml>
+
+    <token name="@INPUT_FILENAME_SNAPTRON_SAMPLES@"><![CDATA[
+        #if $sample_file and $sample_file is not None:
+        --sample_file '$sample_file'
+        #end if
+        ]]>       
+    </token>
+
+
+    <xml name="input_filename_snaptron_junctions">
+        <param argument="--junction_file" label="SNAPTRON junctions" name="junction_file" optional="true" type="data" format="tabular" help="scripts/snaptron/tp53_junctions.txt.gz"/>
+    </xml>
+
+    <token name="@INPUT_FILENAME_SNAPTRON_JUNCTIONS@"><![CDATA[
+        #if $junction_file and $junction_file is not None:
+        --junction_file '$junction_file'
+        #end if
+        ]]>    
+    </token>
+
+    <xml name="inputs_copy_number_file">
+        <param argument="--filename_copy_loss" label="File with Copy number loss" name="filename_copy_loss" optional="true" type="data" format="tabular" help="data/copy_number_loss_status.tsv.gz"/>
+        <param argument="--filename_copy_gain" label="File with Copy number gain" name="filename_copy_gain" optional="true" type="data" format="tabular" help="data/copy_number_gain_status.tsv.gz"/>
+    </xml>
+
+    <xml name="inputs_copy_number_class_file">
+        <expand macro="inputs_copy_number_file" />
+        <param argument="--filename_cancer_gene_classification" label="File with cancer gene classification table" name="filename_cancer_gene_classification" optional="true" type="data" format="tabular" help="data/cosmic_cancer_classification.tsv"/>
+    </xml>
+
+    <xml name="inputs_copy_number_file_conditional">
+        <conditional name="copy_number_conditional">
+          <param argument="--copy_number" checked="false" label="Supplement Y matrix with copy number events" name="copy_number" type="boolean" truevalue="--copy_number" falsevalue=""/>
+          <when value="--copy_number">
+            <expand macro="inputs_copy_number_file" />
+          </when>
+          <when value=""/>
+        </conditional>
+    </xml>
+
+    <xml name="inputs_copy_number_class_file_conditional">
+        <conditional name="copy_number_conditional">
+          <param argument="--copy_number" checked="false" label="Supplement Y matrix with copy number events" name="copy_number" type="boolean" truevalue="--copy_number" falsevalue=""/>
+          <when value="--copy_number">
+            <expand macro="inputs_copy_number_class_file" />
+          </when>
+          <when value=""/>
+        </conditional>
+    </xml>
+
+    <token name="@INPUTS_COPY_NUMBER_FILE_PREFIX@"><![CDATA[
+        #set $copy_number_conditional = type('',(object,),{'filename_copy_loss':$filename_copy_loss,'filename_copy_gain':$filename_copy_gain})()
+                ]]>
+    </token>
+
+    <token name="@INPUTS_COPY_NUMBER_FILE@"><![CDATA[
+        #if $copy_number_conditional.filename_copy_loss and $copy_number_conditional.filename_copy_loss is not None:
+        --filename_copy_loss '$copy_number_conditional.filename_copy_loss'
+        #end if
+        #if $copy_number_conditional.filename_copy_gain and $copy_number_conditional.filename_copy_gain is not None:
+        --filename_copy_gain '$copy_number_conditional.filename_copy_gain'
+        #end if
+        ]]>
+    </token>
+    
+    <token name="@INPUTS_COPY_NUMBER_FILE_CONDITIONAL@"><![CDATA[
+        #if $copy_number_conditional.copy_number
+        $copy_number_conditional.copy_number
+        #if $copy_number_conditional.filename_copy_loss and $copy_number_conditional.filename_copy_loss is not None:
+        --filename_copy_loss '$copy_number_conditional.filename_copy_loss'
+        #end if
+        #if $copy_number_conditional.filename_copy_gain and $copy_number_conditional.filename_copy_gain is not None:
+        --filename_copy_gain '$copy_number_conditional.filename_copy_gain'
+        #end if
+        ##@INPUTS_COPY_NUMBER_FILE@
+        #end if
+        ]]>
+    </token>
+
+    <token name="@INPUTS_COPY_NUMBER_CLASS_FILE_PREFIX@"><![CDATA[
+        #set $copy_number_conditional = type('',(object,),{'filename_copy_loss':$filename_copy_loss,'filename_copy_gain':$filename_copy_gain,'filename_cancer_gene_classification':$filename_cancer_gene_classification})()
+        ]]>
+    </token>
+
+    <token name="@INPUTS_COPY_NUMBER_CLASS_FILE@"><![CDATA[
+        #if $copy_number_conditional.filename_copy_loss and $copy_number_conditional.filename_copy_loss is not None:
+        --filename_copy_loss '$copy_number_conditional.filename_copy_loss'
+        #end if
+        #if $copy_number_conditional.filename_copy_gain and $copy_number_conditional.filename_copy_gain is not None:
+        --filename_copy_gain '$copy_number_conditional.filename_copy_gain'
+        #end if
+        #if $copy_number_conditional.filename_cancer_gene_classification and $copy_number_conditional.filename_cancer_gene_classification is not None:
+        --filename_cancer_gene_classification '$copy_number_conditional.filename_cancer_gene_classification'
+        #end if
+        ]]>
+    </token>
+    
+    <token name="@INPUTS_COPY_NUMBER_CLASS_FILE_CONDITIONAL@"><![CDATA[
+        #if $copy_number_conditional.copy_number
+        $copy_number_conditional.copy_number
+        ##
+        #if $copy_number_conditional.filename_copy_loss and $copy_number_conditional.filename_copy_loss is not None:
+        --filename_copy_loss '$copy_number_conditional.filename_copy_loss'
+        #end if
+        #if $copy_number_conditional.filename_copy_gain and $copy_number_conditional.filename_copy_gain is not None:
+        --filename_copy_gain '$copy_number_conditional.filename_copy_gain'
+        #end if
+        #if $copy_number_conditional.filename_cancer_gene_classification and $copy_number_conditional.filename_cancer_gene_classification is not None:
+        --filename_cancer_gene_classification '$copy_number_conditional.filename_cancer_gene_classification'
+        #end if
+        ##@INPUTS_COPY_NUMBER_CLASS_FILE@
+        #end if
+        ]]> 
+    </token>
+
+    <xml name="input_remove_hyper">
+        <param argument="--remove_hyper" checked="false" label="Remove hypermutated samples" name="remove_hyper" type="boolean" truevalue="--remove_hyper" falsevalue=""/>
+    </xml>
+    <token name="@INPUT_REMOVE_HYPER@"><![CDATA[$remove_hyper]]></token>
+       
+    <xml name="input_alphas">
+        <param argument="--alphas" label="the alphas for parameter sweep" name="alphas" optional="true" type="text" value="0.1,0.13,0.15,0.18,0.2,0.3,0.4,0.6,0.7"/>
+    </xml>
+
+    <token name="@INPUTS_ALPHAS@"><![CDATA[
+        #if $alphas and $alphas is not None:
+        --alphas '$alphas'
+        #end if
+        ]]>
+    </token>
+
+    <xml name="input_l1_ratios">
+        <param argument="--l1_ratios" label="the l1 ratios for parameter sweep" name="l1_ratios" optional="true" type="text" value="0.1,0.125,0.15,0.2,0.25,0.3,0.35"/>
+    </xml>
+
+    <token name="@INPUTS_L1_RATIOS@"><![CDATA[
+        #if $l1_ratios and $l1_ratios is not None:
+        --l1_ratios '$l1_ratios'
+        #end if
+        ]]>
+    </token>
+    <xml name="citations">
+        <citations>
+            <yield />
+        </citations>
+    </xml>
+</macros>
+

--- a/tools/papaa/map_mutation_class.xml
+++ b/tools/papaa/map_mutation_class.xml
@@ -1,0 +1,59 @@
+<tool id="pancancer_map_mutation_class" name="PAPAA: PanCancer map mutation class" version="@VERSION@">
+  <description>map mutation class</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="stdio"/>
+  <version_command><![CDATA['papaa_map_mutation_class.py' --version]]></version_command>
+  <command><![CDATA[
+      mkdir 'classifier' &&
+      ln -s '${classifier_decisions}' 'classifier/classifier_decisions.tsv' && 
+      papaa_map_mutation_class.py
+      --classifier_decisions 'classifier'
+      #if $path_genes and str($path_genes):
+      --path_genes '$path_genes'
+      #end if
+      @INPUTS_COPY_NUMBER_FILE_CONDITIONAL@
+      @INPUT_FILENAME_RAW_MUT@
+      > '${log}'
+    ]]> 
+  </command>
+  <inputs>
+    <param argument="--classifier_decisions" label="pancancer decisions" name="classifier_decisions" optional="false" type="data" format="tabular" help="classifier_decisions.tsv"/>
+    <param argument="--path_genes" label="string of the genes to extract or genelist file" name="path_genes" optional="true" type= "data" format="txt"/>
+    <expand macro="inputs_copy_number_file_conditional" />
+    <expand macro="input_filename_raw_mut" />
+  </inputs>
+  <outputs>
+    <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+    <data format="tabular" name="mutation_classification_scores" label="${tool.name} on ${on_string} (mutation_classification_scores.tsv)" from_work_dir="classifier/tables/mutation_classification_scores.tsv"/>
+  </outputs>
+  <tests>
+        <test>
+          <param name="classifier_decisions" value="classifier_decisions.tsv" ftype="tabular"/>
+          <param name="path_genes" value="path_genes.txt" ftype="txt"/>
+          <param name="copy_number" value="yes"/>
+          <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular"/>
+          <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular"/>
+          <param name="filename_raw_mut" value="mc3.v0.2.8.PUBLIC_t1p.maf.gz" ftype="tabular"/>
+          <output name="log" file="map_mutation_class_Log.txt"/>
+          <output name="mutation_classification_scores" file="mutation_classification_scores.tsv" />
+        </test>
+  </tests>
+  <help><![CDATA[
+
+    **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_map_mutation_class.py:**
+      
+      **Inputs:**
+        --classifer_decisions   String of the location of folder containing classifier_decisions.tsv
+        --path_genes  comma separated string of HUGO symbols for all genes in the pathway or Pathway genes list file
+        --filename_copy_loss  Filename of copy number loss
+        --filename_copy_gain  Filename of copy number gain
+        --filename_raw_mut  Filename of raw mut MAF
+        
+      **Outputs:**
+      Merge per sample classifier scores with mutation types present in each sample and generate "mutation_classification_scores.tsv" file  ]]>
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/pancancer_apply_weights.xml
+++ b/tools/papaa/pancancer_apply_weights.xml
@@ -1,0 +1,70 @@
+<tool id="pancancer_apply_weights" name="PAPAA: PanCancer apply weights" version="@VERSION@">
+  <description>apply weights</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="stdio"/>
+  <version_command><![CDATA['papaa_apply_weights.py' --version]]></version_command>
+  <command><![CDATA[
+  mkdir 'classifier' &&
+  ln -s '${pancan_classifier_summary}' 'classifier/classifier_summary.txt' &&
+  ln -s '${pancan_classifier_coefficients}' 'classifier/classifier_coefficients.tsv' &&
+  papaa_apply_weights.py 
+  --classifier_summary 'classifier'
+  @INPUTS_BASIC@
+  @INPUTS_COPY_NUMBER_CLASS_FILE_CONDITIONAL@
+  > '${log}'
+ ]]></command>
+  <inputs>
+    <expand macro="inputs_basic"/>
+    <expand macro="inputs_copy_number_class_file_conditional"/>
+    <param argument="--classifier_summary" label="pancancer classifier summary" name="pancan_classifier_summary" optional="false" type="data" format="txt" help="classifier_summary.txt"/>
+    <param label="pancancer classifier coefficients" name="pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="classifier_coefficients.tsv"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+    <data format="tabular" name="classifier_decisions" label="${tool.name} on ${on_string} (classifier_decisions.tsv)" from_work_dir="classifier/classifier_decisions.tsv"/>
+  </outputs>
+  <tests>
+        <test>
+            <param name="x_matrix" value="pancan_rnaseq_freeze_t1p.tsv.gz" ftype="tabular"/>
+            <param name="filename_mut" value="pancan_mutation_freeze_t1p.tsv.gz" ftype="tabular"/>
+            <param name="filename_mut_burden" value="mutation_burden_freeze.tsv" ftype="tabular"/>
+            <param name="filename_sample" value="sample_freeze.tsv" ftype="tabular"/>
+            <param name="copy_number" value="yes"/>
+            <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular"/>
+            <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular"/>
+            <param name="filename_cancer_gene_classification" value="cosmic_cancer_classification.tsv" ftype="tabular"/>
+            <param name="pancan_classifier_summary" value="classifier_summary.txt" ftype="txt"/>
+            <param name="pancan_classifier_coefficients" value="classifier_coefficients.tsv" ftype="tabular"/>
+            <output name="log" file="apply_weights_Log.txt"/>
+            <output name="classifier_decisions">
+              <assert_contents>
+                  <has_line line="SAMPLE_BARCODE&#009;log10_mut&#009;total_status&#009;weight&#009;AKT1&#009;AKT1_gain&#009;ERBB2&#009;ERBB2_gain&#009;KRAS&#009;KRAS_gain&#009;PIK3CA&#009;PIK3CA_gain&#009;PATIENT_BARCODE&#009;DISEASE&#009;SUBTYPE&#009;hypermutated&#009;include" />
+                  <has_n_columns n="17" />
+                  <has_n_lines n="90" />
+              </assert_contents>
+          </output>
+        </test>
+    </tests>
+  <help><![CDATA[
+    
+    **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_apply_weights.py:**
+
+      **Inputs:**
+        --classifier_summary  String of the location of classifier_summary.txt file
+        --copy_number   Supplement Y matrix with copy number events
+        --x_matrix  Filename of features to use in model
+        --filename_mut_burden   Filename of sample/gene mutations to use in model
+        --filename_mut_burden   Filename of sample mutation burden to use in model
+        --filename_sample   Filename of patient/samples to use in model
+        --filename_copy_loss  Filename of copy number loss
+        --filename_copy_gain  Filename of copy number gain
+        --filename_cancer_gene_classification   Filename of cancer gene classification table
+
+      **Outputs:**
+      Apply a logit transform on expression values (y = 1/(1+e^(-wX))) to output mutational probabilities. Generates "classifier_decisions.tsv" file which has scores/probabilities and other covariate information.  The scores/probabilities will be used for gene ranking and variant specific classification. ]]>  
+  </help>
+  <expand macro="citations" />
+</tool>

--- a/tools/papaa/pancancer_classifier.xml
+++ b/tools/papaa/pancancer_classifier.xml
@@ -1,0 +1,207 @@
+<tool id="pancancer_classifier" name="PAPAA: PanCancer classifier" version="@VERSION@" python_template_version="3.6">
+    <description>classifier for pathway aberrant activity</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command>
+        <![CDATA['papaa_pancancer_classifier.py' --version]]></version_command>
+    <command detect_errors="exit_code"><![CDATA[
+        papaa_pancancer_classifier.py
+        #if $folds and $folds is not None:
+        --folds '$folds'
+        #end if
+        #if $seed and $seed is not None:
+        --seed '$seed'
+        #end if
+        $drop
+        #if $filter_count and $filter_count is not None:
+        --filter_count '$filter_count'
+        #end if
+        #if $filter_prop and $filter_prop is not None:
+        --filter_prop '$filter_prop'
+        #end if
+        #if $num_features and $num_features is not None:
+        --num_features '$num_features'
+        #end if
+        @INPUTS_ALPHAS@
+        @INPUTS_L1_RATIOS@
+        #if $alt_genes and str($alt_genes) != '':
+        --alt_genes '$alt_genes'
+        #end if
+        #if $alt_diseases and str($alt_diseases) != '':
+        --alt_diseases '$alt_diseases'
+        #end if
+        #if $alt_filter_count and $alt_filter_count is not None:
+        --alt_filter_count '$alt_filter_count'
+        #end if
+        #if $alt_filter_prop and $alt_filter_prop is not None:
+        --alt_filter_prop '$alt_filter_prop'
+        #end if
+        --classifier_results 'classifier'
+        @INPUT_REMOVE_HYPER@
+        $keep_intermediate
+        @INPUTS_BASIC@
+        @INPUTS_GENES_DISEASES@
+        $drop
+        $shuffled
+        $shuffled_before_training
+        $no_mutation
+        #if str($drop_x_genes)
+        --drop_x_genes '$drop_x_genes'
+        #end if
+        $drop_expression
+        $drop_covariates
+        @INPUTS_COPY_NUMBER_CLASS_FILE_CONDITIONAL@
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <expand macro="inputs_basic" />
+        <expand macro="inputs_genes_diseases" />
+        <param argument="--seed" label="option to set seed" name="seed" optional="true" type="integer" value="1234"/>
+        <param argument="--folds" label="Number of cross validation folds to perform" name="folds" optional="true" type="integer" value="5"/>
+        <param argument="--drop" checked="false" label="Decision to drop input genes from X matrix" name="drop" type="boolean" truevalue="--drop" falsevalue=""/>
+        <expand macro="inputs_copy_number_class_file_conditional" />
+        <param argument="--filter_count" label="Min number of mutations in diseases to include" name="filter_count" optional="true" type="integer" value="15"/>
+        <param argument="--filter_prop" label="Min proportion of positives to include disease" name="filter_prop" optional="true" type="float" value="0.05"/>
+        <param argument="--num_features" label="Number of MAD genes to include in classifier" name="num_features" optional="true" type="integer" value="8000"/>
+        <expand macro="input_alphas" />
+        <expand macro="input_l1_ratios" />
+        <param argument="--alt_genes" label="alternative genes to test performance" name="alt_genes" optional="true" type="text" />
+        <param argument="--alt_diseases" label="The alternative diseases to test performance" name="alt_diseases" optional="true" type="text" />
+        <param argument="--alt_filter_count" label="Min number of mutations in disease to include in alternate" name="alt_filter_count" optional="true" type="integer" value="15"/>
+        <param argument="--alt_filter_prop" label="Min proportion of positives to include disease in alternate" name="alt_filter_prop" optional="true" type="float" value="0.05"/>
+        <expand macro="input_remove_hyper" />
+        <param argument="--keep_intermediate" checked="false" label="Keep intermediate ROC values for plotting" name="keep_intermediate" type="boolean" truevalue="--keep_intermediate" falsevalue=""/>
+        <param argument="--shuffled" checked="false" label="Shuffle the input gene exprs matrix alongside" name="shuffled" type="boolean" truevalue="--shuffled" falsevalue=""/>
+        <param argument="--shuffled_before_training" checked="false" label="Shuffle the gene exprs matrix before training" name="shuffled_before_training" type="boolean" truevalue="--shuffled_before_training" falsevalue=""/>
+        <param argument="--no_mutation" checked="false" label="Remove mutation data from y matrix" name="no_mutation" type="boolean" truevalue="--no_mutation" falsevalue=""/>
+        <param argument="--drop_x_genes" label="Comma separated list of genes to be dropped from X matrix" name="drop_x_genes" optional="true" type="text" value=""/>
+        <param argument="--drop_expression" checked="false" label="Decision to drop gene expression values from X" name="drop_expression" type="boolean" truevalue="--drop_expression" falsevalue=""/>
+        <param argument="--drop_covariates" checked="false" label="Decision to drop covariate information from X" name="drop_covariates" type="boolean" truevalue="--drop_covariates" falsevalue=""/>
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)" />
+        <data format="tabular" name="alt_gene_alt_disease_summary" label="${tool.name} on ${on_string} (alt_gene_alt_disease_summary.tsv)" from_work_dir="classifier/alt_gene_alt_disease_summary.tsv"/>
+        <data format="csv" name="alt_summary_counts" label="${tool.name} on ${on_string} (alt_summary_counts.csv" from_work_dir="classifier/alt_summary_counts.csv"/>
+        <data format="tabular" name="classifier_coefficients" label="${tool.name} on ${on_string} (classifier_coefficients.tsv)" from_work_dir="classifier/classifier_coefficients.tsv"/>
+        <data format="txt" name="classifier_summary" label="${tool.name} on ${on_string} (classifier_summary.txt)" from_work_dir="classifier/classifier_summary.txt"/>
+        <data format="tabular" name="pancan_roc_results" label="${tool.name} on ${on_string} (pancan_roc_results.tsv)" from_work_dir="classifier/pancan_roc_results.tsv"/>
+        <data format="csv" name="summary_counts" label="${tool.name} on ${on_string} (summary_counts.csv)" from_work_dir="classifier/summary_counts.csv"/>
+        <data format="pdf" name="cv_heatmap" label="${tool.name} on ${on_string} (cv_heatmap.pdf)" from_work_dir="classifier/cv_heatmap.pdf"/>
+        <collection name="disease_figures" type="list:list" label="Disease classifier figures">
+          <discover_datasets pattern="classifier_(?P&lt;identifier_1&gt;.+)__pred_(?P&lt;identifier_0&gt;.+)\.pdf" format="pdf" directory="classifier/disease" visible="false" />
+        </collection>
+        <data format="pdf" name="all_disease_pr" label="${tool.name} on ${on_string} (all_disease_pr.pdf)" from_work_dir="classifier/all_disease_pr.pdf"/>
+        <data format="pdf" name="all_disease_roc" label="${tool.name} on ${on_string} (all_disease_roc.pdf)" from_work_dir="classifier/all_disease_roc.pdf"/>
+        <data format="pdf" name="alt_gene_alt_disease_aupr_bar" label="${tool.name} on ${on_string} (alt_gene_alt_disease_aupr_bar.pdf)" from_work_dir="classifier/alt_gene_alt_disease_aupr_bar.pdf"/>
+        <data format="pdf" name="alt_gene_alt_disease_auroc_bar" label="${tool.name} on ${on_string} (alt_gene_alt_disease_auroc_bar.pdf)" from_work_dir="classifier/alt_gene_alt_disease_auroc_bar.pdf"/>
+        <data format="pdf" name="disease_aupr" label="${tool.name} on ${on_string} (disease_aupr.pdf)" from_work_dir="classifier/disease_aupr.pdf"/>
+        <data format="pdf" name="disease_auroc" label="${tool.name} on ${on_string} (disease_auroc.pdf)" from_work_dir="classifier/disease_auroc.pdf"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="genes" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+            <param name="diseases" value="GBM"/>
+            <param name="x_matrix" value="pancan_rnaseq_freeze_t1p.tsv.gz" ftype="tabular"/>
+            <param name="filename_mut" value="pancan_mutation_freeze_t1p.tsv.gz" ftype="tabular"/>
+            <param name="filename_mut_burden" value="mutation_burden_freeze.tsv" ftype="tabular"/>
+            <param name="filename_sample" value="sample_freeze.tsv" ftype="tabular"/>
+            <param name="seed" value="1234"/>
+            <param name="folds" value="5"/>
+            <param name="drop" value="true"/>
+            <param name="copy_number" value="true"/>
+            <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular"/>
+            <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular"/>
+            <param name="filename_cancer_gene_classification" value="cosmic_cancer_classification.tsv" ftype="tabular"/>
+            <param name="filter_count" value="15"/>
+            <param name="filter_prop" value="0.05"/>
+            <param name="num_features" value="8000"/>
+            <param name="alphas" value="0.1,0.13,0.15,0.18,0.2,0.3,0.4,0.6,0.7"/>
+            <param name="l1_ratios" value="0.1,0.125,0.15,0.2,0.25,0.3,0.35"/>
+            <param name="alt_genes" value="PTEN,PIK3R1,STK11"/>
+            <param name="alt_diseases" value="GBM"/>
+            <param name="alt_filter_count" value="15"/>
+            <param name="alt_filter_prop" value="0.05"/>
+            <param name="remove_hyper" value="true"/>
+            <param name="keep_intermediate" value="true"/>
+            <param name="shuffled" value="true"/>
+            <param name="shuffled_before_training" value="false"/>
+            <param name="no_mutation" value="false"/>
+            <param name="drop_expression" value="false"/>
+            <param name="drop_covariates" value="false"/>
+            <output name="log" file="Log.txt"/>
+            <output name="alt_gene_alt_disease_summary" file="alt_gene_alt_disease_summary.tsv"/>
+            <output name="alt_summary_counts" file="alt_summary_counts.csv"/>
+            <output name="classifier_coefficients" file="classifier_coefficients.tsv"/>
+            <output name="classifier_summary" file="classifier_summary.txt"/>
+            <output name="pancan_roc_results">
+              <assert_contents>
+                  <has_line line="&#009;fpr&#009;tpr&#009;threshold&#009;train_type&#009;disease" />
+                  <has_n_columns n="6" />
+                  <has_n_lines n="253" />
+              </assert_contents>
+            </output>
+            <output name="summary_counts" file="summary_counts.csv"/>
+            <output name="cv_heatmap" file="cv_heatmap.pdf" compare="sim_size" delta="50"/>
+            <output name="all_disease_pr" file="all_disease_pr.pdf" compare="sim_size" delta="50" />
+            <output name="all_disease_roc" file="all_disease_roc.pdf" compare="sim_size" delta="50"/>
+            <output name="alt_gene_alt_disease_aupr_bar" file="alt_gene_alt_disease_aupr_bar.pdf" compare="sim_size" delta="50"/>
+            <output name="alt_gene_alt_disease_auroc_bar" file="alt_gene_alt_disease_auroc_bar.pdf" compare="sim_size" delta="50"/>
+            <output name="disease_aupr" file="disease_aupr.pdf" compare="sim_size" delta="50"/>
+            <output name="disease_auroc" file="disease_auroc.pdf" compare="sim_size" delta="50"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+        
+        **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_pancancer_classifier.py:**
+
+            **Inputs:**
+                --genes     comma separated string of HUGO symbols for target genes or targenes_list.csv file
+                --diseases  comma separated string of disease types/TCGA acronyms for classifier
+                            default: Auto (will pick diseases from filter args)
+                --folds     number of cross validation folds
+                            default: 5
+                --seed  value specifies the initial value of the random number seed
+                        default: 1234
+                --drop  drop the input genes from the X matrix
+                        default: False if flag omitted
+                --copy_number   optional flag to supplement copy number to define Y
+                                default: False if flag omitted
+                --filter_count  int of low count of mutation to include disease
+                                default: 15
+                --filter_prop   float of low proportion of mutated samples per disease
+                                default: 0.05
+                --num_features  int of number of genes to include in classifier
+                                default: 8000
+                --alphas    comma separated string of alphas to test in pipeline default: '0.1,0.15,0.2,0.5,0.8,1'
+                --l1_ratios     comma separated string of l1 parameters to test
+                                default: '0,0.1,0.15,0.18,0.2,0.3'
+                --alt_genes     comma separated string of alternative genes to test
+                                default: None
+                --alt_diseases  comma separated string of alternative diseases to test
+                                default: Auto
+                --alt_filter_count  int of low count of mutations to include alt_diseases
+                                    default: 15
+                --alt_filter_prop   float of low proportion of mutated samples alt_disease
+                                    default: 0.05
+                --classifier_results    string of the location to save the classifier results/figures
+                                        default: Auto
+                --remove_hyper  store_true: remove hypermutated samples
+                                default: False if flag omitted
+                --keep_intermediate     store_true: keep intermediate roc curve items
+                                        default: False if flag omitted
+                --x_matrix  string of which feature matrix to use
+                            default: raw
+                --remove_hyper  store_true: remove hypermutated samples
+                                default: False if flag omitted
+                --keep_intermediate     store_true: keep intermediate roc curve items
+                                        default: False if flag omitted
+        
+            **Outputs:**
+            ROC curves, AUROC across diseases, and classifier coefficients  ]]>
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/targene_cell_line_predictions.xml
+++ b/tools/papaa/targene_cell_line_predictions.xml
@@ -1,0 +1,165 @@
+<tool id="pancancer_targene_cell_line_predictions" name="PAPAA: PanCancer targene cell line predictions" version="@VERSION@">
+    <description>targene status in ccle cell lines </description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_targene_cell_line_predictions.py' --version]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        mkdir -p 'classifier/figures' &&
+        mkdir -p 'classifier/figures/cell_line' &&  
+        mkdir -p 'classifier/tables' &&
+        mkdir -p 'classifier/results' &&
+        ln -s '${classifier_summary}' 'classifier/classifier_summary.txt' &&
+        ln -s '${pancan_classifier_coefficients}' 'classifier/classifier_coefficients.tsv' &&
+        ln -s '${nucleotide_mutation_scores}' 'classifier/tables/nucleotide_mutation_scores.tsv' &&
+        ln -s '${amino_acid_mutation_scores}' 'classifier/tables/amino_acid_mutation_scores.tsv' &&
+        papaa_targene_cell_line_predictions.py
+        --classifier_summary 'classifier'
+        #if $targenes and str($targenes):
+        --targenes '$targenes'
+        #end if
+        #if $path_genes and str($path_genes):
+        --path_genes '$path_genes'
+        #end if
+        #if $ccle_rnaseq and $ccle_rnaseq is not None:
+        --ccle_rnaseq '$ccle_rnaseq'
+        #end if
+        #if $ccle_mut and $ccle_mut is not None:
+        --ccle_mut '$ccle_mut'
+        #end if
+        #if $ccle_maf and $ccle_maf is not None:
+        --ccle_maf '$ccle_maf'
+        #end if
+        #if $gdsc_rnaseq and $gdsc_rnaseq is not None:
+        --gdsc_rnaseq '$gdsc_rnaseq'
+        #end if
+        #if $gdsc_mut and $gdsc_mut is not None:
+        --gdsc_mut '$gdsc_mut'
+        #end if
+        #if $gdsc1_phar and $gdsc1_phar is not None:
+        --gdsc1_phar '$gdsc1_phar'
+        #end if
+        #if $gdsc2_phar and $gdsc2_phar is not None:
+        --gdsc2_phar '$gdsc2_phar'
+        #end if
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param argument="--classifier_summary" label="Classifier data" name="classifier_summary" optional="false" type="data" format="txt" help="classifier_summary.txt"/>
+        <param label="pancancer classifier coefficients" name="pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="classifier_coefficients.tsv"/>
+        <param label="nucleotide mutation scores" name="nucleotide_mutation_scores" optional="false" type="data" format="tabular" help="nucleotide_mutation_scores.tsv"/>
+        <param label="amino acid mutation scores" name="amino_acid_mutation_scores" optional="false" type="data" format="tabular" help="amino_acid_mutation_scores.tsv"/>
+        <param argument="--targenes" label="Comma separated string of HUGO targene symbols" name="targenes" optional="False" type="text" value="ERBB2_MUT,PIK3CA_MUT,KRAS_MUT,AKT1_MUT"/>
+        <param argument="--path_genes" label="string of the genes to extract or genelist file" name="path_genes" optional="true" type= "data" format="txt"/>
+        <param argument="--ccle_rnaseq" label="Filename ccle rnaseq data" name="ccle_rnaseq" optional="false" type="data" format="tabular" help="data/ccle_rnaseq_genes_rpkm_20180929_mod.tsv"/>
+        <param argument="--ccle_mut" label="Filename ccle mutational data" name="ccle_mut" optional="true" type="data" format="txt" help="data/CCLE_MUT_CNA_AMP_DEL_binary_Revealer.gct"/>
+        <param argument="--ccle_maf" label="Filename ccle variant data" name="ccle_maf"  optional="true" type="data" format="txt" help="data/CCLE_DepMap_18Q1_maf_20180207.txt" />
+        <param argument="--gdsc_rnaseq" label="Filename gdsc rnaseq data" name="gdsc_rnaseq" optional="false" type="data" format="tabular" help="data/GDSC_EXP_CCLE_converted_name.tsv"/>
+        <param argument="--gdsc_mut" label="Filename gdsc mutational data" name="gdsc_mut" optional="true" type="data" format="tabular" help="data/GDSC_CCLE_common_mut_cnv_binary.tsv"/>
+        <param argument="--gdsc1_phar" label="Filename for gdsc1 pharmacological data file" name="gdsc1_phar" optional="false" type="data" format="txt" help="data/gdsc1_ccle_pharm_fitted_dose_data.txt"/>
+        <param argument="--gdsc2_phar" label="Filename for gdsc2 pharmacological data file" name="gdsc2_phar" optional="false" type="data" format="txt" help="data/gdsc2_ccle_pharm_fitted_dose_data.txt"/>
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+        <data format="png" name="ccle_histogram" label="${tool.name} on ${on_string} (ccle_histogram.png)" from_work_dir="classifier/figures/ccle_histogram.png"/>
+        <data format="tabular" name="ccle_targene_classifier_scores" label="${tool.name} on ${on_string} (ccle_targene_classifier_scores.tsv)" from_work_dir="classifier/tables/ccle_targene_classifier_scores.tsv"/>
+        <data format="pdf" name="ccle_targene_WT_MUT_predictions" label="${tool.name} on ${on_string} (ccle_targene_WT_MUT_predictions.pdf)" from_work_dir="classifier/figures/cell_line/ccle_targene_WT_MUT_predictions.pdf"/>
+        <data format="csv" name="updated_data_nucleotide_scores" label="${tool.name} on ${on_string} (updated_data_nucleotide_scores.csv)" from_work_dir="classifier/tables/updated_data_nucleotide_scores.csv"/>
+        <data format="csv" name="updated_data_aminoacid_scores" label="${tool.name} on ${on_string} (updated_data_aminoacid_scores.csv)" from_work_dir="classifier/tables/updated_data_aminoacid_scores.csv"/>
+        <data format="png" name="gdsc_scores_histogram" label="${tool.name} on ${on_string} (gdsc_scores_histogram.png)" from_work_dir="classifier/figures/gdsc_scores_histogram.png"/>
+        <data format="tabular" name="gdsc_targene_classifier_scores" label="${tool.name} on ${on_string} (gdsc_targene_classifier_scores.tsv)" from_work_dir="classifier/tables/gdsc_targene_classifier_scores.tsv"/>
+        <data format="pdf" name="gdsc_targene_WT_MUT_predictions" label="${tool.name} on ${on_string} (gdsc_targene_WT_MUT_predictions.pdf)" from_work_dir="classifier/figures/cell_line/gdsc_targene_WT_MUT_predictions.pdf"/>
+        <data format="tabular" name="gdsc1_targene_pharmacology_predictions" label="${tool.name} on ${on_string} (gdsc1_targene_pharmacology_predictions.tsv)" from_work_dir="classifier/tables/gdsc1_targene_pharmacology_predictions.tsv"/>
+        <data format="tabular" name="gdsc2_targene_pharmacology_predictions" label="${tool.name} on ${on_string} (gdsc2_targene_pharmacology_predictions.tsv)" from_work_dir="classifier/tables/gdsc2_targene_pharmacology_predictions.tsv"/>
+        <data format="tabular" name="gdsc1_ccle_targene_pharmacology_predictions" label="${tool.name} on ${on_string} (gdsc1_ccle_targene_pharmacology_predictions.tsv)" from_work_dir="classifier/tables/gdsc1_ccle_targene_pharmacology_predictions.tsv"/>
+        <data format="tabular" name="gdsc2_ccle_targene_pharmacology_predictions" label="${tool.name} on ${on_string} (gdsc2_ccle_targene_pharmacology_predictions.tsv)" from_work_dir="classifier/tables/gdsc2_ccle_targene_pharmacology_predictions.tsv"/>
+    </outputs>
+    <tests>
+        <test>
+          <param name="classifier_summary" value="classifier_summary.txt" ftype="txt"/>
+          <param name="pancan_classifier_coefficients" value="classifier_coefficients.tsv" ftype="tabular"/>
+          <param name="nucleotide_mutation_scores" value="nucleotide_mutation_scores.tsv" ftype="tabular"/>
+          <param name="amino_acid_mutation_scores" value="amino_acid_mutation_scores.tsv" ftype="tabular"/>
+          <param name="targenes" value="ERBB2_MUT,PIK3CA_MUT,KRAS_MUT,AKT1_MUT"/>
+          <param name="path_genes" value="path_genes.txt" ftype="txt"/>
+          <param name="ccle_rnaseq" value="ccle_rnaseq_genes_rpkm_20180929_mod_t5p.tsv.gz" ftype="tabular"/>
+          <param name="ccle_mut" value="CCLE_MUT_CNA_AMP_DEL_binary_Revealer.gct.gz" ftype="tabular"/>
+          <param name="ccle_maf" value="CCLE_DepMap_18Q1_maf_20180207_t1p.txt.gz" ftype="txt"/>
+          <param name="gdsc_rnaseq" value="GDSC_EXP_CCLE_converted_name_t10p.tsv.gz" ftype="tabular"/>
+          <param name="gdsc_mut" value="GDSC_CCLE_common_mut_cnv_binary.tsv.gz" ftype="tabular"/>
+          <param name="gdsc1_phar" value="gdsc1_ccle_pharm_fitted_dose_data_t10p.txt.gz" ftype="txt"/>
+          <param name="gdsc2_phar" value="gdsc2_ccle_pharm_fitted_dose_data_t10p.txt.gz" ftype="txt"/>
+          <output name="log" file="targene_cell_line_predictions_Log.txt" lines_diff="2"/>
+          <output name="ccle_histogram" file="ccle_histogram.png" compare="sim_size" delta="50"/>
+          <output name="ccle_targene_classifier_scores" file="ccle_targene_classifier_scores.tsv" />
+          <output name="ccle_targene_WT_MUT_predictions" file="ccle_targene_WT_MUT_predictions.pdf" compare="sim_size" delta="100"/>
+          <output name="updated_data_nucleotide_scores" file="updated_data_nucleotide_scores.csv" />
+          <output name="updated_data_aminoacid_scores" file="updated_data_aminoacid_scores.csv" />
+          <output name="gdsc_scores_histogram" file="gdsc_scores_histogram.png" />
+          <output name="gdsc_targene_classifier_scores" file="gdsc_targene_classifier_scores.tsv" />
+          <output name="gdsc_targene_WT_MUT_predictions" file="gdsc_targene_WT_MUT_predictions.pdf" compare="sim_size" delta="50"/>
+          <output name="gdsc1_targene_pharmacology_predictions">
+            <assert_contents>
+                <has_line line="&#009;GDSC1_cell_line&#009;NLME_CURVE_ID&#009;COSMIC_ID&#009;SANGER_MODEL_ID&#009;TCGA_DESC&#009;DRUG_ID&#009;Compound&#009;PUTATIVE_TARGET&#009;PATHWAY_NAME&#009;MIN_CONC&#009;MAX_CONC&#009;LN_IC50&#009;AUC&#009;RMSE&#009;Z_SCORE&#009;tissue&#009;ERBB2_MUT&#009;PIK3CA_MUT&#009;KRAS_MUT&#009;AKT1_MUT&#009;targene_status&#009;weight&#009;sample_name&#009;predictions" />
+                <has_n_columns n="25" />
+                <has_n_lines n="10281" />
+            </assert_contents>
+          </output>
+          <output name="gdsc2_targene_pharmacology_predictions">
+            <assert_contents>
+                <has_line line="&#009;GDSC1_cell_line&#009;NLME_CURVE_ID&#009;COSMIC_ID&#009;SANGER_MODEL_ID&#009;TCGA_DESC&#009;DRUG_ID&#009;Compound&#009;PUTATIVE_TARGET&#009;PATHWAY_NAME&#009;MIN_CONC&#009;MAX_CONC&#009;LN_IC50&#009;AUC&#009;RMSE&#009;Z_SCORE&#009;tissue&#009;ERBB2_MUT&#009;PIK3CA_MUT&#009;KRAS_MUT&#009;AKT1_MUT&#009;targene_status&#009;weight&#009;sample_name&#009;predictions" />
+                <has_n_columns n="25" />
+                <has_n_lines n="10281" />
+            </assert_contents>
+          </output>
+          <output name="gdsc1_ccle_targene_pharmacology_predictions" file="gdsc1_ccle_targene_pharmacology_predictions.tsv" />
+          <output name="gdsc2_ccle_targene_pharmacology_predictions" file="gdsc2_ccle_targene_pharmacology_predictions.tsv" />
+        </test>
+    </tests>
+    <help><![CDATA[
+      
+      **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/viz/papaa_targene_cell_line_predictions_mod.py:**
+        
+        **Inputs:**
+          --targenes  comma separated string of HUGO symbols for target genes or targenes_list.csv file
+          --path_genes  comma separated string of HUGO symbols for all genes in the target pathway or path_genes.txt file
+          --classifier_summary  String of the location of classifier_summary file
+          --ccle_rnaseq   Filename of CCLE gene expression data file
+          --ccle_mut  Filename of CCLE cell lines/gene mutations data file
+          --ccle_maf  Filename of CCLE mutational variant level data file
+          --gdsc_rnaseq   Filename of GDSC gene expression data file
+          --gdsc_mut  Filename of GDSC cell lines/gene mutations data file
+          --gdsc1_phar  Filename of GDSC1 pharmacological response data
+          --gdsc2_phar  Filename of GDSC2 pharmacological response data
+
+        **Outputs:**
+          Generate predictions for CCLE data using targene classifier(ccle_histogram.png)  
+
+          Generate classifier scores for CCLE cell lines and combines CCLE mutational data and variant data with classifier scores (ccle_targene_classifier_scores.tsv)  
+
+          Performs t-test on classifier weights across targene mutant vs targene wildtype cell-line groups(ccle_targene_WT_MUT_predictions.pdf)  
+
+          Add CCLE nucleotide scores at variant level and update nucleotide_mutation_scores.tsv (updated_data_nucleotide_scores.csv)  
+
+          Add CCLE protein scores at variant level and update aminoacid_mutation_scores.tsv (updated_data_aminoacid_scores.csv)  
+
+          Generate predictions for GDSC data using targene classifier(gdsc_scores_histogram.png)  
+
+          Generate classifier scores for GDSC cell lines and combines CCLE mutational data and variant data with classifier scores (gdsc_targene_classifier_scores.tsv)  
+
+          Performs t-test on classifier weights across targene mutant vs targene wildtype cell-line groups(gdsc_targene_WT_MUT_predictions.pdf)  
+
+          Apply GDSC classifier scores to evaluate GDSC1 pharmacological data response(gdsc1_targene_pharmacology_predictions.tsv)  
+
+          Apply GDSC classifier scores to evaluate GDSC2 pharmacological data response(gdsc2_targene_pharmacology_predictions.tsv)  
+
+          Apply CCLE classifier scores to evaluate GDSC1 pharmacological data response(gdsc1_ccle_targene_pharmacology_predictions.tsv)  
+
+          Apply CCLE classifier scores to evaluate GDSC2 pharmacological data response(gdsc2_ccle_targene_pharmacology_predictions.tsv) ]]>
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/targene_pathway_count_heatmaps.xml
+++ b/tools/papaa/targene_pathway_count_heatmaps.xml
@@ -1,0 +1,107 @@
+<tool id="pancancer_pathway_count_heatmaps" name="PAPAA: PanCancer pathway count heatmaps" version="@VERSION@">
+    <description>pathway count heatmaps</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_targene_pathway_count_heatmaps.py' --version]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        mkdir -p 'classifier/tables' &&
+        ln -s '${classifier_decisions}' 'classifier/classifier_decisions.tsv' &&
+        ln -s '${pathway_metrics}' 'classifier/tables/pathway_metrics_pathwaymapper.txt' &&
+        ln -s '${all_gene_metric_ranks}' 'classifier/tables/all_gene_metric_ranks.tsv' &&
+        papaa_targene_pathway_count_heatmaps.py
+        --classifier_decisions 'classifier'
+        #if $genes and str($genes):
+        --genes '$genes'
+        #end if
+        #if $path_genes and str($path_genes):
+        --path_genes '$path_genes'
+        #end if
+        @INPUTS_BASIC@
+        #if $filename_copy_loss and $filename_copy_loss is not None:
+        --filename_copy_loss '$filename_copy_loss'
+        #end if
+        #if $filename_copy_gain and $filename_copy_gain is not None:
+        --filename_copy_gain '$filename_copy_gain'
+        #end if
+        #if $filename_cancer_gene_classification and $filename_cancer_gene_classification is not None:
+        --filename_cancer_gene_classification '$filename_cancer_gene_classification'
+        #end if
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param argument="--classifier_decisions" label="pancancer decisions" name="classifier_decisions" optional="false" type="data" format="tabular" help="classifier_decisions.tsv"/>
+        <param label="pancancer metrics pathwaymapper" name="pathway_metrics" optional="false" type="data" format="txt" help="pathway_metrics_pathwaymapper.txt"/>
+        <param label="all gene metric ranks" name="all_gene_metric_ranks" optional="false" type="data" format="tabular" help="all_gene_metric_ranks.tsv"/>
+        <param argument="--genes" label="Comma separated string of HUGO gene symbols" name="genes" optional="False" type="text" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+        <param argument="--path_genes" label="String of the pathway genes to extract" name="path_genes" optional="true" type= "data" format="txt"/>
+        <expand macro="inputs_basic"/>
+        <param argument="--filename_mut" label="Filename mutations" name="filename_mut" optional="true" type="data" format="tabular" help="data/pancan_mutation_freeze.tsv"/>
+        <param argument="--filename_sample" label="Filename of sample" name="filename_sample" optional="true" type="data" format="tabular" help="data/sample_freeze.tsv"/>
+        <param argument="--filename_copy_loss" label="File with Copy number loss" name="filename_copy_loss" optional="false" type="data" format="tabular" help="data/copy_number_loss_status.tsv"/>
+        <param argument="--filename_copy_gain" label="File with Copy number gain" name="filename_copy_gain" optional="false" type="data" format="tabular" help="data/copy_number_gain_status.tsv"/>
+        <param argument="--filename_cancer_gene_classification" label="File with cancer gene classification table" name="filename_cancer_gene_classification" optional="false" type="data" format="tabular" help="data/cosmic_cancer_classification.tsv"/>
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+        <data format="pdf" name="cancer_type_mutation_heatmap" label="${tool.name} on ${on_string} (cancer_type_mutation_heatmap.pdf)" from_work_dir="classifier/cancer_type_mutation_heatmap.pdf"/>
+        <data format="pdf" name="cancer_type_copy_number_heatmap" label="${tool.name} on ${on_string} (cancer_type_copy_number_heatmap.pdf)" from_work_dir="classifier/cancer_type_copy_number_heatmap.pdf"/>
+        <data format="pdf" name="cancer_type_combined_total_heatmap" label="${tool.name} on ${on_string} (cancer_type_combined_total_heatmap.pdf)" from_work_dir="classifier/cancer_type_combined_total_heatmap.pdf"/>
+        <data format="txt" name="pathway_mapper_percentages" label="${tool.name} on ${on_string} (pathway_mapper_percentages.txt)" from_work_dir="classifier/tables/pathway_mapper_percentages.txt"/>
+        <data format="tabular" name="path_events_per_sample" label="${tool.name} on ${on_string} (path_events_per_sample.tsv)" from_work_dir="classifier/tables/path_events_per_sample.tsv"/>
+    </outputs>
+    <tests>
+        <test>
+          <param name="classifier_decisions" value="classifier_decisions.tsv" ftype="tabular"/>
+          <param name="x_matrix" value="pancan_rnaseq_freeze_t1p.tsv.gz" ftype="tabular"/>
+          <param name="genes" value="ERBB2,KRAS,PIK3CA,AKT1"/>
+          <param name="path_genes" value="path_genes.txt" ftype="txt"/>
+          <param name="pathway_metrics_pathwaymapper" value="pathway_metrics_pathwaymapper.txt" ftype="txt"/>
+          <param name="all_gene_metric_ranks" value="all_gene_metric_ranks.tsv" ftype="tabular"/>
+          <param name="filename_mut" value="pancan_mutation_freeze_t1p.tsv.gz" ftype="tabular"/>
+          <param name="filename_sample" value="sample_freeze.tsv" ftype="tabular"/>
+          <param name="copy_number" value="yes"/>
+          <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular" />
+          <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular" />
+          <param name="filename_cancer_gene_classification" value="cosmic_cancer_classification.tsv" ftype="tabular" />
+          <output name="log" file="pathway_count_heatmaps_Log.txt"/>
+          <output name="cancer_type_mutation_heatmap" file="cancer_type_mutation_heatmap.pdf" compare="sim_size" delta="50"/>
+          <output name="cancer_type_copy_number_heatmap" file="cancer_type_copy_number_heatmap.pdf" compare="sim_size" delta="50"/>
+          <output name="cancer_type_combined_total_heatmap" file="cancer_type_combined_total_heatmap.pdf" compare="sim_size" delta="50"/>
+          <output name="pathway_mapper_percentages" file="pathway_mapper_percentages.txt" />
+          <output name="path_events_per_sample" file="path_events_per_sample.tsv" />
+        </test>
+    </tests>
+    <help><![CDATA[
+
+      **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_targene_pathway_count_heatmaps.py:**
+
+        **Inputs:**
+          --genes   comma separated string of HUGO symbols for target genes or targenes_list.csv file
+          --path_genes  comma separated string of HUGO symbols for all genes in the target pathway or path_genes.txt file
+          --classifier_decisions  String of the location of classifier scores/alt_folder
+          --x_matrix  Filename of features to use in model
+          --filename_mut  Filename of sample/gene mutations to use in model
+          --filename_mut_burden   Filename of sample mutation burden to use in model
+          --filename_sample   Filename of patient/samples to use in model
+          --filename_copy_loss  Filename of copy number loss
+          --filename_copy_gain  Filename of copy number gain
+          --filename_cancer_gene_classification   Filename of cancer gene classification table
+
+        **Outputs:**
+          Mutational count heatmap for all genes in the target pathway with in each cancer type (cancer_type_mutation_heatmap.pdf)
+
+          Copy number count heatmap for all genes in the target pathway with in each cancer type (cancer_type_copy_number_heatmap.pdf)
+
+          Combined count heatmap for all genes in the target pathway with in each cancer type (cancer_type_combined_total_heatmap.pdf)
+
+          Calculates Mutations and copy number percentages of the genes in the pathway and generates "pathway_mapper_percentages.txt" file  
+
+          Summarizes mutation, copy, and total counts per sample by targene pathway and generates "path_events_per_sample.tsv" file ]]>
+      </help>
+      <expand macro="citations" />
+</tool>

--- a/tools/papaa/targene_pharmacology.xml
+++ b/tools/papaa/targene_pharmacology.xml
@@ -1,0 +1,71 @@
+<tool id="pancancer_targene_pharmacology" name="PAPAA: PanCancer targene pharmacology" version="@VERSION@">
+    <description>ccle pharmocology predictions </description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+    <version_command><![CDATA['papaa_targene_pharmacology.R' --version 2>&1 | grep PAPAA]]></version_command>
+    <command><![CDATA[
+        mkdir 'classifier' &&
+        mkdir -p 'classifier/figures' &&
+        mkdir -p 'classifier/figures/cell_line' && 
+        mkdir -p 'classifier/tables' && 
+        ln -s '${gdsc1_targene_pharmacology_predictions}' 'classifier/tables/gdsc1_targene_pharmacology_predictions.tsv' &&
+        ln -s '${gdsc2_targene_pharmacology_predictions}' 'classifier/tables/gdsc2_targene_pharmacology_predictions.tsv' &&
+        ln -s '${gdsc1_ccle_targene_pharmacology_predictions}' 'classifier/tables/gdsc1_ccle_targene_pharmacology_predictions.tsv' &&
+        ln -s '${gdsc2_ccle_targene_pharmacology_predictions}' 'classifier/tables/gdsc2_ccle_targene_pharmacology_predictions.tsv' &&
+        papaa_targene_pharmacology.R
+        --classifier_results 'classifier'
+        #if $compound and str($compound):
+        --compound '$compound'
+        #end if
+        > '${log}'
+        ]]>
+    </command>
+    <inputs>
+        <param label="gdsc1 targene pharmacology predictions" name="gdsc1_targene_pharmacology_predictions" optional="false" type="data" format="tabular" help="gdsc1_targene_pharmacology_predictions.tsv"/>
+        <param label="gdsc2 targene pharmacology predictions" name="gdsc2_targene_pharmacology_predictions" optional="false" type="data" format="tabular" help="gdsc2_targene_pharmacology_predictions.tsv"/>
+        <param label="gdsc1 ccle targene pharmacology predictions" name="gdsc1_ccle_targene_pharmacology_predictions" optional="false" type="data" format="tabular" help="gdsc1_ccle_targene_pharmacology_predictions.tsv"/>
+        <param label="gdsc2 ccle targene pharmacology predictions" name="gdsc2_ccle_targene_pharmacology_predictions" optional="false" type="data" format="tabular" help="gdsc2_ccle_targene_pharmacology_predictions.tsv"/>
+        <param argument="--compound" label="Filename list of compounds" name="compound" optional="false" type="data" format="txt" help="data/compounds_of_interest.txt"/>
+    </inputs>
+    <outputs>
+        <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+        <data format="pdf" name="GDSC1_targene_all_drug_response" label="${tool.name} on ${on_string} (GDSC1_targene_all_drug_response.pdf)" from_work_dir="classifier/figures/cell_line/GDSC1_targene_all_drug_response.pdf"/>
+        <data format="pdf" name="GDSC2_targene_all_drug_response" label="${tool.name} on ${on_string} (GDSC2_targene_all_drug_response.pdf)" from_work_dir="classifier/figures/cell_line/GDSC2_targene_all_drug_response.pdf"/>
+        <data format="pdf" name="GDSC1_ccle_targene_all_drug_response" label="${tool.name} on ${on_string} (GDSC1_ccle_targene_all_drug_response.pdf)" from_work_dir="classifier/figures/cell_line/GDSC1_ccle_targene_all_drug_response.pdf"/>
+        <data format="pdf" name="GDSC2_ccle_targene_all_drug_response" label="${tool.name} on ${on_string} (GDSC2_ccle_targene_all_drug_response.pdf)" from_work_dir="classifier/figures/cell_line/GDSC2_ccle_targene_all_drug_response.pdf"/>
+    </outputs>
+    <tests>
+        <test>
+          <param name="compound" value="compounds_of_interest.txt" ftype="txt"/>
+          <param name="gdsc1_targene_pharmacology_predictions" value="gdsc1_targene_pharmacology_predictions.tsv" ftype="tabular"/>
+          <param name="gdsc2_targene_pharmacology_predictions" value="gdsc2_targene_pharmacology_predictions.tsv" ftype="tabular"/>
+          <param name="gdsc1_ccle_targene_pharmacology_predictions" value="gdsc1_ccle_targene_pharmacology_predictions.tsv" ftype="tabular"/>
+          <param name="gdsc2_ccle_targene_pharmacology_predictions" value="gdsc2_ccle_targene_pharmacology_predictions.tsv" ftype="tabular"/>
+          <output name="log" file="targene_pharmacology_Log.txt"/>
+          <output name="GDSC1_targene_all_drug_response" file="GDSC1_targene_all_drug_response.pdf" compare="sim_size" delta="50"/>
+          <output name="GDSC2_targene_all_drug_response" file="GDSC2_targene_all_drug_response.pdf" compare="sim_size" delta="50"/>
+          <output name="GDSC1_ccle_targene_all_drug_response" file="GDSC1_ccle_targene_all_drug_response.pdf" compare="sim_size" delta="50"/>
+          <output name="GDSC2_ccle_targene_all_drug_response" file="GDSC2_ccle_targene_all_drug_response.pdf" compare="sim_size" delta="50"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+      **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/viz/papaa_targene_pharmacology.R:**
+
+        **Inputs:**
+          --classifier_results  String of the location of classifier results folder
+          --compound  Filename of list of GDSC pharmacological compounds for evaluation
+
+        **Outputs:**
+          Scatter plots with visualizing drug response compared to GDSC targene classifier scores for GDSC1 pharmacological   dataset (GDSC1_targene_all_drug_response.pdf)  
+
+          Scatter plots with visualizing drug response compared to CCLE targene classifier scores for GDSC1 pharmacological dataset (GDSC1_ccle_targene_all_drug_response.pdf)  
+
+          Scatter plots with visualizing drug response compared to GDSC targene classifier scores for GDSC2 pharmacological dataset (GDSC2_targene_all_drug_response.pdf)  
+
+          Scatter plots with visualizing drug response compared to CCLE targene classifier scores for GDSC2 pharmacological dataset (GDSC2_ccle_targene_all_drug_response.pdf) ]]>
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/targene_summary_figures.xml
+++ b/tools/papaa/targene_summary_figures.xml
@@ -1,0 +1,99 @@
+<tool id="pancancer_targene_summary_figures" name="PAPAA: PanCancer targene summary figures" version="@VERSION@">
+  <description>Visualize targene summary</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="stdio"/>
+  <version_command><![CDATA['papaa_targene_summary_figures.R' --version 2>&1 | grep PAPAA]]></version_command>
+  <command><![CDATA[
+    mkdir 'classifier' &&
+    mkdir -p 'classifier/figures' && 
+    mkdir -p 'classifier/tables' &&
+        ln -s '${classifier_summary}' 'classifier/classifier_summary.txt' &&
+        ln -s '${pancan_classifier_coefficients}' 'classifier/classifier_coefficients.tsv' &&
+        ln -s '${summary_counts}' 'classifier/summary_counts.csv' &&
+        ln -s '${mutation_classification_scores}' 'classifier/tables/mutation_classification_scores.tsv' &&
+        ln -s '${path_events_per_sample}' 'classifier/tables/path_events_per_sample.tsv' &&
+        ln -s '${all_gene_metric_ranks}' 'classifier/tables/all_gene_metric_ranks.tsv' &&
+    papaa_targene_summary_figures.R
+    --classifier_summary 'classifier'
+    #if $seed and $seed is not None:
+    --seed '$seed'
+    #end if
+    > '${log}'
+    ]]>
+  </command>
+  <inputs>
+    <param argument="--classifier_summary" label="Classifier data" name="classifier_summary" optional="false" type="data" format="txt" help="classifier_summary.txt"/>
+    <param label="pancancer classifier coefficients" name="pancan_classifier_coefficients" optional="false" type="data" format="tabular" help="classifier_coefficients.tsv"/>
+    <param argument="--seed" label="option to set seed" name="seed" optional="true" type="integer" value="123"/>
+    <param label="summary counts" name="summary_counts" optional="false" type="data" format="csv" help="summary_counts.csv"/>
+    <param label="mutation classification scores" name="mutation_classification_scores" optional="false" type="data" format="tabular" help="mutation_classification_scores.tsv"/>
+    <param label="path events per sample" name="path_events_per_sample" optional="false" type="data" format="tabular" help="path_events_per_sample.tsv"/>
+    <param label="all gene metric ranks" name="all_gene_metric_ranks" optional="false" type="data" format="tabular" help="all_gene_metric_ranks.tsv"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+    <data format="pdf" name="targene_heatmap" label="${tool.name} on ${on_string} (targene_heatmap.pdf)" from_work_dir="classifier/figures/targene_heatmap.pdf"/>
+    <data format="pdf" name="all_targene_heatmap" label="${tool.name} on ${on_string} (all_targene_heatmap.pdf)" from_work_dir="classifier/figures/all_targene_heatmap.pdf"/>
+    <data format="pdf" name="targene_coef_plot" label="${tool.name} on ${on_string} (targene_coef_plot.pdf)" from_work_dir="classifier/figures/targene_coef_plot.pdf"/>
+    <data format="pdf" name="variant_OG_fill_map" label="${tool.name} on ${on_string} (variant_OG_fill_map.pdf)" from_work_dir="classifier/figures/variant_OG_fill_map.pdf"/>
+    <data format="pdf" name="variant_TSG_fill_map" label="${tool.name} on ${on_string} (variant_TSG_fill_map.pdf)" from_work_dir="classifier/figures/variant_TSG_fill_map.pdf"/>
+    <data format="pdf" name="aupr_distribution" label="${tool.name} on ${on_string} (aupr_distribution.pdf)" from_work_dir="classifier/figures/aupr_distribution.pdf"/>
+    <data format="pdf" name="auroc_distribution" label="${tool.name} on ${on_string} (auroc_distribution.pdf)" from_work_dir="classifier/figures/auroc_distribution.pdf"/>
+    <data format="pdf" name="targene_pathway_events_counts" label="${tool.name} on ${on_string} (targene_pathway_events_counts.pdf)" from_work_dir="classifier/figures/targene_pathway_events_counts.pdf"/>
+    <data format="txt" name="targene_pathway_variant_AUPR_ttest" label="${tool.name} on ${on_string} (targene_pathway_variant_AUPR_ttest.txt)" from_work_dir="classifier/tables/targene_pathway_variant_AUPR_ttest.txt"/>
+    <data format="tabular" name="amino_acid_mutation_scores" label="${tool.name} on ${on_string} (amino_acid_mutation_scores.tsv)" from_work_dir="classifier/tables/amino_acid_mutation_scores.tsv"/>
+    <data format="tabular" name="nucleotide_mutation_scores" label="${tool.name} on ${on_string} (nucleotide_mutation_scores.tsv)" from_work_dir="classifier/tables/nucleotide_mutation_scores.tsv"/>
+  </outputs>
+  <tests>
+        <test>
+          <param name="classifier_summary" value="classifier_summary.txt" ftype="txt"/>
+          <param name="pancan_classifier_coefficients" value="classifier_coefficients.tsv" ftype="tabular"/>
+          <param name="summary_counts" value="summary_counts.csv" ftype="csv"/>
+          <param name="all_gene_metric_ranks" value="all_gene_metric_ranks.tsv" ftype="tabular"/>
+          <param name="mutation_classification_scores" value="mutation_classification_scores.tsv" ftype="tabular"/>
+          <param name="path_events_per_sample" value="path_events_per_sample.tsv" ftype="tabular"/>
+          <param name="all_gene_metric_ranks" value="all_gene_metric_ranks.tsv" ftype="tabular"/>
+          <output name="log" file="targene_summary_figures_Log.txt"/>
+          <output name="targene_heatmap" file="targene_heatmap.pdf" compare="sim_size" delta="50"/>
+          <output name="all_targene_heatmap" file="all_targene_heatmap.pdf" compare="sim_size" delta="50"/>
+          <output name="targene_coef_plot" file="targene_coef_plot.pdf" compare="sim_size" delta="1000"/>
+          <output name="variant_OG_fill_map" file="variant_OG_fill_map.pdf" compare="sim_size" delta="50"/>
+          <output name="aupr_distribution" file="aupr_distribution.pdf" compare="sim_size" delta="50"/>
+          <output name="variant_TSG_fill_map" file="variant_TSG_fill_map.pdf" compare="sim_size" delta="50"/>
+          <output name="auroc_distribution" file="auroc_distribution.pdf" compare="sim_size" delta="50"/>
+          <output name="targene_pathway_events_counts" file="targene_pathway_events_counts.pdf" compare="sim_size" delta="50"/>
+          <output name="targene_pathway_variant_AUPR_ttest" file="targene_pathway_variant_AUPR_ttest.txt" compare="sim_size" delta="50"/>
+          <output name="amino_acid_mutation_scores" file="amino_acid_mutation_scores.tsv" compare="sim_size" delta="50"/>
+          <output name="nucleotide_mutation_scores" file="nucleotide_mutation_scores.tsv" compare="sim_size" delta="50"/>
+        </test>
+    </tests>
+  <help><![CDATA[
+    **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_targene_summary_figures.R:**
+
+      **Inputs:**
+          --classifier_summary   String of the location of classifier data
+          --seed  value specifies the initial value of the random number seed default: 1234
+      
+      **Outputs:**
+          Heatmap for mutation and gain proportions for the genes used in model across all the TCGA cancer types (all_targene_heatmap.pdf)
+
+          Heatmap for total mutation and total gain proportions for the genes used in model across all the TCGA cancer types (targene_heatmap.pdf")
+
+          Gene weights/Coefficients contributing to the model (targene_coef_plot.pdf)  
+
+          Plot distributions of predictions according to variant classification for OG and TSG ("variant_OG_fill_map.pdf" and "variant_TSG_fill_map.pdf")  
+
+          Targene pathway events counts ("targene_pathway_events_counts.pdf")  
+
+          Performance Metrics Distribution across pathway members ("aupr_distribution.pdf" and "auroc_distribution.pdf")
+          T-Test for AUPR between targene pathway genes and Other genes ("targene_pathway_variant_AUPR_ttest.txt") 
+
+          Extracting sample classifier scores for nucleotide level alterations in each sample and generate "nucleotide_mutation_scores.tsv" file
+
+          Extracting sample classifier scores for amino-acid level alterations in each sample and generate "amino_acid_mutation_scores.tsv" file ]]>
+    </help>
+    <expand macro="citations" />
+</tool>

--- a/tools/papaa/visualize_decisions.xml
+++ b/tools/papaa/visualize_decisions.xml
@@ -1,0 +1,64 @@
+<tool id="pancancer_visualize_decisions" name="PAPAA: PanCancer visualize decisions" version="@VERSION@">
+  <description>visualize decisions</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="stdio"/>
+  <version_command><![CDATA['papaa_visualize_decisions.py' --version]]></version_command>
+  <command><![CDATA[
+    mkdir 'classifier' &&
+    ln -s '${classifier_decisions}' 'classifier/classifier_decisions.tsv' &&
+    papaa_visualize_decisions.py
+    --classifier_decisions 'classifier'
+    #if str($custom):
+    --custom '$custom'
+    #end if
+    > '${log}'
+    ]]>
+  </command>
+  <inputs>
+    <param argument="--classifier_decisions" label="pancancer decisions" name="classifier_decisions" optional="false" type="data" format="tabular" help="classifier_decisions.tsv"/>
+    <param area="false" argument="--custom" label="comma separated list of columns to plot" name="custom" optional="true" type="text"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)"/>
+    <collection name="classifier_decisions_figures" type="list" label="Disease classifier decisions figures">
+      <discover_datasets pattern="decision_plot_(?P&lt;identifier_0&gt;.+)\.pdf" format="pdf" directory="classifier/figures" visible="false" />
+    </collection>
+    <data format="pdf" name="total_decisions" label="${tool.name} on ${on_string} (total_decisions.pdf)" from_work_dir="classifier/figures/total_decisions.pdf"/>
+    <data format="pdf" name="hyper_mutated" label="${tool.name} on ${on_string} (hyper_mutated.pdf)" from_work_dir="classifier/figures/hyper_mutated.pdf" />
+    <collection name="custom_classifier_decisions_figures" type="list" label="custom classifier decisions figures">
+      <filter>custom != ""</filter>
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_decision_plot\.pdf" format="pdf" directory="classifier" visible="false" />
+    </collection>
+  </outputs>
+  <tests>
+      <test>
+          <param name="classifier_decisions" value="classifier_decisions.tsv" ftype="tabular"/>
+          <output_collection name="classifier_decisions_figures" type="list">
+                <element name="OV" file="OV.pdf" compare="sim_size" delta="50"/>
+                <element name="LUAD" file="LUAD.pdf" compare="sim_size" delta="50"/>
+                <element name="GBM" file="GBM.pdf" compare="sim_size" delta="50"/>
+          </output_collection>    
+          <output name="log" file="visualize_decisions_Log.txt"/>
+          <output name="total_decisions" file="total_decisions.pdf" compare="sim_size" delta="30"/>
+          <output name="hyper_mutated" file="hyper_mutated.pdf" compare="sim_size" delta="30"/>
+      </test>
+  </tests>
+  <help><![CDATA[
+    **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_visualize_decisions.py:**
+
+      **Inputs:**
+          --classifier_decisions  String of the folder location of classifier_decisions.tsv
+          --custom  comma separated list of columns to plot (optional: True)
+      
+      **Outputs:**
+          Visualize decision function for all samples ("total_decisions.pdf")  
+
+          Plot disease type specific decision functions ("decision_plot_{}.pdf")  
+
+          Visualize decision function for hyper mutated tumors ("hyper_mutated.pdf") ]]>
+  </help>
+  <expand macro="citations" />
+</tool>

--- a/tools/papaa/within_disease_analysis.xml
+++ b/tools/papaa/within_disease_analysis.xml
@@ -1,0 +1,140 @@
+<tool id="pancancer_within_disease_analysis" name="PAPAA: PanCancer within disease analysis" version="@VERSION@">
+  <description>within disease analysis</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <expand macro="stdio"/>
+  <version_command><![CDATA['papaa_within_disease_analysis.py' --version]]></version_command>
+  <command><![CDATA[
+    papaa_within_disease_analysis.py
+    @INPUTS_ALPHAS@
+    @INPUTS_L1_RATIOS@
+    @INPUT_REMOVE_HYPER@
+    @INPUTS_BASIC@
+    @INPUTS_GENES_DISEASES@
+    @INPUTS_COPY_NUMBER_CLASS_FILE_PREFIX@
+    @INPUTS_COPY_NUMBER_CLASS_FILE@
+    --classifier_results 'classifier'
+    #if $seed and $seed is not None:
+    --seed '$seed'
+    #end if
+    #if $num_features and $num_features is not None:
+    --num_features '$num_features'
+    #end if
+    > '${log}'
+    && papaa_flatten_classifier_directory.py -i 'classifier/within_disease' -o 'classifier_within'
+   ]]>
+  </command>
+  <inputs>
+    <expand macro="inputs_basic" />
+    <expand macro="inputs_genes_diseases" />
+    <expand macro="inputs_copy_number_class_file" />
+    <expand macro="input_alphas" />
+    <expand macro="input_l1_ratios" />
+    <expand macro="input_remove_hyper" />
+    <param argument="--seed" label="option to set seed" name="seed" optional="true" type="integer" value="1234"/>
+    <param argument="--num_features" label="Number of MAD genes to include in classifier" name="num_features" optional="true" type="integer" value="8000"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="log" label="${tool.name} on ${on_string} (Log)" />
+    <collection name="classifier_summary" type="list" label="classifier_summary.txt">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_classifier_summary\.txt" format="txt" directory="classifier_within/within_disease" visible="false" />
+    </collection>
+    <collection name="classifier_coefficients" type="list" label="classifier_coefficients.tsv">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_classifier_coefficients\.tsv" format="tabular" directory="classifier_within/within_disease" visible="false" />
+    </collection>
+    <collection name="pancan_roc_results" type="list" label="pancan_roc_results.tsv">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_pancan_roc_results\.tsv" format="tabular" directory="classifier_within/within_disease" visible="false" />
+    </collection>
+    <collection name="summary_counts" type="list" label="summary_counts.csv">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_summary_counts\.csv" format="csv" directory="classifier_within/within_disease" visible="false" />
+    </collection>
+    <collection name="within_disease" type="list:list" label="Within disease figures">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;.+)\.pdf" format="pdf" directory="classifier_within/within_disease" visible="false" />
+    </collection>
+    <collection name="disease_figures" type="list:list" label="Disease classifier figures">
+      <discover_datasets pattern="classifier_(?P&lt;identifier_1&gt;.+)__pred_(?P&lt;identifier_0&gt;.+)\.pdf" format="pdf" directory="classifier_within/disease" visible="false" />
+    </collection>
+  </outputs>
+  <tests>
+        <test>
+              <param name="genes" value="ERBB2,PIK3CA,KRAS,AKT1"/>
+              <param name="diseases" value="GBM"/>
+              <param name="x_matrix" value="pancan_rnaseq_freeze_t1p.tsv.gz" ftype="tabular"/>
+              <param name="filename_mut" value="pancan_mutation_freeze_t1p.tsv.gz" ftype="tabular"/>
+              <param name="filename_mut_burden" value="mutation_burden_freeze.tsv" ftype="tabular"/>
+              <param name="filename_sample" value="sample_freeze.tsv" ftype="tabular"/>
+              <param name="filename_copy_loss" value="copy_number_loss_status_t10p.tsv.gz" ftype="tabular"/>
+              <param name="filename_copy_gain" value="copy_number_gain_status_t10p.tsv.gz" ftype="tabular"/>
+              <param name="filename_cancer_gene_classification" value="cosmic_cancer_classification.tsv" ftype="tabular"/>
+              <param name="alphas" value="0.1,0.13,0.15,0.18,0.2,0.3,0.4,0.6,0.7"/>
+              <param name="l1_ratios" value="0.1,0.125,0.15,0.2,0.25,0.3,0.35"/>
+              <param name="seed" value="1234"/>
+              <param name="num_features" value="8000"/>
+              <param name="remove_hyper" value="true"/>
+              <output name="log">
+                <assert_contents>
+                  <has_line line="[&apos;ERBB2&apos;, &apos;PIK3CA&apos;, &apos;KRAS&apos;, &apos;AKT1&apos;]" />
+                  <has_line line="GBM" />
+                  <has_n_lines n="2" />
+                </assert_contents>
+              </output>
+              <output_collection name="classifier_coefficients" type="list">
+                 <element name="GBM" file="GBM_108_coef.tabular" ftype="tabular" />
+              </output_collection>
+              <output_collection name="classifier_summary" type="list">
+                 <element name="GBM" file="GBM_111_summary.txt" ftype="txt" />
+              </output_collection>
+              <output_collection name="pancan_roc_results" type="list">
+                 <element name="GBM" ftype="tabular">
+                    <assert_contents>
+                        <has_line line="&#009;fpr&#009;tpr&#009;threshold&#009;train_type&#009;disease" />
+                        <has_n_columns n="6" />
+                        <has_n_lines n="253" />
+                    </assert_contents>
+                  </element>
+              </output_collection>
+              <output_collection name="summary_counts" type="list">
+                 <element name="GBM" file="GBM_106_summary_counts.csv" ftype="csv" />
+              </output_collection>
+              <output_collection name="within_disease" type="list:list">
+                <element name="GBM" >
+                  <element name="cv_heatmap" file="GBM_cv_heatmap_103.pdf" compare="sim_size" delta="50"/>
+                  <element name="all_disease_pr" file="GBM_all_disease_pr_101.pdf" compare="sim_size" delta="50" />
+                  <element name="all_disease_roc" file="GBM_all_disease_roc_102.pdf" compare="sim_size" delta="50"/>
+                  <element name="disease_aupr" file="GBM_disease_aupr_104.pdf" compare="sim_size" delta="50"/>
+                  <element name="disease_auroc" file="GBM_disease_auroc_105.pdf" compare="sim_size" delta="50"/>
+                </element>
+              </output_collection>
+              <output_collection name="disease_figures" type="list:list">
+                <element name="GBM" >
+                  <element name="pr" file="GBM_pr_99.pdf" compare="sim_size" delta="50"/>
+                  <element name="roc" file="GBM_roc_100.pdf" compare="sim_size" delta="50"/>
+                </element>
+              </output_collection>
+        </test>
+    </tests>
+  <help><![CDATA[
+    **Pancancer_Aberrant_Pathway_Activity_Analysis scripts/papaa_within_disease_analysis.py:**
+
+      **Inputs:**
+        --genes   comma separated string of HUGO symbols for target genes or targenes_list.csv file
+        --diseases  Comma separated diseases list in a file
+        --alphas  The alphas for parameter sweep
+        --l1_ratios   The l1 ratios for parameter sweep
+        --remove_hyper  Remove hypermutated samples
+        --classifier_results  String of location to classification folder extending to individual diseases
+        --x_matrix  Filename of features to use in model
+        --filename_mut  Filename of sample/gene mutations to use in model
+        --filename_mut_burden   Filename of sample mutation burden to use in model
+        --filename_sample   Filename of patient/samples to use in model
+        --filename_copy_loss  Filename of copy number loss
+        --filename_copy_gain  Filename of copy number gain
+        --filename_cancer_gene_classification   Filename of cancer gene classification table
+
+      **Outputs:**
+        ROC curves, AUROC across diseases, and classifier coefficients for individual diseases ]]>
+  </help>
+  <expand macro="citations" />
+</tool>


### PR DESCRIPTION
Importing the PAPAA tools from @nvk747 and @blankenberg into the IUC. 

This way the tools can be installed on usegalaxy.*, which would also support the nice [GTN tutorial](https://training.galaxyproject.org/training-material/topics/statistics/tutorials/aberrant_pi3k_pathway_analysis/tutorial.html) for the tools suite. (I would love to include this tutorial in future Smorgasbords and there is interest from EMBL-EBI to include it in one of their course next year.)

@nvk747: I did not see the test data for the planemo tests in your [original papaa repo](https://github.com/nvk747/papaa/tree/master/galaxy), do you still have them available somewhere?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [x] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
