### PR TITLE
Updating tools/dnabot from version 3.1.0 to 4.1.0

### DIFF
--- a/tools/dnabot/dnabot.xml
+++ b/tools/dnabot/dnabot.xml
@@ -1,7 +1,7 @@
 <tool id="dnabot" name="DNA-Bot" version="@TOOL_VERSION@" profile="21.09">
     <description>DNA assembly using BASIC on OpenTrons</description>
     <macros>
-        <token name="@TOOL_VERSION@">3.1.0</token>
+        <token name="@TOOL_VERSION@">4.1.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">dnabot</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/dnabot**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/dnabot from version 3.1.0 to 4.1.0.

**Project home page:** https://github.com/BASIC-DNA-ASSEMBLY/DNA-BOT/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).