### PR TITLE
Update shovill tool to accept fastq and fastq.gz

### DIFF
--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -2,7 +2,7 @@
     <description>Faster SPAdes assembly of Illumina reads</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">shovill</xref>
@@ -78,11 +78,11 @@
                 <option value="collection">Paired Collection</option>
             </param>
             <when value="paired">
-                <param name="R1" type="data" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2" label="Forward reads (R1)" help="The file of forward reads in FASTQ format"/>
-                <param name="R2" type="data" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2" label="Reverse reads (R2)" help="The file of reverse reads in FASTQ format"/>
+                <param name="R1" type="data" format="fastq,fastq.gz,fastqsanger,fastqsanger.gz,fastqsanger.bz2" label="Forward reads (R1)" help="The file of forward reads in FASTQ format"/>
+                <param name="R2" type="data" format="fastq,fastq.gz,fastqsanger,fastqsanger.gz,fastqsanger.bz2" label="Reverse reads (R2)" help="The file of reverse reads in FASTQ format"/>
             </when>
             <when value="collection">
-                <param name="input1" format="fastqsanger,fastqsanger.gz,fastqsanger.bz2" type="data_collection" collection_type="paired" label="Paired collection" help="See help section for an explanation of dataset collections"/>
+                <param name="input1" format="fastq,fastq.gz,fastqsanger,fastqsanger.gz,fastqsanger.bz2" type="data_collection" collection_type="paired" label="Paired collection" help="See help section for an explanation of dataset collections"/>
             </when>
         </conditional>
         <param name="trim" argument="--trim" type="boolean" truevalue="--trim" falsevalue="" label="Trim reads" help="Use Trimmomatic to remove common adaptors first (default: OFF)" />

--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -85,15 +85,15 @@
                 <param name="input1" format="fastq,fastq.gz,fastqsanger,fastqsanger.gz,fastqsanger.bz2" type="data_collection" collection_type="paired" label="Paired collection" help="See help section for an explanation of dataset collections"/>
             </when>
         </conditional>
-        <param name="trim" argument="--trim" type="boolean" truevalue="--trim" falsevalue="" label="Trim reads" help="Use Trimmomatic to remove common adaptors first (default: OFF)" />
-        <param name="assembler" argument="--assembler" type="select" label="Assembler to use" help="Which assembler would you like shovill to use, default is Spades">
+        <param argument="--trim" type="boolean" truevalue="--trim" falsevalue="" label="Trim reads" help="Use Trimmomatic to remove common adaptors first (default: OFF)" />
+        <param argument="--assembler" type="select" label="Assembler to use" help="Which assembler would you like shovill to use, default is Spades">
             <option value="skesa">skesa</option>
             <option value="megahit">megahit</option>
             <option value="velvet">velvet</option>
             <option value="spades" selected="true">Spades</option>
         </param>
         <section name="adv" title="Advanced options" expanded="False">
-            <param name="namefmt" argument="--namefmt" type="text" value="contig%05d" label="Contig name format" help="Format of contig FASTA IDs in 'printf' style (default: 'contig%05d')" >
+            <param argument="--namefmt" type="text" value="contig%05d" label="Contig name format" help="Format of contig FASTA IDs in 'printf' style (default: 'contig%05d')" >
                 <sanitizer>
                     <valid initial="string.printable">
                         <remove value="&apos;" />
@@ -103,22 +103,22 @@
                     </mapping>
                 </sanitizer>
             </param>
-            <param name="depth" argument="--depth" type="integer" value="100" label="Depth" help="Sub-sample --R1/--R2 to this depth. Disable with --depth 0 (default: 100)" />
-            <param name="gsize" argument="--gsize" type="text" value="" label="Estimated genome size" help="An estimate of the final genome size, it will autodetect if this is blank. (default: '')" />
-            <param name="kmers" argument="--kmers" type="text" value="" label="List of kmer sizes to use" help="List of K-mer sizes to use in SPAdes. Blank is AUTO. default: ''" />
-            <param name="opts" argument="--opts" type="text" value="" label="Extra SPAdes options" help="eg. --plasmid --sc ... (default: '')" />
+            <param argument="--depth" type="integer" value="100" label="Depth" help="Sub-sample --R1/--R2 to this depth. Disable with --depth 0 (default: 100)" />
+            <param argument="--gsize" type="text" value="" label="Estimated genome size" help="An estimate of the final genome size, it will autodetect if this is blank. (default: '')" />
+            <param argument="--kmers" type="text" value="" label="List of kmer sizes to use" help="List of K-mer sizes to use in SPAdes. Blank is AUTO. default: ''" />
+            <param argument="--opts" type="text" value="" label="Extra SPAdes options" help="eg. --plasmid --sc ... (default: '')" />
             <conditional name="keep_files">
-                <param name="nocorr" argument="--nocorr" type="select" label="Disable post-assembly correction" help="Disable post assembly correction with pilon (default: ON)">
+                <param argument="--nocorr" type="select" label="Disable post-assembly correction" help="Disable post assembly correction with pilon (default: ON)">
                     <option value="no_correction" selected="true">No corrections</option>
                     <option value="yes_correction">Post assembly corrections</option>
                 </param>
                 <when value="no_correction"/>
                 <when value="yes_correction">
-                    <param name="keepfiles" argument="--keepfiles" type="boolean" truevalue="--keepfiles"  checked="False" falsevalue=""  label="Keep bam files" help="Keep bam files only if post-assembly correction is enable"/>
+                    <param argument="--keepfiles" type="boolean" truevalue="--keepfiles"  checked="False" falsevalue=""  label="Keep bam files" help="Keep bam files only if post-assembly correction is enable"/>
                 </when>
             </conditional>
-            <param name="minlen" argument="--minlen" type="integer" value="0" label="Minimum contig length" help="Minimum length of contig to be output. 0 is AUTO (default: 0)" />
-            <param name="mincov" argument="--mincov" type="integer" value="2" label="Minimum contig coverage" help="Minimum coverage to call part of a contig. 0 is AUTO (default: 2)" />
+            <param argument="--minlen" type="integer" value="0" label="Minimum contig length" help="Minimum length of contig to be output. 0 is AUTO (default: 0)" />
+            <param argument="--mincov" type="integer" value="2" label="Minimum contig coverage" help="Minimum coverage to call part of a contig. 0 is AUTO (default: 2)" />
         </section>
         <param name="log" type="boolean" label="Output log file?" checked="true" help="Return the Shovill log file as part of the output. Default is on" />
 


### PR DESCRIPTION
Shovill seem to failed when input is indicated as fast or fastq.gz while it can work with this input.
I just add the fastq as input format