### PR TITLE
sra dump: allow spaces in defline

### DIFF
--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -187,6 +187,27 @@
                 </element>
             </output_collection>
         </test>
+        <test expect_num_outputs="4">
+            <param name="input_select" value="file_list"/>
+            <param name="file_list" value="sra_manifest.tabular" ftype="sra_manifest.tabular"/>
+            <section name="adv">
+                <param name="seq_defline" value="@$ac.$si/$ri $sn length=$rl"/>
+            </section>
+            <output_collection name="list_paired" type="list:paired" count="1">
+                <element name="SRR11953971">
+                    <element name="forward" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@SRR11953971.2053/1 2053 length=101"/>
+                        </assert_contents>
+                    </element>
+                    <element name="reverse" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@SRR11953971.2053/2 2053 length=101"/>
+                        </assert_contents>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
     </tests>
     <help><![CDATA[
 **What it does?**

--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -197,12 +197,15 @@
                 <element name="SRR11953971">
                     <element name="forward" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@SRR11953971.2053/1 2053 length=101"/>
+                            <!-- TODO replace has_size by has_line -->
+                            <has_size min="56206"/>
+                            <!-- <has_line line="@SRR11953971.2053/1 2053 length=101"/> -->
                         </assert_contents>
                     </element>
                     <element name="reverse" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@SRR11953971.2053/2 2053 length=101"/>
+                            <has_size min="59843"/>
+                            <!-- <has_line line="@SRR11953971.2053/2 2053 length=101"/> -->
                         </assert_contents>
                     </element>
                 </element>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -240,7 +240,8 @@
                             <!-- decompressed content assertions only work from 23.1
                                  therefore we test for size being at least one byte
                                  larger than the results of the previous test which
-                                 uses the shorter default deflines-->
+                                 uses the shorter default deflines
+                                 TODO replace has_size by has_line-->
                             <has_size min="147"/>
                             <!-- <has_line line="@ERR086330.1/1 1 length=76"/> -->
                         </assert_contents>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -237,24 +237,32 @@
                 <element name="ERR086330">
                     <element name="forward" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@ERR086330.1/1 1 length=76"/>
+                            <!-- decompressed content assertions only work from 23.1
+                                 therefore we test for size being at least one byte
+                                 larger than the results of the previous test which
+                                 uses the shorter default deflines-->
+                            <has_size min="147"/>
+                            <!-- <has_line line="@ERR086330.1/1 1 length=76"/> -->
                         </assert_contents>
                     </element>
                     <element name="reverse" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@ERR086330.1/2 1 length=76"/>
+                            <has_size min="141"/>
+                            <!-- <has_line line="@ERR086330.1/2 1 length=76"/> -->
                         </assert_contents>
                     </element>
                 </element>
                 <element name="SRR11953971">
                     <element name="forward" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@SRR11953971.1/1 1 length=101"/>
+                            <has_size min="56206"/>
+                            <!-- <has_line line="@SRR11953971.1/1 1 length=101"/> -->
                         </assert_contents>
                     </element>
                     <element name="reverse" ftype="fastqsanger.gz" decompress="True">
                         <assert_contents>
-                            <has_line line="@SRR11953971.1/2 1 length=101"/>
+                            <has_size min="59843"/>
+                            <!-- <has_line line="@SRR11953971.1/2 1 length=101"/> -->
                         </assert_contents>
                     </element>
                 </element>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -226,6 +226,40 @@
                 </element>
             </output_collection>
         </test>
+        <test expect_num_outputs="2">
+            <param name="input_select" value="accession_number"/>
+            <param name="outputformat" value="fastqsanger.gz"/>
+            <param name="accession" value="ERR086330, SRR11953971"/>
+            <section name="adv">
+                <param name="defline_seq" value="@$ac.$si/$ri $sn length=$rl"/>
+            </section>
+            <output_collection name="list_paired" type="list:paired" count="2">
+                <element name="ERR086330">
+                    <element name="forward" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@ERR086330.1/1 1 length=76"/>
+                        </assert_contents>
+                    </element>
+                    <element name="reverse" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@ERR086330.1/2 1 length=76"/>
+                        </assert_contents>
+                    </element>
+                </element>
+                <element name="SRR11953971">
+                    <element name="forward" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@SRR11953971.1/1 1 length=101"/>
+                        </assert_contents>
+                    </element>
+                    <element name="reverse" ftype="fastqsanger.gz" decompress="True">
+                        <assert_contents>
+                            <has_line line="@SRR11953971.1/2 1 length=101"/>
+                        </assert_contents>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
     </tests>
     <help><![CDATA[
 **What it does?**

--- a/tools/sra-tools/macros.xml
+++ b/tools/sra-tools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.0.5</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>
@@ -144,6 +144,8 @@
                     <add value=":" />
                     <add value="/" />
                     <add value="?" />
+                    <add value=" " />
+                    <add value="=" />
                 </valid>
             </sanitizer>
             <validator type="regex" message="Must start with @">^.*</validator>


### PR DESCRIPTION
Hrm.. tests will only work with 23.1 (https://github.com/galaxyproject/galaxy/pull/15085)

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
