### PR TITLE
query_tabular: Fix regex incompatibility error for Python3.11

### DIFF
--- a/tools/query_tabular/macros.xml
+++ b/tools/query_tabular/macros.xml
@@ -128,7 +128,7 @@
         <param name="sqlquery" type="text" area="true" size="20x80" value="" optional="true" label="SQL Query to generate tabular output">
             <help>By default: tables are named: t1,t2,...,tn and columns in each table: c1,c2,...,cn</help>
             <sanitizer sanitize="False"/>
-            <validator type="regex" message="">^(?ims)\s*select\s+.*\s+from\s+.*$</validator>
+            <validator type="regex" message="">(?ims)^\s*select\s+.*\s+from\s+.*$</validator>
         </param>
   </xml>
   <xml name="macro_line_filters">

--- a/tools/query_tabular/query_tabular.xml
+++ b/tools/query_tabular/query_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="query_tabular" name="Query Tabular" version="3.3.0">
+<tool id="query_tabular" name="Query Tabular" version="3.3.1">
     <description>using sqlite sql</description>
 
     <macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

See https://github.com/galaxyproject/galaxy/issues/16676 and https://github.com/python/cpython/issues/91222#issuecomment-1093946864 for more details.

In summary, from the Python issue description:

>This warning was introduced in 3.6. The reason is that in most other regular expression implementations global inline flags in the middle of the expression have different semantic: they affect only the part of the expression after the flag. But in Python they affect the whole expression. It caused confusion and was a source of bugs.
>
>After 5 releases it is a time to convert this warning into error. In future we can allow global inline flags in the middle of the expression with different semantic. It is safer if one or more intermediate versions will raise an error.