### PR TITLE
Add tests for broken snpfreqplot bmp and tiff options

### DIFF
--- a/tools/snpfreqplot/snpfreqplot.xml
+++ b/tools/snpfreqplot/snpfreqplot.xml
@@ -237,6 +237,26 @@ source('$__tool_directory__/heatmap_for_variants.R')
             </section>
             <output name="outfile" ftype="pdf" value="heatmap.from_vcf.pdf" compare="sim_size" delta="250" />
         </test>
+        -->
+        <test expect_num_outputs="1">
+            <!-- BMP, vcf test -->
+            <param name="sinputs" ftype="vcf" value="snpeff.123.vcf,snpeff.456.vcf,snpeff.789.vcf" />
+            <section name="advanced" >
+                <param name="color" value="PuBuGn" />
+                <param name="output_type" value="bmp" />
+            </section>
+            <output name="outfile" ftype="pdf" value="heatmap.from_vcf.bmp" compare="sim_size" delta="250" />
+        </test>
+        <test expect_num_outputs="1">
+            <!-- TIFF, vcf test -->
+            <param name="sinputs" ftype="vcf" value="snpeff.123.vcf,snpeff.456.vcf,snpeff.789.vcf" />
+            <section name="advanced" >
+                <param name="color" value="PuBuGn" />
+                <param name="output_type" value="tiff" />
+            </section>
+            <output name="outfile" ftype="tiff" value="heatmap.from_vcf.tiff" compare="sim_size" delta="250" />
+        </test>
+        <!--
         <test expect_num_outputs="1">
             <!-- SVG, problematic vcf test -->
             <param name="sinputs" ftype="vcf" value="1084592.vcf,1085080.vcf,1085445.vcf,1085841.vcf,1085990.vcf" />


### PR DESCRIPTION
These are failing with

```
snpeff.123.vcf : converted from VCF to tabular
snpeff.456.vcf : converted from VCF to tabular
snpeff.789.vcf : converted from VCF to tabular
Error in stop("Unknown extension: ", ext, ", aborting.") : 
  object 'ext' not found
Calls: source -> withVisible -> eval -> eval
Execution halted
```

@wm75 do you know if this ever worked, and if so, do you happen to know if this is because of a missing dependency ?
If not, should we just drop the options that don't work ?

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
