### PR TITLE
Abyss mem

### DIFF
--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -2,7 +2,7 @@
     <description>de novo sequence assembler</description>
     <macros>
         <token name="@TOOL_VERSION@">2.3.6</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <xml name="reads_conditional">
             <conditional name="reads">
                 <param name="reads_selector" type="select" label="Type of paired-end datasets">
@@ -85,7 +85,8 @@
 abyss-pe
 name=abyss
 j=\${GALAXY_SLOTS:-1}
-B=\${GALAXY_MEMORY_MB:-2048}M
+B=\$((\${GALAXY_MEMORY_MB:-2048} * 8 /10 ))M
+
 k=$k
 
 #if str($K)

--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -85,7 +85,7 @@
 abyss-pe
 name=abyss
 j=\${GALAXY_SLOTS:-1}
-B=\$((\${GALAXY_MEMORY_MB:-2048} * 8 /10 ))M
+B=\$((\${GALAXY_MEMORY_MB:-2048} * 9 /10 ))M
 
 k=$k
 

--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -228,7 +228,7 @@ k=$k
     </outputs>
 
     <tests>
-        <test>
+        <test expect_num_outputs="5">
             <repeat name="lib_repeat">
                 <conditional name="reads">
                     <param name="reads_selector" value="paired" />
@@ -243,14 +243,14 @@ k=$k
             <output name="indels" file="empty_file.fasta" />
             <output name="stats" file="abyss-stats1.tab" />
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="se_reads" ftype="fastq.gz" value="assembly_sample-R1.fastq.gz,assembly_sample-R2.fastq.gz" />
             <param name="k" value="50" />
             <output name="unitigs" file="abyss-unitigs2.fa" />
             <output name="indels" file="empty_file.fasta" />
             <output name="stats" file="abyss-stats2.tab" />
         </test>
-        <test>
+        <test expect_num_outputs="4">
             <param name="se_reads" ftype="fasta" value="assembly_sample-R1.fasta,assembly_sample-R2.fasta" />
             <param name="long_seqs" ftype="fasta" value="assembly_sample-R2.fasta" />
             <param name="k" value="50" />


### PR DESCRIPTION
Abyss is being killed by the OOM killer on GA. The intention is to pass 90% of the allocated RAM to the tool to allow some overhead.

cc @cat-bro 

---

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
