### PR TITLE
Fix CI badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Galaxy Tool Linting and Tests for push and PR](https://github.com/galaxyproject/tools-iuc/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/galaxyproject/tools-iuc/actions/workflows/pr.yaml/badge.svg)
-[![Weekly global Tool Linting and Tests](https://github.com/galaxyproject/tools-iuc/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/galaxyproject/tools-iuc/actions/workflows/ci.yaml/badge.svg)
+[![Galaxy Tool Linting and Tests for push and PR](https://github.com/galaxyproject/tools-iuc/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/galaxyproject/tools-iuc/actions/workflows/pr.yaml?query=branch:main)
+[![Weekly global Tool Linting and Tests](https://github.com/galaxyproject/tools-iuc/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/galaxyproject/tools-iuc/actions/workflows/ci.yaml?query=branch:main)
 [![Gitter](https://badges.gitter.im/galaxyproject/tools-iuc.svg)](https://gitter.im/galaxy-iuc/iuc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
 
 Galaxy Tools maintained by IUC


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Previously the badges in the README just linked to the badge image, not the CI results.
