### PR TITLE
Copy medaka fasta inputs

### DIFF
--- a/tools/medaka/macros.xml
+++ b/tools/medaka/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.7.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="bio_tools">
         <xrefs>
@@ -37,10 +37,10 @@
             #if $reference_source.ref_file.ext.endswith(".gz")
                 gunzip -c '$reference_source.ref_file' > reference.fa &&
             #else
-                ln -f -s '$reference_source.ref_file' reference.fa &&
+                cp '$reference_source.ref_file' reference.fa &&
             #end if
         #else:
-            ln -f -s '$reference_source.ref_file.fields.path' reference.fa &&
+            cp '$reference_source.ref_file.fields.path' reference.fa &&
         #end if
     ]]></token>
 

--- a/tools/medaka/snp.xml
+++ b/tools/medaka/snp.xml
@@ -140,6 +140,7 @@
 This module decodes probabilities to SNPs but NOT indels.
 
 For a more general solution see the medaka *variant* tool.
+
 ----
 
 .. class:: infomark


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tools-iuc/issues/4119. The fasta input is many times smaller than the sequence data, so this is minimal overhead and we can move to singularity for this tool.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
