### PR TITLE
Fix EdgeR: Deal with factor names on unified factor file

### DIFF
--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -283,7 +283,7 @@ if (!is.null(opt$filesPath)) {
     }
     # order samples as in counts matrix
     factordata <- factordata[match(colnames(counts), factordata[, 1]), ]
-    factors <- factordata[, -1, drop = FALSE]
+    factors <- sapply(factordata[, -1, drop = FALSE], make.names)
   } else {
     factors <- unlist(strsplit(opt$factInput, "|", fixed = TRUE))
     factordata <- list()

--- a/tools/edger/edger.R
+++ b/tools/edger/edger.R
@@ -283,7 +283,7 @@ if (!is.null(opt$filesPath)) {
     }
     # order samples as in counts matrix
     factordata <- factordata[match(colnames(counts), factordata[, 1]), ]
-    factors <- sapply(factordata[, -1, drop = FALSE], make.names)
+    factors <- data.frame(sapply(factordata[, -1, drop = FALSE], make.names))
   } else {
     factors <- unlist(strsplit(opt$factInput, "|", fixed = TRUE))
     factordata <- list()

--- a/tools/edger/edger.xml
+++ b/tools/edger/edger.xml
@@ -4,7 +4,7 @@
     </description>
     <macros>
         <token name="@TOOL_VERSION@">3.36.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <edam_topics>
         <edam_topic>topic_3308</edam_topic>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

When providing a single file to EdgeR for the factors, the levels of the different factors were not being passed through make.names to ensure their compliance with later R operations. As a result, you could get errors like:

```
Error in makeContrasts(contrasts = contrastData, levels = design) : 
  The levels must by syntactically valid names in R, see help(make.names).  Non-valid names:
```