### PR TITLE
Updating tools/bioext from version 0.20.4 to 0.21.0

### DIFF
--- a/tools/bioext/bealign.xml
+++ b/tools/bioext/bealign.xml
@@ -6,8 +6,8 @@
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.1.0">gawk</requirement>
-        <requirement type="package" version="1.14">samtools</requirement>
+        <requirement type="package" version="5.2.2">gawk</requirement>
+        <requirement type="package" version="1.17">samtools</requirement>
     </expand>
     <version_command>bealign --version</version_command>
     <command detect_errors="exit_code">

--- a/tools/bioext/macros.xml
+++ b/tools/bioext/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">0.20.4</token>
+    <token name="@TOOL_VERSION@">0.21.0</token>
     <token name="@PROFILE@">20.05</token>
     <token name="@SANITIZE@"><![CDATA[| gawk '{ if (\$0 ~ "^[^>]") {a = gensub(/[^ACGTURYKMSWBDHVNacgturykmswbdhvn?-]/, "", "g"); } else {a=gensub(/[^>A-Za-z0-9_]/, "_", "g"); }; print a } ' | sed 's,_\\+,_,g' >]]></token>
     <xml name="requirements">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/bioext**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/bioext from version 0.20.4 to 0.21.0.

**Project home page:** https://pypi.python.org/pypi/biopython-extensions

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).