### PR TITLE
coverm: fix usage of cached reference genomes

### DIFF
--- a/tools/coverm/coverm_genome.xml
+++ b/tools/coverm/coverm_genome.xml
@@ -33,10 +33,8 @@ mkdir 'bam/' &&
 ln -s '$genome' '$fn' &&
             #end for
         #else
-            #for $i, $genome in enumerate($mapped.genome.genomic.genome_fasta_files)
-                #set $fn = re.sub('[^\s\w\-\\.]', '_', str($genome.fields.path.element_identifier))
-                #silent $genome_fp.append( $fn )
-ln -s '$genome' '$fn' &&
+            #for $genome in $mapped.genome.genomic.genome_fasta_files
+                #silent $genome_fp.append($genome)
             #end for
         #end if
     #end if
@@ -455,8 +453,8 @@ coverm
                     <conditional name="genome">
                         <param name="ref_or_genome" value="genomic"/>
                         <conditional name="genomic">
-                            <param name="source" value="history"/>
-                            <param name="genome_fasta_files" value="500kb.fna,1mbp.fna"/>
+                            <param name="source" value="builtin"/>
+                            <param name="genome_fasta_files" value="500kb_name,1mbp_name"/>
                         </conditional>
                     </conditional>
                     <param name="sharded" value="" />

--- a/tools/coverm/macros.xml
+++ b/tools/coverm/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.6.1</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="requirements">
         <requirements>
@@ -74,7 +74,10 @@ ln -s '$bam' '$fn' &&
             </when>
             <when value="builtin">
                 <param argument="--genome-fasta-files" type="select" multiple="true" label="Reference genome(s)">
-                    <options from_data_table="all_fasta" />
+                    <options from_data_table="all_fasta">
+                        <column name="name" index="2"/>
+                        <column name="value" index="3"/>
+                    </options>
                 </param>
             </when>
         </conditional>
@@ -178,6 +181,8 @@ ln -s '$reads.interleaved' '$fn' &&
 ln -s '$ref' '${fn}' &&
 ]]></token>
     <token name="@GENOME_FOR_READS@"><![CDATA[
+        echo "GENOME_FOR_READS mapped.mode.genome.genomic.source=$mapped.mode.genome.genomic.source" &&
+        echo "GENOME_FOR_READS mapped.mode.genome.genomic.genome_fasta_files=$mapped.mode.genome.genomic.genome_fasta_files" &&
             #if $mapped.mode.genome.genomic.source == 'history'
                 #for $i, $genome in enumerate($mapped.mode.genome.genomic.genome_fasta_files)
                     #set $fn = re.sub('[^\s\w\-\\.]', '_', str($genome.element_identifier))
@@ -185,10 +190,8 @@ ln -s '$ref' '${fn}' &&
 ln -s '$genome' '$fn' &&
                 #end for
             #else
-                #for $i, $genome in enumerate($mapped.mode.genome.genomic.genome_fasta_files)
-                    #set $fn = re.sub('[^\s\w\-\\.]', '_', str($genome.fields.path.element_identifier))
-                    #silent $genome_fp.append( $fn )
-ln -s '$genome' '$fn' &&
+                #for $genome in $mapped.mode.genome.genomic.genome_fasta_files
+                    #silent $genome_fp.append($genome)
                 #end for
             #end if
 ]]></token>

--- a/tools/coverm/test-data/all_fasta.loc
+++ b/tools/coverm/test-data/all_fasta.loc
@@ -27,4 +27,6 @@
 #hg18full	hg18	Human (Homo sapiens): hg18 Full	/depot/data2/galaxy/hg18/hg18full.fasta
 #hg19canon	hg19	Human (Homo sapiens): hg19 Canonical	/depot/data2/galaxy/hg19/hg19canon.fasta
 #hg19full	hg19	Human (Homo sapiens): hg19 Full	/depot/data2/galaxy/hg19/hg19full.fasta
-test1tg01	"TestGenome"	${__HERE__}/reference.fasta
+500kb_value	50kb_dbkey	500kb_name	${__HERE__}/500kb.fna
+1mbp_value	1mbp_dbkey	1mbp_name	${__HERE__}/1mbp.fna
+1mbp


### PR DESCRIPTION
when iterating over dynamic selects one can not access
the fields property, but name and path column need to
be set manually for the select options, xref https://github.com/galaxyproject/galaxy/pull/16885

also adapts a test to check if code works

this never worked since there is obviously no element_identifier
attribute even if `.fields.path` would exist.



FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
