### PR TITLE
maf_stats: remove unused parameter

### DIFF
--- a/tools/maf_stats/.shed.yml
+++ b/tools/maf_stats/.shed.yml
@@ -1,6 +1,7 @@
 name: maf_stats
 owner: iuc
 description: MAF Coverage statistics
+long_description: computes the coverage of a genomic interval by a specified alignment
 homepage_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/interval2maf/
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/interval2maf/
 categories:

--- a/tools/maf_stats/maf_stats.xml
+++ b/tools/maf_stats/maf_stats.xml
@@ -109,7 +109,7 @@ Alternatively, you can request only summary information for a set of intervals:
     panTro2      30390      0.2353
     ========  ===========  ========
 
-where **coverage** is the number of nucleotides divided by the total length of the provider intervals.
+where **coverage** is the number of nucleotides divided by the total length of the intervals provided in the BED file.
     </help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btr398</citation>

--- a/tools/maf_stats/maf_stats.xml
+++ b/tools/maf_stats/maf_stats.xml
@@ -76,40 +76,40 @@
         </test>
     </tests>
     <help>
-        **What it does**
+**What it does**
 
-        This tool takes a MAF file and an interval file and relates coverage information by interval for each species.
-        If a column does not exist in the reference genome, it is not included in the output.
+This tool takes an MAF file and an interval file and relates coverage information by interval for each species.
+If a column does not exist in the reference genome, it is not included in the output.
 
-        Consider the interval: "chrX 1000 1100 myInterval"
-        Let's suppose we want to do stats on three way alignments for H, M, and R. The result look like this:
+Consider the interval: "chrX 1000 1100 myInterval"
+Let's suppose we want to do stats on three way alignments for H, M, and R. The result look like this:
 
-            chrX 1000 1100 myInterval H XXX YYY
+    chrX 1000 1100 myInterval H XXX YYY
 
-            chrX 1000 1100 myInterval M XXX YYY
+    chrX 1000 1100 myInterval M XXX YYY
 
-            chrX 1000 1100 myInterval R XXX YYY
+    chrX 1000 1100 myInterval R XXX YYY
 
 
-        where XXX and YYY are:
+where XXX and YYY are:
 
-            XXX = number of nucleotides
+    XXX = number of nucleotides
 
-            YYY = number of gaps
+    YYY = number of gaps
 
-        ----
+----
 
-        Alternatively, you can request only summary information for a set of intervals:
+Alternatively, you can request only summary information for a set of intervals:
 
-        ========  ===========  ========
-        #species  nucleotides  coverage
-        ========  ===========  ========
-        hg18         30639      0.2372
-        rheMac2      7524       0.0582
-        panTro2      30390      0.2353
-        ========  ===========  ========
+    ========  ===========  ========
+    #species  nucleotides  coverage
+    ========  ===========  ========
+    hg18         30639      0.2372
+    rheMac2      7524       0.0582
+    panTro2      30390      0.2353
+    ========  ===========  ========
 
-        where **coverage** is the number of nucleotides divided by the total length of the provided intervals.
+where **coverage** is the number of nucleotides divided by the total length of the provider intervals.
     </help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btr398</citation>

--- a/tools/maf_stats/maf_stats.xml
+++ b/tools/maf_stats/maf_stats.xml
@@ -1,4 +1,4 @@
-<tool id="maf_stats1" name="MAF Coverage Stats" version="1.0.1+galaxy0">
+<tool id="maf_stats1" name="MAF Coverage Stats" version="1.0.2+galaxy0">
     <description>Alignment coverage information</description>
     <command>
         <![CDATA[
@@ -34,11 +34,6 @@
                     </options>
                     <validator type="dataset_ok_validator" />
                 </param>
-                <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment">
-                    <options>
-                        <filter type="data_meta" ref="input2" key="species" />
-                    </options>
-                </param>
             </when>
             <when value="cached">
                 <param name="mafType" type="select" label="Choose alignments">
@@ -48,12 +43,6 @@
                         <column name="indexed_for" index="2"/>
                         <column name="exists_in_maf" index="3" />
                         <column name="path" index="4" />
-                    </options>
-                </param>
-                <param name="species" type="select" display="checkboxes" multiple="true" label="Choose species" help="Select species to be included in the final alignment">
-                    <options from_data_table="maf_indexes">
-                        <column name="value" index="3"/>
-                        <filter type="multiple_splitter" column="3" separator=","/>
                     </options>
                 </param>
             </when>


### PR DESCRIPTION
No idea what the tool does (the generated command line and the python script are super confusing) .. but species is not used.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
