### PR TITLE
add missing skip rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         mode: lint
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
-        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd
+        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,tool_urls,shed_metadata
     - uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:


### PR DESCRIPTION
note: tool_urls,shed_metadata effectively disable two tests that are by default enabled in the planemo-ci-action with `--ensure_metadata --urls` https://github.com/galaxyproject/planemo-ci-action/blob/fd4d12c417215f7cd9075227e784f4cd61c60044/planemo_ci_actions.sh#L115C7-L115C134

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
