### PR TITLE
Make species_name parameter required

### DIFF
--- a/tools/repeatmasker/repeatmasker.xml
+++ b/tools/repeatmasker/repeatmasker.xml
@@ -109,17 +109,19 @@
             </param>
           </when>
           <when value="no">
-            <param name="species_name" type="text" value="human" label="Repeat source species" help="Source species (or clade name) used to select repeats from DFam" />
+            <param name="species_name" type="text" value="human" label="Repeat source species" help="Source species (or clade name) used to select repeats from DFam">
+                <validator type="empty_field"/>
+            </param>
           </when>
         </conditional>
       </when>
       <when value="dfam_up">
           <param name="dfam_lib" type="data" format="h5" label="DFam library" help="The full DFam library can be downloaded from https://www.dfam.org/releases/current/families/Dfam.h5.gz" />
-          <param name="species_name" type="text" value="human" label="Repeat source species" help="Source species (or clade name) used to select repeats from DFam" />
+          <param name="species_name" type="text" value="human" optional="false" label="Repeat source species" help="Source species (or clade name) used to select repeats from DFam" />
       </when>
       <when value="library">
         <param name="repeat_lib" type="data" format="fasta" label="Custom library of repeats" />
-        <param name="cutoff" type="integer" argument="-cutoff" value="225" label="Cutoff score for masking repeats" />
+        <param type="integer" argument="-cutoff" value="225" label="Cutoff score for masking repeats" />
       </when>
     </conditional>
     <param type="boolean" argument="-gff" truevalue="-gff" falsevalue="" label="Output annotation of repeats in GFF format" checked="false" />


### PR DESCRIPTION
Got an error report where the command line contains `-species ''` and the stderr has:

```
Species "homo sapiens" is not known to RepeatMasker.  There may
not be any TE families defined in the libraries for this
species/clade or there may be an error in the spelling.
Please check your entry against the NCBI Taxonomy database
and/or try using a broader clade or related species instead.
The full list of species/clades defined in the library may be
obtained using the famdb.py script.
```

The default value is human, but it can be removed as text parameters are optional by default. Now I don't know how that would lead to the stderr above ... maybe an upstream bug ??

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
