### PR TITLE
Updating tools/cutadapt from version 4.4 to 4.5

### DIFF
--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">4.4</token>
+    <token name="@TOOL_VERSION@">4.5</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@FASTQ_TYPES@">fastq.gz,fastq,fasta</token>
     <xml name="edam_ontology">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cutadapt**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cutadapt from version 4.4 to 4.5.

**Project home page:** https://cutadapt.readthedocs.org/en/stable

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).