### PR TITLE
Updating tools/freebayes from version 1.3.6 to 1.3.7

### DIFF
--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -7,8 +7,8 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements">
-        <requirement type="package" version="5.1.0">gawk</requirement>
-        <requirement type="package" version="20211222">parallel</requirement>
+        <requirement type="package" version="5.3.0">gawk</requirement>
+        <requirement type="package" version="20230922">parallel</requirement>
     </expand>
     <expand macro="version_command" />
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/freebayes/macros.xml
+++ b/tools/freebayes/macros.xml
@@ -1,9 +1,9 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.3.6</token>
+    <token name="@TOOL_VERSION@">1.3.7</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">freebayes</requirement>
-            <requirement type="package" version="1.14">samtools</requirement>
+            <requirement type="package" version="1.18">samtools</requirement>
             <yield />
         </requirements>
     </xml>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/freebayes**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/freebayes from version 1.3.6 to 1.3.7.

**Project home page:** https://github.com/ekg/freebayes/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).