### PR TITLE
Updating tools/beagle from version 5.2_21Apr21.304 to 5.4_22Jul22.46e

### DIFF
--- a/tools/beagle/macros.xml
+++ b/tools/beagle/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">5.2_21Apr21.304</token>
-    <token name="@SUFFIX_VERSION@">1</token>
+    <token name="@TOOL_VERSION@">5.4_22Jul22.46e</token>
+    <token name="@SUFFIX_VERSION@">0</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
             <edam_topic>topic_0196</edam_topic>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/beagle**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/beagle from version 5.2_21Apr21.304 to 5.4_22Jul22.46e.

**Project home page:** https://faculty.washington.edu/browning/beagle/beagle.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).