### PR TITLE
Fix fallback workflow concurrency

### DIFF
--- a/.github/workflows/pr_without_tool_change.yaml
+++ b/.github/workflows/pr_without_tool_change.yaml
@@ -1,13 +1,11 @@
-name: Galaxy Tool Linting and Tests for push and PR
+name: Fallback
 # Fallback workflow that provides a succeeding "Check workflow success" job
 # as this is a requirement for being able to merge a PR
 # see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 on:
   pull_request:
 concurrency:
-  # Group runs by PR, but keep runs on the default branch separate
-  # because we do not want to cancel ToolShed uploads
-  group: pr-${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.run_number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   determine-success:


### PR DESCRIPTION
Include workflow name in group. No need for workaround for runs on default branch.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
