### PR TITLE
Updating tools/cat from version 5.2.3 to 5.3

### DIFF
--- a/tools/cat/macros.xml
+++ b/tools/cat/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">5.2.3</token>
+    <token name="@TOOL_VERSION@">5.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cat**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cat from version 5.2.3 to 5.3.

**Project home page:** https://github.com/dutilh/CAT/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).