### PR TITLE
Updating tools/mcl from version 14.137 to 22.282

### DIFF
--- a/tools/mcl/mcl.xml
+++ b/tools/mcl/mcl.xml
@@ -1,7 +1,7 @@
 <tool id="mcl" name="MCL" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <description>Markov Cluster Algorithm for graphs</description>
     <macros>
-        <token name="@TOOL_VERSION@">14.137</token>
+        <token name="@TOOL_VERSION@">22.282</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <xrefs>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mcl**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mcl from version 14.137 to 22.282.

**Project home page:** https://micans.org/mcl/man/mcl.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).