### PR TITLE
Updating tools/mosdepth from version 0.3.4 to 0.3.5

### DIFF
--- a/tools/mosdepth/mosdepth.xml
+++ b/tools/mosdepth/mosdepth.xml
@@ -25,11 +25,11 @@
             </sanitizer>
             <validator type="regex">([0-9A-Za-z!#$%&amp;+./:;?@^_|~-][0-9A-Za-z!#$%&amp;*+./:;=?@^_|~-]*)?</validator>
         </xml>
-        <token name="@TOOL_VERSION@">0.3.4</token>
+        <token name="@TOOL_VERSION@">0.3.5</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">mosdepth</requirement>
-        <requirement type="package" version="1.12">gzip</requirement>
+        <requirement type="package" version="1.13">gzip</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         #if $advanced.options == "yes" and len($advanced.quantize)


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mosdepth**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mosdepth from version 0.3.4 to 0.3.5.

**Project home page:** https://github.com/brentp/mosdepth/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).