### PR TITLE
Updating tools/mzmine from version 3.6.0 to 3.9.0

### DIFF
--- a/tools/mzmine/mzmine_batch.xml
+++ b/tools/mzmine/mzmine_batch.xml
@@ -1,6 +1,6 @@
 <tool id="mzmine_batch" name="MZMine batch" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <macros>
-        <token name="@TOOL_VERSION@">3.6.0</token>
+        <token name="@TOOL_VERSION@">3.9.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <xrefs>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mzmine**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mzmine from version 3.6.0 to 3.9.0.

**Project home page:** http://mzmine.github.io

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).