### PR TITLE
Updating tools/repeatmodeler from version 2.0.4 to 2.0.5

### DIFF
--- a/tools/repeatmodeler/macros.xml
+++ b/tools/repeatmodeler/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.0.4</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.0.5</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">
         <requirement type="package" version="@TOOL_VERSION@">repeatmodeler</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/repeatmodeler**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/repeatmodeler from version 2.0.4 to 2.0.5.

**Project home page:** https://www.repeatmasker.org/RepeatModeler

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).