### PR TITLE
Updating tools/rseqc from version 5.0.1 to 5.0.3

### DIFF
--- a/tools/rseqc/rseqc_macros.xml
+++ b/tools/rseqc/rseqc_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">5.0.1</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">5.0.3</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@GALAXY_VERSION@">20.01</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rseqc**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rseqc from version 5.0.1 to 5.0.3.

**Project home page:** https://code.google.com/p/rseqc

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).