### PR TITLE
Fix datamash for pulsar, use file_size

### DIFF
--- a/tools/datamash/datamash-transpose.xml
+++ b/tools/datamash/datamash-transpose.xml
@@ -2,6 +2,7 @@
     <description>rows/columns in a tabular file</description>
     <macros>
         <import>macros.xml</import>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <edam_topics>
         <edam_topic>topic_3570</edam_topic> <!-- Pure math / linear algebra -->
@@ -13,7 +14,7 @@
     <expand macro="stdio"/>
     <command><![CDATA[
         #import os
-        #set file_size_MB = os.path.getsize(str($in_file)) / (1024 * 1024)
+        #set file_size_MB = $in_file.get_size() / (1024 * 1024)
         #set size_threshold_MB = 1024
         #if $file_size_MB <= $size_threshold_MB:
             datamash transpose @FIELD_SEPARATOR@ < $in_file > $out_file


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tools-iuc/issues/5621

You can never open files in cheetah templates, but this is impossible to check for systematically. Time to adopt cwl style command line bindings ?

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
