### PR TITLE
Fix abritamr wrapper bug

### DIFF
--- a/tools/abritamr/abritamr.xml
+++ b/tools/abritamr/abritamr.xml
@@ -2,7 +2,7 @@
     <description>AMR gene detection with AMRFinderPlus</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.14</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">22.05</token>
     </macros>
     <requirements>
@@ -44,7 +44,7 @@ ${i.element_identifier}	${i}
             <option value="Streptococcus_pneumoniae">Streptococcus pneumoniae</option>
             <option value="Streptococcus_pyogenes">Streptococcus pyogenes</option>
         </param>
-        <param argument="identity" value="0.9" type="float" optional="true" min="0.0" max="1" label="Minimum identity of matches with armfinder. Default: 0.9, unless curated threshold is present for the gene."/>
+        <param argument="identity" type="float" optional="true" min="0.0" max="1" label="Minimum identity of matches with armfinder. Default: unset, uses a curated threshold for the gene if present, otherwise defaults to 0.9."/>
         <param name="log_file" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Generate log file."/>
     </inputs>
     <outputs>

--- a/tools/abritamr/abritamr.xml
+++ b/tools/abritamr/abritamr.xml
@@ -44,7 +44,7 @@ ${i.element_identifier}	${i}
             <option value="Streptococcus_pneumoniae">Streptococcus pneumoniae</option>
             <option value="Streptococcus_pyogenes">Streptococcus pyogenes</option>
         </param>
-        <param argument="identity" type="float" optional="true" min="0.0" max="1" label="Minimum identity of matches with armfinder. Default: unset, uses a curated threshold for the gene if present, otherwise defaults to 0.9."/>
+        <param argument="identity" type="float" optional="true" min="0.0" max="1.0" label="Minimum identity of matches with armfinder" help="The default is unset, uses a curated threshold for the gene if present, otherwise defaults to 0.9."/>
         <param name="log_file" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Generate log file."/>
     </inputs>
     <outputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

The identity argument should be unset.

If identity is not set, abritamr uses a curated threshold per gene. If a threshold is not present, it defaults to 0.9. The current default always uses a 0.9 threshold.