### PR TITLE
Write sra-tools config settings to config file

### DIFF
--- a/tools/sra-tools/macros.xml
+++ b/tools/sra-tools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.0.8</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>
@@ -36,11 +36,6 @@
     <token name="@COPY_CONFIGFILE@"><![CDATA[
         mkdir -p ~/.ncbi &&
         cp '$user_settings_mkfg' ~/.ncbi/user-settings.mkfg &&
-        vdb-config -s "/repository/user/main/public/root=\$PWD" &&
-        vdb-config -s "/repository/user/ad/public/root=\$PWD" &&
-        vdb-config -s "/repository/user/default-path=\$PWD" &&
-        vdb-config -s "/repository/user/main/public/root=\$PWD" &&
-        vdb-config -s /http/timeout/read=10000 &&
     ]]></token>
     <token name="@SET_ACCESSIONS@"><![CDATA[
         #if $input.input_select == "sra_file":
@@ -69,6 +64,11 @@
 /config/default = "false"
 /libs/temp_cache = "."
 /tools/prefetch/download_to_cache = "false"
+/http/timeout/read = "1000"
+/repository/user/main/public/root = "."
+/repository/user/ad/public/root = "."
+/repository/user/default-path = "."
+/repository/user/main/public/root = "."
             ]]></configfile>
         </configfiles>
     </macro>


### PR DESCRIPTION
Avoids `2023-11-17T08:54:02 vdb-config.3.0.8 err: condition violated while updating node - Warning: normally this application should not be run as root/superuser`, which vdb-config emits for whatever reason. Unclear why this has passed on the CI in the past, but this makes the script simpler, saves some repeated calls to the binary and importantly fixes `--biocontainers` locally.

FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
