### PR TITLE
pretext map allow for map quality 0

### DIFF
--- a/tools/pretext/.shed.yml
+++ b/tools/pretext/.shed.yml
@@ -13,6 +13,6 @@ auto_tool_repositories:
   name_template: "{{ tool_id }}"
   description_template: "Wrapper for Pretext: {{ tool_name }}"
 suite:
-  name: "pretext_suite"
+  name: "suite_pretext"
   description: "A suite of tools from the Pretext suite for contact mapping"
   type: repository_suite_definition

--- a/tools/pretext/pretext_map.xml
+++ b/tools/pretext/pretext_map.xml
@@ -2,7 +2,7 @@
     <description>converts SAM or BAM files into genome contact maps</description>
     <macros>
         <token name="@TOOL_VERSION@">0.1.9</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pretextmap</requirement>
@@ -23,7 +23,7 @@
             --sortby name
             --sortorder $sorting.sortorder
         #end if
-        #if $map_qual:
+        #if $map_qual or $map_qual == 0:
             --mapq $map_qual
         #end if
         #if $filter.filter_type == "in":

--- a/tools/pretext/pretext_map.xml
+++ b/tools/pretext/pretext_map.xml
@@ -23,7 +23,7 @@
             --sortby name
             --sortorder $sorting.sortorder
         #end if
-        #if $map_qual or $map_qual == 0:
+        #if str($map_qual):
             --mapq $map_qual
         #end if
         #if $filter.filter_type == "in":

--- a/tools/pretext/pretext_snapshot.xml
+++ b/tools/pretext/pretext_snapshot.xml
@@ -43,12 +43,12 @@
             <when value="png"/>
             <when value="bmp"/>
             <when value="jpeg">
-                <param name="jpegQuality" argument="--jpegQuality" type="integer" label="JPEG quality factor" value="80" min="0" max="100" help="An integer between 1 and 100, default 80. Larger values result in increased image quality and file size."/>
+                <param argument="--jpegQuality" type="integer" label="JPEG quality factor" value="80" min="0" max="100" help="An integer between 1 and 100, default 80. Larger values result in increased image quality and file size."/>
             </when>
         </conditional>
         <param name="resolution" argument="-r" type="integer" label="Output image resolution" min="1" value="1000" help="Image resolution, a positive integer, default 1080. For non-square images this will be the resolution of the longest dimension."/>
         <param name="colormap" argument='-c' type="integer" label="Color Map" value="5" min="0" max="30" help="Color map based on list available in the help section"/>
-        <param name="sequences" argument="--sequences" type="text" label="Sequence specification string" value="=full, =all" help="Each entry, except for '=all', corresponds to one output image. More information available in the help section.">
+        <param argument="--sequences" type="text" label="Sequence specification string" value="=full, =all" help="Each entry, except for '=all', corresponds to one output image. More information available in the help section.">
             <sanitizer invalid_char="">
                 <valid initial="string.ascii_letters,string.digits">
                     <add value="="/>
@@ -67,7 +67,10 @@
         </param>
         <param name="mintexels" argument="--minTexels" type="integer" min="1" label="Min Texels" value="64" help="Minimum map texels per image (along a single dimension), a positive integer, Output images over too small a range that violate this minimum will not be created."/>
         <conditional name="grid">
-            <param name="showGrid" label="Show grid?" type="boolean" truevalue="yes" falsevalue="no"/>
+            <param name="showGrid" label="Show grid?" type="select">
+                <option value="yes">Yes</option>
+                <option value="no">No</option>
+            </param>
             <when value="yes">
                 <param name="gridsize" argument="--gridSize" type="integer" label="Grid size" value="1" min="1" help="Width in pixels of the sequence separation grid, a non-negative integer. Set to 0 to not overlay a grid."/>
                 <param name="gridcolor" argument="--gridColour" type="text" label="Grid color" value="black" help="Colour of the sequence separation grid. Either, one of: 'black'(default), 'white', 'red', 'green', 'blue', 'yellow', 'cyan' or 'magenta'. Or, a sRGBA 32-bit hex code in RRGGBBAA format, e.g. 'ff00ff80' (magenta at half-occupancy)."/>

--- a/tools/pretext/pretext_snapshot.xml
+++ b/tools/pretext/pretext_snapshot.xml
@@ -1,11 +1,11 @@
-<tool id="pretext_snapshot" name="Pretext Snapshot"  version="@WRAPPER_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
+<tool id="pretext_snapshot" name="Pretext Snapshot"  version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
         <description>image generator for Pretext contact maps</description>
     <macros>
-        <token name="@WRAPPER_VERSION@">0.0.3</token>
+        <token name="@TOOL_VERSION@">0.0.3</token>
         <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
-        <requirement type="package" version="@WRAPPER_VERSION@">pretextsnapshot</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">pretextsnapshot</requirement>
         <requirement type="package" version="1.601">rename</requirement>
     </requirements>
     <version_command>PretextSnapshot --version</version_command>
@@ -43,7 +43,7 @@
             <when value="png"/>
             <when value="bmp"/>
             <when value="jpeg">
-                <param argument="--jpegQuality" type="integer" label="JPEG quality factor" value="80" min="0" max="100" help="An integer between 1 and 100, default 80. Larger values result in increased image quality and file size."/>
+                <param argument="--jpegQuality" type="integer" label="JPEG quality factor" value="80" min="0" max="100" help="An integer between 0 and 100, default 80. Larger values result in increased image quality and file size."/>
             </when>
         </conditional>
         <param name="resolution" argument="-r" type="integer" label="Output image resolution" min="1" value="1000" help="Image resolution, a positive integer, default 1080. For non-square images this will be the resolution of the longest dimension."/>
@@ -68,8 +68,8 @@
         <param name="mintexels" argument="--minTexels" type="integer" min="1" label="Min Texels" value="64" help="Minimum map texels per image (along a single dimension), a positive integer, Output images over too small a range that violate this minimum will not be created."/>
         <conditional name="grid">
             <param name="showGrid" label="Show grid?" type="select">
-                <option value="yes">Yes</option>
                 <option value="no">No</option>
+                <option value="yes">Yes</option>
             </param>
             <when value="yes">
                 <param name="gridsize" argument="--gridSize" type="integer" label="Grid size" value="1" min="1" help="Width in pixels of the sequence separation grid, a non-negative integer. Set to 0 to not overlay a grid."/>

--- a/tools/pretext/pretext_snapshot.xml
+++ b/tools/pretext/pretext_snapshot.xml
@@ -2,7 +2,7 @@
         <description>image generator for Pretext contact maps</description>
     <macros>
         <token name="@WRAPPER_VERSION@">0.0.3</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@WRAPPER_VERSION@">pretextsnapshot</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)

Current version of pretext map evaluates setting a minimum mapping quality as 0 to be false, and therefore sets it to the default of 10, despite 0 being a valid entry. This fixes that bug