### PR TITLE
funannotate_annotate pick up sequin files with discover_datasets

### DIFF
--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -3,9 +3,9 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <expand macro="biotools" />
+    <expand macro="biotools"/>
     <requirements>
-        <expand macro="requirements" />
+        <expand macro="requirements"/>
     </requirements>
     <version_command>funannotate check --show-versions</version_command>
     <command><![CDATA[
@@ -88,75 +88,65 @@ find output/annotate_results
 
     ]]></command>
     <inputs>
-
         <conditional name="input">
             <param name="input_type" type="select" label="Input format">
                 <option value="gbk" selected="True">GenBank (from 'Funannotate predict annotation' tool)</option>
                 <option value="gff">GFF</option>
             </param>
             <when value="gbk">
-                <param argument="--genbank" type="data" format="genbank" label="Genome annotation in genbank format" help="Output from 'Funannotate predict annotation' tool" />
+                <param argument="--genbank" type="data" format="genbank" label="Genome annotation in genbank format" help="Output from 'Funannotate predict annotation' tool"/>
             </when>
             <when value="gff">
-                <param argument="--gff" type="data" format="gff3" label="Genome annotation in gff format" />
-                <param argument="--fasta" type="data" format="fasta" label="Genome sequence" />
+                <param argument="--gff" type="data" format="gff3" label="Genome annotation in gff format"/>
+                <param argument="--fasta" type="data" format="fasta" label="Genome sequence"/>
                 <param argument="--species" type="text" optional="false" label="Name of the species to annotate" help="e.g. Genus species">
-                    <validator type="empty_field" />
+                    <validator type="empty_field"/>
                 </param>
             </when>
         </conditional>
-
         <param name="database" label="Funannotate database" type="select">
             <options from_data_table="funannotate">
-                <column name="value" index="0" />
-                <column name="name" index="1" />
-                <column name="path" index="3" />
-                <filter type="sort_by" column="0" />
-                <filter type="static_value" column="2" value="1.0" />
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <column name="path" index="3"/>
+                <filter type="sort_by" column="0"/>
+                <filter type="static_value" column="2" value="1.0"/>
             </options>
         </param>
-
-        <param argument="--sbt" type="data" format="txt" optional="true" label="NCBI submission template file" help="Create it on https://submit.ncbi.nlm.nih.gov/genbank/template/submission/ (or leave empty to use a default one, not suitable for submission at NCBI)" />
-
-        <param argument="--eggnog" type="data" format="tabular" optional="true" label="Eggnog-mapper annotations file" help="'annotations' output from 'eggNOG Mapper' tool" />
-        <param argument="--antismash" type="data" format="genbank" optional="true" label="antiSMASH secondary metabolism results" help="Genbank output from 'Antismash' tool" />
-        <param argument="--iprscan" type="data" format="xml" optional="true" label="InterProScan5 XML file" help="XML output from InterProScan" />
-        <param argument="--phobius" type="data" format="tabular" optional="true" label="Phobius pre-computed results" />
-
+        <param argument="--sbt" type="data" format="txt" optional="true" label="NCBI submission template file" help="Create it on https://submit.ncbi.nlm.nih.gov/genbank/template/submission/ (or leave empty to use a default one, not suitable for submission at NCBI)"/>
+        <param argument="--eggnog" type="data" format="tabular" optional="true" label="Eggnog-mapper annotations file" help="'annotations' output from 'eggNOG Mapper' tool"/>
+        <param argument="--antismash" type="data" format="genbank" optional="true" label="antiSMASH secondary metabolism results" help="Genbank output from 'Antismash' tool"/>
+        <param argument="--iprscan" type="data" format="xml" optional="true" label="InterProScan5 XML file" help="XML output from InterProScan"/>
+        <param argument="--phobius" type="data" format="tabular" optional="true" label="Phobius pre-computed results"/>
         <param argument="--busco_db" type="select" label="BUSCO models">
             <expand macro="busco_species"/>
         </param>
-
-        <param argument="--annotations" type="data" format="tabular" optional="true" label="Custom annotations" help="3 column tsv file" />
-
-        <param argument="--isolate" type="text" label="Isolate name" help="If relevant (e.g. Af293)" />
-        <param argument="--strain" type="text" label="Strain name" help="If relevant (e.g. FGSCA4)" />
-
-        <param argument="--rename" type="text" label="locus_tag from NCBI to rename GFF gene models with" />
-        <param argument="--fix" type="data" format="tabular" optional="true" label="Gene/Product names fixed" help="TSV: GeneID	Name	Product" />
-        <param argument="--remove" type="data" format="tabular" optional="true" label="Gene/Product names to remove" help="TSV: Gene	Product" />
-
-        <param argument="--header_length" type="integer" value="16" min="1" label="Maximum length of FASTA headers" help="The NCBI max FASTA header length is 16. Increase if you don't submit to NCBI." />
-
+        <param argument="--annotations" type="data" format="tabular" optional="true" label="Custom annotations" help="3 column tsv file"/>
+        <param argument="--isolate" type="text" label="Isolate name" help="If relevant (e.g. Af293)"/>
+        <param argument="--strain" type="text" label="Strain name" help="If relevant (e.g. FGSCA4)"/>
+        <param argument="--rename" type="text" label="locus_tag from NCBI to rename GFF gene models with"/>
+        <param argument="--fix" type="data" format="tabular" optional="true" label="Gene/Product names fixed" help="TSV: GeneID Name Product"/>
+        <param argument="--remove" type="data" format="tabular" optional="true" label="Gene/Product names to remove" help="TSV: Gene Product"/>
+        <param argument="--header_length" type="integer" value="16" min="1" label="Maximum length of FASTA headers" help="The NCBI max FASTA header length is 16. Increase if you don't submit to NCBI."/>
     </inputs>
     <outputs>
-        <collection name="funannotate_outputs" type="list" label="${tool.name} on ${on_string}" >
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gbk)" directory="output/annotate_results" format='genbank' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.annotations)\.txt" directory="output/annotate_results" format='tabular' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.contigs)\.fsa" directory="output/annotate_results" format='fasta' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.agp)" directory="output/annotate_results" format='tabular' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.tbl)" directory="output/annotate_results" format='txt' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.sqn)" directory="output/annotate_results" format='txt' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.scaffolds)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.proteins)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.mrna-transcripts)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.cds-transcripts)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gff3)" directory="output/annotate_results" format='gff3' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.discrepency\.report)\.txt" directory="output/annotate_results" format='txt' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.stats)\.json" directory="output/annotate_results" format='json' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.must-fix)\.txt" directory="output/annotate_results" format='json' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.need-curating)\.txt" directory="output/annotate_results" format='json' recurse="false" />
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" format='json' recurse="false" />
+        <collection name="funannotate_outputs" type="list" label="${tool.name} on ${on_string}">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gbk)" directory="output/annotate_results" format="genbank" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.annotations)\.txt" directory="output/annotate_results" format="tabular" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.contigs)\.fsa" directory="output/annotate_results" format="fasta" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.agp)" directory="output/annotate_results" format="tabular" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.tbl)" directory="output/annotate_results" format="txt" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.sqn)" directory="output/annotate_results" format="txt" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.scaffolds)\.fa" directory="output/annotate_results" format="fasta" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.proteins)\.fa" directory="output/annotate_results" format="fasta" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.mrna-transcripts)\.fa" directory="output/annotate_results" format="fasta" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.cds-transcripts)\.fa" directory="output/annotate_results" format="fasta" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gff3)" directory="output/annotate_results" format="gff3" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.discrepency\.report)\.txt" directory="output/annotate_results" format="txt" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.stats)\.json" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.must-fix)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.need-curating)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
         </collection>
         <!--
             This would be preferable, but in my testing 
@@ -171,183 +161,183 @@ find output/annotate_results
     <tests>
         <test expect_num_outputs="16">
             <conditional name="input">
-                <param name="input_type" value="gbk" />
-                <param name="genbank" value="predict_augustus/Genus_species.gbk" />
+                <param name="input_type" value="gbk"/>
+                <param name="genbank" value="predict_augustus/Genus_species.gbk"/>
             </conditional>
-            <param name="database" value="2021-07-20-120000" />
-            <param name="busco_db" value="insecta" />
-            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed" />
+            <param name="database" value="2021-07-20-120000"/>
+            <param name="busco_db" value="insecta"/>
+            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed"/>
             <output name="gbk">
                 <assert_contents>
-                    <has_text text="DEFINITION  Genus species." />
+                    <has_text text="DEFINITION  Genus species."/>
                 </assert_contents>
             </output>
             <output name="annot">
                 <assert_contents>
-                    <has_text text="EC_number" />
-                    <has_text text="EOG090W0T3K" />
+                    <has_text text="EC_number"/>
+                    <has_text text="EOG090W0T3K"/>
                 </assert_contents>
             </output>
             <output name="contigs_fsa">
                 <assert_contents>
-                    <has_text text=">contig_1" />
+                    <has_text text="&gt;contig_1"/>
                 </assert_contents>
             </output>
             <output name="agp">
                 <assert_contents>
-                    <has_text text="contig_1" />
+                    <has_text text="contig_1"/>
                 </assert_contents>
             </output>
             <output name="tbl">
                 <assert_contents>
-                    <has_text text="locus_tag" />
+                    <has_text text="locus_tag"/>
                 </assert_contents>
             </output>
             <output name="sqn">
                 <assert_contents>
-                    <has_text text="Seq-submit" />
+                    <has_text text="Seq-submit"/>
                 </assert_contents>
             </output>
             <output name="fa_scaffolds">
                 <assert_contents>
-                    <has_text text=">sample" />
+                    <has_text text="&gt;sample"/>
                 </assert_contents>
             </output>
             <output name="fa_proteins">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="fa_transcripts_mrna">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="fa_transcripts_cds">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="gff3">
                 <assert_contents>
-                    <has_text text="ID=FUN_000001;" />
+                    <has_text text="ID=FUN_000001;"/>
                 </assert_contents>
             </output>
             <output name="tbl2asn_report">
                 <assert_contents>
-                    <has_text text="Discrepancy Report Results" />
+                    <has_text text="Discrepancy Report Results"/>
                 </assert_contents>
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="avg_gene_length" />
+                    <has_text text="avg_gene_length"/>
                 </assert_contents>
             </output>
             <output name="must_fix">
                 <assert_contents>
-                    <has_text text="tbl2asn Error" />
+                    <has_text text="tbl2asn Error"/>
                 </assert_contents>
             </output>
             <output name="need_curating">
                 <assert_contents>
-                    <has_text text="Original Description" />
+                    <has_text text="Original Description"/>
                 </assert_contents>
             </output>
             <output name="new_names_passed">
                 <assert_contents>
-                    <has_text text="Passed Description" />
+                    <has_text text="Passed Description"/>
                 </assert_contents>
             </output>
         </test>
         <test expect_num_outputs="16">
             <conditional name="input">
-                <param name="input_type" value="gff" />
-                <param name="gff" value="predict_augustus/Genus_species.gff3" />
-                <param name="fasta" value="genome.fa" />
-                <param name="species" value="Genus species" />
+                <param name="input_type" value="gff"/>
+                <param name="gff" value="predict_augustus/Genus_species.gff3"/>
+                <param name="fasta" value="genome.fa"/>
+                <param name="species" value="Genus species"/>
             </conditional>
-            <param name="database" value="2021-07-20-120000" />
-            <param name="busco_db" value="insecta" />
-            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed" />
+            <param name="database" value="2021-07-20-120000"/>
+            <param name="busco_db" value="insecta"/>
+            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed"/>
             <output name="gbk">
                 <assert_contents>
-                    <has_text text="DEFINITION  Genus species." />
+                    <has_text text="DEFINITION  Genus species."/>
                 </assert_contents>
             </output>
             <output name="annot">
                 <assert_contents>
-                    <has_text text="EC_number" />
-                    <has_text text="EOG090W0T3K" />
+                    <has_text text="EC_number"/>
+                    <has_text text="EOG090W0T3K"/>
                 </assert_contents>
             </output>
             <output name="contigs_fsa">
                 <assert_contents>
-                    <has_text text=">contig_1" />
+                    <has_text text="&gt;contig_1"/>
                 </assert_contents>
             </output>
             <output name="agp">
                 <assert_contents>
-                    <has_text text="contig_1" />
+                    <has_text text="contig_1"/>
                 </assert_contents>
             </output>
             <output name="tbl">
                 <assert_contents>
-                    <has_text text="locus_tag" />
+                    <has_text text="locus_tag"/>
                 </assert_contents>
             </output>
             <output name="sqn">
                 <assert_contents>
-                    <has_text text="Seq-submit" />
+                    <has_text text="Seq-submit"/>
                 </assert_contents>
             </output>
             <output name="fa_scaffolds">
                 <assert_contents>
-                    <has_text text=">sample" />
+                    <has_text text="&gt;sample"/>
                 </assert_contents>
             </output>
             <output name="fa_proteins">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="fa_transcripts_mrna">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="fa_transcripts_cds">
                 <assert_contents>
-                    <has_text text=">FUN_000001-T1 FUN_000001" />
+                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
                 </assert_contents>
             </output>
             <output name="gff3">
                 <assert_contents>
-                    <has_text text="ID=FUN_000001;" />
+                    <has_text text="ID=FUN_000001;"/>
                 </assert_contents>
             </output>
             <output name="tbl2asn_report">
                 <assert_contents>
-                    <has_text text="Discrepancy Report Results" />
+                    <has_text text="Discrepancy Report Results"/>
                 </assert_contents>
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="avg_gene_length" />
+                    <has_text text="avg_gene_length"/>
                 </assert_contents>
             </output>
             <output name="must_fix">
                 <assert_contents>
-                    <has_text text="tbl2asn Error" />
+                    <has_text text="tbl2asn Error"/>
                 </assert_contents>
             </output>
             <output name="need_curating">
                 <assert_contents>
-                    <has_text text="Original Description" />
+                    <has_text text="Original Description"/>
                 </assert_contents>
             </output>
             <output name="new_names_passed">
                 <assert_contents>
-                    <has_text text="Passed Description" />
+                    <has_text text="Passed Description"/>
                 </assert_contents>
             </output>
         </test>
@@ -363,5 +353,5 @@ annotation from PFAM, InterPro, EggNog, UniProtKB, MEROPS, CAZyme, and GO ontolo
 
 .. _Funannotate: http://funannotate.readthedocs.io
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -1,4 +1,4 @@
-<tool id="funannotate_annotate" name="Funannotate functional" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="funannotate_annotate" name="Funannotate functional" profile="20.01" version="@TOOL_VERSION@+galaxy5">
     <description>annotation</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -72,27 +72,20 @@ funannotate annotate
 
 &&
 
+touch output/annotate_results/dummy.gbk
+
+&&
+
+ls -lh output/annotate_results 
+
+&&
+
 ## funannotate sometimes leaves multiple *part.tbl and *part.sqn files
 ## https://github.com/nextgenusfs/funannotate/issues/777
 find output/annotate_results 
 -regex ".*part_[0-9]+\.\(sqn\|tbl\)$"
 -delete
 
-&&
-
-mv output/annotate_results/*.gbk out.gbk &&
-mv output/annotate_results/*.annotations.txt out.annotations.txt &&
-mv output/annotate_results/*.contigs.fsa out.contigs.fsa &&
-mv output/annotate_results/*.agp out.agp &&
-mv output/annotate_results/*.tbl out.tbl &&
-mv output/annotate_results/*.sqn out.sqn &&
-mv output/annotate_results/*.scaffolds.fa out.scaffolds.fa &&
-mv output/annotate_results/*.proteins.fa out.proteins.fa &&
-mv output/annotate_results/*.mrna-transcripts.fa out.mrna-transcripts.fa &&
-mv output/annotate_results/*.cds-transcripts.fa out.cds-transcripts.fa &&
-mv output/annotate_results/*.gff3 out.gff3 &&
-mv output/annotate_results/*.discrepency.report.txt out.discrepency.report.txt &&
-mv output/annotate_results/*.stats.json out.stats.json
     ]]></command>
     <inputs>
 
@@ -144,74 +137,36 @@ mv output/annotate_results/*.stats.json out.stats.json
         <param argument="--remove" type="data" format="tabular" optional="true" label="Gene/Product names to remove" help="TSV: Gene	Product" />
 
         <param argument="--header_length" type="integer" value="16" min="1" label="Maximum length of FASTA headers" help="The NCBI max FASTA header length is 16. Increase if you don't submit to NCBI." />
-        <param name="outputs" type="select" optional="true" multiple="true" label="Which outputs should be generated">
-            <option value="gbk" selected="true">Annotated genome (genbank)</option>
-            <option value="annotations">TSV file of all annotations added to genome. (i.e. import into excel)</option>
-            <option value="contigs_fsa">Multi-fasta file of contigs, split at gaps (use for NCBI submission)</option>
-            <option value="agp">AGP file; showing linkage/location of contigs (use for NCBI submission)</option>
-            <option value="tbl">NCBI tbl annotation file (use for NCBI submission)</option>
-            <option value="sqn">NCBI Sequin genome file (use for NCBI submission)</option>
-            <option value="scaffolds_fa">Multi-fasta file of scaffolds</option>
-            <option value="proteins_fa">Multi-fasta file of protein coding genes</option>
-            <option value="mrna_transcripts_fa">Multi-fasta file of transcripts (mRNA)</option>
-            <option value="cds_transcripts_fa">Multi-fasta file of transcripts (CDS)</option>
-            <option value="gff3">Annotation in GFF3 format</option>
-            <option value="discrepency">tbl2asn summary report of annotated genome</option>
-            <option value="stats">Statistics</option>
-            <option value="must_fix">TSV file of Gene Name/Product deflines that failed to pass tbl2asn checks and must be fixed</option>
-            <option value="need_curating">TSV file of Gene Name/Product defines that need to be curated</option>
-            <option value="new_names_passed">TSV file of Gene Name/Product deflines that passed tbl2asn but are not in Gene2Products database.</option>
-        </param>
+
     </inputs>
     <outputs>
-        <data name='gbk' format='genbank' label="${tool.name} on ${on_string}: annotated genome (genbank)" from_work_dir="out.gbk">
-            <filter>outputs and 'gbk' in outputs</filter>
-        </data>
-        <data name='annot' format='tabular' label="${tool.name} on ${on_string}: all annotations" from_work_dir="out.annotations.txt">
-            <filter>outputs and 'annotations' in outputs</filter>
-        </data>
-        <data name='contigs_fsa' format='fasta' label="${tool.name} on ${on_string}: contigs fasta, split at gaps" from_work_dir="out.contigs.fsa">
-            <filter>outputs and 'contigs_fsa' in outputs</filter>
-        </data>
-        <data name='agp' format='tabular' label="${tool.name} on ${on_string}: AGP file" from_work_dir="out.agp">
-            <filter>outputs and 'agp' in outputs</filter>
-        </data>
-        <data name='tbl' format='txt' label="${tool.name} on ${on_string}: NCBI tbl annotation file" from_work_dir="out.tbl">
-            <filter>outputs and 'tbl' in outputs</filter>
-        </data>
-        <data name='sqn' format='txt' label="${tool.name} on ${on_string}: NCBI Sequin genome" from_work_dir="out.sqn">
-            <filter>outputs and 'sqn' in outputs</filter>
-        </data>
-        <data name='fa_scaffolds' format='fasta' label="${tool.name} on ${on_string}: scaffolds sequences" from_work_dir="out.scaffolds.fa">
-            <filter>outputs and 'scaffolds_fa' in outputs</filter>
-        </data>
-        <data name='fa_proteins' format='fasta' label="${tool.name} on ${on_string}: protein sequences" from_work_dir="out.proteins.fa">
-            <filter>outputs and 'proteins_fa' in outputs</filter>
-        </data>
-        <data name='fa_transcripts_mrna' format='fasta' label="${tool.name} on ${on_string}: transcript mRNA sequences" from_work_dir="out.mrna-transcripts.fa">
-            <filter>outputs and 'mrna_transcripts_fa' in outputs</filter>
-        </data>
-        <data name='fa_transcripts_cds' format='fasta' label="${tool.name} on ${on_string}: transcript CDS sequences" from_work_dir="out.cds-transcripts.fa">
-            <filter>outputs and 'cds_transcripts_fa' in outputs</filter>
-        </data>
-        <data name='gff3' format='gff3' label="${tool.name} on ${on_string}: annotation (GFF3)" from_work_dir="out.gff3">
-            <filter>outputs and 'gff3' in outputs</filter>
-        </data>
-        <data name='tbl2asn_report' format='txt' label="${tool.name} on ${on_string}: tbl2asn summary report of annotated genome" from_work_dir="out.discrepency.report.txt">
-            <filter>outputs and 'discrepency' in outputs</filter>
-        </data>
-        <data name='stats' format='json' label="${tool.name} on ${on_string}: stats" from_work_dir="out.stats.json">
-            <filter>outputs and 'gbk' in outputs</filter>
-        </data>
-        <data name='must_fix' format='json' label="${tool.name} on ${on_string}: Gene Name/Product must-fix" from_work_dir="output/annotate_results/Gene2Products.must-fix.txt">
-            <filter>outputs and 'must_fix' in outputs</filter>
-        </data>
-        <data name='need_curating' format='json' label="${tool.name} on ${on_string}: Gene Name/Product need-curating" from_work_dir="output/annotate_results/Gene2Products.need-curating.txt">
-            <filter>outputs and 'need_curating' in outputs</filter>
-        </data>
-        <data name='new_names_passed' format='json' label="${tool.name} on ${on_string}: Gene Name/Product new-names-passed" from_work_dir="output/annotate_results/Gene2Products.new-names-passed.txt">
+        <collection name="funannotate_outputs" type="list" label="${tool.name} on ${on_string}" >
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gbk)" directory="output/annotate_results" format='genbank' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.annotations)\.txt" directory="output/annotate_results" format='tabular' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.contigs)\.fsa" directory="output/annotate_results" format='fasta' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.agp)" directory="output/annotate_results" format='tabular' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.tbl)" directory="output/annotate_results" format='txt' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.sqn)" directory="output/annotate_results" format='txt' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.scaffolds)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.proteins)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.mrna-transcripts)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.cds-transcripts)\.fa" directory="output/annotate_results" format='fasta' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.gff3)" directory="output/annotate_results" format='gff3' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.discrepency\.report)\.txt" directory="output/annotate_results" format='txt' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.stats)\.json" directory="output/annotate_results" format='json' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.must-fix)\.txt" directory="output/annotate_results" format='json' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.need-curating)\.txt" directory="output/annotate_results" format='json' recurse="false" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" format='json' recurse="false" />
+        </collection>
+        <!--
+            This would be preferable, but in my testing 
+            assign_primary_output="true" is not working and you end up with two
+            outputs for each file.
+        <data name='new_names_passed' format='json' label="${tool.name} on ${on_string}: Gene Name/Product new-names-passed">
+            <discover_datasets pattern="(?P&lt;name&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" recurse="false" assign_primary_output="true" />
             <filter>outputs and 'new_names_passed' in outputs</filter>
         </data>
+         -->
     </outputs>
     <tests>
         <test expect_num_outputs="16">

--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -70,22 +70,6 @@ funannotate annotate
 --header_length $header_length
 --cpus \${GALAXY_SLOTS:-2}
 
-&&
-
-touch output/annotate_results/dummy.gbk
-
-&&
-
-ls -lh output/annotate_results 
-
-&&
-
-## funannotate sometimes leaves multiple *part.tbl and *part.sqn files
-## https://github.com/nextgenusfs/funannotate/issues/777
-find output/annotate_results 
--regex ".*part_[0-9]+\.\(sqn\|tbl\)$"
--delete
-
     ]]></command>
     <inputs>
         <conditional name="input">
@@ -144,112 +128,113 @@ find output/annotate_results
             <discover_datasets pattern="(?P&lt;designation&gt;.+\.gff3)" directory="output/annotate_results" format="gff3" recurse="false"/>
             <discover_datasets pattern="(?P&lt;designation&gt;.+\.discrepency\.report)\.txt" directory="output/annotate_results" format="txt" recurse="false"/>
             <discover_datasets pattern="(?P&lt;designation&gt;.+\.stats)\.json" directory="output/annotate_results" format="json" recurse="false"/>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.must-fix)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.need-curating)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="Gene2Products\.(?P&lt;designation&gt;must-fix)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="Gene2Products\.(?P&lt;designation&gt;need-curating)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
+            <discover_datasets pattern="Gene2Products\.(?P&lt;designation&gt;new-names-passed)\.txt" directory="output/annotate_results" format="json" recurse="false"/>
         </collection>
-        <!--
+        <!-- 
             This would be preferable, but in my testing 
             assign_primary_output="true" is not working and you end up with two
             outputs for each file.
-        <data name='new_names_passed' format='json' label="${tool.name} on ${on_string}: Gene Name/Product new-names-passed">
-            <discover_datasets pattern="(?P&lt;name&gt;.+\.new-names-passed)\.txt" directory="output/annotate_results" recurse="false" assign_primary_output="true" />
+        <data name='new_names_passed' label="${tool.name} on ${on_string}: Gene Name/Product new-names-passed">
+            <discover_datasets pattern="(?P&lt;name&gt;.+\.new-names-passed)\.txt" ext="json" directory="output/annotate_results" recurse="false" assign_primary_output="false" />
             <filter>outputs and 'new_names_passed' in outputs</filter>
         </data>
          -->
     </outputs>
     <tests>
-        <test expect_num_outputs="16">
+        <test expect_num_outputs="1">
             <conditional name="input">
                 <param name="input_type" value="gbk"/>
                 <param name="genbank" value="predict_augustus/Genus_species.gbk"/>
             </conditional>
             <param name="database" value="2021-07-20-120000"/>
             <param name="busco_db" value="insecta"/>
-            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed"/>
-            <output name="gbk">
-                <assert_contents>
-                    <has_text text="DEFINITION  Genus species."/>
-                </assert_contents>
-            </output>
-            <output name="annot">
-                <assert_contents>
-                    <has_text text="EC_number"/>
-                    <has_text text="EOG090W0T3K"/>
-                </assert_contents>
-            </output>
-            <output name="contigs_fsa">
-                <assert_contents>
-                    <has_text text="&gt;contig_1"/>
-                </assert_contents>
-            </output>
-            <output name="agp">
-                <assert_contents>
-                    <has_text text="contig_1"/>
-                </assert_contents>
-            </output>
-            <output name="tbl">
-                <assert_contents>
-                    <has_text text="locus_tag"/>
-                </assert_contents>
-            </output>
-            <output name="sqn">
-                <assert_contents>
-                    <has_text text="Seq-submit"/>
-                </assert_contents>
-            </output>
-            <output name="fa_scaffolds">
-                <assert_contents>
-                    <has_text text="&gt;sample"/>
-                </assert_contents>
-            </output>
-            <output name="fa_proteins">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="fa_transcripts_mrna">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="fa_transcripts_cds">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="gff3">
-                <assert_contents>
-                    <has_text text="ID=FUN_000001;"/>
-                </assert_contents>
-            </output>
-            <output name="tbl2asn_report">
-                <assert_contents>
-                    <has_text text="Discrepancy Report Results"/>
-                </assert_contents>
-            </output>
-            <output name="stats">
-                <assert_contents>
-                    <has_text text="avg_gene_length"/>
-                </assert_contents>
-            </output>
-            <output name="must_fix">
-                <assert_contents>
-                    <has_text text="tbl2asn Error"/>
-                </assert_contents>
-            </output>
-            <output name="need_curating">
-                <assert_contents>
-                    <has_text text="Original Description"/>
-                </assert_contents>
-            </output>
-            <output name="new_names_passed">
-                <assert_contents>
-                    <has_text text="Passed Description"/>
-                </assert_contents>
-            </output>
+            <output_collection name="funannotate_outputs" type="list">
+                <element name="Genus_species.gbk">
+                    <assert_contents>
+                        <has_text text="DEFINITION  Genus species."/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.annotations">
+                    <assert_contents>
+                        <has_text text="EC_number"/>
+                        <has_text text="EOG090W0T3K"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.contigs">
+                    <assert_contents>
+                        <has_text text="&gt;contig_1"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.agp">
+                    <assert_contents>
+                        <has_text text="contig_1"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.tbl">
+                    <assert_contents>
+                        <has_text text="locus_tag"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.sqn">
+                    <assert_contents>
+                        <has_text text="Seq-submit"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.scaffolds">
+                    <assert_contents>
+                        <has_text text="&gt;sample"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.proteins">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.mrna-transcripts">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.cds-transcripts">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.gff3">
+                    <assert_contents>
+                        <has_text text="ID=FUN_000001;"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.discrepency.report">
+                    <assert_contents>
+                        <has_text text="Discrepancy Report Results"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.stats">
+                    <assert_contents>
+                        <has_text text="avg_gene_length"/>
+                    </assert_contents>
+                </element>
+                <element name="must-fix">
+                    <assert_contents>
+                        <has_text text="tbl2asn Error"/>
+                    </assert_contents>
+                </element>
+                <element name="need-curating">
+                    <assert_contents>
+                        <has_text text="Original Description"/>
+                    </assert_contents>
+                </element>
+                <element name="new-names-passed">
+                    <assert_contents>
+                        <has_text text="Passed Description"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
         </test>
-        <test expect_num_outputs="16">
+        <test expect_num_outputs="1">
             <conditional name="input">
                 <param name="input_type" value="gff"/>
                 <param name="gff" value="predict_augustus/Genus_species.gff3"/>
@@ -258,88 +243,89 @@ find output/annotate_results
             </conditional>
             <param name="database" value="2021-07-20-120000"/>
             <param name="busco_db" value="insecta"/>
-            <param name="outputs" value="gbk,annotations,contigs_fsa,agp,tbl,sqn,scaffolds_fa,proteins_fa,mrna_transcripts_fa,cds_transcripts_fa,gff3,discrepency,stats,must_fix,need_curating,new_names_passed"/>
-            <output name="gbk">
-                <assert_contents>
-                    <has_text text="DEFINITION  Genus species."/>
-                </assert_contents>
-            </output>
-            <output name="annot">
-                <assert_contents>
-                    <has_text text="EC_number"/>
-                    <has_text text="EOG090W0T3K"/>
-                </assert_contents>
-            </output>
-            <output name="contigs_fsa">
-                <assert_contents>
-                    <has_text text="&gt;contig_1"/>
-                </assert_contents>
-            </output>
-            <output name="agp">
-                <assert_contents>
-                    <has_text text="contig_1"/>
-                </assert_contents>
-            </output>
-            <output name="tbl">
-                <assert_contents>
-                    <has_text text="locus_tag"/>
-                </assert_contents>
-            </output>
-            <output name="sqn">
-                <assert_contents>
-                    <has_text text="Seq-submit"/>
-                </assert_contents>
-            </output>
-            <output name="fa_scaffolds">
-                <assert_contents>
-                    <has_text text="&gt;sample"/>
-                </assert_contents>
-            </output>
-            <output name="fa_proteins">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="fa_transcripts_mrna">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="fa_transcripts_cds">
-                <assert_contents>
-                    <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
-                </assert_contents>
-            </output>
-            <output name="gff3">
-                <assert_contents>
-                    <has_text text="ID=FUN_000001;"/>
-                </assert_contents>
-            </output>
-            <output name="tbl2asn_report">
-                <assert_contents>
-                    <has_text text="Discrepancy Report Results"/>
-                </assert_contents>
-            </output>
-            <output name="stats">
-                <assert_contents>
-                    <has_text text="avg_gene_length"/>
-                </assert_contents>
-            </output>
-            <output name="must_fix">
-                <assert_contents>
-                    <has_text text="tbl2asn Error"/>
-                </assert_contents>
-            </output>
-            <output name="need_curating">
-                <assert_contents>
-                    <has_text text="Original Description"/>
-                </assert_contents>
-            </output>
-            <output name="new_names_passed">
-                <assert_contents>
-                    <has_text text="Passed Description"/>
-                </assert_contents>
-            </output>
+            <output_collection name="funannotate_outputs" type="list">
+                <element name="Genus_species.gbk">
+                    <assert_contents>
+                        <has_text text="DEFINITION  Genus species."/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.annotations">
+                    <assert_contents>
+                        <has_text text="EC_number"/>
+                        <has_text text="EOG090W0T3K"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.contigs">
+                    <assert_contents>
+                        <has_text text="&gt;contig_1"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.agp">
+                    <assert_contents>
+                        <has_text text="contig_1"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.tbl">
+                    <assert_contents>
+                        <has_text text="locus_tag"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.sqn">
+                    <assert_contents>
+                        <has_text text="Seq-submit"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.scaffolds">
+                    <assert_contents>
+                        <has_text text="&gt;sample"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.proteins">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.mrna-transcripts">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.cds-transcripts">
+                    <assert_contents>
+                        <has_text text="&gt;FUN_000001-T1 FUN_000001"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.gff3">
+                    <assert_contents>
+                        <has_text text="ID=FUN_000001;"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.discrepency.report">
+                    <assert_contents>
+                        <has_text text="Discrepancy Report Results"/>
+                    </assert_contents>
+                </element>
+                <element name="Genus_species.stats">
+                    <assert_contents>
+                        <has_text text="avg_gene_length"/>
+                    </assert_contents>
+                </element>
+                <element name="must-fix">
+                    <assert_contents>
+                        <has_text text="tbl2asn Error"/>
+                    </assert_contents>
+                </element>
+                <element name="need-curating">
+                    <assert_contents>
+                        <has_text text="Original Description"/>
+                    </assert_contents>
+                </element>
+                <element name="new-names-passed">
+                    <assert_contents>
+                        <has_text text="Passed Description"/>
+                    </assert_contents>
+                </element>
+            </output_collection>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/funannotate/funannotate_compare.xml
+++ b/tools/funannotate/funannotate_compare.xml
@@ -28,7 +28,7 @@ $inputs
     --run_dnds ${run_dnds}
 #end if
 
-## TODO add --outgroup option some day (hard to get an up to date/customizable list)
+## need to add --outgroup option some day (hard to get an up to date/customizable list)
 
 --go_fdr ${go_fdr}
 

--- a/tools/funannotate/macros.xml
+++ b/tools/funannotate/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.8.15</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <xml name="biotools">
         <xrefs>
             <xref type="bio.tools">


### PR DESCRIPTION
I think I have made a mess of the `funannotate_annotate` wrapper :upside_down_face: 

We are still getting errors like this on Galaxy AU:

```
[Dec 22 04:43 AM]: Funannotate annotate has completed successfully!

... 

mv: cannot stat 'output/annotate_results/*.sqn': No such file or directory
```

It's hard to debug on Galaxy because it only happens with large inputs.  It has been reported upstream https://github.com/nextgenusfs/funannotate/issues/777#issuecomment-1771800833.

In this PR I've removed the `mv` commands by using a wildcard in `from_work_dir` instead for most outputs. The exception is the sqn files, which are picked up with `discover_datasets`.

@abretaud What do you think?

<details>
  <summary>Edits</summary>

~~In this PR I've used discover_datasets to pick up files from the output directory and specify their formats. That means we can skip the `mv` commands. We can also remove the output selector, since that is not being used in the wrapper except to filter the output.~~



~~The downside is that the output looks much less tidy (although it's in a collection) and I can't seem to relabel the datasets because of the way `discover_datasets` works. Here's a screenshot:~~

![screenshot-localhost_9090-2024 01 09-14_29_13](https://github.com/galaxyproject/tools-iuc/assets/5971975/89a9ee57-434a-4d75-ab14-8d1dded950fd)

</details>


---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
