### PR TITLE
Update orthofinder and pick up new orthogroup output

### DIFF
--- a/tools/orthofinder/macros.xml
+++ b/tools/orthofinder/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.5.4</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">2.5.5</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="citations">
         <citations>

--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -157,6 +157,9 @@
         <!-- Orthogroups results -->
         <data format="txt" name="orthogroups1" label="OrthoFinder on ${on_string}: orthogroups (txt)" from_work_dir="results/Orthogroups/Orthogroups.txt" />
         <data format="tsv" name="orthogroups2" label="OrthoFinder on ${on_string}: orthogroups (tsv)" from_work_dir="results/Orthogroups/Orthogroups.tsv" />
+        <data format="tsv" name="hogs" label="OrthoFinder on ${on_string}: hierarchical orthogroups (tsv)" from_work_dir="results/Phylogenetic_Hierarchical_Orthogroups/N0.tsv" >
+            <filter>trees['run_mode'] == "full"</filter>
+        </data>
         <data format="tsv" name="specs_overlap" label="OrthoFinder on ${on_string}: species overlaps" from_work_dir="results/Comparative_Genomics_Statistics/Orthogroups_SpeciesOverlaps.tsv" />
         <data format="tsv" name="unassigned_genes" label="OrthoFinder on ${on_string}: unassigned genes" from_work_dir="results/Orthogroups/Orthogroups_UnassignedGenes.tsv" />
         <data format="tsv" name="stat_overall" label="OrthoFinder on ${on_string}: overall comparative genomics statistics" from_work_dir="results/Comparative_Genomics_Statistics/Statistics_Overall.tsv" />

--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -1,14 +1,14 @@
 <tool name="OrthoFinder" id="orthofinder_onlygroups" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>finds orthogroups in a set of proteomes</description>
-    <xrefs>
-        <xref type="bio.tools">OrthoFinder</xref>
-    </xrefs>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">OrthoFinder</xref>
+    </xrefs>
     <requirements>
+        <container type="singularity">
         <requirement type="package" version="@TOOL_VERSION@">orthofinder</requirement>
-        <requirement type="package" version="2.36">util-linux</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         #import re

--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -494,7 +494,7 @@
             <output name="stat_specs" value="results_fromblast/Statistics_PerSpecies.tsv"/>
         </test>
         <!-- full mode + diamond + input files have extension fasta/faa/fa -->
-        <test expect_num_outputs="9">
+        <test expect_num_outputs="10">
             <conditional name="init">
                 <param name="start" value="fasta" />
                 <param name="input_fasta" ftype="fasta" value="inputs/proteomes/Mycoplasma_agalactiae.faa,inputs/proteomes/Mycoplasma_gallisepticum.faa,inputs/proteomes/Mycoplasma_genitalium.faa,inputs/proteomes/Mycoplasma_hyopneumoniae.faa" />
@@ -552,9 +552,21 @@
             </output>
             <output name="species_tree" value="results/SpeciesTree_rooted.txt" compare="sim_size"/>
             <output_collection name="genetrees" type="list" count="0"/>
+            <output name="hogs">
+                <assert_contents>
+                    <has_text text="HOG" />
+                    <has_text text="OG" />
+                    <has_text text="Gene Tree Parent Clade" />
+                    <has_text text="Mycoplasma_agalactiae"/>
+                    <has_text text="Mycoplasma_gallisepticum"/>
+                    <has_text text="Mycoplasma_genitalium"/>
+                    <has_text text="Mycoplasma_hyopneumoniae"/>
+                    <has_n_columns n="7"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- full mode + diamond + input files have extension fasta/faa/fa + duplications -->
-        <test expect_num_outputs="14">
+        <test expect_num_outputs="15">
             <conditional name="init">
                 <param name="start" value="fasta" />
                 <param name="input_fasta" ftype="fasta" value="inputs/proteomes/Mycoplasma_agalactiae.faa,inputs/proteomes/Mycoplasma_gallisepticum.faa,inputs/proteomes/Mycoplasma_genitalium.faa,inputs/proteomes/Mycoplasma_hyopneumoniae.faa" />
@@ -618,6 +630,18 @@
             <output name="duplications_per_species_tree_node" value="results/Duplications_per_Species_Tree_Node.tsv" compare="sim_size"/>
             <output_collection name="genetrees" type="list" count="325"/>
             <output_collection name="resolved_trees" type="list" count="325"/>
+            <output name="hogs">
+                <assert_contents>
+                    <has_text text="HOG" />
+                    <has_text text="OG" />
+                    <has_text text="Gene Tree Parent Clade" />
+                    <has_text text="Mycoplasma_agalactiae"/>
+                    <has_text text="Mycoplasma_gallisepticum"/>
+                    <has_text text="Mycoplasma_genitalium"/>
+                    <has_text text="Mycoplasma_hyopneumoniae"/>
+                    <has_n_columns n="7"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- trees + diamond + input files have no extension fasta/faa/fa + msa -->
         <test expect_num_outputs="6">
@@ -683,7 +707,7 @@
             </output>
         </test>
         <!-- trees + diamond + input files have no extension fasta/faa/fa + msa -->
-        <test expect_num_outputs="9">
+        <test expect_num_outputs="10">
             <conditional name="init">
                 <param name="start" value="fasta" />
                 <param name="input_fasta" ftype="fasta" value="inputs/proteomes/Mycoplasma_agalactiae.faa,inputs/proteomes/Mycoplasma_gallisepticum.faa,inputs/proteomes/Mycoplasma_genitalium.faa,inputs/proteomes/Mycoplasma_hyopneumoniae.faa" />
@@ -742,6 +766,18 @@
                     <has_text text="Number of orthogroups"/>
                     <has_text text="Number of genes"/>
                     <has_n_columns n="5"/>
+                </assert_contents>
+            </output>
+            <output name="hogs">
+                <assert_contents>
+                    <has_text text="HOG" />
+                    <has_text text="OG" />
+                    <has_text text="Gene Tree Parent Clade" />
+                    <has_text text="Mycoplasma_agalactiae"/>
+                    <has_text text="Mycoplasma_gallisepticum"/>
+                    <has_text text="Mycoplasma_genitalium"/>
+                    <has_text text="Mycoplasma_hyopneumoniae"/>
+                    <has_n_columns n="7"/>
                 </assert_contents>
             </output>
             <assert_command>

--- a/tools/orthofinder/orthofinder_only_groups.xml
+++ b/tools/orthofinder/orthofinder_only_groups.xml
@@ -7,7 +7,6 @@
         <xref type="bio.tools">OrthoFinder</xref>
     </xrefs>
     <requirements>
-        <container type="singularity">
         <requirement type="package" version="@TOOL_VERSION@">orthofinder</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Pick up new ["Hierarchical Orthogroups"](https://github.com/davidemms/OrthoFinder#phylogenetic-hierarchical-orthogroups-directory) output

Fixed  bioconda recipe (https://github.com/bioconda/bioconda-recipes/pull/45149) and update orthofinder to 2.5.5 (closes #5312)

---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
