### PR TITLE
pick_value: allow for an optional default

### DIFF
--- a/tools/pick_value/pick_value.xml
+++ b/tools/pick_value/pick_value.xml
@@ -1,4 +1,4 @@
-<tool name="Pick parameter value" id="pick_value" version="0.1.0" profile="21.01" tool_type="expression">
+<tool name="Pick parameter value" id="pick_value" version="0.1.0" profile="24.0" tool_type="expression">
     <macros>
         <xml name="booleans">
             <repeat name="pick_from" title="Pick from">

--- a/tools/pick_value/pick_value.xml
+++ b/tools/pick_value/pick_value.xml
@@ -83,7 +83,7 @@
                 </when>
                 <when value="data">
                     <expand macro="datas" />
-                    <param name="default_value" type="data" format="data" label="Default Value" />
+                    <param name="default_value" type="data" optional="true" format="data" label="Default Value" />
                 </when>
             </conditional>
         </xml>
@@ -368,6 +368,28 @@ taken.
             </conditional>
             <output name="data_param" value="simple_line.txt" />
         </test>
+
+        <!-- with first_or_default an "empty" file (containing the text `"null"`)
+             is created if no data value is given and also the optional default
+             is left empty -->
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_default" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="data" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="data_param">
+                <assert_contents>
+                    <has_text text="null"/>
+                    <has_size value="4"/>
+                </assert_contents>
+            </output>
+        </test>
+
     </tests>
 </tool>
 


### PR DESCRIPTION
the use case is to connect an optional workflow input to a mandatory tool input (the tool is conditionally executed only of a dataset is given - which is implemented via the map_value tool functionality https://github.com/galaxyproject/tools-iuc/pull/5706).

the optional WF input can not be connected to the mandatory tool input. with the pick value tool we can transform the optional input in a non-optional one, before this change a default value needed to be specified, i.e. an (empty) file needed to be provided somehow. now the tool does this automatically if no default is given.

potentially nice is that now for all input types the default parameter is optional.

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
