### PR TITLE
`pick_value`: implement `format_souce`

### DIFF
--- a/tools/pick_value/pick_value.xml
+++ b/tools/pick_value/pick_value.xml
@@ -1,4 +1,4 @@
-<tool name="Pick parameter value" id="pick_value" version="0.1.0" profile="21.01" tool_type="expression">
+<tool name="Pick parameter value" id="pick_value" version="0.2.0" profile="21.01" tool_type="expression">
     <macros>
         <xml name="booleans">
             <repeat name="pick_from" title="Pick from">
@@ -146,7 +146,11 @@ return { 'output': out };
         <output type="boolean" name="boolean_param" from="output">
             <filter>style_cond['type_cond']['param_type'] == 'boolean'</filter>
         </output>
-        <output type="data" name="data_param" from="output">
+        <!-- Galaxy already copies the dataset with all its properties (including format)
+             in exec_after_process. setting the format_source here is in this sense
+             redundant, but helps the workflow editor to infer the data type
+             (from the dataset in the first repeat element) -->
+        <output type="data" name="data_param" from="output" format_source="style_cond|type_cond|pick_from_0|value">
             <filter>style_cond['type_cond']['param_type'] == 'data'</filter>
         </output>
     </outputs>
@@ -185,14 +189,14 @@ taken.
                         <param name="value" value_json="null" />
                     </repeat>
                     <repeat name="pick_from">
-                        <param name="value" value="simple_line.txt" />
+                        <param name="value" value="simple_line.txt" ftype="tsv"/>
                     </repeat>
                     <repeat name="pick_from">
-                        <param name="value" value="simple_line_alternative.txt" />
+                        <param name="value" value="simple_line_alternative.txt" ftype="csv" />
                     </repeat>
                 </conditional>
             </conditional>
-            <output name="data_param" value="simple_line.txt" />
+            <output name="data_param" value="simple_line.txt" ftype="tsv" />
         </test>
         <test expect_num_outputs="1">
             <conditional name="style_cond">
@@ -363,11 +367,30 @@ taken.
                     <repeat name="pick_from">
                         <param name="value" value_json="null" />
                     </repeat>
-                    <param name="default_value" value="simple_line.txt" />
+                    <param name="default_value" value="simple_line.txt" ftype="tsv" />
                 </conditional>
             </conditional>
-            <output name="data_param" value="simple_line.txt" />
+            <output name="data_param" value="simple_line.txt" ftype="tsv" />
         </test>
+
+        <!-- with first_or_default that the default is used if given -->
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_default" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="data" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value="simple_line.txt" ftype="csv" />
+                    </repeat>
+                    <param name="default_value" value="simple_line_alternative.txt" ftype="tabular" />
+                </conditional>
+            </conditional>
+            <output name="data_param" value="simple_line.txt" ftype="csv"/>
+        </test>
+
     </tests>
 </tool>
 


### PR DESCRIPTION
Gives the workflow editor the needed info for the output's data type. Otherwise connection to downstream tools (in particular if it accepts multiple datatypes, eg fasta,fasta.gz) were not possible.

I adapted and added tests to check for `ftypes`, to ensure that empty first repeat element does not create trouble.

The workflow functionality has been tested manually.

Should allow to run https://github.com/galaxyproject/iwc/pull/321.

We can independently check https://github.com/galaxyproject/tools-iuc/pull/5713 and simplify the IWC workflow a bit later. 



FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
