### PR TITLE
update bracken to v2.9  and add subspecies level in filter (S1 and S2 level)

### DIFF
--- a/tools/bracken/est-abundance.xml
+++ b/tools/bracken/est-abundance.xml
@@ -33,6 +33,8 @@
             </options>
         </param>
         <param name="level" type="select" label="Level" help="Level to push all reads to">
+            <option value="S2">Subspecies 2</option>
+            <option value="S1">Subspecies 1</option>
             <option value="S" selected="true">Species</option>
             <option value="G">Genus</option>
             <option value="F">Family</option>
@@ -73,6 +75,20 @@
             <output name="report" file="NC_011750.1_simulated_bracken_report.txt" ftype="tabular"/>
             <output name="kraken_report" file="NC_011750.1_simulated_kraken_style_bracken_report.txt" ftype="tabular"/>
             <output name="logfile" file="test2.log" lines_diff="8"/>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="input" value="NC_003198.1_simulated_kraken_report.txt" ftype="tabular"/>
+            <param name="level" value="S1"/>
+            <param name="kmer_distr" value="test_entry"/>
+            <param name="logfile_output" value="False"/>
+            <output name="report" file="NC_003198.1_simulated_bracken_report_S1.txt" ftype="tabular"/>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="input" value="NC_003198.1_simulated_kraken_report.txt" ftype="tabular"/>
+            <param name="level" value="S2"/>
+            <param name="kmer_distr" value="test_entry"/>
+            <param name="logfile_output" value="False"/>
+            <output name="report" file="NC_003198.1_simulated_bracken_report_S2.txt" ftype="tabular"/>
         </test>
     </tests>
     <help>

--- a/tools/bracken/macros.xml
+++ b/tools/bracken/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.8</token>
+    <token name="@TOOL_VERSION@">2.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="requirements">

--- a/tools/bracken/test-data/NC_003198.1_simulated_bracken_report_S1.txt
+++ b/tools/bracken/test-data/NC_003198.1_simulated_bracken_report_S1.txt
@@ -1,0 +1,2 @@
+name	taxonomy_id	taxonomy_lvl	kraken_assigned_reads	added_reads	new_est_reads	fraction_total_reads
+Salmonella enterica subsp. enterica	59201	S1	40	2	42	1.00000

--- a/tools/bracken/test-data/NC_003198.1_simulated_bracken_report_S2.txt
+++ b/tools/bracken/test-data/NC_003198.1_simulated_bracken_report_S2.txt
@@ -1,0 +1,2 @@
+name	taxonomy_id	taxonomy_lvl	kraken_assigned_reads	added_reads	new_est_reads	fraction_total_reads
+Salmonella enterica subsp. enterica serovar Typhi	90370	S2	40	2	42	1.00000

--- a/tools/bracken/test-data/test2.log
+++ b/tools/bracken/test-data/test2.log
@@ -1,5 +1,5 @@
-PROGRAM START TIME: 08-05-2022 14:41:48
-BRACKEN SUMMARY (Kraken report: /tmp/tmpy56dgetr/files/f/5/4/dataset_f5412c50-3888-4466-b041-32814cdda47c.dat)
+PROGRAM START TIME: 01-18-2024 14:06:58
+BRACKEN SUMMARY (Kraken report: /tmp/tmp49rzn0wx/files/f/a/a/dataset_faa2d0a2-78f4-4cc2-b304-c8202c4ffb77.dat)
     >>> Threshold: 10 
     >>> Number of species in sample: 1 
 	  >> Number of species with reads > threshold: 1 
@@ -10,5 +10,5 @@ BRACKEN SUMMARY (Kraken report: /tmp/tmpy56dgetr/files/f/5/4/dataset_f5412c50-38
 	  >> Reads distributed: 1
 	  >> Reads not distributed (eg. no species above threshold): 0
 	  >> Unclassified reads: 2
-BRACKEN OUTPUT PRODUCED: /tmp/tmpy56dgetr/job_working_directory/000/4/outputs/galaxy_dataset_e099cc44-07e6-4507-b11f-137722113078.dat
-PROGRAM END TIME: 08-05-2022 14:41:48
+BRACKEN OUTPUT PRODUCED: /tmp/tmp49rzn0wx/job_working_directory/000/4/outputs/galaxy_dataset_27bf8d97-38f4-489a-a61b-6b567bbc8761.dat
+PROGRAM END TIME: 01-18-2024 14:06:58


### PR DESCRIPTION
I just updated the tool version and add the level options S1 and S2.