### PR TITLE
MITOS2: fix plotting of RNA structures only

### DIFF
--- a/tools/mitos/mitos2.xml
+++ b/tools/mitos/mitos2.xml
@@ -4,7 +4,7 @@
     <import>macros.xml</import>
     <token name="@MITOS_NAME@">MITOS2</token>
     <token name="@TOOL_VERSION@">2.1.7</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
   </macros>
   <xrefs>
       <xref type="bio.tools">mitos</xref>
@@ -47,7 +47,7 @@ $advanced_ncrna.sensitive
 --maxtrnaovl $advanced_ncrna.maxtrnaovl
 --maxrrnaovl $advanced_ncrna.maxrrnaovl
 
-#if not ("protein_plot" in $addoutputs or "ncRNA_plot" in $addoutputs):
+#if not ("protein_plot" in $addoutputs or "ncRNA_plot" in $addoutputs or "ncRNA_structure_svg_plots" in $addoutputs):
   --noplots
 #end if
 #if "raw" in str($addoutputs).split(','):
@@ -294,17 +294,18 @@ $advanced_ncrna.sensitive
       </assert_command>
     </test>
     <!-- missing genes -->
-    <test expect_num_outputs="2">
+    <test expect_num_outputs="3">
       <param name="input" value="NC_012920.fasta"/>
       <param name="code" value="2"/>
       <param name="refseqver" value="mitos2-refdata" />
-      <param name="addoutputs" value="bed,missing"/>
+      <param name="addoutputs" value="bed,missing,ncRNA_structure_svg_plots"/>
       <output name="bedout" file="mitos2_NC_012920.bed" compare="re_match" ftype="bed"/>
       <output name="missing_genes" ftype="txt">
         <assert_contents>
           <has_size value="167"/>
         </assert_contents>
       </output>
+      <output_collection name="ncRNA_structure_plot_svg_out" type="list" count="5"/>
       <assert_command>
         <has_text text="--code 2"/>
         <has_text text="--finovl 50"/>
@@ -323,7 +324,7 @@ $advanced_ncrna.sensitive
         <has_text text="--ncev 0.01"/>
         <has_text text="--maxtrnaovl 50"/>
         <has_text text="--maxrrnaovl 50"/>
-        <has_text text="--noplots"/>
+        <has_text text="--noplots" negate="true"/>
       </assert_command>
     </test>
   </tests>


### PR DESCRIPTION
`--noplots` also needs to be disabled for `ncRNA_structure_svg_plots`

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
