### PR TITLE
Bump hicexplorer to 3.7.3; add dbkey if missing from input bams

### DIFF
--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="hicexplorer_hicbuildmatrix" name="@BINARY@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="hicexplorer_hicbuildmatrix" name="@BINARY@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@_1">
     <description>create a contact matrix</description>
     <macros>
         <token name="@BINARY@">hicBuildMatrix</token>

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -18,7 +18,7 @@
             #end for
 
             --restrictionCutFile '$restrictionCutFile'
-            
+
             #if $restrictionSequence:
                 --restrictionSequence '$restrictionSequence'
             #end if
@@ -31,7 +31,7 @@
             #if $maxLibraryInsertSize:
                 --maxLibraryInsertSize $maxLibraryInsertSize
             #end if
-           
+
             #if $binSizes:
                 --binSize
                 #for $repeat in $binSizes
@@ -39,13 +39,20 @@
                 #end for
             #end if
 
-            --genomeAssembly $samFiles[0].samFile.metadata.dbkey
+            #if $chromosomeSizes:
+                --chromosomeSizes '$chromosomeSizes'
+            #end if
+            #if "$dbKey" > "":
+                --genomeAssembly '$dbKey'
+            #else
+                --genomeAssembly '$samFiles[0].samFile.metadata.dbkey'
+            #end if
 
             #if $region:
                 --region '$region'
             #end if
 
-            --outFileName matrix.$outputFormat
+            --outFileName 'matrix.$outputFormat'
 
             #if $outBam:
                 $outBam ./unsorted.bam
@@ -57,10 +64,6 @@
 
             #if $minMappingQuality and $minMappingQuality is not None:
                 --minMappingQuality $minMappingQuality
-            #end if
-
-            #if $chromosomeSizes:
-                --chromosomeSizes '$chromosomeSizes'
             #end if
 
             --threads @THREADS@
@@ -107,11 +110,13 @@
         <expand macro="minMappingQuality" />
         <param argument="--skipDuplicationCheck" type="boolean" truevalue="--skipDuplicationCheck" falsevalue="" label="Skip duplication check" help="Identification of duplicated read pairs is memory consuming. Thus, in case of memory errors this check can be skipped." />
         <param argument="--chromosomeSizes" type="data" format="tabular" optional="true" label="Chromosome sizes for your genome" help="File with the chromosome sizes for your genome. A tab-delimited two column layout 'chr_name size' is expected
-                    Usually the sizes can be determined from the SAM/BAM input files, however, 
-                    for cHi-C or scHi-C it can be that at the start or end no data is present. 
+                    Usually the sizes can be determined from the SAM/BAM input files, however,
+                    for cHi-C or scHi-C it can be that at the start or end no data is present.
                     Please consider that this option causes that only reads are considered which are on the listed chromosomes.
-                    Use this option to guarantee fixed sizes. An example file is available via UCSC: 
+                    Use this option to guarantee fixed sizes. An example file is available via UCSC:
                     http://hgdownload.soe.ucsc.edu/goldenPath/dm3/bigZips/dm3.chrom.sizes" />
+        <param argument="--dbKey" type="text" optional="true" label="Optional dbkey for your genome"
+        help="Input sam/bam mapped to a history genome have no metadata dbkey, so you must provide one, for the cool file" />
 
         <param argument="--outBam" type="boolean" truevalue="--outBam" falsevalue="" checked="false" label="Save valid Hi-C reads in BAM file" help="A bam
                     file containing all valid Hi-C reads can be created

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -42,7 +42,7 @@
             #if $chromosomeSizes:
                 --chromosomeSizes '$chromosomeSizes'
             #end if
-            #if "$dbKey" > "":
+            #if $dbKey:
                 --genomeAssembly '$dbKey'
             #else
                 --genomeAssembly '$samFiles[0].samFile.metadata.dbkey'
@@ -84,7 +84,6 @@
         <!-- can we use multiple=True here with min="2" and max="2" ? -->
         <repeat max="2" min="2" name="samFiles" title="Sam/Bam files to process (forward/reverse)" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
             <param name="samFile" type="data" format="sam,qname_input_sorted.bam">
-                <validator type="unspecified_build" />
             </param>
         </repeat>
 
@@ -115,7 +114,7 @@
                     Please consider that this option causes that only reads are considered which are on the listed chromosomes.
                     Use this option to guarantee fixed sizes. An example file is available via UCSC:
                     http://hgdownload.soe.ucsc.edu/goldenPath/dm3/bigZips/dm3.chrom.sizes" />
-        <param argument="--dbKey" type="text" optional="true" label="Optional dbkey for your genome"
+        <param name="dbKey" type="text" optional="true" label="Optional dbkey for your genome"
         help="Input sam/bam mapped to a history genome have no metadata dbkey, so you must provide one, for the cool file" />
 
         <param argument="--outBam" type="boolean" truevalue="--outBam" falsevalue="" checked="false" label="Save valid Hi-C reads in BAM file" help="A bam

--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -114,8 +114,8 @@
                     Please consider that this option causes that only reads are considered which are on the listed chromosomes.
                     Use this option to guarantee fixed sizes. An example file is available via UCSC:
                     http://hgdownload.soe.ucsc.edu/goldenPath/dm3/bigZips/dm3.chrom.sizes" />
-        <param name="dbKey" type="text" optional="true" label="Optional dbkey for your genome"
-        help="Input sam/bam mapped to a history genome have no metadata dbkey, so you must provide one, for the cool file" />
+        <param name="dbKey" type="text" optional="true" label="Use this dbkey for your history genome"
+        help="sam/bam mapped to a history genome will not have a metadata dbkey (build will show '?') so one must be provided here or the job will fail" />
 
         <param argument="--outBam" type="boolean" truevalue="--outBam" falsevalue="" checked="false" label="Save valid Hi-C reads in BAM file" help="A bam
                     file containing all valid Hi-C reads can be created

--- a/tools/hicexplorer/macros.xml
+++ b/tools/hicexplorer/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@THREADS@">\${GALAXY_SLOTS:-4}</token>
-    <token name="@TOOL_VERSION@">3.7.2</token>
+    <token name="@TOOL_VERSION@">3.7.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@USE_RANGE@">
         #if $use_range.select_use_range == "yes_use_range":
@@ -248,7 +248,7 @@
         #set $matrices = []
         #set $mlabels = []
         #for $counter, $i in enumerate($input_files):
-            ln -s '$i.matrix' '${counter}_matrix.$i.matrix.ext'; 
+            ln -s '$i.matrix' '${counter}_matrix.$i.matrix.ext';
             #silent $matrices.append( '\'%s_matrix.%s\'' % ($counter,  $i.matrix.ext))
 
             #if str($i.mlabel.value) != "":


### PR DESCRIPTION
1. Hicexplorer update removes pandas dependency problems with report generation
2. If inputs were generated with a history genome, they have no metadata dbkey needed for the cool output so hicbuildmatrix failed - add an optional user supplied dbkey for those situations.



FOR CONTRIBUTOR:
* [X] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [X] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
