### PR TITLE
OMark: fix optional options

### DIFF
--- a/tools/omark/macros.xml
+++ b/tools/omark/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.3.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
 
     <xml name="requirements">
         <requirement type="package" version="@TOOL_VERSION@">omark</requirement>

--- a/tools/omark/omark.xml
+++ b/tools/omark/omark.xml
@@ -17,11 +17,20 @@
     -f 'output_omamer'
     -d '$database.fields.path'
     $omark_mode
-    -i '$input_iso'
-    -t '$t'
-    -r '$r'
-    -o omark_galaxy
 
+    #if $input_iso:
+        -i '$input_iso'
+    #end if
+
+    #if $t:
+        -t '$t'
+    #end if
+
+    #if $r:
+        -r '$r'
+    #end if
+
+    -o omark_galaxy
     ]]></command>
 
     <inputs>
@@ -49,7 +58,7 @@
             <validator type="regex">[0-9a-zA-Z_]+</validator>
         </param>
 
-        <param name="outputs" type="select" optional="true" multiple="true" label="Which outputs should be generated">
+        <param name="outputs" type="select" multiple="true" label="Which outputs should be generated">
             <option value="detail_sum" selected="true">Detailed summary</option>
             <option value="hog">HOG identifiers</option>
             <option value="pdf">PDF Graphic representation </option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)

Fixing some problems with optional options, tested everything on usegalaxy.fr