### PR TITLE
Added bio.tools ref to tb-profiler

### DIFF
--- a/tools/tb-profiler/tb_profiler_profile.xml
+++ b/tools/tb-profiler/tb_profiler_profile.xml
@@ -3,6 +3,9 @@
     <macros>
         <token name="@TOOL_VERSION@">4.4.1</token>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">tb-profiler</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">tb-profiler</requirement>
     </requirements>


### PR DESCRIPTION
This PR links tb-profiler to its bio.tools [entry](https://bio.tools/tb-profiler).