### PR TITLE
Add bio.tools ref to iqtree

### DIFF
--- a/tools/iqtree/.shed.yml
+++ b/tools/iqtree/.shed.yml
@@ -1,6 +1,7 @@
 name: iqtree
 owner: iuc
 description: Efficient phylogenomic software by maximum likelihood
+long_description: A fast and effective stochastic algorithm to infer phylogenetic trees by maximum likelihood. IQ-TREE compares favorably to RAxML and PhyML in terms of likelihoods with similar computing time.
 homepage_url: http://www.iqtree.org/
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/iqtree/
 categories:

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -1060,9 +1060,9 @@ To overcome the computational burden required by the nonparametric bootstrap, IQ
 
 * **example.phy.splits**: support values in percentage for all splits (bipartitions), computed as the occurence frequencies in the bootstrap trees. This file is in "star-dot" format.
 
-* **example.phy.splits.nex**: has the same information as **example.phy.splits** but in NEXUS format, which can be viewed with the program SplitsTree_ to explore the conflicting signals in the data. So it is more informative than consensus tree, e.g. you can see how highly supported the second best conflicting split is, which had no chance to enter the consensus tree.
+* **example.phy.splits.nex**: has the same information as **example.phy.splits** but in NEXUS format, which can be viewed with the program IcyTree_ to explore the conflicting signals in the data. So it is more informative than consensus tree, e.g. you can see how highly supported the second best conflicting split is, which had no chance to enter the consensus tree.
 
-.. _SplitsTree: http://www.splitstree.org
+.. _IcyTree: https://icytree.org
 
 
 Reducing impact of severe model violations with UFBoot

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -428,7 +428,7 @@ Note that --seqtype CODON is always necessary when using codon models and you al
 
                     <param name="opt_custommodel" type="select" label="Do you want to use a custom model" help="See http://www.iqtree.org/doc/Substitution-Models">
                         <option value="true" selected="True">Yes, I want to use a custom model</option>
-                        <option value="false">No, a custom model not needed</option>
+                        <option value="false">No, a custom model is not needed</option>
                     </param>
                     <when value="true">
                         <param argument="-m" type="text" label="Model">

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -3,6 +3,7 @@
     <macros>
         <import>iqtree_macros.xml</import>
     </macros>
+    <expand macro="xrefs"/>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
 iqtree

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -770,7 +770,6 @@ IQ-TREE also works for codon, binary and morphogical data.
             <param name="bcor" value="0.99" />
             <param name="nstep" value="100" />
             <param name="beps" value="0.5" />
-            <param name="b" value="2" />
             <output name="iqtree">
                 <assert_contents>
                     <has_text_matching expression="GTR\+F\+I(\s+((-|\d|\.)+))+" />
@@ -804,7 +803,6 @@ IQ-TREE also works for codon, binary and morphogical data.
             <param name="bcor" value="0.99" />
             <param name="nstep" value="100" />
             <param name="beps" value="0.5" />
-            <!-- <param name="b" value="100" /> -->
             <output name="iqtree">
                 <assert_contents>
                     <has_text_matching expression="GTR\+F\+I\+G4(\s+((-|\d|\.)+))+" />

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -927,9 +927,8 @@ Running example
 ---------------------
 
 From the download_ there is an example alignment called `example.phy`
-in PHYLIP format. This example contains parts of the mitochondrial DNA sequences of several animals (Source: `Phylogenetic Handbook`_)
+in PHYLIP format. This example contains parts of the mitochondrial DNA sequences of several animals.
 
-.. _`Phylogenetic Handbook` : http://www.kuleuven.be/aidslab/phylogenybook/home.html)).
 .. _download: http://www.iqtree.org/#download
 
 You can now start to reconstruct a maximum-likelihood tree

--- a/tools/iqtree/iqtree.xml
+++ b/tools/iqtree/iqtree.xml
@@ -425,7 +425,11 @@ Note that --seqtype CODON is always necessary when using codon models and you al
         <section name="modelling_parameters" title="Modelling Parameters">
             <section name="automatic_model" expanded="False" title="Automatic model selection">
                 <conditional name="cond_model" >
-                    <param name="opt_custommodel" type="boolean" checked="false" label="Use Custom Model" help="See http://www.iqtree.org/doc/Substitution-Models"/>
+
+                    <param name="opt_custommodel" type="select" label="Do you want to use a custom model" help="See http://www.iqtree.org/doc/Substitution-Models">
+                        <option value="true" selected="True">Yes, I want to use a custom model</option>
+                        <option value="false">No, a custom model not needed</option>
+                    </param>
                     <when value="true">
                         <param argument="-m" type="text" label="Model">
                             <expand macro="sanitize_query"
@@ -436,7 +440,7 @@ Note that --seqtype CODON is always necessary when using codon models and you al
                         <param argument="-m" type="select" label="Perform standard model selection like jModelTest (for DNA) and ProtTest (for protein)" >
                             <help><![CDATA[
 <b>Note:</b> Only <code>TEST</code> and custom models that do not rely on <code>MF</code> can be used in conjunction with bootstrap parameters (-b)<br/><br/>
-IQ-TREE also works for codon, binary and morphogical data.
+IQ-TREE also works for codon, binary and morphological data.
 <table>
     <tr>
         <td><i>TESTONLY</i></td>

--- a/tools/iqtree/iqtree_macros.xml
+++ b/tools/iqtree/iqtree_macros.xml
@@ -8,6 +8,12 @@
         </requirements>
     </xml>
 
+    <xml name="xrefs">
+        <xrefs>
+            <xref type="bio.tools">iqtree</xref>
+        </xrefs>
+    </xml>
+
     <xml name="sanitize_query" token_validinitial="string.printable">
         <sanitizer>
             <valid initial="@VALIDINITIAL@">


### PR DESCRIPTION
This PR links iqtree to its bio.tools [entry](https://bio.tools/iqtree).