### PR TITLE
Check InterProScan seqtype

### DIFF
--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -39,7 +39,6 @@ if [ \$detected_seqtype != '$seqtype' ]; then
     exit 1 ;
 fi;
 
-
 ## Now run interproscan
 interproscan.sh
 
@@ -257,36 +256,26 @@ $iprlookup
             </assert_stdout>
         </test>
         <!-- protein used but nucleotide selected -->
-        <test expect_num_outputs="1">
+        <test expect_failure="true">
             <param name="input" value="prots.fa" />
             <param name="seqtype" value="n" />
             <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <param name="oformat" value="TSV" />
-            <output name="outfile_tsv">
-                <assert_contents>
-                    <has_text text="FUN_000011-T1" />
-                    <has_text text="ea9924e11f7decc417e8d9ed8b9c682e" />
-                    <has_text text="FUN_000012-T1" />
-                    <has_text text="01beedc2fbf8012cba37f0c0d39aa071" />
-                </assert_contents>
-            </output>
+            <assert_stderr>
+                <has_text text="mismatch between the selected type of input sequence and the content"/>
+            </assert_stderr>
         </test>
         <!-- nucleotide used but protein selected -->
-        <test expect_num_outputs="1">
+        <test expect_failure="true">
             <param name="input" value="transcripts.fa" />
             <param name="seqtype" value="p" />
             <param name="database" value="@TOOL_VERSION@" />
             <param name="applications" value="MobiDBLite" />
             <param name="oformat" value="TSV" />
-            <output name="outfile_tsv">
-                <assert_contents>
-                    <has_text text="FUN_000011-T1" />
-                    <has_text text="ea9924e11f7decc417e8d9ed8b9c682e" />
-                    <has_text text="FUN_000012-T1" />
-                    <has_text text="01beedc2fbf8012cba37f0c0d39aa071" />
-                </assert_contents>
-            </output>
+            <assert_stderr>
+                <has_text text="mismatch between the selected type of input sequence and the content"/>
+            </assert_stderr>
         </test>
     </tests>
 

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -20,6 +20,26 @@ sed 's|^\(data.directory=\).*$|\1${database.fields.path}/data|' \$(dirname \$(re
 export _JAVA_OPTIONS=-Duser.home=\$HOME
 &&
 
+## Guess the seqtype. If we find characters that aren't IUPAC nucleotide
+## symbols, we think it's protein.
+#set iupac_nt="[^-ABCDGHIKMNRSTUVWY]"
+match=\$(grep -v "^>" '$input' | grep -m 1 -iE '$iupac_nt' | head -n 1)
+&&
+if grep -q '[^[:space:]]' <<< \${match}; then
+    detected_seqtype="p" ;
+else
+    detected_seqtype="n" ;
+fi;
+
+if [ \$detected_seqtype != '$seqtype' ]; then
+    printf '%s\n'
+    'Galaxy detected a mismatch between the selected type of input sequence and the content of the FASTA file.'
+    'If you are sure you want to do this, disable the check input option and submit your job again.'
+    1>&2 ;
+    exit 1 ;
+fi;
+
+
 ## Now run interproscan
 interproscan.sh
 
@@ -235,6 +255,38 @@ $iprlookup
                 <has_text text="Analysis Phobius does not exist or is deactivated" />
                 <has_text text="Analysis TMHMM does not exist or is deactivated" />
             </assert_stdout>
+        </test>
+        <!-- protein used but nucleotide selected -->
+        <test expect_num_outputs="1">
+            <param name="input" value="prots.fa" />
+            <param name="seqtype" value="n" />
+            <param name="database" value="@TOOL_VERSION@" />
+            <param name="applications" value="MobiDBLite" />
+            <param name="oformat" value="TSV" />
+            <output name="outfile_tsv">
+                <assert_contents>
+                    <has_text text="FUN_000011-T1" />
+                    <has_text text="ea9924e11f7decc417e8d9ed8b9c682e" />
+                    <has_text text="FUN_000012-T1" />
+                    <has_text text="01beedc2fbf8012cba37f0c0d39aa071" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- nucleotide used but protein selected -->
+        <test expect_num_outputs="1">
+            <param name="input" value="transcripts.fa" />
+            <param name="seqtype" value="p" />
+            <param name="database" value="@TOOL_VERSION@" />
+            <param name="applications" value="MobiDBLite" />
+            <param name="oformat" value="TSV" />
+            <output name="outfile_tsv">
+                <assert_contents>
+                    <has_text text="FUN_000011-T1" />
+                    <has_text text="ea9924e11f7decc417e8d9ed8b9c682e" />
+                    <has_text text="FUN_000012-T1" />
+                    <has_text text="01beedc2fbf8012cba37f0c0d39aa071" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
 

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -243,7 +243,7 @@ $iprlookup
                 </assert_contents>
             </output>
         </test>
-        <test expect_failure="true" expect_num_outputs="1">
+        <test expect_failure="true">
             <param name="input" value="prots.fa" />
             <param name="seqtype" value="p" />
             <param name="database" value="@TOOL_VERSION@" />

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -21,24 +21,23 @@ export _JAVA_OPTIONS=-Duser.home=\$HOME
 &&
 
 #if $check_seqtype
-## Guess the seqtype. If we find characters that aren't IUPAC nucleotide
-## symbols, we think it's protein.
-#set iupac_nt="[^-ABCDGHIKMNRSTUVWY]"
-match=\$(grep -v "^>" '$input' | grep -m 1 -iE '$iupac_nt' | head -n 1)
-&&
-if grep -q '[^[:space:]]' <<< \${match}; then
-    detected_seqtype="p" ;
-else
-    detected_seqtype="n" ;
-fi;
+    ## Guess the seqtype. If we find characters that aren't IUPAC nucleotide
+    ## symbols, we think it's protein.
+    #set iupac_nt="[^-ABCDGHIKMNRSTUVWY]"
+    match=\$(grep -v "^>" '$input' | grep -m 1 -iE '$iupac_nt' | head -n 1)
+    &&
+    if grep -q '[^[:space:]]' <<< \${match}; then
+        detected_seqtype="p" ;
+    else
+        detected_seqtype="n" ;
+    fi;
 
-if [ \$detected_seqtype != '$seqtype' ]; then
-    printf '%s\n'
-    'Galaxy detected a mismatch between the selected type of input sequence and the content of the FASTA file.'
-    'If you are sure you want to do this, disable the check input option and submit your job again.'
-    1>&2 ;
-    exit 1 ;
-fi;
+    if [ \$detected_seqtype != '$seqtype' ]; then
+        printf '%s\n'
+        'Galaxy detected a mismatch between the selected type of input sequence and the content of the FASTA file. If you are sure you want to do this, disable the "Check input sequences" option and submit your job again.'
+        1>&2 ;
+        exit 1 ;
+    fi;
 #end if
 
 ## Now run interproscan
@@ -73,7 +72,7 @@ $iprlookup
             <option value="n">DNA / RNA</option>
         </param>
 
-        <param name="check_seqtype" type="boolean" checked="true" label="Check input sequences" help="Galaxy will try to check if the FASTA file matches the selected type." />
+        <param name="check_seqtype" type="boolean" checked="true" label="Check input sequences" help="Should Galaxy try to check if the FASTA file matches the selected type?" />
 
         <param name="database" label="InterProScan database" type="select">
             <options from_data_table="interproscan">

--- a/tools/interproscan/interproscan.xml
+++ b/tools/interproscan/interproscan.xml
@@ -20,6 +20,7 @@ sed 's|^\(data.directory=\).*$|\1${database.fields.path}/data|' \$(dirname \$(re
 export _JAVA_OPTIONS=-Duser.home=\$HOME
 &&
 
+#if $check_seqtype
 ## Guess the seqtype. If we find characters that aren't IUPAC nucleotide
 ## symbols, we think it's protein.
 #set iupac_nt="[^-ABCDGHIKMNRSTUVWY]"
@@ -38,6 +39,7 @@ if [ \$detected_seqtype != '$seqtype' ]; then
     1>&2 ;
     exit 1 ;
 fi;
+#end if
 
 ## Now run interproscan
 interproscan.sh
@@ -64,12 +66,14 @@ $iprlookup
 --output-file-base 'output'
     ]]></command>
     <inputs>
-        <param argument="--input" type="data" format="fasta" label="Protein FASTA File"/>
+        <param argument="--input" type="data" format="fasta" label="FASTA File"/>
 
         <param argument="--seqtype" type="select" label="Type of the input sequences" help="">
             <option value="p" selected="true">Protein</option>
             <option value="n">DNA / RNA</option>
         </param>
+
+        <param name="check_seqtype" type="boolean" checked="true" label="Check input sequences" help="Galaxy will try to check if the FASTA file matches the selected type." />
 
         <param name="database" label="InterProScan database" type="select">
             <options from_data_table="interproscan">
@@ -277,6 +281,18 @@ $iprlookup
                 <has_text text="mismatch between the selected type of input sequence and the content"/>
             </assert_stderr>
         </test>
+        <!-- protein used, nucleotide selected, check disabled -->
+        <test expect_failure="true">
+            <param name="input" value="prots.fa" />
+            <param name="seqtype" value="n" />
+            <param name="check_seqtype" value="false" />
+            <param name="database" value="@TOOL_VERSION@" />
+            <param name="applications" value="MobiDBLite" />
+            <param name="oformat" value="TSV" />
+            <assert_stderr>
+                <has_text text="not a nucleotide sequence"/>
+            </assert_stderr>
+        </test>        
     </tests>
 
     <help><![CDATA[

--- a/tools/interproscan/macros.xml
+++ b/tools/interproscan/macros.xml
@@ -6,7 +6,7 @@
         The version should also be bumped in test-data/interproscan.loc
     -->
     <token name="@TOOL_VERSION@">5.59-91.0</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@VERSION_SUFFIX@">4</token>
 
     <xml name="citations">
         <citations>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
---

This tool is causing a bit of support work when users input nucleotide sequences but select protein as the sequence type.

This greps for anything that is not an IUPAC nucleotide and checks the result against the selected seqtype.

It won't always be correct because a protein consisting only of amino acid residues that are in the nucleotide alphabet is valid (but probably not common). It could also take a long time to search through valid nucleotide input. I could limit it to the first 1000 lines or something?

Ping @igormakunin 
