### PR TITLE
Fix obisort key logic and documentation

### DIFF
--- a/tools/obitools/obisort.xml
+++ b/tools/obitools/obisort.xml
@@ -11,7 +11,9 @@
         @GUNZIP_INPUT@
         obisort
         --without-progress-bar
+        #if $key:
         -k '$key'
+        #end if
         ${reverse}
         @INPUT_FORMAT@
         @OUT_FORMAT@
@@ -22,8 +24,14 @@
     ]]></command>
     <inputs>
         <param name="input" type="data" format="@INPUT_FORMATS@,txt,tabular" label="Input sequences file" />
-        <param name="key" type="text" label="key"/>
-        <param name="reverse" type="boolean" checked="false" truevalue="-r" falsevalue="" label="sorts in reverse order?" />
+        <param
+            name="key"
+            type="text"
+            label="Key"
+            help="This key must be encoded in your FASTA/FASTQ headers as key=value. See help (below) for more information."
+            optional="false"
+        />
+        <param name="reverse" type="boolean" checked="false" truevalue="-r" falsevalue="" label="Sort in reverse order?" />
         <expand macro="input_format_options_macro"/>
         <expand macro="out_format_macro"/>
     </inputs>
@@ -56,8 +64,29 @@ obisort sorts sequence records according to the value of a given attribute, whic
 
 @OBITOOLS_LINK@
 
-        ]]>
+**Inputs:**
 
+For sorting by key, the input file must be in the
+`OBITools FASTA/FASTQ format <https://pythonhosted.org/OBITools/attributes.html>`_.
+If your file is an OBITools output, it should already be formatted correctly.
+
+For FASTA files, your headers should look like this::
+
+    >my_sequence taxid=3456; direct=True; sample=A354; this is my pretty sequence
+    ACGTTGCAGTACGTTGCAGTACGTTGCAGTACGTTGCAGTACGTTGCAGTACGTTGCAGT
+    GTGCTGACGTTGCAGTACGTTGCAGTACGTTGCAGTACGTTGCAGTACGTTGCAGTGTTT
+    AACGACGTTGCAGTACGTTGCAGT
+
+Where ``taxid``, ``direct``, and ``sample`` are keys that can be used for sorting.
+
+If your sequences don't have title, you can format the headers with a trailing semicolon like so::
+
+    >my_sequence key1=value1;
+
+For sorting OBITools output files, a list of OBITools sequence attributes are documented
+`here <https://pythonhosted.org/OBITools/attributes.html#names-reserved-for-attributes>`_.
+
+]]>
     </help>
     <expand macro="citation" />
 </tool>


### PR DESCRIPTION
Complaint from user about a bug in ObiSort. Seems more like it's not documented well, so added some help text etc. and marked the `key` field as required to be consistent with the CLI interface.

* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document 
* [x] this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [x] This PR updates an existing tool or tool collection
