### PR TITLE
Fix bam2fastx outputs

### DIFF
--- a/tools/pbtk/bam2fastx.xml
+++ b/tools/pbtk/bam2fastx.xml
@@ -18,9 +18,9 @@ pbindex input.bam &&
 #end if
 input.bam
 --num-threads  "\${GALAXY_SLOTS:-1}"  &&
-#if $output_format == "fasta":
+#if $output_format == "fasta_gz":
     mv output.fasta.gz '$output_fasta_gz'
-#elif $output_format == "fastq":
+#elif $output_format == "fastq_gz":
     mv output.fastq.gz '$output_fastq_gz'
 #end if
     ]]></command>
@@ -33,28 +33,28 @@ input.bam
     </inputs>
     <outputs>
         <data name="output_fasta_gz" format="fasta.gz" label="${tool.name} on ${on_string}: Fasta">
-            <filter>output_format == "fasta"</filter>
+            <filter>output_format == "fasta_gz"</filter>
         </data>
         <data name="output_fastq_gz" format="fastqsanger.gz" label="${tool.name} on ${on_string}: Fastq">
-            <filter>output_format == "fastq"</filter>
+            <filter>output_format == "fastq_gz"</filter>
         </data>
     </outputs>
     <tests>
         <test expect_num_outputs="1">
             <param name="input_bam" ftype="unsorted.bam" value="sample.bam"/>
-            <param name="output_format" value="fastq_gz" />
-            <output name="output_fastq_gz">
+            <param name="output_format" value="fastq.gz" />
+            <output name="output_fastq_gz" decompress="true">
                 <assert_contents>
-                    <has_size min="9000" />
+                    <has_text text="AATGCCTTATTAAGTTAAGAAATGGTTTTTTTTAAACTTACAGATGGAA" />
                 </assert_contents>
             </output>
         </test>
         <test expect_num_outputs="1" >
             <param name="input_bam" ftype="bam" value="sample.bam"/>
-            <param name="output_format" value="fasta_gz" />
-            <output name="output_fasta_gz" >
+            <param name="output_format" value="fasta.gz" />
+            <output name="output_fasta_gz" decompress="true">
                 <assert_contents>
-                    <has_size min="9000" />
+                    <has_text text="AATGCCTTATTAAGTTAAGAAATGGTTTTTTTTAAACTTACAGATGGAA" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/pbtk/bam2fastx.xml
+++ b/tools/pbtk/bam2fastx.xml
@@ -2,7 +2,7 @@
     <description>PacBio BAM to Fastx</description>
     <macros>
         <token name="@TOOL_VERSION@">3.1.1</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">pbtk</requirement>


### PR DESCRIPTION
The outputs were never going to be produced. Together with https://github.com/galaxyproject/galaxy/issues/17829 we ended up with passing tests when they should have failed.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
