### PR TITLE
minor bug fix for pretext graph to function in workflows

### DIFF
--- a/tools/pretext/pretext_graph.xml
+++ b/tools/pretext/pretext_graph.xml
@@ -23,7 +23,7 @@
         -o output.pretext
     ]]></command>
     <inputs>
-        <param name="input" type="data" format="bigwig, bedgraph" label="Input bigwig or bedgraph file"/>
+        <param name="input" type="data" format="bigwig,bedgraph" label="Input bigwig or bedgraph file"/>
         <param name="pretext" type="data" format="pretext" label="Pretext file" help="Sequence names in the Pretext file must match sequence names in the bedgraph data; although relative sort order is unimportant."/>
         <param name="name" type="text" label="Label for the graph" optional="true"/>
     </inputs>


### PR DESCRIPTION
There appears to be an inconsistency in how the workflow editor reads input formats vs the tool form, where the accidental space left in the formats section of the inputs functioned ok on a tool form, but not in the workflow editor, which didn't recognize the bedgraph format as a valid connection. Fixing the space here and adding an issue on the galaxy repo for the inconsistency problem. Not bumping version because it's a minor bug fix of the wrapper, not the tool