### PR TITLE
Need bai for dexseq-count

### DIFF
--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -20,6 +20,8 @@
         '$mode.gtffile'
         '$flattened_gtf_out'
 #elif $mode.mode_select == "count":
+    ln -s -f '${mode.bamfile}' 'input.bam' &&
+    ln -s -f '${mode.bamfile.metadata.bam_index}' 'input.bam.bai' &&
     dexseq_count.py
         --format bam
         --paired $mode.paired
@@ -27,7 +29,7 @@
         --minaqual $mode.qual
         --order $mode.order
         $mode.flattened_gtf_in
-        '$mode.bamfile'
+        'input.bam'
         '$counts_file'
     &&
     sed -i 's/\"//g' '$counts_file'
@@ -73,14 +75,14 @@
     </outputs>
 
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="mode_select" value="prepare" />
             <param name="gtffile" ftype="gff" value="original.gtf"/>
             <param name="aggregate" value="True"/>
             <output name="flattened_gtf_out" ftype="gtf" compare="sim_size" file="flattened.gtf"/>
         </test>
         <!-- Ensure count mode works -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="mode_select" value="count" />
             <param name="bamfile" ftype="bam" value="in.bam" />
             <param name="flattened_gtf_in" ftype="gff" value="flattened.gtf"/>

--- a/tools/dexseq/dexseq_count.xml
+++ b/tools/dexseq/dexseq_count.xml
@@ -16,19 +16,19 @@
     <command><![CDATA[
 #if $mode.mode_select == "prepare":
     dexseq_prepare_annotation.py
-        -r $mode.aggregate
-        '$mode.gtffile'
+        -r '${mode.aggregate}'
+        '${mode.gtffile}'
         '$flattened_gtf_out'
 #elif $mode.mode_select == "count":
     ln -s -f '${mode.bamfile}' 'input.bam' &&
     ln -s -f '${mode.bamfile.metadata.bam_index}' 'input.bam.bai' &&
     dexseq_count.py
         --format bam
-        --paired $mode.paired
-        --stranded $mode.stranded
-        --minaqual $mode.qual
-        --order $mode.order
-        $mode.flattened_gtf_in
+        --paired '${mode.paired}'
+        --stranded '${mode.stranded}'
+        --minaqual '${mode.qual}'
+        --order '${mode.order}'
+        '${mode.flattened_gtf_in}'
         'input.bam'
         '$counts_file'
     &&

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.44</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/dexseq/macros.xml
+++ b/tools/dexseq/macros.xml
@@ -1,12 +1,11 @@
-<?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.44</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">1.48.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-dexseq</requirement>
-            <requirement type="package" version="1.20.3">r-getopt</requirement>
+            <requirement type="package" version="1.20.4">r-getopt</requirement>
             <requirement type="package" version="0.2.21">r-rjson</requirement>
         </requirements>
     </xml>


### PR DESCRIPTION
I'm getting `[E::idx_find_and_load] Could not retrieve index file for '/mnt/user-data-volC/data13/c/e/b/dataset_cebddb26-4aa7-4051-9740-b79025ccddd4.dat'` running dexseq-count on Galaxy Australia.

I'm just pushing this as a quick fix for version 1.44 - the bioconductor package seems to be missing the htseq dependency for later versions (see https://github.com/galaxyproject/tools-iuc/pull/4295)

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
