### PR TITLE
Fix typo in bigscape argument for excluded classes

### DIFF
--- a/tools/bigscape/bigscape.xml
+++ b/tools/bigscape/bigscape.xml
@@ -146,7 +146,7 @@
             <option value="PKSI" selected="False">PKSI</option>
             <option value="PKSother" selected="False">PKSother</option>
             <option value="NRPS" selected="False">NRPS</option>
-            <option value="RIPPs" selected="False">RIPPs</option>
+            <option value="RiPPs" selected="False">RiPPs</option>
             <option value="Saccharides" selected="False">Saccharides</option>
             <option value="Terpene" selected="False">Terpene</option>
             <option value="PKS-NRP_Hybrids" selected="False">PKS-NRP_Hybrids</option>

--- a/tools/bigscape/bigscape.xml
+++ b/tools/bigscape/bigscape.xml
@@ -2,7 +2,7 @@
     <description>Construct sequence similarity networks of BGCs and group them into GCF</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.9</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bigscape</requirement>


### PR DESCRIPTION
From a user error report:

**File: tool_stderr**
```
usage: BiG-SCAPE [-h] [-l LABEL] [-i INPUTDIR] -o OUTPUTDIR
                 [--pfam_dir PFAM_DIR] [-c CORES]
                 [--include_gbk_str INCLUDE_GBK_STR [INCLUDE_GBK_STR ...]]
                 [--exclude_gbk_str EXCLUDE_GBK_STR [EXCLUDE_GBK_STR ...]]
                 [-v] [--include_singletons] [-d DOMAIN_OVERLAP_CUTOFF]
                 [-m MIN_BGC_SIZE] [--mix] [--no_classify]
                 [--banned_classes {PKSI,PKSother,NRPS,RiPPs,Saccharides,Terpene,PKS-NRP_Hybrids,Others} [{PKSI,PKSother,NRPS,RiPPs,Saccharides,Terpene,PKS-NRP_Hybrids,Others} ...]]
                 [--cutoffs CUTOFFS [CUTOFFS ...]] [--clans-off]
                 [--clan_cutoff CLAN_CUTOFF CLAN_CUTOFF] [--hybrids-off]
                 [--mode {global,glocal,auto}] [--anchorfile ANCHORFILE]
                 [--force_hmmscan] [--skip_ma] [--mibig] [--mibig21]
                 [--mibig14] [--mibig13] [--query_bgc QUERY_BGC]
                 [--domain_includelist] [--version]
BiG-SCAPE: error: argument --banned_classes: invalid choice: 'RIPPs' (choose from 'PKSI', 'PKSother', 'NRPS', 'RiPPs', 'Saccharides', 'Terpene', 'PKS-NRP_Hybrids', 'Others')
```

This PR fixes the argument `RiPPs` in the "exclude classes" list.