### PR TITLE
Add `$GALAXY_SLOTS` and `$GALAXY_MEMORY_MB` to bbmerge

### DIFF
--- a/tools/bbtools/bbmerge.xml
+++ b/tools/bbtools/bbmerge.xml
@@ -39,7 +39,12 @@
     ln -s '${read2}' '${read2_file}' &&
 #end if
 
-bbmerge.sh
+if [[ "\${_JAVA_OPTIONS}" != *-Xmx* && "\${JAVA_TOOL_OPTIONS}" != *-Xmx* ]]; then
+    export _JAVA_OPTIONS="\${_JAVA_OPTIONS} -Xmx\${GALAXY_MEMORY_MB:-4096}m -Xms256m";
+fi &&
+
+bbmerge.sh tmpdir="\$TMPDIR" t="\${GALAXY_SLOTS:-2}"
+
 #### Input parameters
 #if str($input_type_cond.input_type) == 'single':
     in='${read1_file}'

--- a/tools/bbtools/macros.xml
+++ b/tools/bbtools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">39.06</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>


### PR DESCRIPTION
Worth noting that setting `-Xmx` via `$_JAVA_OPTIONS` in the job env as many admins do still overrides this. I pulled the clever bit of handling for that from bbnorm.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
