### PR TITLE
Tools/rseqc: Fixed linting error and updated test parameters in some tools

### DIFF
--- a/tools/rseqc/FPKM_count.xml
+++ b/tools/rseqc/FPKM_count.xml
@@ -3,15 +3,10 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[FPKM_count.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         FPKM_count.py -i 'input.${extension}' -o output -r '${refgene}'
@@ -36,12 +31,11 @@
         --single-read="${singleread}"
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="strand_type_param" />
-        <expand macro="multihits_param" />
+        <expand macro="bam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="strand_type_param"/>
+        <expand macro="multihits_param"/>
         <param name="onlyexonic" type="boolean" value="false" truevalue="--only-exonic" falsevalue="" label="Only use exonic (UTR exons and CDS exons) reads, otherwise use all reads" help="(--only-exonic)"/>
         <param name="singleread" type="select" label="How should read-pairs that only have one end mapped be counted?" help="(--single-read)">
             <option value="1" selected="true">Treat it as a whole fragment (1)</option>
@@ -49,18 +43,16 @@
             <option value="0">Ignore it (0)</option>
         </param>
     </inputs>
-
     <outputs>
         <data format="tabular" name="output" from_work_dir="output.FPKM.xls" label="${tool.name} on ${on_string}: FPKM counts"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <output name="output" file="output01.tab"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <conditional name="multihits_type">
@@ -69,11 +61,10 @@
             </conditional>
             <output name="output" file="output02.tab"/>
             <assert_command>
-                <has_text text="--mapq=20" />
+                <has_text text="--mapq=20"/>
             </assert_command>
         </test>
     </tests>
-
     <help><![CDATA[
 FPKM_count.py
 +++++++++++++
@@ -134,7 +125,5 @@ chr1    32479294   32509482   NM_006559  2891.0     ‘+’          2151.0     
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/RNA_fragment_size.xml
+++ b/tools/rseqc/RNA_fragment_size.xml
@@ -6,49 +6,41 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[RNA_fragment_size.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         RNA_fragment_size.py -i 'input.${extension}' --refgene='${refgene}' --mapq=${mapq} --frag-num=${fragnum} > '${output}'
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="mapq_param" />
-        <param name="fragnum" type="integer" value="3" label="Minimum number of fragments (default: 3)" help="(--frag-num)" />
+        <expand macro="bam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="mapq_param"/>
+        <param name="fragnum" type="integer" value="3" label="Minimum number of fragments (default: 3)" help="(--frag-num)"/>
     </inputs>
-
     <outputs>
-        <data format="tabular" name="output" />
+        <data format="tabular" name="output"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
+        <test expect_num_outputs="1">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <output name="output">
                 <assert_contents>
-                    <has_line_matching expression="^chrom\ttx_start\ttx_end\tsymbol\tfrag_count\tfrag_mean\tfrag_median\tfrag_std$" />
-                    <has_line_matching expression="^chr1\t11873\t14409\tNR_046018\t1\t0\t0\t0$" />
-                    <has_line_matching expression="^chr1\t14361\t29370\tNR_024540\t14\t66.5\t51.0\t41.119599080\d+$" />
-                    <has_line_matching expression="^chr1\t17368\t17436\tNR_106918\t0\t0\t0\t0$" />
-                    <has_line_matching expression="^chr1\t17368\t17436\tNR_107062\t0\t0\t0\t0$" />
-                    <has_line_matching expression="^chr1\t34610\t36081\tNR_026818\t0\t0\t0\t0$" />
-                    <has_line_matching expression="^chr1\t34610\t36081\tNR_026820\t0\t0\t0\t0$" />
-                    <has_line_matching expression="^chr1\t69090\t70008\tNM_001005484\t0\t0\t0\t0$" />
+                    <has_line_matching expression="^chrom\ttx_start\ttx_end\tsymbol\tfrag_count\tfrag_mean\tfrag_median\tfrag_std$"/>
+                    <has_line_matching expression="^chr1\t11873\t14409\tNR_046018\t1\t0\t0\t0$"/>
+                    <has_line_matching expression="^chr1\t14361\t29370\tNR_024540\t14\t66.5\t51.0\t41.119599080\d+$"/>
+                    <has_line_matching expression="^chr1\t17368\t17436\tNR_106918\t0\t0\t0\t0$"/>
+                    <has_line_matching expression="^chr1\t17368\t17436\tNR_107062\t0\t0\t0\t0$"/>
+                    <has_line_matching expression="^chr1\t34610\t36081\tNR_026818\t0\t0\t0\t0$"/>
+                    <has_line_matching expression="^chr1\t34610\t36081\tNR_026820\t0\t0\t0\t0$"/>
+                    <has_line_matching expression="^chr1\t69090\t70008\tNM_001005484\t0\t0\t0\t0$"/>
                 </assert_contents>
             </output>
         </test>
     </tests>
-
     <help><![CDATA[
 RNA_fragment_size.py
 ++++++++++++++++++++
@@ -80,7 +72,5 @@ Minimum number of fragments
 ]]>
 
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/RPKM_saturation.xml
+++ b/tools/rseqc/RPKM_saturation.xml
@@ -4,13 +4,9 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[RPKM_saturation.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         RPKM_saturation.py -i 'input.${extension}' -o output -r '${refgene}'
@@ -36,53 +32,49 @@
         -l ${percentileFloor} -u ${percentileCeiling} -s ${percentileStep} -c ${rpkmCutoff}
         --mapq $mapq
     ]]></command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="strand_type_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="strand_type_param"/>
         <param name="percentileFloor" type="integer" value="5" label="Begin sampling from this percentile (default=5)" help="(--percentile-floor)"/>
-        <param name="percentileCeiling" type="integer" value="100" label="End sampling at this percentile (default=100)" help="(--percentile-ceiling)" />
-        <param name="percentileStep" type="integer" value="5" label="Sampling step size (default=5)" help="(--percentile-step)" />
-        <param name="rpkmCutoff" type="text" value="0.01" label="Ignore transcripts with RPKM smaller than this number (default=0.01)" help="(--rpkm-cutoff)" />
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <param name="percentileCeiling" type="integer" value="100" label="End sampling at this percentile (default=100)" help="(--percentile-ceiling)"/>
+        <param name="percentileStep" type="integer" value="5" label="Sampling step size (default=5)" help="(--percentile-step)"/>
+        <param name="rpkmCutoff" type="text" value="0.01" label="Ignore transcripts with RPKM smaller than this number (default=0.01)" help="(--rpkm-cutoff)"/>
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <expand macro="pdf_output_data" filename="output.saturation.pdf" />
+        <expand macro="pdf_output_data" filename="output.saturation.pdf"/>
         <data format="tabular" name="outputxls" from_work_dir="output.eRPKM.xls" label="${tool.name} on ${on_string}: RPKM"/>
         <data format="tabular" name="outputrawxls" from_work_dir="output.rawCount.xls" label="${tool.name} on ${on_string}: raw count"/>
-        <expand macro="rscript_output_data" filename="output.saturation.r" />
+        <expand macro="rscript_output_data" filename="output.saturation.r"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="4">
             <param name="input" value="pairend_strandspecific_51mer_hg19_random.bam"/>
             <param name="refgene" value="hg19.HouseKeepingGenes_30.bed"/>
-            <param name="rscript_output" value="true" />
+            <param name="rscript_output" value="true"/>
             <output name="outputxls">
-              <assert_contents>
-                <has_n_columns n="26" />
-                <has_line_matching expression="chr1\t16174358\t16266950\tNM_015001.*" />
-              </assert_contents>
+                <assert_contents>
+                    <has_n_columns n="26"/>
+                    <has_line_matching expression="chr1\t16174358\t16266950\tNM_015001.*"/>
+                </assert_contents>
             </output>
             <output name="outputrawxls">
-              <assert_contents>
-                <has_n_columns n="26" />
-                <has_line_matching expression="chr1\t16174358\t16266950\tNM_015001.*" />
-              </assert_contents>
+                <assert_contents>
+                    <has_n_columns n="26"/>
+                    <has_line_matching expression="chr1\t16174358\t16266950\tNM_015001.*"/>
+                </assert_contents>
             </output>
             <output name="outputr">
-              <assert_contents>
-                <has_text text="pdf('output.saturation.pdf')" />
-                <has_line_matching expression="S5=c\(\d+\.\d+\)" />
-              </assert_contents>
+                <assert_contents>
+                    <has_text text="pdf('output.saturation.pdf')"/>
+                    <has_line_matching expression="S5=c\(\d+\.\d+\)"/>
+                </assert_contents>
             </output>
-            <output name="outputpdf" file="output.saturation.pdf" compare="sim_size" />
+            <output name="outputpdf" file="output.saturation.pdf" compare="sim_size"/>
         </test>
     </tests>
-
     <help><![CDATA[
 RPKM_saturation.py
 ++++++++++++++++++
@@ -163,7 +155,5 @@ Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/bam2wig.xml
+++ b/tools/rseqc/bam2wig.xml
@@ -1,19 +1,14 @@
 <tool id="rseqc_bam2wig" name="BAM to Wiggle" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@GALAXY_VERSION@">
     <description>
-        converts all types of RNA-seq data from .bam to .wig
+        converts all types of RNA-seq data from BAM to Wiggle
     </description>
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-    
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[bam2wig.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         bam2wig.py -i 'input.${extension}' -s '${chromsize}' -o outfile
@@ -44,9 +39,9 @@
         ]]>
     </command>
     <inputs>
-        <expand macro="bam_param" />
+        <expand macro="bam_param"/>
         <param name="chromsize" type="data" label="Chromosome size file (tab or space separated)" format="txt,tabular" help="(--chromSize)"/>
-        <expand macro="multihits_param" />
+        <expand macro="multihits_param"/>
         <conditional name="wigsum_type">
             <param name="wigsum_type_selector" type="select" label="Normalization">
                 <option value="normalize">Normalize to specified sum</option>
@@ -57,9 +52,8 @@
             </when>
             <when value="raw"/>
         </conditional>
-        <expand macro="strand_type_param" />
+        <expand macro="strand_type_param"/>
     </inputs>
-
     <outputs>
         <data format="wig" name="output" from_work_dir="outfile.wig">
             <filter>strand_type['strand_specific'] == 'none'</filter>
@@ -71,21 +65,20 @@
             <filter>strand_type['strand_specific'] != 'none'</filter>
         </data>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="chromsize" value="hg19.chrom.sizes"/>
             <output name="output" file="testwig.wig"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="chromsize" value="hg19.chrom.sizes"/>
             <param name="multihits_type_selector" value="skip_multihits"/>
             <param name="mapq" value="20"/>
             <output name="output" file="testwig.wig"/>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="chromsize" value="hg19.chrom.sizes"/>
             <param name="strand_specific" value="pair"/>
@@ -93,7 +86,7 @@
             <output name="outputfwd" file="testwig.Forward.wig"/>
             <output name="outputrv" file="testwig.Reverse.wig"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="chromsize" value="hg19.chrom.sizes"/>
             <param name="wigsum_type_selector" value="normalize"/>
@@ -101,7 +94,6 @@
             <output name="output" file="testwig_wigsum100.wig"/>
         </test>
     </tests>
-
     <help><![CDATA[
 bam2wig.py
 ++++++++++
@@ -149,7 +141,5 @@ is strand specific, two wig files corresponding to Forward and Reverse will be g
 .. _bigwig: http://genome.ucsc.edu/FAQ/FAQformat.html#format6.1
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/bam_stat.xml
+++ b/tools/rseqc/bam_stat.xml
@@ -5,37 +5,28 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[bam_stat.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         bam_stat.py -i 'input.${extension}' -q ${mapq} > '${output}'
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="mapq_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="mapq_param"/>
     </inputs>
-
     <outputs>
         <data format="txt" name="output" label="${tool.name} on ${on_string}: stats"/>
     </outputs>
-
     <tests>
         <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <output name="output" file="output.bamstats.txt" />
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <output name="output" file="output.bamstats.txt"/>
         </test>
     </tests>
-
     <help><![CDATA[
 bam_stat.py
 +++++++++++
@@ -68,6 +59,5 @@ Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/clipping_profile.xml
+++ b/tools/rseqc/clipping_profile.xml
@@ -26,7 +26,7 @@
         <expand macro="rscript_output_data" filename="output.clipping_profile.r" label="${tool.name} on ${on_string}: Rscript"/>
     </outputs>
     <tests>
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="2">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <output name="outputpdf" file="output.clipping_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.clipping_profile.xls" ftype="tabular"/>

--- a/tools/rseqc/clipping_profile.xml
+++ b/tools/rseqc/clipping_profile.xml
@@ -5,49 +5,40 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[clipping_profile.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         clipping_profile.py -i 'input.${extension}' -o output -q ${mapq} -s "${layout}"
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="mapq_param" />
-        <expand macro="layout_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="layout_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
         <expand macro="pdf_output_data" filename="output.clipping_profile.pdf" label="${tool.name} on ${on_string}: PDF"/>
         <expand macro="xls_output_data" filename="output.clipping_profile.xls" label="${tool.name} on ${on_string}: XML"/>
         <expand macro="rscript_output_data" filename="output.clipping_profile.r" label="${tool.name} on ${on_string}: Rscript"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <output name="outputpdf" file="output.clipping_profile.pdf" compare="sim_size" />
+        <test expect_num_outputs="1">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <output name="outputpdf" file="output.clipping_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.clipping_profile.xls" ftype="tabular"/>
         </test>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <param name="rscript_output" value="true" />
-            <output name="outputpdf" file="output.clipping_profile.pdf" compare="sim_size" />
+        <test expect_num_outputs="3">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputpdf" file="output.clipping_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.clipping_profile.xls" ftype="tabular"/>
-            <output name="outputr" file="output.clipping_profile_r" />
+            <output name="outputr" file="output.clipping_profile_r"/>
         </test>
     </tests>
-
     <help><![CDATA[
 clipping_profile.py
 +++++++++++++++++++
@@ -81,7 +72,5 @@ Sample Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/deletion_profile.xml
+++ b/tools/rseqc/deletion_profile.xml
@@ -5,46 +5,37 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[deletion_profile.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         deletion_profile.py -i 'input.${extension}' -o output -l ${read_align_length} -n ${read_num} -q ${mapq}
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="readlength_param" />
-        <expand macro="readnum_param" />
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_param"/>
+        <expand macro="readlength_param"/>
+        <expand macro="readnum_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <expand macro="pdf_output_data" filename="output.deletion_profile.pdf" />
-        <expand macro="xls_output_data" filename="output.deletion_profile.txt" />
-        <expand macro="rscript_output_data" filename="output.deletion_profile.r" />
+        <expand macro="pdf_output_data" filename="output.deletion_profile.pdf"/>
+        <expand macro="xls_output_data" filename="output.deletion_profile.txt"/>
+        <expand macro="rscript_output_data" filename="output.deletion_profile.r"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <param name="read_align_length" value="101" />
-            <param name="rscript_output" value="true" />
-            <output name="outputpdf" file="output.deletion_profile.pdf" compare="sim_size" />
+        <test expect_num_outputs="3">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <param name="read_align_length" value="101"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputpdf" file="output.deletion_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.deletion_profile.txt" ftype="tabular"/>
-            <output name="outputr" file="output.deletion_profile_r" />
+            <output name="outputr" file="output.deletion_profile_r"/>
         </test>
     </tests>
-
     <help><![CDATA[
 deletion_profile.py
 +++++++++++++++++++
@@ -83,7 +74,5 @@ Sample Output
 ]]>
 
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/geneBody_coverage.xml
+++ b/tools/rseqc/geneBody_coverage.xml
@@ -4,8 +4,8 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-    <expand macro="requirements" />
-    <expand macro="stdio" />
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[geneBody_coverage.py --version]]></version_command>
     <command><![CDATA[
     #if str($batch_mode.batch_mode_selector) == "merge":
@@ -30,63 +30,58 @@
     #end if
     ]]>
   </command>
-
-  <inputs>
-    <conditional name="batch_mode">
-        <param name="batch_mode_selector" type="select" label="Run each sample separately, or combine mutiple samples into one plot">
-            <option value="batch" selected="true">Run each sample separately</option>
-            <option value="merge">Combine multiple samples into a single plot</option>
-        </param>
-        <when value="batch">
-            <param name="input" type="data" label="Input .bam file" format="bam" help="(--input-file)"/>
-        </when>
-        <when value="merge">
-            <param name="inputs" type="data" label="Input .bam file(s)" format="bam" help="(--input-file)" multiple="true"/>
-        </when>
-    </conditional>
-    <expand macro="refgene_param" />
-    <param name="minimum_length" type="integer" value="100" label="Minimum mRNA length (default: 100)" help="Minimum mRNA length in bp, mRNA that are shorter than this value will be skipped (--minimum_length)." />
-    <expand macro="rscript_output_param" />
-  </inputs>
-
-  <outputs>
-    <data name="outputcurvespdf" format="pdf" from_work_dir="output.geneBodyCoverage.curves.pdf" label="${tool.name} on ${on_string}: curves (PDF)" />
-    <data name="outputheatmappdf" format="pdf" from_work_dir="output.geneBodyCoverage.heatMap.pdf" label="${tool.name} on ${on_string}: heatmap (PDF)">
-      <filter>batch_mode['batch_mode_selector'] == 'merge' and len(inputs) >= 3</filter>
-    </data>
-    <expand macro="rscript_output_data" filename="output.geneBodyCoverage.r" label="${tool.name} on ${on_string}: Rscript"/>
-    <data name="outputtxt" format="txt" from_work_dir="output.geneBodyCoverage.txt" label="${tool.name} on ${on_string}: stats (TXT)" />
-  </outputs>
-
-  <!-- PDF Files contain R version, must avoid checking for diff -->
-  <tests>
-    <test>
-      <conditional name="batch_mode">
-        <param name="batch_mode_selector" value="batch" />
-        <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-      </conditional>
-      <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" />
-      <param name="rscript_output" value="true" />
-      <output name="outputcurvespdf" file="output.geneBodyCoverage.curves.pdf" compare="sim_size" />
-      <output name="outputr" file="output.geneBodyCoverage_r" />
-      <output name="outputtxt" file="output.geneBodyCoverage.txt" />
-    </test>
-    <test>
-      <conditional name="batch_mode">
-        <param name="batch_mode_selector" value="merge" />
-        <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam,pairend_strandspecific_51mer_hg19_chr1_1-100000.bam,pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-      </conditional>
-      <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
-      <param name="rscript_output" value="true" />
-      <output name="outputcurvespdf" file="output2.geneBodyCoverage.curves.pdf" compare="sim_size" />
-      <output name="outputheatmappdf" file="output2.geneBodyCoverage.heatMap.pdf" compare="sim_size" />
-      <output name="outputr" file="output2.geneBodyCoverage_r" />
-      <output name="outputtxt" file="output2.geneBodyCoverage.txt" />
-    </test>
-
-  </tests>
-
-  <help><![CDATA[
+    <inputs>
+        <conditional name="batch_mode">
+            <param name="batch_mode_selector" type="select" label="Run each sample separately, or combine mutiple samples into one plot">
+                <option value="batch" selected="true">Run each sample separately</option>
+                <option value="merge">Combine multiple samples into a single plot</option>
+            </param>
+            <when value="batch">
+                <param name="input" type="data" label="Input .bam file" format="bam" help="(--input-file)"/>
+            </when>
+            <when value="merge">
+                <param name="inputs" type="data" label="Input .bam file(s)" format="bam" help="(--input-file)" multiple="true"/>
+            </when>
+        </conditional>
+        <expand macro="refgene_param"/>
+        <param name="minimum_length" type="integer" value="100" label="Minimum mRNA length (default: 100)" help="Minimum mRNA length in bp, mRNA that are shorter than this value will be skipped (--minimum_length)."/>
+        <expand macro="rscript_output_param"/>
+    </inputs>
+    <outputs>
+        <data name="outputcurvespdf" format="pdf" from_work_dir="output.geneBodyCoverage.curves.pdf" label="${tool.name} on ${on_string}: curves (PDF)"/>
+        <data name="outputheatmappdf" format="pdf" from_work_dir="output.geneBodyCoverage.heatMap.pdf" label="${tool.name} on ${on_string}: heatmap (PDF)">
+            <filter>batch_mode['batch_mode_selector'] == 'merge' and len(inputs) &gt;= 3</filter>
+        </data>
+        <expand macro="rscript_output_data" filename="output.geneBodyCoverage.r" label="${tool.name} on ${on_string}: Rscript"/>
+        <data name="outputtxt" format="txt" from_work_dir="output.geneBodyCoverage.txt" label="${tool.name} on ${on_string}: stats (TXT)"/>
+    </outputs>
+    <!-- PDF Files contain R version, must avoid checking for diff -->
+    <tests>
+        <test expect_num_outputs="3">
+            <conditional name="batch_mode">
+                <param name="batch_mode_selector" value="batch"/>
+                <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            </conditional>
+            <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputcurvespdf" file="output.geneBodyCoverage.curves.pdf" compare="sim_size"/>
+            <output name="outputr" file="output.geneBodyCoverage_r"/>
+            <output name="outputtxt" file="output.geneBodyCoverage.txt"/>
+        </test>
+        <test expect_num_outputs="4">
+            <conditional name="batch_mode">
+                <param name="batch_mode_selector" value="merge"/>
+                <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam,pairend_strandspecific_51mer_hg19_chr1_1-100000.bam,pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            </conditional>
+            <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputcurvespdf" file="output2.geneBodyCoverage.curves.pdf" compare="sim_size"/>
+            <output name="outputheatmappdf" file="output2.geneBodyCoverage.heatMap.pdf" compare="sim_size"/>
+            <output name="outputr" file="output2.geneBodyCoverage_r"/>
+            <output name="outputtxt" file="output2.geneBodyCoverage.txt"/>
+        </test>
+    </tests>
+    <help><![CDATA[
 ## geneBody_coverage.py
 
 Read coverage over gene body. This module is used to check if read coverage is uniform and if there is any 5\'/3\' bias. This module scales all transcripts to 100 nt and calculates the number of reads covering each nucleotide position. Finally, it generates plots illustrating the coverage profile along the gene body.
@@ -138,7 +133,5 @@ Example plots:
 
     ]]>
   </help>
-
-  <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/infer_experiment.xml
+++ b/tools/rseqc/infer_experiment.xml
@@ -3,15 +3,10 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[infer_experiment.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         infer_experiment.py -i 'input.${extension}' -r '${refgene}'
@@ -20,26 +15,22 @@
             > '${output}'
             ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="sample_size_param" />
-        <expand macro="mapq_param" />
+        <expand macro="bam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="sample_size_param"/>
+        <expand macro="mapq_param"/>
     </inputs>
-
     <outputs>
-        <data format="txt" name="output" label="${tool.name} on ${on_string}: RNA-seq experiment configuration" />
+        <data format="txt" name="output" label="${tool.name} on ${on_string}: RNA-seq experiment configuration"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <output name="output" file="output.infer_experiment.txt"/>
         </test>
     </tests>
-
     <help><![CDATA[
 infer_experiment.py
 +++++++++++++++++++
@@ -137,7 +128,5 @@ Example Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/inner_distance.xml
+++ b/tools/rseqc/inner_distance.xml
@@ -3,15 +3,10 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[inner_distance.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         inner_distance.py -i 'input.${extension}' -o output -r '${refgene}'
@@ -22,37 +17,33 @@
             --mapq ${mapq}
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="sample_size_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="sample_size_param"/>
         <param name="lowerBound" type="integer" value="-250" label="Lower bound (bp, default=-250)" help="Used for plotting histogram (--lower-bound)"/>
         <param name="upperBound" type="integer" value="250" label="Upper bound (bp, default=250)" help="Used for plotting histogram (--upper-bound)"/>
         <param name="step" type="integer" value="5" label="Step size of histogram (bp, default=5)" help="(--step)"/>
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
         <expand macro="pdf_output_data" filename="output.inner_distance_plot.pdf" label="${tool.name} on ${on_string}: plot (PDF)"/>
         <data format="txt" name="outputtxt" from_work_dir="output.inner_distance.txt" label="${tool.name} on ${on_string}: TXT"/>
-        <data format="txt" name="outputfreqtxt" from_work_dir="output.inner_distance_freq.txt" label="${tool.name} on ${on_string}: frequency (TXT)" />
-        <expand macro="rscript_output_data" filename="output.inner_distance_plot.r"  label="${tool.name} on ${on_string}: Rscript"/>
+        <data format="txt" name="outputfreqtxt" from_work_dir="output.inner_distance_freq.txt" label="${tool.name} on ${on_string}: frequency (TXT)"/>
+        <expand macro="rscript_output_data" filename="output.inner_distance_plot.r" label="${tool.name} on ${on_string}: Rscript"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="4">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
-            <param name="rscript_output" value="true" />
-            <output name="outputtxt" file="output.inner_distance.txt" />
-            <output name="outputfreqtxt" file="output.inner_distance_freq.txt" />
+            <param name="rscript_output" value="true"/>
+            <output name="outputtxt" file="output.inner_distance.txt"/>
+            <output name="outputfreqtxt" file="output.inner_distance_freq.txt"/>
             <output name="outputpdf" file="output.inner_distance_plot.pdf" compare="sim_size"/>
-            <output name="outputr" file="output.inner_distance_plot_r" />
+            <output name="outputr" file="output.inner_distance_plot_r"/>
         </test>
     </tests>
-
     <help><![CDATA[
 inner_distance.py
 +++++++++++++++++
@@ -109,7 +100,5 @@ Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/insertion_profile.xml
+++ b/tools/rseqc/insertion_profile.xml
@@ -5,44 +5,35 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[insertion_profile.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         insertion_profile.py -i 'input.${extension}' -o output -q ${mapq} -s "${layout}"
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="mapq_param" />
-        <expand macro="layout_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="layout_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <expand macro="pdf_output_data" filename="output.insertion_profile.pdf" />
-        <expand macro="xls_output_data" filename="output.insertion_profile.xls" />
-        <expand macro="rscript_output_data" filename="output.insertion_profile.r" />
+        <expand macro="pdf_output_data" filename="output.insertion_profile.pdf"/>
+        <expand macro="xls_output_data" filename="output.insertion_profile.xls"/>
+        <expand macro="rscript_output_data" filename="output.insertion_profile.r"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <param name="rscript_output" value="true" />
-            <output name="outputpdf" file="output.insertion_profile.pdf" compare="sim_size" />
+        <test expect_num_outputs="3">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputpdf" file="output.insertion_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.insertion_profile.xls" ftype="tabular"/>
-            <output name="outputr" file="output.insertion_profile_r" />
+            <output name="outputr" file="output.insertion_profile_r"/>
         </test>
     </tests>
-
     <help><![CDATA[
 insertion_profile.py
 ++++++++++++++++++++
@@ -84,7 +75,5 @@ Read-2 insertion profile:
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/junction_annotation.xml
+++ b/tools/rseqc/junction_annotation.xml
@@ -39,7 +39,7 @@
         <data format="txt" name="stats" from_work_dir="stats.txt" label="${tool.name} on ${on_string}: stats"/>
     </outputs>
     <tests>
-        <test expect_num_outputs="4">
+        <test expect_num_outputs="5">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <param name="rscript_output" value="true"/>

--- a/tools/rseqc/junction_annotation.xml
+++ b/tools/rseqc/junction_annotation.xml
@@ -3,9 +3,7 @@
     <macros>
         <import>rseqc_macros.xml</import>
     </macros>
-
     <expand macro="bio_tools"/>
-
     <expand macro="requirements">
         <!--
             Required due to conda solver bug: https://github.com/conda/conda/issues/6269
@@ -13,11 +11,8 @@
         -->
         <requirement type="package" version="4.2.2">r-base</requirement>
     </expand>
-
-    <expand macro="stdio" />
-
+    <expand macro="stdio"/>
     <version_command><![CDATA[junction_annotation.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         junction_annotation.py
@@ -29,36 +24,32 @@
         2> >(tee -a stats.txt >&2)
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="min_intron_param" />
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="min_intron_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
         <data format="pdf" name="outputpdf" from_work_dir="output.splice_events.pdf" label="${tool.name} on ${on_string}: splice events (PDF)"/>
-        <data format="pdf" name="outputjpdf" from_work_dir="output.splice_junction.pdf" label="${tool.name} on ${on_string}: splice junction (PDF)" />
-        <expand macro="xls_output_data" filename="output.junction.xls" label="${tool.name} on ${on_string}: splice junction (XLS)" />
+        <data format="pdf" name="outputjpdf" from_work_dir="output.splice_junction.pdf" label="${tool.name} on ${on_string}: splice junction (PDF)"/>
+        <expand macro="xls_output_data" filename="output.junction.xls" label="${tool.name} on ${on_string}: splice junction (XLS)"/>
         <expand macro="rscript_output_data" filename="output.junction_plot.r" label="${tool.name} on ${on_string}: Rscript"/>
-        <data format="txt" name="stats" from_work_dir="stats.txt" label="${tool.name} on ${on_string}: stats" />
+        <data format="txt" name="stats" from_work_dir="stats.txt" label="${tool.name} on ${on_string}: stats"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
+        <test expect_num_outputs="4">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
-            <param name="rscript_output" value="true" />
+            <param name="rscript_output" value="true"/>
             <output name="outputxls" file="output.junction.xls" ftype="tabular"/>
-            <output name="outputr" file="output.junction_plot_r" />
-            <output name="outputpdf" file="output.splice_events.pdf" compare="sim_size" />
-            <output name="outputjpdf" file="output.splice_junction.pdf" compare="sim_size" />
-            <output name="stats" file="output.splice_junction.txt" ftype="txt" lines_diff="2" />
+            <output name="outputr" file="output.junction_plot_r"/>
+            <output name="outputpdf" file="output.splice_events.pdf" compare="sim_size"/>
+            <output name="outputjpdf" file="output.splice_junction.pdf" compare="sim_size"/>
+            <output name="stats" file="output.splice_junction.txt" ftype="txt" lines_diff="2"/>
         </test>
     </tests>
-
     <help><![CDATA[
 junction_annotation.py
 ++++++++++++++++++++++
@@ -112,7 +103,5 @@ Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/junction_saturation.xml
+++ b/tools/rseqc/junction_saturation.xml
@@ -4,8 +4,8 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-    <expand macro="requirements" />
-    <expand macro="stdio" />
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[junction_saturation.py --version]]></version_command>
     <command><![CDATA[
         @BAM_SAM_INPUTS@
@@ -23,13 +23,12 @@
         #end if
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="refgene_param" />
-        <expand macro="min_intron_param" />
-        <param name="min_coverage" type="integer" label="Minimum number of supporting reads to call a junction (default=1)" value="1" help="(--min-coverage)" />
-        <expand macro="mapq_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="refgene_param"/>
+        <expand macro="min_intron_param"/>
+        <param name="min_coverage" type="integer" label="Minimum number of supporting reads to call a junction (default=1)" value="1" help="(--min-coverage)"/>
+        <expand macro="mapq_param"/>
         <conditional name="percentiles_type">
             <param name="percentiles_type_selector" type="select" label="Sampling bounds and frequency">
                 <option value="default" selected="true">Default sampling bounds and frequency</option>
@@ -37,40 +36,37 @@
             </param>
             <when value="specify">
                 <param name="lowBound" type="integer" value="5" label="Lower Bound Sampling Frequency (bp, default=5)" help="(--percentile-floor)">
-                    <validator type="in_range" min="0" max="100" />
+                    <validator type="in_range" min="0" max="100"/>
                 </param>
                 <param name="upBound" type="integer" value="100" label="Upper Bound Sampling Frequency (bp, default=100)" help="(--percentile-ceiling)">
-                    <validator type="in_range" min="0" max="100" />
+                    <validator type="in_range" min="0" max="100"/>
                 </param>
                 <param name="percentileStep" type="integer" value="5" label="Sampling increment (default=5)" help="(--percentile-step)">
-                    <validator type="in_range" min="0" max="100" />
+                    <validator type="in_range" min="0" max="100"/>
                 </param>
             </when>
             <when value="default"/>
         </conditional>
-        <expand macro="rscript_output_param" />
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
         <expand macro="pdf_output_data" filename="output.junctionSaturation_plot.pdf" label="${tool.name} on ${on_string}: junction saturation (PDF)"/>
         <expand macro="rscript_output_data" filename="output.junctionSaturation_plot.r" label="${tool.name} on ${on_string}: junction saturation (Rscript)"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
+        <test expect_num_outputs="2">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
-            <param name="rscript_output" value="true" />
+            <param name="rscript_output" value="true"/>
             <output name="outputr" file="output.junctionSaturation_plot_r" compare="sim_size">
                 <assert_contents>
-                    <has_line line="pdf('output.junctionSaturation_plot.pdf')" />
-                    <has_line line="x=c(5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85,90,95,100)" />
+                    <has_line line="pdf('output.junctionSaturation_plot.pdf')"/>
+                    <has_line line="x=c(5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85,90,95,100)"/>
                 </assert_contents>
             </output>
-            <output name="outputpdf" file="output.junctionSaturation_plot.pdf" compare="sim_size" />
+            <output name="outputpdf" file="output.junctionSaturation_plot.pdf" compare="sim_size"/>
         </test>
     </tests>
-
     <help><![CDATA[
 junction_saturation.py
 ++++++++++++++++++++++
@@ -120,7 +116,5 @@ In this example, current sequencing depth is almost saturated for "known junctio
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/mismatch_profile.xml
+++ b/tools/rseqc/mismatch_profile.xml
@@ -6,44 +6,36 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[mismatch_profile.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         mismatch_profile.py -i 'input.${extension}' -o output -l ${read_align_length} -n ${read_num} -q ${mapq}
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_param" />
-        <expand macro="readlength_param" />
-        <expand macro="readnum_param" />
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_param"/>
+        <expand macro="readlength_param"/>
+        <expand macro="readnum_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <expand macro="pdf_output_data" filename="output.mismatch_profile.pdf" />
-        <expand macro="xls_output_data" filename="output.mismatch_profile.xls" />
-        <expand macro="rscript_output_data" filename="output.mismatch_profile.r" />
+        <expand macro="pdf_output_data" filename="output.mismatch_profile.pdf"/>
+        <expand macro="xls_output_data" filename="output.mismatch_profile.xls"/>
+        <expand macro="rscript_output_data" filename="output.mismatch_profile.r"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="3">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
-            <param name="read_align_length" value="101" />
-            <param name="rscript_output" value="true" />
-            <output name="outputpdf" file="output.mismatch_profile.pdf" compare="sim_size" />
+            <param name="read_align_length" value="101"/>
+            <param name="rscript_output" value="true"/>
+            <output name="outputpdf" file="output.mismatch_profile.pdf" compare="sim_size"/>
             <output name="outputxls" file="output.mismatch_profile.xls" ftype="tabular"/>
             <output name="outputr" file="output.mismatch_profile_r"/>
         </test>
     </tests>
-
     <help><![CDATA[
 mismatch_profile.py
 +++++++++++++++++++
@@ -84,7 +76,5 @@ Sample Output
 ]]>
 
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/read_GC.xml
+++ b/tools/rseqc/read_GC.xml
@@ -4,13 +4,9 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[read_GC.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         read_GC.py
@@ -19,29 +15,25 @@
             --mapq ${mapq}
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
         <expand macro="pdf_output_data" filename="output.GC_plot.pdf" label="${tool.name} on ${on_string}: plot (PDF)"/>
         <expand macro="xls_output_data" filename="output.GC.xls" label="${tool.name} on ${on_string}: XLS"/>
         <expand macro="rscript_output_data" filename="output.GC_plot.r" label="${tool.name} on ${on_string}: Rscript"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <param name="rscript_output" value="true" />
+        <test expect_num_outputs="3">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <param name="rscript_output" value="true"/>
             <output name="outputxls" file="output.GC.xls" ftype="tabular"/>
-            <output name="outputr" file="output.GC_plot_r" />
-            <output name="outputpdf" file="output.GC_plot.pdf" compare="sim_size" />
+            <output name="outputr" file="output.GC_plot_r"/>
+            <output name="outputpdf" file="output.GC_plot.pdf" compare="sim_size"/>
         </test>
     </tests>
-
     <help><![CDATA[
 read_GC.py
 ++++++++++
@@ -69,7 +61,5 @@ Output
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/read_NVC.xml
+++ b/tools/rseqc/read_NVC.xml
@@ -4,13 +4,9 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[read_NVC.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         read_NVC.py
@@ -20,30 +16,26 @@
             --mapq ${mapq}
     ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
+        <expand macro="bam_sam_param"/>
         <param name="nx" type="boolean" value="false" truevalue="--nx" falsevalue="" label="Include N,X in NVC plot" help="(--nx)"/>
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <expand macro="pdf_output_data" filename="output.NVC_plot.pdf" />
-        <expand macro="xls_output_data" filename="output.NVC.xls" />
-        <expand macro="rscript_output_data" filename="output.NVC_plot.r" />
+        <expand macro="pdf_output_data" filename="output.NVC_plot.pdf"/>
+        <expand macro="xls_output_data" filename="output.NVC.xls"/>
+        <expand macro="rscript_output_data" filename="output.NVC_plot.r"/>
     </outputs>
-
     <tests>
-        <test>
-            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
-            <param name="rscript_output" value="true" />
+        <test expect_num_outputs="3">
+            <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
+            <param name="rscript_output" value="true"/>
             <output name="outputxls" file="output.NVC.xls" ftype="tabular"/>
-            <output name="outputr" file="output.NVC_plot_r" />
-            <output name="outputpdf" file="output.NVC_plot.pdf" compare="sim_size" />
+            <output name="outputr" file="output.NVC_plot_r"/>
+            <output name="outputpdf" file="output.NVC_plot.pdf" compare="sim_size"/>
         </test>
     </tests>
-
     <help><![CDATA[
 read_NVC.py
 +++++++++++
@@ -86,7 +78,5 @@ This module is used to check the nucleotide composition bias. Due to random prim
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/read_distribution.xml
+++ b/tools/rseqc/read_distribution.xml
@@ -4,36 +4,28 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[read_distribution.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         read_distribution.py -i 'input.${extension}' -r '${refgene}' > '${output}'
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
-        <expand macro="refgene_param" />
+        <expand macro="bam_sam_param"/>
+        <expand macro="refgene_param"/>
     </inputs>
-
     <outputs>
-        <data format="txt" name="output"  label="${tool.name} on ${on_string}: stats (TXT)"/>
+        <data format="txt" name="output" label="${tool.name} on ${on_string}: stats (TXT)"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam"/>
             <param name="refgene" value="hg19_RefSeq_chr1_1-100000.bed" ftype="bed12"/>
             <output name="output" file="output.read_distribution.txt"/>
         </test>
     </tests>
-
     <help><![CDATA[
 read_distribution.py
 ++++++++++++++++++++
@@ -91,7 +83,5 @@ TES_down_10kb       140361190           896882              6.39
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/read_duplication.xml
+++ b/tools/rseqc/read_duplication.xml
@@ -7,27 +7,23 @@
     <expand macro="requirements" />
     <expand macro="stdio" />
     <version_command><![CDATA[read_duplication.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         read_duplication.py -i 'input.${extension}' -o output -u ${upLimit} -q ${mapq}
         ]]>
     </command>
-
     <inputs>
         <expand macro="bam_sam_param" />
         <param name="upLimit" type="integer" label="Upper Limit of Plotted Duplicated Times (default=500)" value="500" help="(--up-limit)"/>
         <expand macro="mapq_param" />
         <expand macro="rscript_output_param" />
     </inputs>
-
     <outputs>
         <expand macro="pdf_output_data" filename="output.DupRate_plot.pdf"  label="${tool.name} on ${on_string}: plot (PDF)"/>
         <data format="tabular" name="outputxls" from_work_dir="output.pos.DupRate.xls" label="${tool.name} on ${on_string}: positon"/>
         <data format="tabular" name="outputseqxls" from_work_dir="output.seq.DupRate.xls" label="${tool.name} on ${on_string}: sequences"/>
         <expand macro="rscript_output_data" filename="output.DupRate_plot.r" label="${tool.name} on ${on_string}: Rscript"/>
     </outputs>
-
     <tests>
         <test expect_num_outputs="4">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
@@ -73,6 +69,7 @@ Output
 @ABOUT@
 
 ]]>
+    <expand macro="citations" />
     </help>
 
     <expand macro="citations" />

--- a/tools/rseqc/read_duplication.xml
+++ b/tools/rseqc/read_duplication.xml
@@ -34,7 +34,6 @@
             <output name="outputpdf" file="output.DupRate_plot.pdf" compare="sim_size" />
         </test>
     </tests>
-
     <help><![CDATA[
 read_duplication.py
 +++++++++++++++++++
@@ -69,9 +68,6 @@ Output
 @ABOUT@
 
 ]]>
-    <expand macro="citations" />
     </help>
-
     <expand macro="citations" />
-
 </tool>

--- a/tools/rseqc/read_duplication.xml
+++ b/tools/rseqc/read_duplication.xml
@@ -4,11 +4,8 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
     <expand macro="requirements" />
-
     <expand macro="stdio" />
-
     <version_command><![CDATA[read_duplication.py --version]]></version_command>
 
     <command><![CDATA[
@@ -32,7 +29,7 @@
     </outputs>
 
     <tests>
-        <test>
+        <test expect_num_outputs="4">
             <param name="input" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" />
             <param name="rscript_output" value="true" />
             <output name="outputxls" file="output.pos.DupRate.xls" ftype="tabular"/>

--- a/tools/rseqc/read_hexamer.xml
+++ b/tools/rseqc/read_hexamer.xml
@@ -6,12 +6,9 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[read_hexamer.py --version]]></version_command>
-
     <command><![CDATA[
         #import re
         #set $input_list = []
@@ -39,51 +36,48 @@
         > '${output}'
         ]]>
     </command>
-
     <inputs>
-        <param name="inputs" type="data" label="Read sequences in fasta or fastq format" format="fasta,fastq,fastqsanger,fastq.gz,fastqsanger.gz" help="(--input)" multiple="true" />
-        <param name="refgenome" type="data" label="Reference genome seqeunce (fasta)" format="fasta" optional="true" help="(--refgenome)" />
-        <param name="refgene" type="data" label="Reference mRNA sequence (fasta)" format="fasta" optional="true" help="(--refgene)" />
+        <param name="inputs" type="data" label="Read sequences in fasta or fastq format" format="fasta,fastq,fastqsanger,fastq.gz,fastqsanger.gz" help="(--input)" multiple="true"/>
+        <param name="refgenome" type="data" label="Reference genome seqeunce (fasta)" format="fasta" optional="true" help="(--refgenome)"/>
+        <param name="refgene" type="data" label="Reference mRNA sequence (fasta)" format="fasta" optional="true" help="(--refgene)"/>
     </inputs>
-
     <outputs>
-        <data name="output" format="tabular" label="${tool.name} on ${on_string}" />
+        <data name="output" format="tabular" label="${tool.name} on ${on_string}"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.R1.fastq"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="Hexamer&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq" />
-                    <has_text text="0.002173913043478261" />
+                    <has_line line="Hexamer&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq"/>
+                    <has_text text="0.002173913043478261"/>
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.R1.fastq.gz" ftype="fastqsanger.gz"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="Hexamer&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq_gz" />
-                    <has_text text="0.002173913043478261" />
+                    <has_line line="Hexamer&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq_gz"/>
+                    <has_text text="0.002173913043478261"/>
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.R1.fastq,pairend_strandspecific_51mer_hg19_chr1_1-100000.R2.fastq"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="Hexamer&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R2_fastq" />
-                    <has_text text="0.002173913043478261" />
+                    <has_line line="Hexamer&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R2_fastq"/>
+                    <has_text text="0.002173913043478261"/>
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="inputs" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.R1.fastq,pairend_strandspecific_51mer_hg19_chr1_1-100000.R1.fastq"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="Hexamer&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq&#009;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq.1" />
-                    <has_text text="0.002173913043478261" />
+                    <has_line line="Hexamer&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq&#9;pairend_strandspecific_51mer_hg19_chr1_1-100000_R1_fastq.1"/>
+                    <has_text text="0.002173913043478261"/>
                 </assert_contents>
             </output>
         </test>
@@ -99,7 +93,6 @@
         </test>
         -->
     </tests>
-
     <help><![CDATA[
 read_hexamer.py
 +++++++++++++++++++++
@@ -130,7 +123,5 @@ Tabular file of hexamer frequences in for each input.
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/read_quality.xml
+++ b/tools/rseqc/read_quality.xml
@@ -11,11 +11,8 @@
         -->
         <requirement type="package" version="4.2.2">r-base</requirement>
     </expand>
-
-    <expand macro="stdio" />
-
+    <expand macro="stdio"/>
     <version_command><![CDATA[read_quality.py --version]]></version_command>
-
     <command><![CDATA[
         @BAM_SAM_INPUTS@
         read_quality.py
@@ -25,30 +22,26 @@
             --mapq ${mapq}
         ]]>
     </command>
-
     <inputs>
-        <expand macro="bam_sam_param" />
+        <expand macro="bam_sam_param"/>
         <param name="reduce" type="integer" label="Ignore Phred scores less than this amount (only applies to 'boxplot', default=1000)" value="1000" help="(--reduce)"/>
-        <expand macro="mapq_param" />
-        <expand macro="rscript_output_param" />
+        <expand macro="mapq_param"/>
+        <expand macro="rscript_output_param"/>
     </inputs>
-
     <outputs>
-        <data format="pdf" name="outputheatpdf" from_work_dir="output.qual.heatmap.pdf" label="${tool.name} on ${on_string} (Heatmap pdf)" />
-        <data format="pdf" name="outputboxpdf" from_work_dir="output.qual.boxplot.pdf" label="${tool.name} on ${on_string} (Boxplot pdf)" />
-        <expand macro="rscript_output_data" filename="output.qual.r" />
+        <data format="pdf" name="outputheatpdf" from_work_dir="output.qual.heatmap.pdf" label="${tool.name} on ${on_string} (Heatmap pdf)"/>
+        <data format="pdf" name="outputboxpdf" from_work_dir="output.qual.boxplot.pdf" label="${tool.name} on ${on_string} (Boxplot pdf)"/>
+        <expand macro="rscript_output_data" filename="output.qual.r"/>
     </outputs>
-
     <tests>
-        <test>
+        <test expect_num_outputs="3">
             <param name="input" value="pairend_strandspecific_51mer_hg19_random.bam"/>
-            <param name="rscript_output" value="true" />
+            <param name="rscript_output" value="true"/>
             <output name="outputr" file="output.qual_r"/>
-            <output name="outputheatpdf" file="output.qual.heatmap.pdf" compare="sim_size" />
-            <output name="outputboxpdf" file="output.qual.boxplot.pdf" compare="sim_size" />
+            <output name="outputheatpdf" file="output.qual.heatmap.pdf" compare="sim_size"/>
+            <output name="outputboxpdf" file="output.qual.boxplot.pdf" compare="sim_size"/>
         </test>
     </tests>
-
     <help><![CDATA[
 read_quality.py
 +++++++++++++++
@@ -92,7 +85,5 @@ Heatmap: use different color to represent nucleotide density ("blue"=low density
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>

--- a/tools/rseqc/rseqc_macros.xml
+++ b/tools/rseqc/rseqc_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">5.0.1</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">5.0.3</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@GALAXY_VERSION@">20.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/rseqc/rseqc_macros.xml
+++ b/tools/rseqc/rseqc_macros.xml
@@ -15,52 +15,41 @@
     </xml>
     <xml name="stdio">
         <stdio>
-            <exit_code range="1:" level="fatal" description="An error occured during execution, see stderr and stdout for more information" />
-            <regex match="[Ee]rror" source="both" description="An error occured during execution, see stderr and stdout for more information" />
+            <exit_code range="1:" level="fatal" description="An error occured during execution, see stderr and stdout for more information"/>
+            <regex match="[Ee]rror" source="both" description="An error occured during execution, see stderr and stdout for more information"/>
         </stdio>
     </xml>
-
     <!-- Params -->
     <xml name="bam_param">
         <param name="input" type="data" label="Input BAM file" format="bam" help="(--input-file)"/>
     </xml>
-
     <xml name="bam_sam_param">
         <param name="input" type="data" label="Input BAM/SAM file" format="bam,sam" help="(--input-file)"/>
     </xml>
-
     <xml name="refgene_param">
         <param argument="--refgene" type="data" format="bed12" label="Reference gene model" help="Reference gene model in BED fomat"/>
     </xml>
-
     <xml name="mapq_param">
-        <param argument="--mapq" type="integer" label="Minimum mapping quality" value="30" 
-            help="Minimum mapping quality for an alignment to be considered as &quot;uniquely mapped&quot;"/>
+        <param argument="--mapq" type="integer" label="Minimum mapping quality" value="30" help="Minimum mapping quality for an alignment to be considered as &quot;uniquely mapped&quot;"/>
     </xml>
-
     <xml name="readlength_param">
         <param argument="--read-align-length" type="integer" value="" label="Alignment length" optional="false" help="Alignment length of read, usually set to the orignial read length"/>
     </xml>
-
     <xml name="readnum_param">
         <param argument="--read-num" type="integer" label="Number of aligned reads" value="1000000" help="Number of aligned reads with mismatches used to calculate the mismatch profile"/>
     </xml>
-
     <xml name="sample_size_param">
         <param argument="--sample-size" type="integer" label="Number of reads sampled" value="200000" min="1" help="Number of reads sampled from SAM/BAM file"/>
     </xml>
-
     <xml name="min_intron_param">
-        <param argument="--min-intron" type="integer" value="50" label="Minimum intron length (bp)" help="Default: 50" />
+        <param argument="--min-intron" type="integer" value="50" label="Minimum intron length (bp)" help="Default: 50"/>
     </xml>
-
     <xml name="layout_param">
         <param name="layout" type="select" label="Sequencing layout" help="(--sequencing)">
             <option value="SE" selected="true">Single-end</option>
             <option value="PE">Paired-end</option>
         </param>
     </xml>
-
     <xml name="strand_type_param">
         <conditional name="strand_type">
             <param name="strand_specific" type="select" label="Strand-specific?">
@@ -69,21 +58,20 @@
                 <option value="single">Single-End RNA-seq</option>
             </param>
             <when value="pair">
-                <param name="pair_type" type="select" display="radio" label="Pair-End Read Type (format: mapped --> parent)" help="(--strand)">
-                    <option value="sd" selected="true"> read1 (positive --> positive; negative --> negative), read2 (positive --> negative; negative --> positive)</option>
-                    <option value="ds">read1 (positive --> negative; negative --> positive), read2 (positive --> positive; negative --> negative)</option>
+                <param name="pair_type" type="select" display="radio" label="Pair-End Read Type (format: mapped --&gt; parent)" help="(--strand)">
+                    <option value="sd" selected="true"> read1 (positive --&gt; positive; negative --&gt; negative), read2 (positive --&gt; negative; negative --&gt; positive)</option>
+                    <option value="ds">read1 (positive --&gt; negative; negative --&gt; positive), read2 (positive --&gt; positive; negative --&gt; negative)</option>
                 </param>
             </when>
             <when value="single">
-                <param name="single_type" type="select" display="radio" label="Single-End Read Type (format: mapped --> parent)" help="(--strand)">
-                    <option value="s" selected="true">positive --> positive; negative --> negative</option>
-                    <option value="d">positive --> negative; negative --> positive</option>
+                <param name="single_type" type="select" display="radio" label="Single-End Read Type (format: mapped --&gt; parent)" help="(--strand)">
+                    <option value="s" selected="true">positive --&gt; positive; negative --&gt; negative</option>
+                    <option value="d">positive --&gt; negative; negative --&gt; positive</option>
                 </param>
             </when>
-            <when value="none"></when>
+            <when value="none"/>
         </conditional>
     </xml>
-
     <xml name="multihits_param">
         <conditional name="multihits_type">
             <param name="multihits_type_selector" type="select" label="Reads with multiple hits" help="(--skip-multi-hits)">
@@ -91,34 +79,26 @@
                 <option value="skip_multihits">Skip Multiple Hit Reads/Only Use Uniquely Mapped Reads</option>
             </param>
             <when value="skip_multihits">
-                <expand macro="mapq_param" />
+                <expand macro="mapq_param"/>
             </when>
-            <when value="use_multihits" />
+            <when value="use_multihits"/>
         </conditional>
     </xml>
-
     <xml name="rscript_output_param">
-        <param name="rscript_output" type="boolean" value="false" label="Output R-Script"
-            help="Output the R-Script used to generate the plots" />
+        <param name="rscript_output" type="boolean" value="false" label="Output R-Script" help="Output the R-Script used to generate the plots"/>
     </xml>
-
-
     <!-- Output -->
-
     <xml name="pdf_output_data" token_filename="output.pdf" token_label="${tool.name} on ${on_string}: PDF">
-        <data format="pdf" name="outputpdf" from_work_dir="@FILENAME@" label="@LABEL@" />
+        <data format="pdf" name="outputpdf" from_work_dir="@FILENAME@" label="@LABEL@"/>
     </xml>
-
     <xml name="xls_output_data" token_filename="output.xls" token_label="${tool.name} on ${on_string}: XLS">
-        <data format="tabular" name="outputxls" from_work_dir="@FILENAME@" label="@LABEL@" />
+        <data format="tabular" name="outputxls" from_work_dir="@FILENAME@" label="@LABEL@"/>
     </xml>
-
     <xml name="rscript_output_data" token_filename="output.r" token_label="${tool.name} on ${on_string}: Rscript">
         <data format="txt" name="outputr" from_work_dir="@FILENAME@" label="@LABEL@">
             <filter>rscript_output</filter>
         </data>
     </xml>
-
     <!-- Command -->
     <token name="@MULTIHITS@"><![CDATA[
         #if str($multihits_type.multihits_type_selector) == "skip_multihits"
@@ -126,7 +106,6 @@
             --mapq=${multihits_type.mapq}
         #end if
     ]]></token>
-
     <token name="@BAM_SAM_INPUTS@"><![CDATA[
         #set $extension = str($input.ext)
         ln -s -f '${input}' 'input.${extension}' &&
@@ -134,7 +113,6 @@
             ln -s -f '${input.metadata.bam_index}' 'input.bam.bai' &&
         #end if
     ]]></token>
-
     <token name="@ABOUT@">
 
 -----
@@ -158,7 +136,6 @@ The RSeQC package is licensed under the GNU GPL v3 license.
 
 
     </token>
-
     <xml name="citations">
         <citations>
             <citation type="doi">10.1093/bioinformatics/bts356</citation>

--- a/tools/rseqc/tin.xml
+++ b/tools/rseqc/tin.xml
@@ -6,13 +6,9 @@
         <import>rseqc_macros.xml</import>
     </macros>
     <expand macro="bio_tools"/>
-
-    <expand macro="requirements" />
-
-    <expand macro="stdio" />
-
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
     <version_command><![CDATA[tin.py --version]]></version_command>
-
     <!-- Generate output files here because tin.py removes all instances of "bam"
     in the filename -->
     <command><![CDATA[
@@ -34,28 +30,17 @@
         && mv *tin.xls tin.xls
         ]]>
     </command>
-
     <inputs>
         <param name="input" type="data" format="bam" multiple="true" label="Input BAM file" help="(--input-file)"/>
-        <expand macro="refgene_param" />
-        <param name="minCov" type="integer" value="10" label="Minimum coverage (default=10)"
-            help="Minimum number of reads mapped to a transcript (--minCov)." />
-        <param name="samplesize" type="integer" value="100" label="Sample size (default=100)"
-            help="Number of equal-spaced nucleotide positions picked from mRNA.
-            Note: if this number is larger than the length of mRNA (L), it will
-            be halved until is's smaller than L. (--sample-size)." />
-        <param name="subtractbackground" type="boolean" value="false" falsevalue=""
-            truevalue="--subtract-background" label="Subtract background noise
-            (default=No)" help="Subtract background noise (estimated from
-            intronic reads). Only use this option if there are substantial
-            intronic reads (--subtract-background)." />
+        <expand macro="refgene_param"/>
+        <param name="minCov" type="integer" value="10" label="Minimum coverage (default=10)" help="Minimum number of reads mapped to a transcript (--minCov)."/>
+        <param name="samplesize" type="integer" value="100" label="Sample size (default=100)" help="Number of equal-spaced nucleotide positions picked from mRNA.             Note: if this number is larger than the length of mRNA (L), it will             be halved until is's smaller than L. (--sample-size)."/>
+        <param name="subtractbackground" type="boolean" value="false" falsevalue="" truevalue="--subtract-background" label="Subtract background noise             (default=No)" help="Subtract background noise (estimated from             intronic reads). Only use this option if there are substantial             intronic reads (--subtract-background)."/>
     </inputs>
-
     <outputs>
-        <data name="outputsummary" format="tabular" from_work_dir="summary.tab" label="TIN on ${on_string} (summary)" />
-        <data name="outputxls" format="tabular" from_work_dir="tin.xls" label="TIN on ${on_string} (tin)" />
+        <data name="outputsummary" format="tabular" from_work_dir="summary.tab" label="TIN on ${on_string} (summary)"/>
+        <data name="outputxls" format="tabular" from_work_dir="tin.xls" label="TIN on ${on_string} (tin)"/>
     </outputs>
-
     <!-- PDF Files contain R version, must avoid checking for diff -->
     <tests>
         <test expect_num_outputs="2">
@@ -65,7 +50,6 @@
             <output name="outputxls" file="output.tin.xls" ftype="tabular"/>
         </test>
     </tests>
-
     <help><![CDATA[
 ## tin.py
 
@@ -149,7 +133,5 @@ RUFY2   chr10   70100863   70167051   43.8967503948
 
 ]]>
     </help>
-
-    <expand macro="citations" />
-
+    <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
Based on last commit of @bgruening in #5618, fixed minor linting errors and updated `expected_num_outputs` parameters in some tools where it was incorrect.