### PR TITLE
Fix and simplify nanoplot cheetah

### DIFF
--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -1,4 +1,4 @@
-<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy0" profile="22.05">
+<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy1" profile="22.05">
     <description>Plotting suite for Oxford Nanopore sequencing data and alignments</description>
     <macros>
         <token name="@TOOL_VERSION@">1.42.0</token>
@@ -16,47 +16,20 @@
     </stdio-->
     <version_command>NanoPlot --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-## set TMPDIR if not already set by admin
-## otherwise kalleido fails with `Less than 64MB of free space in temporary directory for shared memory files: 0`
-## export TMPDIR=\${TMPDIR:-\$_GALAXY_JOB_TMP_DIR};
-
-#set $myfiles = $mode.reads.files
+#set $myfiles = $mode.reads.files if $mode.choice == 'combined' else [$mode.reads.files]
 #set reads_temp = []
-#if $mode.choice == 'combined':
-    #for $i, $f in enumerate($myfiles)
-        #if $f.ext.startswith("fastq"):
-            #set $extension = 'fastq'
-        #else
-            #set $extension = $f.ext
-        #end if
-        #if $f.ext.endswith(".gz"):
-            #set $f = $extension + ".gz"
-        #else if $f.ext.endswith(".bz"):
-            #set $extension = $extension + "bz2"
-        #end if
-        ln -s '$f' './read_${i}.$extension' &&
-        #if "bam" in $extension
-            ln -s '$f.metadata.bam_index' './read_${i}.${extension}.bai' &&
-        #end if
-        $reads_temp.append("read_" + str($i) + "." + str($extension))
-    #end for
-#else
-    #if $myfiles.ext.startswith("fastq"):
-        #set $extension = 'fastq'
+#for $i, $f in enumerate($myfiles)
+    #if $f.ext.startswith("fastq"):
+       #set $extension = "fastq" if "." not in $f.ext else "fastq.%s" % $f.ext.split(".")[-1]
     #else
-        #set $extension = $myfiles.ext
+        #set $extension = $f.ext
     #end if
-    #if $myfiles.ext.endswith(".gz"):
-        #set $extension = $extension + ".gz"
-    #else if $myfiles.ext.endswith(".bz"):
-        #set $extension = $extension + "bz2"
+    ln -s '$f' './read_${i}.$extension' &&
+    #if $extension == "bam"
+        ln -s '$f.metadata.bam_index' './read_${i}.${extension}.bai' &&
     #end if
-    ln -s '$myfiles' './read.$extension' &&
-    #if "bam" in $extension
-        ln -s '$myfiles.metadata.bam_index' './read.${extension}.bai' &&
-    #end if
-    $reads_temp.append("read." + str($extension))
-#end if
+    $reads_temp.append("read_" + str($i) + "." + str($extension))
+#end for
 
 NanoPlot
     --threads \${GALAXY_SLOTS:-4}


### PR DESCRIPTION
The previous version has set `#set $f = $extension + ".gz"`, which then generates invalid symlinks.
By having fewer if statements here there are less things that can go wrong and we get test coverage with the existing tests.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
