### PR TITLE
das tool: do not allow empty labels

### DIFF
--- a/tools/das_tool/das_tool.xml
+++ b/tools/das_tool/das_tool.xml
@@ -7,18 +7,25 @@
     <expand macro="requirements"/>
     <expand macro="version"/>
     <command detect_errors="exit_code"><![CDATA[
-#set $bins = ""
-#set $labels = ""
-#set $sep = ""
+#import re
+
+#set $bins = []
+#set $labels = []
 #for $i, $s in enumerate($binning)
-    #set $bins += "%s%s" %($sep, $s.bins)
-    #set $labels += "%s%s" %($sep, $s.labels)
-    #set $sep = ","
+    #silent $bins.append(str($s.bins))
+    #if $s.labels != ''
+        #silent $labels.append(str($s.labels))
+    #else
+        #silent $labels.append(re.sub('[^\w\-_\.]', '_', $s.bins.element_identifier))
+    #end if
 #end for
 
 #if $adv.proteins
     ln -s '$adv.proteins' 'proteins' &&
 #end if
+
+#set $bins = ','.join($bins)
+#set $labels = ','.join($labels)
 
 DAS_Tool
     --contigs '$contigs'
@@ -46,7 +53,15 @@ DAS_Tool
         <param argument="--contigs" type="data" format="fasta" label="Contig sequences"/>
         <repeat name="binning" title="Bins" min="1">
             <param argument="--bins" type="data" format="tabular" label="Contigs-to-bin table" help="Tabular with two columns: contig-IDs and bin-IDs. Fasta_to_Contigs2Bin can be used to  Converts genome bins in fasta format to Contigs-to-bin table"/>
-            <param argument="--labels" type="text" value="" label="Name of binning prediction tool used to generate the table"/>
+            <param argument="--labels" type="text" value="" label="Name of binning prediction name" help="If left empty the identifier of the contig-to-bin table is used. Only alphanumeric characters, dash, underscore and dor are allowed. Other characters are replaced by underscore.">
+                <sanitizer invalid_char="_">
+                    <valid initial="string.ascii_letters,string.digits">
+                        <add value="-" />
+                        <add value="_" />
+                        <add value="." />
+                    </valid>
+                </sanitizer>
+            </param>
         </repeat>
         <section name="adv" title="Advanced options">
             <param argument="--search_engine" type="select" label="Engine used for single copy gene identification">
@@ -99,6 +114,52 @@ DAS_Tool
             <repeat name="binning">
                 <param name="bins" value="metabat.tabular"/>
                 <param name="labels" value="metabat"/>
+            </repeat>
+            <section name="adv">
+                <param name="search_engine" value="diamond"/>
+                <param name="proteins" value="proteins.fasta"/>
+                <param name="score_threshold" value="0.5"/>
+                <param name="duplicate_penalty" value="0.6"/>
+                <param name="megabin_penalty" value="0.5" />
+            </section>
+            <section name="output">
+                <param name="write_bin_evals" value="true"/>
+                <conditional name="write_bins">
+                    <param name="write_bins" value=""/>
+                </conditional>
+                <param name="debug" value="true"/>
+            </section>
+            <output name="summary" ftype="tabular">
+                <assert_contents>
+                    <has_text text="unique_SCGs"/>
+                    <has_text text="metabat.8"/>
+                    <has_text text="bacteria"/>
+                </assert_contents>
+            </output>
+            <output name="contigs2bin" ftype="tabular">
+                <assert_contents>
+                    <has_text text="Ley3_66761_scaffold_6"/>
+                </assert_contents>
+            </output>
+            <output name="log" ftype="txt">
+                <assert_contents>
+                    <has_text text="Skipping gene prediction"/>
+                    <has_text text="#Target sequences to report alignments for: 1"/>
+                </assert_contents>
+            </output>
+            <output name="eval" ftype="tabular">
+                <assert_contents>
+                    <has_text text="unique_SCGs"/>
+                    <has_text text="metabat.8"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- like the first test, but with empty label  -->
+        <test expect_num_outputs="4">
+            <param name="contigs" value="contigs.fasta"/>
+            <repeat name="binning">
+                <param name="bins" value="metabat.tabular"/>
+                <!-- <param name="labels" value="metabat"/> -->
             </repeat>
             <section name="adv">
                 <param name="search_engine" value="diamond"/>

--- a/tools/das_tool/macros.xml
+++ b/tools/das_tool/macros.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.1.7</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">21.01</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">22.01</token>
     <xml name="biotools">
         <xrefs>
             <xref type="bio.tools">dastool</xref>


### PR DESCRIPTION
just use element identifiers if not given. Seems to be what the tool does by default: https://github.com/cmks/DAS_Tool/blob/bb0954f4f45a2340e9cb9b896d412e477c6c49fc/src/DAS_Tool.R#L398

No idea what the `--labels` argument is good for. But with `--labels ''` the program just fails. So this might be a solution.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
