### PR TITLE
Fix bbduk, bbmerge bbmap for non-unique names

### DIFF
--- a/tools/bbtools/bbduk.xml
+++ b/tools/bbtools/bbduk.xml
@@ -7,7 +7,6 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
 #import os
-#import re
 
 #if str($input_type_cond.input_type) in ['single', 'pair']:
     #set read1 = $input_type_cond.read1
@@ -25,17 +24,15 @@
     #end if
 #else:
     #set read1 = $input_type_cond.reads_collection['forward']
-    #set read1_identifier = re.sub('[^\s\w\-]', '_', str($read1.name))
     ## bbduk uses the file extension to determine the input format.
-    #set ext = $read1_identifier + '.fastq'
+    #set ext = '.fastq'
     #if $read1.ext.endswith('.gz'):
         #set ext = $ext + '.gz'
     #end if
-    #set read1_file = $read1_identifier + $ext
+    #set read1_file = 'forward' + $ext
     ln -s '${read1}' '${read1_file}' &&
     #set read2 = $input_type_cond.reads_collection['reverse']
-    #set read2_identifier = re.sub('[^\s\w\-]', '_', str($read2.name))
-    #set read2_file = $read2_identifier + $ext
+    #set read2_file = 'reverse' + $ext
     ln -s '${read2}' '${read2_file}' &&
 #end if
 

--- a/tools/bbtools/bbmap.xml
+++ b/tools/bbtools/bbmap.xml
@@ -6,9 +6,6 @@
     <expand macro="edam_ontology"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-#import os
-#import re
-
 #if str($ref_source_cond.ref_source) == 'cached'
     #set ref = str($ref_source_cond.reference.fields.path)
 #else:
@@ -31,17 +28,15 @@
     #end if
 #else:
     #set read1 = $input_type_cond.reads_collection['forward']
-    #set read1_identifier = re.sub('[^\s\w\-]', '_', str($read1.element_identifier))
     ## bbmap uses the file extension to determine the input format.
-    #set ext = $read1_identifier + '.fastq'
+    #set ext = '.fastq'
     #if $read1.ext.endswith('.gz'):
         #set ext = $ext + '.gz'
     #end if
-    #set read1_file = $read1_identifier + $ext
+    #set read1_file = 'forward' + $ext
     ln -s '${read1}' '${read1_file}' &&
     #set read2 = $input_type_cond.reads_collection['reverse']
-    #set read2_identifier = re.sub('[^\s\w\-]', '_', str($read2.element_identifier))
-    #set read2_file = $read2_identifier + $ext
+    #set read2_file = 'reverse' + $ext
     ln -s '${read2}' '${read2_file}' &&
 #end if
 

--- a/tools/bbtools/bbmerge.xml
+++ b/tools/bbtools/bbmerge.xml
@@ -6,9 +6,6 @@
     <expand macro="edam_ontology"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-#import os
-#import re
-
 #if str($input_type_cond.input_type) in ['single', 'pair']:
     #set read1 = $input_type_cond.read1
     ## bbmerge uses the file extension to determine the input format.
@@ -25,17 +22,15 @@
     #end if
 #else:
     #set read1 = $input_type_cond.reads_collection['forward']
-    #set read1_identifier = re.sub('[^\s\w\-]', '_', str($read1.element_identifier))
     ## bbmap uses the file extension to determine the input format.
-    #set ext = $read1_identifier + '.fastq'
+    #set ext = '.fastq'
     #if $read1.ext.endswith('.gz'):
         #set ext = $ext + '.gz'
     #end if
-    #set read1_file = $read1_identifier + $ext
+    #set read1_file = 'forward' + $ext
     ln -s '${read1}' '${read1_file}' &&
     #set read2 = $input_type_cond.reads_collection['reverse']
-    #set read2_identifier = re.sub('[^\s\w\-]', '_', str($read2.element_identifier))
-    #set read2_file = $read2_identifier + $ext
+    #set read2_file = 'reverse' + $ext
     ln -s '${read2}' '${read2_file}' &&
 #end if
 

--- a/tools/bbtools/macros.xml
+++ b/tools/bbtools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">39.06</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>


### PR DESCRIPTION
The name attribute is not guaranteed to be unique, we can just use forward / reverse as symlink targets, which is also simpler.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
