### PR TITLE
Bux Fix for Metaphlan3 : Renamed `--unknown-estimation` parameter to `--unclassified-estimation`

### DIFF
--- a/tools/metaphlan/macros.xml
+++ b/tools/metaphlan/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">4.0.6</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">22.05</token>
     <!-- Metaphlan DB compatible with this version of Metaphlan
     v4 introduced single genome level bins (SGB) and the index syntax differs from previous versions --> 

--- a/tools/metaphlan/metaphlan.xml
+++ b/tools/metaphlan/metaphlan.xml
@@ -180,7 +180,7 @@ metaphlan
     $out.use_group_representative
     $out.legacy_output
     $out.CAMI_format_output
-    $out.unknown_estimation
+    $out.unclassified_estimation
     -o '$output_file'
     --bowtie2out 'bowtie2out'
     -s '$sam_output_file'
@@ -347,7 +347,7 @@ python '$__tool_directory__/formatoutput.py'
                 label="Old MetaPhlAn2 two columns output?"/>
             <param argument="--CAMI_format_output" type='boolean' checked="false" truevalue='--CAMI_format_output' falsevalue='' 
                 label="Report the profiling using the CAMI output format?"/>
-            <param argument="--unknown_estimation" type='boolean' checked="false" truevalue='--unknown_estimation' falsevalue='' 
+            <param argument="--unclassified_estimation" type='boolean' checked="false" truevalue='--unclassified_estimation' falsevalue='' 
                 label="Scale relative abundances to the number of reads mapping to known clades in order to estimate unknowness?"/>
             <param name="krona_output" type='boolean' checked="false" truevalue='true' falsevalue='false' label="Output for Krona?"/>
         </section>
@@ -412,7 +412,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="true"/>
             </section>
             <output name="output_file" ftype="tabular">
@@ -559,7 +559,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="true"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-abundances.tabular" compare="sim_size">
@@ -705,7 +705,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="false"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-abundances.tabular" compare="sim_size">
@@ -776,7 +776,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="false"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-abundances.tabular" compare="sim_size">
@@ -838,7 +838,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="false"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-abundances.tabular" compare="sim_size">
@@ -897,7 +897,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="false"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="false"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-abundances.tabular" compare="sim_size">
@@ -957,7 +957,7 @@ python '$__tool_directory__/formatoutput.py'
                 <param name="use_group_representative" value="false"/>
                 <param name="legacy_output" value="true"/>
                 <param name="CAMI_format_output" value="false"/>
-                <param name="unknown_estimation" value="false"/>
+                <param name="unclassified_estimation" value="false"/>
                 <param name="krona_output" value="true"/>
             </section>
             <output name="output_file" ftype="tabular" file="SRS014464-Anterior_nares-legacy-abundances.tabular" compare="sim_size">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Hi, 

This PR fixes the #5958 reported at https://help.galaxyproject.org/t/metaphlan-issue-with-unknown-estimation-parameter/12157

The reported bug in the tool wrapper was due to an old parameter name `--unknown_estimation` that was renamed to `--unclassified_estimation` since **version 4.0.0**. 

**CHANGELOG Reference:** https://github.com/biobakery/MetaPhlAn/blob/3080d946db5bbe0dafaf05de91dbd38e4d0e6e22/CHANGELOG.md?plain=1#L125

Cheers,
Saim