### PR TITLE
Add missing labels to the cached kofam DB parameters

### DIFF
--- a/tools/kofamscan/kofamscan.xml
+++ b/tools/kofamscan/kofamscan.xml
@@ -2,7 +2,7 @@
     <description>gene function annotation based on KEGG orthology and HMM</description>
     <macros>
         <token name="@TOOL_VERSION@">1.3.0</token>
-        <token name="@VERSION_SUFFIX@">3</token>
+        <token name="@VERSION_SUFFIX@">4</token>
         <xml name="reportannotation" token_selected="">
             <param name="reportannotation" type="boolean" truevalue="--report-unannotated" falsevalue="--no-report-unannotated" checked="@SELECTED@" label="Include sequence name to outputs even if no KOs are assigned?"/>
         </xml>
@@ -67,10 +67,11 @@ $ap.f_cond.reportannotation
                 <option value="hmm">HMM file(s)</option>
             </param>
             <when value="cached">
-                <param name="kofam" type="select">
+                <param name="kofam" type="select" label="Kofam database to use">
                     <options from_data_table="kofam"/>
+                    <validator type="no_options" message="No option available for this input."/>
                 </param>
-                <param name="kofam_subset" type="select" optional="true">
+                <param name="kofam_subset" type="select" optional="true" label="Use only a subset of the selected Kofam database" help="If nothing is selected the complete database is used">
                     <options from_data_table="kofam_subset">
                         <filter type="param_value" column="2" ref="kofam"/>
                         <filter type="sort_by" column="1"/>
@@ -78,7 +79,6 @@ $ap.f_cond.reportannotation
                         <column name="name" index="1"/>
                         <column name="value" index="0"/>
                     </options>
-                    <validator type="no_options" message="No option available for this input"/>
                 </param>
             </when>
             <when value="compressed">


### PR DESCRIPTION
and require options for the DB but allow to have no options for the subsets

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
