### PR TITLE
Make limma-voom equivalent to edgeR in terms of formula and sanitisation

### DIFF
--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -108,6 +108,12 @@ unmake_names <- function(string) {
     return(string)
 }
 
+# Sanitise file base names coming from factors or contrasts
+sanitise_basename <- function(string) {
+    string <- gsub("[/^]", "_", string)
+    return(string)
+}
+
 # Generate output folder and paths
 make_out <- function(filename) {
     return(paste0(opt$outPath, "/", filename))

--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -8,7 +8,7 @@
 #       matrixPath", "m", 2, "character"    -Path to count matrix
 #       factFile", "f", 2, "character"      -Path to factor information file
 #       factInput", "i", 2, "character"     -String containing factors if manually input
-#       formula", "y", 2, "character".      -String containing a formula to override default use of factInput
+#       formula", "Y", 2, "character".      -String containing a formula to override default use of factInput
 #       annoPath", "a", 2, "character"      -Path to input containing gene annotations
 #       contrastFile", "C", 1, "character"  -Path to contrasts information file
 #       contrastInput", "D", 1, "character" -String containing contrasts of interest
@@ -184,7 +184,7 @@ spec <- matrix(
         "filesPath", "j", 2, "character",
         "matrixPath", "m", 2, "character",
         "factFile", "f", 2, "character",
-        "formula", "y", 2, "character",
+        "formula", "Y", 2, "character",
         "factInput", "i", 2, "character",
         "annoPath", "a", 2, "character",
         "contrastFile", "C", 1, "character",

--- a/tools/limma_voom/limma_voom.R
+++ b/tools/limma_voom/limma_voom.R
@@ -8,7 +8,7 @@
 #       matrixPath", "m", 2, "character"    -Path to count matrix
 #       factFile", "f", 2, "character"      -Path to factor information file
 #       factInput", "i", 2, "character"     -String containing factors if manually input
-#       formula", "F", 2, "character".      -String containing a formula to override default use of factInput
+#       formula", "y", 2, "character".      -String containing a formula to override default use of factInput
 #       annoPath", "a", 2, "character"      -Path to input containing gene annotations
 #       contrastFile", "C", 1, "character"  -Path to contrasts information file
 #       contrastInput", "D", 1, "character" -String containing contrasts of interest
@@ -184,7 +184,7 @@ spec <- matrix(
         "filesPath", "j", 2, "character",
         "matrixPath", "m", 2, "character",
         "factFile", "f", 2, "character",
-        "formula", "F", 2, "character",
+        "formula", "y", 2, "character",
         "factInput", "i", 2, "character",
         "annoPath", "a", 2, "character",
         "contrastFile", "C", 1, "character",

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -3,8 +3,8 @@
         Perform differential expression with limma-voom or limma-trend
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">3.59.1</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@TOOL_VERSION@">3.58.1</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">20.09</token>
     </macros>
     <edam_topics>

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -780,6 +780,42 @@ cp '$outReport.files_path'/*tsv output_dir/
                 </element>
             </output_collection>
         </test>
+        <!-- Ensure formula and contrast file work -->
+        <test expect_num_outputs="2">
+            <param name="format" value="matrix"/>
+            <param name="counts" value="matrix.txt"/>
+            <repeat name="rep_factor">
+                <param name="factorName" value="Genotype"/>
+                <param name="groupNames" value="Mut,Mut,Mut,WT,WT,WT"/>
+            </repeat>
+            <repeat name="rep_factor">
+                <param name="factorName" value="Batch"/>
+                <param name="groupNames" value="b1,b2,b3,b1,b2,b3"/>
+            </repeat>
+            <param name="cfile" value="yes" />
+            <param name="cinfo" value="complex_contrasts.txt"/>
+            <param name="formula" value="~ 0 + Genotype + Batch"/>
+            <param name="normalisationOption" value="TMM"/>
+            <param name="topgenes" value="6" />
+            <output_collection name="outTables" count="3">
+                <element name="limma-voom_Mut-WT" ftype="tabular">
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
+                        <has_text_matching expression="11304.*0.4584"/>
+                    </assert_contents>
+                </element>
+                <element name="limma-voom_WT-Mut" ftype="tabular">
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
+                    </assert_contents>
+                </element>
+                <element name="limma-voom_(2*Mut_3*WT)-WT" ftype="tabular">
+                    <assert_contents>
+                        <has_text_matching expression="GeneID.*logFC.*AveExpr.*t.*P.Value.*adj.P.Val.*B" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
     </tests>
 
     <help><![CDATA[

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -73,6 +73,10 @@ Rscript '$__tool_directory__/limma_voom.R'
     -a '$anno.geneanno'
 #end if
 
+#if $formula:
+    -F '$formula'
+#end if
+
 #if $cont.cfile=='yes':
     -C '$cont.cinfo'
 #else: 
@@ -241,6 +245,26 @@ cp '$outReport.files_path'/*tsv output_dir/
             </when>
             <when value="no" />
         </conditional>
+        <!-- Optional formula -->
+        <param name="formula" type="text" optional="true" label="Formula for linear model" help="An optional formula for the EdgeR linear model, this will override the use of the fields in factors as a simple sum. The formula can only use elements available in the factors file. This needs to be exactly as EdgeR expect the formula, ie. `~ 0 + factor_A + factor_B:factor_C`. See EdgeR documentation for more details.">
+            <sanitizer invalid_char="">
+                <valid initial="string.letters,string.digits">
+                    <add value="-"/>
+                    <add value="+"/>
+                    <add value="*"/>
+                    <add value="/"/>
+                    <add value="^"/>
+                    <add value=":"/>
+                    <add value="."/>
+                    <add value="~"/>
+                    <add value=" "/>
+                    <add value="("/>
+                    <add value=")"/>
+                    <add value="@"/>
+                    <add value="$"/>
+                </valid>
+            </sanitizer>
+        </param>
 
         <!-- Contrasts -->
         <conditional name="cont">

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -74,7 +74,7 @@ Rscript '$__tool_directory__/limma_voom.R'
 #end if
 
 #if $formula:
-    -y '$formula'
+    -Y '$formula'
 #end if
 
 #if $cont.cfile=='yes':

--- a/tools/limma_voom/limma_voom.xml
+++ b/tools/limma_voom/limma_voom.xml
@@ -3,9 +3,9 @@
         Perform differential expression with limma-voom or limma-trend
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">3.58.1</token>
+        <token name="@TOOL_VERSION@">3.59.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@PROFILE@">23.0</token>
+        <token name="@PROFILE@">20.09</token>
     </macros>
     <edam_topics>
         <edam_topic>topic_3308</edam_topic>
@@ -74,7 +74,7 @@ Rscript '$__tool_directory__/limma_voom.R'
 #end if
 
 #if $formula:
-    -F '$formula'
+    -y '$formula'
 #end if
 
 #if $cont.cfile=='yes':

--- a/tools/limma_voom/test-data/complex_contrasts.txt
+++ b/tools/limma_voom/test-data/complex_contrasts.txt
@@ -1,0 +1,4 @@
+Contrasts
+Mut-WT
+WT-Mut
+(2*Mut/3*WT)-WT


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

This PR brings some additions made to EdgeR last year to Limma-voom. Would it be acceptable to downgrade the profile of the tool to something around 21.x? I need to use this as well with some older instances.