### PR TITLE
bowtie2: do not overcommit

### DIFF
--- a/tools/bowtie2/bowtie2_macros.xml
+++ b/tools/bowtie2/bowtie2_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.5.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <!-- Import this at the top of your command block and then
          define rg_auto_name. -->
     <token name="@define_read_group_helpers@">
@@ -59,7 +59,7 @@
 #if $use_rg
     #if $rg_param('read_group_id_conditional') is None
         #set $rg_id = $rg_auto_name
-    #elif $rg_param('read_group_id_conditional').do_auto_name
+    #elif $rg_param('read_group_id_conditional').do_auto_name == 'true'
         #set $rg_id = $rg_auto_name
     #else
         #set $rg_id = str($rg_param('read_group_id_conditional').ID)
@@ -67,7 +67,7 @@
 
     #if $rg_param('read_group_sm_conditional') is None
         #set $rg_sm = ''
-    #elif $rg_param('read_group_sm_conditional').do_auto_name
+    #elif $rg_param('read_group_sm_conditional').do_auto_name == 'true'
         #set $rg_sm = $rg_auto_name
     #else
         #set $rg_sm = str($rg_param('read_group_sm_conditional').SM)
@@ -81,7 +81,7 @@
 
     #if $rg_param('read_group_lb_conditional') is None
         #set $rg_lb = ''
-    #elif $rg_param('read_group_lb_conditional').do_auto_name
+    #elif $rg_param('read_group_lb_conditional').do_auto_name == 'true'
         #set $rg_lb = $rg_auto_name
     #else
         #set $rg_lb = str($rg_param('read_group_lb_conditional').LB)
@@ -140,9 +140,11 @@
 #set $use_rg = str($rg.rg_selector) != "do_not_set"
     </token>
     <xml name="read_group_auto_name_conditional">
-        <param name="do_auto_name" type="boolean" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value" checked="false" />
-        <when value="true">
-        </when>
+        <param name="do_auto_name" type="select" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value">
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+        </param>
+        <when value="true"/>
         <when value="false">
             <yield />
         </when>

--- a/tools/bowtie2/bowtie2_macros.xml
+++ b/tools/bowtie2/bowtie2_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.5.3</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <!-- Import this at the top of your command block and then
          define rg_auto_name. -->
     <token name="@define_read_group_helpers@">
@@ -59,7 +59,7 @@
 #if $use_rg
     #if $rg_param('read_group_id_conditional') is None
         #set $rg_id = $rg_auto_name
-    #elif $rg_param('read_group_id_conditional').do_auto_name == 'true'
+    #elif $rg_param('read_group_id_conditional').do_auto_name
         #set $rg_id = $rg_auto_name
     #else
         #set $rg_id = str($rg_param('read_group_id_conditional').ID)
@@ -67,7 +67,7 @@
 
     #if $rg_param('read_group_sm_conditional') is None
         #set $rg_sm = ''
-    #elif $rg_param('read_group_sm_conditional').do_auto_name == 'true'
+    #elif $rg_param('read_group_sm_conditional').do_auto_name
         #set $rg_sm = $rg_auto_name
     #else
         #set $rg_sm = str($rg_param('read_group_sm_conditional').SM)
@@ -81,7 +81,7 @@
 
     #if $rg_param('read_group_lb_conditional') is None
         #set $rg_lb = ''
-    #elif $rg_param('read_group_lb_conditional').do_auto_name == 'true'
+    #elif $rg_param('read_group_lb_conditional').do_auto_name
         #set $rg_lb = $rg_auto_name
     #else
         #set $rg_lb = str($rg_param('read_group_lb_conditional').LB)
@@ -140,11 +140,9 @@
 #set $use_rg = str($rg.rg_selector) != "do_not_set"
     </token>
     <xml name="read_group_auto_name_conditional">
-        <param name="do_auto_name" type="select" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value">
-            <option value="false">No</option>
-            <option value="true">Yes</option>
-        </param>
-        <when value="true"/>
+        <param name="do_auto_name" type="boolean" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value" checked="false" />
+        <when value="true">
+        </when>
         <when value="false">
             <yield />
         </when>

--- a/tools/bowtie2/bowtie2_macros.xml
+++ b/tools/bowtie2/bowtie2_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.5.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <!-- Import this at the top of your command block and then
          define rg_auto_name. -->
     <token name="@define_read_group_helpers@">

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -307,10 +307,10 @@ bowtie2
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
     > alignment.sam
-    && samtools sort --no-PG -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output' alignment.sam
+    && samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output' alignment.sam
 #else if $sam_options.reorder:
     > alignment.sam
-    && samtools view --no-PG -b -o '$output' alignment.sam
+    && samtools view -b -o '$output' alignment.sam
 #else:
     > '$output'
 #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -12,6 +12,8 @@
     </requirements>
     <version_command>bowtie2 --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
+## Use pipefail if available to quit with first non-zero exit code
+set -o | grep -q pipefail && set -o pipefail;
 ## prepare bowtie2 index
 #set index_path = ''
 #if str($reference_genome.source) == "history":
@@ -306,11 +308,18 @@ bowtie2
 
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
-    > alignment.sam
-    && samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output' alignment.sam
+    ## Convert SAM output to sorted BAM
+    ## using the two pipe stages has the following effect
+    ## - mapping and sorting run in parallel, during this time sort produces
+    ##   presorted temporary files but does not produce output (hence
+    ##   view does not run)
+    ## - once mapping is finished sort will start to merge the temporary
+    ##   files (which should be fast also on a single thread) gives the
+    ##   sorted output to view which only compresses the files (now
+    ##   using full parallelism again)
+    | samtools sort -l 0 -T "\${TMPDIR:-.}" -O bam | samtools view --no-PG -O bam -@ \${GALAXY_SLOTS:-1} -o '$output'
 #else if $sam_options.reorder:
-    > alignment.sam
-    && samtools view -b -o '$output' alignment.sam
+    | samtools view --no-PG -b -o '$output' 
 #else:
     > '$output'
 #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -12,8 +12,6 @@
     </requirements>
     <version_command>bowtie2 --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
-## Use pipefail if available to quit with first non-zero exit code
-set -o | grep -q pipefail && set -o pipefail;
 ## prepare bowtie2 index
 #set index_path = ''
 #if str($reference_genome.source) == "history":
@@ -303,14 +301,16 @@ bowtie2
 
 ## mapping stats (i.e. stderr from bowtie2)
 #if $save_mapping_stats
-    2> '$mapping_stats'
+    2> >(tee '$mapping_stats' >&2) 
 #end if
 
 ## output file
 #if str( $sam_options.sam_options_selector ) == "no" or (str( $sam_options.sam_opt ) == "false" and str($sam_options.reorder) == ''):
-    | samtools sort --no-PG -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output'
+    > alignment.sam
+    && samtools sort --no-PG -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$output' alignment.sam
 #else if $sam_options.reorder:
-    | samtools view --no-PG -bS - -o '$output'
+    > alignment.sam
+    && samtools view --no-PG -b -o '$output' alignment.sam
 #else:
     > '$output'
 #end if

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -113,12 +113,22 @@ set -o | grep -q pipefail && set -o pipefail;
     ln -f -s '${library.input_1}' ${read1} &&
 #end if
 
+
+## compute number of threads to be used for bowtie2
+## the bowtie parameter -p specifies the number of alignment threads to use (in
+## addition to a control thread) # just using GALAXY_SLOTS will lead to
+## overcommiting ressources (in particular because there may be a samtools view
+## running in parallel). 
+## for now we use one thread less than GALAXY_SLOTS
+THREADS=\${GALAXY_SLOTS:-4} &&
+if [ "\$THREADS" -gt 1 ]; then (( THREADS-- )); fi &&
+
 ## execute bowtie2
 
 bowtie2
 
 ## number of threads
--p \${GALAXY_SLOTS:-4}
+-p "\$THREADS"
 
 ## index file path
 -x '$index_path'

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -117,7 +117,7 @@ set -o | grep -q pipefail && set -o pipefail;
 ## compute number of threads to be used for bowtie2
 ## the bowtie parameter -p specifies the number of alignment threads to use (in
 ## addition to a control thread) # just using GALAXY_SLOTS will lead to
-## overcommiting ressources (in particular because there may be a samtools view
+## overcommiting ressources (in particular because there may be a samtools sort or view
 ## running in parallel). 
 ## for now we use one thread less than GALAXY_SLOTS
 THREADS=\${GALAXY_SLOTS:-4} &&


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/5983

by using a pipe bowtie2 and samtools run in parallel. since already bowtie2 alone uses more CPU than the assigned ones (less than 1 core) we should not do this, but run them serially.
background had a user running 2 fastq files (each 2.6GB) against a file containing 500k contigs. Running bowtie there was extremely efficient (tested up to 40 cores), i.e. for `GALAXY_SLOTS`=X the CPU usage (according to top) was `(X+1)*100%` .. probably because X alignment + 1 control thread are used.  

Alternatively we could do [this](https://github.com/galaxyproject/tools-iuc/blob/921fa90438b4ce2e9cf9c4129568f4036c318d82/tools/hisat2/hisat2.xml#L351), but I do not see a reason why we should.

also properly redirects `stderr`.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
