### PR TITLE
update readgroup macros

### DIFF
--- a/macros/read_group_macros.xml
+++ b/macros/read_group_macros.xml
@@ -57,7 +57,7 @@
 #if $use_rg
     #if $rg_param('read_group_id_conditional') is None
         #set $rg_id = $rg_auto_name
-    #elif $rg_param('read_group_id_conditional').do_auto_name
+    #elif $rg_param('read_group_id_conditional').do_auto_name == "true"
         #set $rg_id = $rg_auto_name
     #else
         #set $rg_id = str($rg_param('read_group_id_conditional').ID)
@@ -65,7 +65,7 @@
 
     #if $rg_param('read_group_sm_conditional') is None
         #set $rg_sm = ''
-    #elif $rg_param('read_group_sm_conditional').do_auto_name
+    #elif $rg_param('read_group_sm_conditional').do_auto_name == "true"
         #set $rg_sm = $rg_auto_name
     #else
         #set $rg_sm = str($rg_param('read_group_sm_conditional').SM)
@@ -79,7 +79,7 @@
 
     #if $rg_param('read_group_lb_conditional') is None
         #set $rg_lb = ''
-    #elif $rg_param('read_group_lb_conditional').do_auto_name
+    #elif $rg_param('read_group_lb_conditional').do_auto_name == "true"
         #set $rg_lb = $rg_auto_name
     #else
         #set $rg_lb = str($rg_param('read_group_lb_conditional').LB)
@@ -138,9 +138,11 @@
 #set $use_rg = str($rg.rg_selector) != "do_not_set"
     </token>
     <xml name="read_group_auto_name_conditional">
-        <param name="do_auto_name" type="boolean" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value" checked="no" />
-        <when value="true">
-        </when>
+        <param name="do_auto_name" type="select" label="Auto-assign" help="Use dataset name or collection information to automatically assign this value" >
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+        </param>
+        <when value="true"/>
         <when value="false">
             <yield />
         </when>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa_mem" name="Map with BWA-MEM" version="@VERSION@.3" profile="22.05">
+<tool id="bwa_mem" name="Map with BWA-MEM" version="@VERSION@.4" profile="22.05">
     <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
     <macros>
         <import>read_group_macros.xml</import>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -315,11 +315,13 @@
     <tests>
         <test>
             <param name="reference_source_selector" value="history"/>
-            <param name="ref_file" ftype="fasta" value="bwa-mem-mt-genome.fa"/>
+            <param name="ref_file" ftype="fasta" value="bwa-mem-mt-genome.fa" dbkey="hg19"/>
             <param name="input_type_selector" value="single"/>
             <param name="fastq_input1" ftype="fasta" value="bwa-mem-fasta1.fa"/>
             <param name="analysis_type_selector" value="illumina"/>
-            <output name="bam_output" ftype="bam" file="bwa-aln-test1-fasta.bam" lines_diff="2"/>
+            <output name="bam_output" ftype="bam" file="bwa-aln-test1-fasta.bam" lines_diff="2">
+                <metadata name="dbkey" value="hg19" />
+            </output>
         </test>
         <test>
             <param name="reference_source_selector" value="history"/>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,9 +1,5 @@
-<?xml version="1.0"?>
-<tool id="bwa" name="Map with BWA" version="@VERSION@.5">
+<tool id="bwa" name="Map with BWA" version="@VERSION@.6">
     <description>- map short reads (&lt; 100 bp) against reference genome</description>
-    <xrefs>
-        <xref type="bio.tools">bwa</xref>
-    </xrefs>
     <macros>
         <import>read_group_macros.xml</import>
         <import>bwa_macros.xml</import>
@@ -77,6 +73,9 @@
             </when>
         </xml>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">bwa</xref>
+    </xrefs>
     <expand macro="requirements"/>
     <expand macro="stdio"/>
     <command>

--- a/tools/bwa_mem2/macros.xml
+++ b/tools/bwa_mem2/macros.xml
@@ -1,8 +1,7 @@
 <macros>
-    <import>read_group_macros.xml</import>
 
     <token name="@TOOL_VERSION@">2.2.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
 
     <xml name="xrefs">
         <xrefs>

--- a/tools/picard/picard_AddOrReplaceReadGroups.xml
+++ b/tools/picard/picard_AddOrReplaceReadGroups.xml
@@ -3,7 +3,7 @@
     <macros>
         <import>picard_macros.xml</import>
         <import>read_group_macros.xml</import>
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
was originally suggested here https://github.com/galaxyproject/tools-iuc/pull/5963 but better done separately .. with bumping all tools using the macros

Just noticed that `bowtie2` uses more or less the same macros. Should we work toward that also bowtie2 uses these macros? Or the other way round?

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
