### PR TITLE
Reduce slightly scanpy tools profile for wider instance support

### DIFF
--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -648,7 +648,7 @@ analysis by Levine et al, 2015.
 This requires to run `pp.neighbors`, first.
 
 More details on the `tl.louvain scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.louvain.html>`_
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.louvain.html>`_
 
 Cluster cells into subgroups (`tl.leiden`)
 ==========================================
@@ -658,7 +658,7 @@ Cluster cells using the Leiden algorithm (Traag et al, 2018), an improved versio
 The Louvain algorithm has been proposed for single-cell analysis by Levine et al, 2015.
 
 More details on the `tl.leiden scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.leiden.html>`_
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.leiden.html>`_
 
 Computes PCA (principal component analysis) coordinates, loadings and variance decomposition, using `pp.pca`
 ============================================================================================================
@@ -666,7 +666,7 @@ Computes PCA (principal component analysis) coordinates, loadings and variance d
 @CMD_pca_outputs@
 
 More details on the `pp.pca scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.pca.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.pca.html>`__
 
 Computes PCA (principal component analysis) coordinates, loadings and variance decomposition, using `tl.pca`
 ============================================================================================================
@@ -674,7 +674,7 @@ Computes PCA (principal component analysis) coordinates, loadings and variance d
 @CMD_pca_outputs@
 
 More details on the `tl.pca scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.pca.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.pca.html>`__
 
 Diffusion Maps, using `tl.diffmap`
 ==================================
@@ -696,7 +696,7 @@ observations annotation (obsm). It is the right eigen basis of the transition ma
 as colum. It can be accessed using the inspect tool for AnnData
 
 More details on the `tl.diffmap scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.diffmap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.diffmap.html>`__
 
 t-distributed stochastic neighborhood embedding (tSNE), using `tl.tsne`
 =======================================================================
@@ -708,7 +708,7 @@ we use the implementation of *scikit-learn* (Pedregosa et al, 2011).
 It returns `X_tsne`, tSNE coordinates of data.
 
 More details on the `tl.tsne scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.tsne.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.tsne.html>`__
 
 Embed the neighborhood graph using UMAP, using `tl.umap`
 ========================================================
@@ -728,7 +728,7 @@ The UMAP coordinates of data are added to the return AnnData in the multi-dimens
 observations annotation (obsm). This data is accessible using the inspect tool for AnnData
 
 More details on the `tl.umap scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.umap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.umap.html>`__
 
 Force-directed graph drawing, using `tl.draw_graph`
 ===================================================
@@ -747,7 +747,7 @@ The coordinates of graph layout are added to the return AnnData in the multi-dim
 observations annotation (obsm). This data is accessible using the inspect tool for AnnData.
 
 More details on the `tl.draw_graph scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.draw_graph.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.draw_graph.html>`__
 
 Infer progression of cells through geodesic distance along the graph (`tl.dpt`)
 ===============================================================================
@@ -776,7 +776,7 @@ If `n_branchings==0`, no field `dpt_groups` will be written.
 The tool is similar to the R package `destiny` of Angerer et al (2016).
 
 More details on the `tl.dpt scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.dpt.html>`_
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.dpt.html>`_
 
 
 Generate cellular maps of differentiation manifolds with complex topologies (`tl.paga`)
@@ -807,7 +807,7 @@ The returned AnnData object contains:
 These datasets are stored in the unstructured annotation (uns) and can be accessed using the inspect tool for AnnData objects
 
 More details on the `tl.paga scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.paga.html>`_
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.paga.html>`_
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tools/scanpy/filter.xml
+++ b/tools/scanpy/filter.xml
@@ -458,7 +458,7 @@ Only provide one of the optional parameters `min_counts`, `min_genes`,
 `max_counts`, `max_genes` per call.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.filter_cells.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.filter_cells.html>`__
 
 
 Filter genes based on number of cells or counts (`pp.filter_genes`)
@@ -472,14 +472,14 @@ Only provide one of the optional parameters `min_counts`, `min_cells`,
 `max_counts`, `max_cells` per call.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.filter_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.filter_genes.html>`__
 
 
 Filters out genes based on fold change and fraction of genes expressing the gene within and outside the groupby categories (`tl.filter_rank_genes_groups`)
 ==========================================================================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.filter_rank_genes_groups.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.filter_rank_genes_groups.html>`__
 
 
 Annotate highly variable genes (`pp.highly_variable_genes`)
@@ -494,7 +494,7 @@ Subsample to a fraction of the number of observations (`pp.subsample`)
 ======================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.subsample.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.subsample.html>`__
 
 Downsample counts (`pp.downsample_counts`)
 ==========================================
@@ -503,7 +503,7 @@ Downsample counts so that each cell has no more than `target_counts`. Cells with
 has been implemented by M. D. Luecken.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.downsample_counts.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.downsample_counts.html>`__
 
 
     ]]></help>

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -912,7 +912,7 @@ The returned AnnData object contains:
 This data are stored in the unstructured annotation (uns) and can be accessed using the inspect tool for AnnData objects
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.neighbors.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.neighbors.html>`__
 
 Score a set of genes, using `tl.score_genes`
 ============================================

--- a/tools/scanpy/inspect.xml
+++ b/tools/scanpy/inspect.xml
@@ -893,7 +893,7 @@ And also the variable level metrics:
 - pct_dropout_by_{expr_type} (e.g. "pct_dropout_by_counts", percentage of cells this feature does not appear in)
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.calculate_qc_metrics.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.calculate_qc_metrics.html>`__
 
 Compute a neighborhood graph of observations, using `pp.neighbors`
 ==================================================================
@@ -912,7 +912,7 @@ The returned AnnData object contains:
 This data are stored in the unstructured annotation (uns) and can be accessed using the inspect tool for AnnData objects
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.neighbors.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.neighbors.html>`__
 
 Score a set of genes, using `tl.score_genes`
 ============================================
@@ -925,7 +925,7 @@ This reproduces the approach in Seurat (Satija et al, 2015) and has been impleme
 for Scanpy by Davide Cittaro.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.score_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.score_genes.html>`__
 
 Score cell cycle genes, using `tl.score_genes_cell_cycle`
 =========================================================
@@ -935,7 +935,7 @@ scores and assigns a cell cycle phase (G1, S or G2M). See
 `score_genes` for more explanation.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.score_genes_cell_cycle.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.score_genes_cell_cycle.html>`__
 
 Rank genes for characterizing groups, using `tl.rank_genes_groups`
 ==================================================================
@@ -951,7 +951,7 @@ The returned AnnData object contains:
 This data are stored in the unstructured annotation (uns) and can be accessed using the inspect tool for AnnData objects
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.tl.rank_genes_groups.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.rank_genes_groups.html>`__
 
 
 Calculate an overlap score between data-deriven marker genes and provided markers (`tl.marker_gene_overlap`)
@@ -964,13 +964,13 @@ Logarithmize the data matrix (`pp.log1p`)
 =========================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.log1p.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.log1p.html>`__
 
 Scale data to unit variance and zero mean (`pp.scale`)
 ======================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.scale.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.scale.html>`__
 
 Computes the square root the data matrix (`pp.sqrt`)
 ====================================================

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.9.6</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@profile@">21.09</token>
     <xml name="requirements">
         <requirements>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.9.6</token>
     <token name="@VERSION_SUFFIX@">2</token>
-    <token name="@profile@">22.05</token>
+    <token name="@profile@">21.09</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">scanpy</requirement>

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -341,7 +341,7 @@ The recipe runs the following steps:
 - scale to unit variance and shift to zero mean
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_zheng17.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.recipe_zheng17.html>`__
 
 
 Normalization and filtering as of Weinreb et al (2017) (`pp.recipe_weinreb17`)
@@ -350,7 +350,7 @@ Normalization and filtering as of Weinreb et al (2017) (`pp.recipe_weinreb17`)
 Expects non-logarithmized data. If using logarithmized data, pass `log=False`.
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_weinreb17.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.recipe_weinreb17.html>`__
 
 
 Normalization and filtering as of Seurat et al (2015) (`pp.recipe_seurat`)
@@ -361,7 +361,7 @@ This uses a particular preprocessing.
 Expects non-logarithmized data. If using logarithmized data, pass `log=False`.
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_seurat.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.recipe_seurat.html>`__
 
 
 Markov Affinity-based Graph Imputation of Cells (MAGIC) as of Van Dijk D et al. (2018) (`external.pp.magic`)

--- a/tools/scanpy/normalize.xml
+++ b/tools/scanpy/normalize.xml
@@ -322,7 +322,7 @@ the same total count after normalization.
 Similar functions are used, for example, by Seurat, Cell Ranger or SPRING.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.normalize_per_cell.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.normalize_per_cell.html>`__
 
 
 Normalization and filtering as of Zheng et al. (2017), the Cell Ranger R Kit of 10x Genomics (`pp.recipe_zheng17`)
@@ -341,7 +341,7 @@ The recipe runs the following steps:
 - scale to unit variance and shift to zero mean
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.recipe_zheng17.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_zheng17.html>`__
 
 
 Normalization and filtering as of Weinreb et al (2017) (`pp.recipe_weinreb17`)
@@ -350,7 +350,7 @@ Normalization and filtering as of Weinreb et al (2017) (`pp.recipe_weinreb17`)
 Expects non-logarithmized data. If using logarithmized data, pass `log=False`.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.recipe_weinreb17.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_weinreb17.html>`__
 
 
 Normalization and filtering as of Seurat et al (2015) (`pp.recipe_seurat`)
@@ -361,7 +361,7 @@ This uses a particular preprocessing.
 Expects non-logarithmized data. If using logarithmized data, pass `log=False`.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.recipe_seurat.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.recipe_seurat.html>`__
 
 
 Markov Affinity-based Graph Imputation of Cells (MAGIC) as of Van Dijk D et al. (2018) (`external.pp.magic`)
@@ -375,7 +375,7 @@ The algorithm implemented here has changed primarily in two ways compared to the
 - Secondly, data diffusion is applied in the PCA space, rather than the data space, for speed and memory improvements.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.external.pp.magic.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.external.pp.magic.html>`__
 
     ]]></help>
     <expand macro="citations"/>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -2299,7 +2299,7 @@ If groupby is not given, the matrixplot assumes that all data belongs to a singl
 category.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.matrixplot.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.matrixplot.html>`__
 
 Generic: Hierarchically-clustered heatmap (`pl.clustermap`)
 ===========================================================
@@ -2317,7 +2317,7 @@ clustergrid.dendrogram_row.reordered_ind
 Column indices, use: clustergrid.dendrogram_col.reordered_ind
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.clustermap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.clustermap.html>`__
 
 Preprocessing: Plot the fraction of counts assigned to each gene over all cells (`pl.highest_expr_genes`)
 =========================================================================================================
@@ -2329,7 +2329,7 @@ plotted as boxplots.
 This plot is similar to the `scater` package function `plotHighestExprs(type= "highest-expression")`
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.highest_expr_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.highest_expr_genes.html>`__
 
 Preprocessing: Plot dispersions versus means for genes (`pl.highly_variable_genes`)
 ===================================================================================
@@ -2337,25 +2337,25 @@ Preprocessing: Plot dispersions versus means for genes (`pl.highly_variable_gene
 It produces Supp. Fig. 5c of Zheng et al. (2017) and MeanVarPlot() of Seurat.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.highly_variable_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.highly_variable_genes.html>`__
 
 PCA: Scatter plot in PCA coordinates (`pl.pca`)
 ===============================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.pca.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca.html>`__
 
 PCA: Rank genes according to contributions to PCs (`pl.pca_loadings`)
 =====================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.pca_loadings.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_loadings.html>`__
 
 PCA: Plot the variance ratio (`pl.pca_variance_ratio`)
 ======================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.pca_variance_ratio.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_variance_ratio.html>`__
 
 PCA: Plot PCA results (`pl.pca_overview`)
 =========================================
@@ -2364,37 +2364,37 @@ The parameters are the ones of the scatter plot. Call pca_ranking separately
 if you want to change the default settings.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.pca_overview.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_overview.html>`__
 
 Embedding: Scatter plot in tSNE basis (`pl.tsne`)
 =================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.tsne.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.tsne.html>`__
 
 Embeddings: Scatter plot in UMAP basis (`pl.umap`)
 ==================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.umap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.umap.html>`__
 
 Embeddings: Scatter plot in Diffusion Map basis (`pl.diffmap`)
 ==============================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.diffmap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.diffmap.html>`__
 
 Branching trajectories and pseudotime, clustering: Plot groups and pseudotime (`pl.dpt_groups_pseudotime`)
 ===========================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.dpt_groups_pseudotime.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.dpt_groups_pseudotime.html>`__
 
 Branching trajectories and pseudotime, clustering: Heatmap of pseudotime series (`pl.dpt_timeseries`)
 =====================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.dpt_timeseries.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.dpt_timeseries.html>`__
 
 
 Branching trajectories and pseudotime, clustering: Plot the abstracted graph through thresholding low-connectivity edges (`pl.paga`)
@@ -2407,56 +2407,56 @@ mirrors coordinates along the x axis... that is, you should increase the
 `maxiter` parameter by 1 if the layout is flipped.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.paga.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga.html>`__
 
 
 Branching trajectories and pseudotime, clustering: Scatter and PAGA graph side-by-side (`pl.paga_compare`)
 ==========================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.paga_compare.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga_compare.html>`__
 
 Branching trajectories and pseudotime, clustering: Gene expression and annotation changes along paths (`pl.paga_path`)
 ======================================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.paga_path.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga_path.html>`__
 
 Marker genes: Plot ranking of genes using dotplot plot (`pl.rank_genes_groups`)
 ===============================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups.html>`__
 
 Marker genes: Plot ranking of genes as violin plot (`pl.rank_genes_groups_violin`)
 ==================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups_violin.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_violin.html>`__
 
 Marker genes: Plot ranking of genes as dotplot plot (`pl.rank_genes_groups_dotplot`)
 ====================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups_dotplot.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_dotplot.html>`__
 
 Marker genes: Plot ranking of genes as heatmap plot (`pl.rank_genes_groups_heatmap`)
 ====================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups_heatmap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_heatmap.html>`__
 
 Marker genes: Plot ranking of genes as matrixplot plot (`pl.rank_genes_groups_matrixplot`)
 ==========================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups_matrixplot.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_matrixplot.html>`__
 
 Marker genes: Plot ranking of genes as stacked violin plot (`pl.rank_genes_groups_stacked_violin`)
 ==================================================================================================
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pl.rank_genes_groups_stacked_violin.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_stacked_violin.html>`__
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -2329,7 +2329,7 @@ plotted as boxplots.
 This plot is similar to the `scater` package function `plotHighestExprs(type= "highest-expression")`
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.highest_expr_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.highest_expr_genes.html>`__
 
 Preprocessing: Plot dispersions versus means for genes (`pl.highly_variable_genes`)
 ===================================================================================
@@ -2337,25 +2337,25 @@ Preprocessing: Plot dispersions versus means for genes (`pl.highly_variable_gene
 It produces Supp. Fig. 5c of Zheng et al. (2017) and MeanVarPlot() of Seurat.
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.highly_variable_genes.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.highly_variable_genes.html>`__
 
 PCA: Scatter plot in PCA coordinates (`pl.pca`)
 ===============================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.pca.html>`__
 
 PCA: Rank genes according to contributions to PCs (`pl.pca_loadings`)
 =====================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_loadings.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.pca_loadings.html>`__
 
 PCA: Plot the variance ratio (`pl.pca_variance_ratio`)
 ======================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_variance_ratio.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.pca_variance_ratio.html>`__
 
 PCA: Plot PCA results (`pl.pca_overview`)
 =========================================
@@ -2364,37 +2364,37 @@ The parameters are the ones of the scatter plot. Call pca_ranking separately
 if you want to change the default settings.
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.pca_overview.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.pca_overview.html>`__
 
 Embedding: Scatter plot in tSNE basis (`pl.tsne`)
 =================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.tsne.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.tsne.html>`__
 
 Embeddings: Scatter plot in UMAP basis (`pl.umap`)
 ==================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.umap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.umap.html>`__
 
 Embeddings: Scatter plot in Diffusion Map basis (`pl.diffmap`)
 ==============================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.diffmap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.diffmap.html>`__
 
 Branching trajectories and pseudotime, clustering: Plot groups and pseudotime (`pl.dpt_groups_pseudotime`)
 ===========================================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.dpt_groups_pseudotime.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.dpt_groups_pseudotime.html>`__
 
 Branching trajectories and pseudotime, clustering: Heatmap of pseudotime series (`pl.dpt_timeseries`)
 =====================================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.dpt_timeseries.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.dpt_timeseries.html>`__
 
 
 Branching trajectories and pseudotime, clustering: Plot the abstracted graph through thresholding low-connectivity edges (`pl.paga`)
@@ -2407,56 +2407,56 @@ mirrors coordinates along the x axis... that is, you should increase the
 `maxiter` parameter by 1 if the layout is flipped.
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.paga.html>`__
 
 
 Branching trajectories and pseudotime, clustering: Scatter and PAGA graph side-by-side (`pl.paga_compare`)
 ==========================================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga_compare.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.paga_compare.html>`__
 
 Branching trajectories and pseudotime, clustering: Gene expression and annotation changes along paths (`pl.paga_path`)
 ======================================================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.paga_path.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.paga_path.html>`__
 
 Marker genes: Plot ranking of genes using dotplot plot (`pl.rank_genes_groups`)
 ===============================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups.html>`__
 
 Marker genes: Plot ranking of genes as violin plot (`pl.rank_genes_groups_violin`)
 ==================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_violin.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups_violin.html>`__
 
 Marker genes: Plot ranking of genes as dotplot plot (`pl.rank_genes_groups_dotplot`)
 ====================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_dotplot.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups_dotplot.html>`__
 
 Marker genes: Plot ranking of genes as heatmap plot (`pl.rank_genes_groups_heatmap`)
 ====================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_heatmap.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups_heatmap.html>`__
 
 Marker genes: Plot ranking of genes as matrixplot plot (`pl.rank_genes_groups_matrixplot`)
 ==========================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_matrixplot.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups_matrixplot.html>`__
 
 Marker genes: Plot ranking of genes as stacked violin plot (`pl.rank_genes_groups_stacked_violin`)
 ==================================================================================================
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pl.rank_genes_groups_stacked_violin.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pl.rank_genes_groups_stacked_violin.html>`__
     ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -180,7 +180,7 @@ Regress out unwanted sources of variation, using simple linear regression. This 
 inspired by Seurat's `regressOut` function in R.
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.regress_out.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.regress_out.html>`__
 
 Correct batch effects by matching mutual nearest neighbors, using `pp.mnn_correct`
 ==================================================================================
@@ -200,7 +200,7 @@ Correct batch effects with ComBat function (`pp.combat`)
 Corrects for batch effects by fitting linear models, gains statistical power via an EB framework where information is borrowed across genes. This uses the implementation of ComBat
 
 More details on the `scanpy documentation
-<https://icb-scanpy.readthedocs-hosted.com/en/stable/api/scanpy.pp.combat.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.combat.html>`__
 
 
     ]]></help>

--- a/tools/scanpy/remove_confounders.xml
+++ b/tools/scanpy/remove_confounders.xml
@@ -200,7 +200,7 @@ Correct batch effects with ComBat function (`pp.combat`)
 Corrects for batch effects by fitting linear models, gains statistical power via an EB framework where information is borrowed across genes. This uses the implementation of ComBat
 
 More details on the `scanpy documentation
-<https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.combat.html>`__
+<https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.combat.html>`__
 
 
     ]]></help>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

The IUC Scanpy tools are using a profile version that doesn't allow us to install them alongside our tools on some private instances that we have. I noticed that the current profile had a value outside of the described ones on the [tools XML docs](https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-profile), so I have nudged the value to the closest lower one.

This doesn't have any impact on tools really, mostly on where they can be installed, but let me know if this merits a `galaxy+<num>` version bump on tools. I hope that this change is acceptable.