### PR TITLE
CI: Fix reactions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        reaction-type: hooray
+        reactions: hooray
     - name: Set galaxy fork and branch
       id: get-fork-branch
       run: |

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         if: github.repository_owner == 'galaxyproject'
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@v4
         with:
           token: ${{ secrets.PAT }}
           commands: |


### PR DESCRIPTION
weekly tests currently show

```
Unexpected input(s) 'reaction-type', valid inputs are ['token', 'repository', 'issue-number', 'comment-id', 'body', 'body-path', 'body-file', 'edit-mode', 'append-separator', 'reactions', 'reactions-edit-mode']
```

also bump slash-command-dispactch (`Node.js 16 actions are deprecated`)

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
