### PR TITLE
Add missing format attributes

### DIFF
--- a/tools/khmer/extract-partitions.xml
+++ b/tools/khmer/extract-partitions.xml
@@ -33,7 +33,7 @@ output
     <outputs>
         <data name="distribution" format="txt" from_work_dir="output.dist" label="${tool.name} on ${on_string}: Partition size distribution" />
         <collection name="groups-of-partitions" type="list" format="fasta">
-            <discover_datasets pattern="__name__" directory="output" />
+            <discover_datasets pattern="__name__" directory="output" format="fasta"/>
         </collection>
     </outputs>
     <tests>

--- a/tools/khmer/extract-partitions.xml
+++ b/tools/khmer/extract-partitions.xml
@@ -23,7 +23,7 @@ output
     </command>
     <inputs>
         <expand macro="input_sequences_filenames" />
-        <param argument="--max-size" name="max_size" type="integer" label="Max group size" value="1000000"
+        <param argument="--max-size" type="integer" label="Max group size" value="1000000"
             help="No more than this many number of sequences will be stored in each output"/>
         <param name="min_partition_size" type="integer" label="Min partition size" value="5"
             help="The minimum partition size worth keeping (--min-partition-size/-m)" />
@@ -32,7 +32,7 @@ output
     </inputs>
     <outputs>
         <data name="distribution" format="txt" from_work_dir="output.dist" label="${tool.name} on ${on_string}: Partition size distribution" />
-        <collection name="groups-of-partitions" type="list">
+        <collection name="groups-of-partitions" type="list" format="fasta">
             <discover_datasets pattern="__name__" directory="output" />
         </collection>
     </outputs>

--- a/tools/mothur/chimera.check.xml
+++ b/tools/mothur/chimera.check.xml
@@ -68,7 +68,7 @@ echo 'chimera.check(
         <expand macro="logfile-output"/>
         <data name="chimeracheck.chimeras" format="txt" from_work_dir="fasta.chimeracheck.chimeras" label="${tool.name} on ${on_string}: chimeracheck.chimeras"/>
         <collection name="images" type="list" label="${tool.name} on ${on_string}: SVG images" format="svg">
-            <discover_datasets pattern="(?P&lt;designation&gt;.*)\.chimeracheck\.svg"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.*)\.chimeracheck\.svg" format="svg"/>
             <filter>svg['gen'] == 'yes'</filter>
         </collection>
     </outputs>

--- a/tools/mothur/chimera.check.xml
+++ b/tools/mothur/chimera.check.xml
@@ -67,7 +67,7 @@ echo 'chimera.check(
     <outputs>
         <expand macro="logfile-output"/>
         <data name="chimeracheck.chimeras" format="txt" from_work_dir="fasta.chimeracheck.chimeras" label="${tool.name} on ${on_string}: chimeracheck.chimeras"/>
-        <collection name="images" type="list" label="${tool.name} on ${on_string}: SVG images">
+        <collection name="images" type="list" label="${tool.name} on ${on_string}: SVG images" format="svg">
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.chimeracheck\.svg"/>
             <filter>svg['gen'] == 'yes'</filter>
         </collection>

--- a/tools/mothur/heatmap.bin.xml
+++ b/tools/mothur/heatmap.bin.xml
@@ -82,7 +82,7 @@ echo 'heatmap.bin(
     <outputs>
         <expand macro="logfile-output"/>
         <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps" format="svg">
-            <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.bin\.svg"/>
+            <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.bin\.svg" format="svg"/>
         </collection>
     </outputs>
     <tests>

--- a/tools/mothur/heatmap.bin.xml
+++ b/tools/mothur/heatmap.bin.xml
@@ -81,7 +81,7 @@ echo 'heatmap.bin(
     </inputs>
     <outputs>
         <expand macro="logfile-output"/>
-        <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps">
+        <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps" format="svg">
             <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.bin\.svg"/>
         </collection>
     </outputs>

--- a/tools/mothur/heatmap.sim.xml
+++ b/tools/mothur/heatmap.sim.xml
@@ -96,7 +96,7 @@ echo 'heatmap.sim(
             <filter>input['source'] != 'shared'</filter>
         </data>
         <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps" format="svg">
-            <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.sim\.svg"/>
+            <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.sim\.svg" format="svg"/>
             <filter>input['source'] == 'shared'</filter>
         </collection>
     </outputs>

--- a/tools/mothur/heatmap.sim.xml
+++ b/tools/mothur/heatmap.sim.xml
@@ -95,7 +95,7 @@ echo 'heatmap.sim(
         <data name="heatmap" format="svg" from_work_dir="input_dist*.heatmap.sim.svg" label="${tool.name} on ${on_string}: heatmap.sim.svg">
             <filter>input['source'] != 'shared'</filter>
         </data>
-        <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps">
+        <collection name="heatmaps" type="list" label="${tool.name} on ${on_string}: Heatmaps" format="svg">
             <discover_datasets pattern=".*?\.(?P&lt;designation&gt;.*)\.sim\.svg"/>
             <filter>input['source'] == 'shared'</filter>
         </collection>


### PR DESCRIPTION
We can find them with
```
planemo lint -s command,tool_xsd,tests,general,help,inputs,citations,xml_order  --recursive
```
If we don't set an output format the hda extension becomes null in the database, and we fail at various places in the galaxy codebase. We can make Galaxy more resilient to it, but this is an easy fix here. Galaxy issue is here: https://github.com/galaxyproject/galaxy/issues/18383

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
