### PR TITLE
Fix bbgbigwig deployment lack of dbkey_loc.sample

### DIFF
--- a/tools/bbgbigwig/bam_bed_gff_to_bigwig.xml
+++ b/tools/bbgbigwig/bam_bed_gff_to_bigwig.xml
@@ -96,7 +96,7 @@ bedGraphToBigWig temp.bg ./CHROMFILE '$output'
 
    Estimates coverage of a reference genome for bam, bed or gff as a bigwig, suitable for viewing in JBrowse2 or other browser.
  
-   A chromosome lengths file must be provided if the input has a missing dbkey='?' on the pencil (edit attributes) tab. 
+   A chromosome lengths file must be provided if the input has a missing dbkey (='?') on the pencil (edit attributes) form. 
    
    The actual reference is not needed. The Compute sequence length tool can generate the lengths file.
  

--- a/tools/bbgbigwig/test-data/dbkeys.loc.sample
+++ b/tools/bbgbigwig/test-data/dbkeys.loc.sample
@@ -1,0 +1,2 @@
+#<dbkey>	<display_name>	<len_file_path>
+hg38	hg38	testing.len

--- a/tools/bbgbigwig/test-data/dbkeys.loc.sample
+++ b/tools/bbgbigwig/test-data/dbkeys.loc.sample
@@ -1,2 +1,0 @@
-#<dbkey>	<display_name>	<len_file_path>
-hg38	hg38	testing.len

--- a/tools/bbgbigwig/tool-data/dbkeys.loc.sample
+++ b/tools/bbgbigwig/tool-data/dbkeys.loc.sample
@@ -1,0 +1,1 @@
+#<dbkey>		<display_name>	<len_file_path>

--- a/tools/bbgbigwig/tool-data/dbkeys.loc.sample
+++ b/tools/bbgbigwig/tool-data/dbkeys.loc.sample
@@ -1,1 +1,2 @@
-#<dbkey>		<display_name>	<len_file_path>
+#<dbkey>	<display_name>	<len_file_path>
+hg38	hg38	testing.len

--- a/tools/bbgbigwig/tool_data_table_conf.xml.sample
+++ b/tools/bbgbigwig/tool_data_table_conf.xml.sample
@@ -2,6 +2,7 @@
     <!-- Locations of dbkeys and len files under genome directory -->
     <table name="__dbkeys__" comment_char="#">
         <columns>value, name, len_path</columns>
-        <file path="tool-data/dbkeys.loc" />
+        <file path="test-data/dbkeys.loc" />
     </table>
 </tables>
+

--- a/tools/bbgbigwig/tool_data_table_conf.xml.sample
+++ b/tools/bbgbigwig/tool_data_table_conf.xml.sample
@@ -2,7 +2,7 @@
     <!-- Locations of dbkeys and len files under genome directory -->
     <table name="__dbkeys__" comment_char="#">
         <columns>value, name, len_path</columns>
-        <file path="test-data/dbkeys.loc" />
+        <file path="tool-data/dbkeys.loc" />
     </table>
 </tables>
 


### PR DESCRIPTION
@mvdbeek:
added a dbkey_loc.sample to test-data to try to fix that deployment problem?
tool-data seems to be MIA in the IUC repo.
Planemo does not like an empty tool_data_table_conf.xml.sample
update to closed PR #6088 
