### PR TITLE
Funannotate: use better tmpdir

### DIFF
--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -26,6 +26,7 @@ funannotate annotate
 #end if
 
 --out output
+--tmpdir "\${_GALAXY_JOB_TMP_DIR:-/tmp}"
 
 --database '$database.fields.path'
 
@@ -76,7 +77,7 @@ funannotate annotate
 ## https://github.com/nextgenusfs/funannotate/issues/777
 ## The partial tbl files are combined by funannotate and are deleted below.
 ## The sqn files are discrete and are collected with discover_datasets.
-find output/annotate_results 
+find output/annotate_results
 -regex ".*part_[0-9]+\.\(tbl\)$"
 -delete
 
@@ -241,7 +242,7 @@ find output/annotate_results
                     <assert_contents>
                         <has_text text="Seq-submit" />
                     </assert_contents>
-                </element>   
+                </element>
             </output_collection>
             <output name="fa_scaffolds">
                 <assert_contents>
@@ -335,7 +336,7 @@ find output/annotate_results
                     <assert_contents>
                         <has_text text="Seq-submit" />
                     </assert_contents>
-                </element>   
+                </element>
             </output_collection>
             <output name="fa_scaffolds">
                 <assert_contents>

--- a/tools/funannotate/funannotate_clean.xml
+++ b/tools/funannotate/funannotate_clean.xml
@@ -12,6 +12,7 @@
 funannotate clean
 --input '${input}'
 --out '${output}'
+--tmpdir "\${_GALAXY_JOB_TMP_DIR:-/tmp}"
 --pident ${pident}
 --cov ${cov}
 --minlen ${minlen}

--- a/tools/funannotate/funannotate_clean.xml
+++ b/tools/funannotate/funannotate_clean.xml
@@ -12,7 +12,6 @@
 funannotate clean
 --input '${input}'
 --out '${output}'
---tmpdir "\${_GALAXY_JOB_TMP_DIR:-/tmp}"
 --pident ${pident}
 --cov ${cov}
 --minlen ${minlen}

--- a/tools/funannotate/funannotate_predict.xml
+++ b/tools/funannotate/funannotate_predict.xml
@@ -29,6 +29,7 @@ ln -s '${input}' input/input.fasta &&
 funannotate predict
 --input input/input.fasta
 --out output
+--tmpdir "\${_GALAXY_JOB_TMP_DIR:-/tmp}"
 #if $uglyTestingHack == "true":
     --database `pwd`'/hacked_database'
 #else

--- a/tools/funannotate/macros.xml
+++ b/tools/funannotate/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.8.15</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <xml name="biotools">
         <xrefs>
             <xref type="bio.tools">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

Trying to fix the following kind of error found with predict tool:

```
[Jun 14 08:11 PM]: Mapping 557,291 proteins to genome using diamond and exonerate
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/funannotate/aux_scripts/funannotate-p2g.py", line 252, in <module>
    os.makedirs(tmpdir)
  File "/usr/local/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
OSError: [Errno 30] Read-only file system: '/tmp/p2g_927b8faa-730b-404d-a862-2631430ec16b'
Traceback (most recent call last):
  File "/usr/local/bin/funannotate", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/funannotate/funannotate.py", line 716, in main
    mod.main(arguments)
  File "/usr/local/lib/python3.8/site-packages/funannotate/predict.py", line 1558, in main
    lib.exonerate2hints(Exonerate, hintsP)
  File "/usr/local/lib/python3.8/site-packages/funannotate/library.py", line 4600, in exonerate2hints
    with open(file, "r") as input:
FileNotFoundError: [Errno 2] No such file or directory: ' foobar'
```

= /tmp is read only (because of apptainer image?) => need to tell funannotate to use a better tmp dir.

Not tested, :crossed_fingers: 