### PR TITLE
Quick fix for fastq-dump reads name issue

### DIFF
--- a/tools/sra-tools/fasterq_dump.xml
+++ b/tools/sra-tools/fasterq_dump.xml
@@ -73,7 +73,7 @@
     <inputs>
         <expand macro="input_conditional"/>
         <section name="adv" title="Advanced Options" expanded="False">
-            <expand macro="defline" defline_param="--seq-defline" defline_default="@$sn/$ri"/>
+            <expand macro="defline" defline_param="--seq-defline" defline_default="@$ac.$sn/$ri"/>
             <param name="minlen" type="integer" label="Minimum read length" optional="true" help="Filter by sequence length. Will dump only reads longer or equal to this value." argument="--min-read-len"/>
             <param name="split" type="select" display="radio" label="Select how to split the spots" help="This option will only be used when there are multiple reads per spot (for example paired-end).">
                 <option value="--split-3">--split-3: write properly paired biological reads into different files and single reads in another file</option>

--- a/tools/sra-tools/fastq_dump.xml
+++ b/tools/sra-tools/fastq_dump.xml
@@ -91,7 +91,7 @@
             <option value="fastqsanger.bz2">bzip2 compressed fastq</option>
         </param>
         <section name="adv" title="Advanced Options" expanded="False">
-            <expand macro="defline" defline_param="--defline-seq" defline_default="@$sn[_$rn]/$ri"/>
+            <expand macro="defline" defline_param="--defline-seq" defline_default="@$ac.$sn[_$rn]/$ri"/>
             <param name="minID" type="integer" label="Minimum spot ID" optional="true" help="Minimum spot id to be dumped." argument="--minSpotId"/>
             <param name="maxID" type="integer" label="Maximum spot ID" optional="true" help="Maximum spot id to be dumped." argument="--maxSpotId"/>
             <param name="minlen" type="integer" label="Minimum read length" optional="true" help="Filter by sequence length. Will dump only reads longer or equal to this value." argument="--minReadLen"/>


### PR DESCRIPTION
In **fastq-dump**, the current default for --defline-seq is `@$sn[_$rn]/$ri`
The program default is `@$ac.$si $ri length=$rl`
Maybe the program default is too much, but missing the accession can produce reads named 1/1, 2/1, 3/1 in some cases. This is problematic if you have several fastq with reads named the same.
I'm proposing bringing back the accession at the beginning to avoid this. It should be `@$ac.$sn[_$rn]/$ri`

Similarly, for **fasterq-dump**, now it is `@$sn/$ri` and it should be `@ac.$sn/$ri`