### PR TITLE
Fix to Diffbind: small wording fix to default score column

### DIFF
--- a/tools/diffbind/diffbind.xml
+++ b/tools/diffbind/diffbind.xml
@@ -139,7 +139,7 @@ Rscript '$__tool_directory__/diffbind.R'
             <param name="bamcontrol" type="data" format="bam" multiple="true" optional="True" label="Control BAM files" help="If specifying a control BAM file, all samples are required to specify one, see Help section below. The input order of the BAM files for the samples MUST match the input order of the peaks files."/>
         </repeat>
 
-        <param name="scorecol" type="integer" min="0" value="8" label="Score Column" help="Column in peak files that contains peak scores. Default: 8 (narrowPeak)">
+        <param name="scorecol" type="integer" min="0" value="5" label="Score Column" help="Column in peak files that contains peak scores. Default: 5 (narrowPeak)">
             <sanitizer>
                 <valid initial="string.digits"/>
             </sanitizer>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Spotted by colleague during one of their analyses. The narrowPeaks score column is column 5 not 8, and led to some confusion when using the defaults.

I did not bump the version due to the one line wording nature of this.