### PR TITLE
Fix unicycler datatype comparisons

### DIFF
--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -2,7 +2,7 @@
 <description>pipeline for bacterial genomes</description>
     <macros>
         <token name="@TOOL_VERSION@">0.5.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <edam_topics>
         <edam_topic>topic_0196</edam_topic>
@@ -23,48 +23,46 @@
 #end for
 
 ## Preparing files
-#set $uncompressed = ('fastqsanger','fastq')
-#set $compressed = ('fastqsanger.gz','fastq.gz')
 #if str( $paired_unpaired.fastq_input_selector ) == "paired"
-    #if $paired_unpaired.fastq_input1.file_ext in $uncompressed
-        #set fq1 = "fq1.fastq"
-    #elif $paired_unpaired.fastq_input1.file_ext in $compressed
+    #if $paired_unpaired.fastq_input1.is_of_type("fastq.gz"):
         #set fq1 = "fq1.fastq.gz"
+    #else
+        #set fq1 = "fq1.fastq"
     #end if
-    #if $paired_unpaired.fastq_input2.file_ext in $uncompressed
-        #set fq2 = "fq2.fastq"
-    #elif $paired_unpaired.fastq_input2.file_ext in $compressed
+    #if $paired_unpaired.fastq_input2.is_of_type("fastq.gz"):
         #set fq2 = "fq2.fastq.gz"
+    #else
+        #set fq2 = "fq2.fastq"
     #end if
     ln -s '${paired_unpaired.fastq_input1}' $fq1 &&
     ln -s '${paired_unpaired.fastq_input2}' $fq2 &&
 #elif str( $paired_unpaired.fastq_input_selector ) == "paired_collection"
-    #if $paired_unpaired.fastq_input1.forward.file_ext in $uncompressed
-        #set fq1 = "fq1.fastq"
-    #elif $paired_unpaired.fastq_input1.forward.file_ext in $compressed
+    #if $paired_unpaired.fastq_input1.forward.is_of_type("fastq.gz"):
         #set fq1 = "fq1.fastq.gz"
+    #else
+        #set fq1 = "fq1.fastq"
     #end if
-    #if $paired_unpaired.fastq_input1.reverse.file_ext in $uncompressed
-        #set fq2 = "fq2.fastq"
-    #elif $paired_unpaired.fastq_input1.reverse.file_ext in $compressed
+    #if $paired_unpaired.fastq_input1.reverse.is_of_type("fastq.gz"):
         #set fq2 = "fq2.fastq.gz"
+    #else
+        #set fq2 = "fq2.fastq"
     #end if
     ln -s '${paired_unpaired.fastq_input1.forward}' $fq1 &&
     ln -s '${paired_unpaired.fastq_input1.reverse}' $fq2 &&
 #elif str( $paired_unpaired.fastq_input_selector ) == "single"
-    #if $paired_unpaired.fastq_input1.file_ext in $uncompressed
-        #set fq = "fq.fastq"
-    #elif $paired_unpaired.fastq_input1.file_ext in $compressed
+    #if $paired_unpaired.fastq_input1.is_of_type("fastqsanger.gz"):
         #set fq = "fq.fastq.gz"
+    #else
+        #set fq = "fq.fastq"
     #end if
     ln -s '${paired_unpaired.fastq_input1}' '$fq' &&
 #end if
 #if $long
-    #if $long.file_ext in $uncompressed
+    #if $long.is_of_type("fastq"):
         #set lr = "lr.fastq"
-    #elif $long.file_ext in $compressed
+    #elif $long.is_of_type("fastq.gz"):
         #set lr = "lr.fastq.gz"
-    #elif $long.is_of_type('fasta')
+    #elif $long.is_of_type("fasta")
         #set lr = "lr.fasta"
     #end if
     ln -s '${long}' '$lr' &&


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/f5ec29350256422da159e25b0875b7ee/ when users attempt to run jobs with unexpected fastq datatypes like fastqcssanger.gz, which is allowed because basic fastq/fastq.gz are allowd (this is a mistake IMO ...):
```
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
NotFound: cannot find 'lr'
  File "galaxy/jobs/runners/__init__.py", line 297, in prepare_job
    job_wrapper.prepare()
  File "galaxy/jobs/__init__.py", line 1260, in prepare
    ) = tool_evaluator.build()
  File "galaxy/tools/evaluation.py", line 588, in build
    global_tool_logs(self._build_command_line, config_file, "Building Command Line")
  File "galaxy/tools/evaluation.py", line 98, in global_tool_logs
    raise e
  File "galaxy/tools/evaluation.py", line 94, in global_tool_logs
    return func()
  File "galaxy/tools/evaluation.py", line 611, in _build_command_line
    command_line = fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 123, in fill_template
    raise first_exception or e
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720043166_6268568_19017.py", line 172, in respond
```
This is hopefully an uncontroversial fix.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
