### PR TITLE
Fix stringie deseq2 output in mixed mode

### DIFF
--- a/tools/stringtie/macros.xml
+++ b/tools/stringtie/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.2.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">stringtie</requirement>

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -91,7 +91,11 @@ $adv.multi_mapping
 
 #if str($guide.use_guide) == 'yes':
     #if $guide.special_outputs.special_outputs_select == 'deseq2':
-        #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($input_bam.element_identifier))
+        #if $input_options.input_mode in ['short_reads','long_reads']:
+            #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($input_bam.element_identifier))
+        #else:
+            #set escaped_element_identifier = re.sub('[^\w\-]', '_', str($input_bam_long.element_identifier))
+        #end if
         &&
         ln -s '$output_gtf' ./special_de_output/sample1/output.gtf
         &&
@@ -417,6 +421,29 @@ $adv.multi_mapping
                 <param name="input_bam_short" ftype="bam" value="short_reads.bam"/>
                 <param name="input_bam_long" ftype="bam" value="long_reads.bam"/>
             </conditional>            
+            <output name="output_gtf" ftype="gtf">
+                <assert_contents>
+                    <has_text text="5.043160"/>
+                    <has_text text="StringTie version @TOOL_VERSION@"/>
+                    <has_n_lines n="87"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Test mixed reads input for deseq2 -->
+        <test expect_num_outputs="3">
+            <conditional name="guide">
+                <param name="guide_gff_select" value="history" />
+                <param name="use_guide" value="yes"/>
+                <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                <conditional name="special_outputs">
+                    <param name="special_outputs_select" value="deseq2"/>
+                </conditional>
+            </conditional>
+            <conditional name="input_options">
+                <param name="input_mode" value="mixed_reads"/>
+                <param name="input_bam_short" ftype="bam" value="short_reads.bam"/>
+                <param name="input_bam_long" ftype="bam" value="long_reads.bam"/>
+            </conditional>
             <output name="output_gtf" ftype="gtf">
                 <assert_contents>
                     <has_text text="5.043160"/>


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/d8a2554ecaab4c7582a17e0e1102b25a/::
```
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
NotFound: cannot find 'input_bam'
  File "galaxy/jobs/runners/pulsar.py", line 499, in __prepare_job
    job_wrapper.prepare(**prepare_kwds)
  File "galaxy/jobs/__init__.py", line 1260, in prepare
    ) = tool_evaluator.build()
  File "galaxy/tools/evaluation.py", line 588, in build
    global_tool_logs(self._build_command_line, config_file, "Building Command Line")
  File "galaxy/tools/evaluation.py", line 98, in global_tool_logs
    raise e
  File "galaxy/tools/evaluation.py", line 94, in global_tool_logs
    return func()
  File "galaxy/tools/evaluation.py", line 611, in _build_command_line
    command_line = fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 123, in fill_template
    raise first_exception or e
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1183, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1720636986_2572532_79544.py", line 272, in respond
```

IMO this tools should have been split into two tools when long reads / mixed read support was added. This would have made the command section a lot simpler. There's just way too many permutations one needs to test in the absence of type checking for cheetah code.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
