### PR TITLE
cutadapt: replace adapter sanitizer by validator

### DIFF
--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -38,6 +38,7 @@
         #end if
     </token>
     <xml name="adapter_sanitizer">
+        <sanitizer sanitize="false" />
         <validator type="regex"><![CDATA[[0-9ATCGURYSWKMBDHVNX{}^$.()]+$]]></validator>
     </xml>
     <xml name="adapter_conditional" tokens="adapter_type,argument">

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -39,7 +39,7 @@
     </token>
     <xml name="adapter_sanitizer">
         <sanitizer sanitize="false" />
-        <validator type="regex"><![CDATA[[0-9ATCGURYSWKMBDHVNX{}^$.()]+$]]></validator>
+        <validator type="regex" message="Invalid adapter sequence. Allowed are strings consisting of digits IUPAC nucleotides (including wildcards) and any of the following '{}^$.()'. See https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences"><![CDATA[[0-9ATCGURYSWKMBDHVNX{}^$.()]+$]]></validator>
     </xml>
     <xml name="adapter_conditional" tokens="adapter_type,argument">
         <conditional name="adapter_source">

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">4.9</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@FASTQ_TYPES@">fastq.bz2,fastq.gz,fastq,fasta.bz2,fasta.gz,fasta</token>
     <xml name="edam_ontology">
         <edam_topics>
@@ -38,34 +38,7 @@
         #end if
     </token>
     <xml name="adapter_sanitizer">
-        <sanitizer>
-            <valid initial="string.digits">
-                <add value="A"/><!--standard nucleotides-->
-                <add value="T"/>
-                <add value="C"/>
-                <add value="G"/>
-                <add value="U"/><!--ambiguous nucleotides-->
-                <add value="R"/>
-                <add value="Y"/>
-                <add value="S"/>
-                <add value="W"/>
-                <add value="K"/>
-                <add value="M"/>
-                <add value="B"/>
-                <add value="D"/>
-                <add value="H"/>
-                <add value="V"/>
-                <add value="N"/>
-                <add value="X"/><!-- don't match any nucleotide-->
-                <add value="{"/><!--specify repeats .. needs digits which are added as default-->
-                <add value="}"/>
-                <add value="^"/><!--anchoring-->
-                <add value="$"/>
-                <add value="."/>
-                <add value="("/><!--specify what to keep-->
-                <add value=")"/>
-            </valid>
-        </sanitizer>
+        <validator type="regex"><![CDATA[[0-9ATCGURYSWKMBDHVNX{}^$.()]+$]]></validator>
     </xml>
     <xml name="adapter_conditional" tokens="adapter_type,argument">
         <conditional name="adapter_source">


### PR DESCRIPTION
I had a user who used spaces in the adapter (for better visual orientation). these were silently replaced by X.

I think replacing the sanitizer by a validator is better, because more explicit behavior.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
