### PR TITLE
fix pp.make_peak_matrix but  and it's test

### DIFF
--- a/tools/snapatac2/macros.xml
+++ b/tools/snapatac2/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.6.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">23.0</token>
     <xml name="requirements">
         <requirement type="package" version="@TOOL_VERSION@">snapatac2</requirement>

--- a/tools/snapatac2/peaks_and_motif_analysis.xml
+++ b/tools/snapatac2/peaks_and_motif_analysis.xml
@@ -152,9 +152,7 @@ sa.pl.regions(
 )
 
 #end if
-#if $method.method != 'pp.make_peak_matrix'
 @CMD_anndata_write_outputs@
-#end if
     ]]></configfile>
     </configfiles>
     <inputs>
@@ -336,13 +334,13 @@ sa.pl.regions(
                     <has_text_matching expression="counting_strategy = 'insertion'"/>
                 </assert_contents>
             </output>
-            <output name="anndata_out" location="https://zenodo.org/records/12751925/files/pp.make_peak_matrix.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
+            <output name="anndata_out" location="https://zenodo.org/records/12800783/files/pp.make_peak_matrix.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
         </test>
         <test expect_num_outputs="3">
             <!-- tl.marker_regions -->
             <conditional name="method">
                 <param name="method" value="tl.marker_regions"/>
-                <param name="adata" location="https://zenodo.org/records/11260316/files/pp.make_peak_matrix.pbmc_500_chr21.h5ad"/>
+                <param name="adata" location="https://zenodo.org/records/12800783/files/pp.make_peak_matrix.pbmc_500_chr21.h5ad"/>
                 <param name="groupby" value="leiden"/>
                 <param name="pvalue" value="0.1"/>
                 <param name="out_file" value="png"/>
@@ -360,14 +358,14 @@ sa.pl.regions(
                     <expand macro="render_plot_matching_text"/>
                 </assert_contents>
             </output>
-            <output name="anndata_out" location="https://zenodo.org/records/11260316/files/tl.marker_regions.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
-            <output name="out_png" location="https://zenodo.org/records/11260316/files/tl.marker_regions.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.1"/>
+            <output name="anndata_out" location="https://zenodo.org/records/12800783/files/tl.marker_regions.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
+            <output name="out_png" location="https://zenodo.org/records/12800783/files/tl.marker_regions.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.1"/>
         </test>
         <test expect_num_outputs="4">
             <!-- tl.diff_test single_group -->
             <conditional name="method">
                 <param name="method" value="tl.diff_test"/>
-                <param name="adata" location="https://zenodo.org/records/11260316/files/tl.marker_regions.pbmc_500_chr21.h5ad"/>
+                <param name="adata" location="https://zenodo.org/records/12800783/files/tl.marker_regions.pbmc_500_chr21.h5ad"/>
                 <param name="merged_peaks" location="https://zenodo.org/records/11260316/files/merged_peaks.tabular"/>
                 <param name="group_key" value="leiden"/>
                 <conditional name="compare">
@@ -390,21 +388,21 @@ sa.pl.regions(
                     <has_text_matching expression="group2 = '2'"/>
                 </assert_contents>
             </output>
-            <output name="anndata_out" location="https://zenodo.org/records/11260316/files/tl.diff_test.single_group.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
+            <output name="anndata_out" location="https://zenodo.org/records/12800783/files/tl.diff_test.single_group.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
             <output name="diff_peaks" >
                 <assert_contents>
-                    <has_text_matching expression="chr21:14215000-14220000\t-1.5951.*\t0.0016.*\t0.0563.*"/>
-                    <has_text_matching expression="chr21:17690000-17695000\t2.2792.*\t0.0996.*\t0.2127.*"/>
-                    <has_text_matching expression="chr21:13975000-13980000\t0.5423.*\t0.9829.*\t0.9829.*"/>
+                    <has_text_matching expression="chr21:17512734-17513235\t-4.0297.*\t4.3713.*\t0.0016.*"/>
+                    <has_text_matching expression="chr21:33384757-33385258\t0.278.*\t0.1502.*\t0.2644.*"/>
+                    <has_text_matching expression="chr21:42683799-42684300\t-0.438.*\t0.992.*\t0.992.*"/>
                 </assert_contents>
             </output>
-            <output name="out_png" location="https://zenodo.org/records/11260316/files/tl.diff_test.single_group.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.1"/>
+            <output name="out_png" location="https://zenodo.org/records/12800783/files/tl.diff_test.single_group.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.1"/>
         </test>
         <test expect_num_outputs="4">
             <!-- tl.diff_test background_group -->
             <conditional name="method">
                 <param name="method" value="tl.diff_test"/>
-                <param name="adata" location="https://zenodo.org/records/11260316/files/tl.marker_regions.pbmc_500_chr21.h5ad"/>
+                <param name="adata" location="https://zenodo.org/records/12800783/files/tl.marker_regions.pbmc_500_chr21.h5ad"/>
                 <param name="merged_peaks" location="https://zenodo.org/records/11260316/files/merged_peaks.tabular"/>
                 <param name="group_key" value="leiden"/>
                 <conditional name="compare">
@@ -428,13 +426,15 @@ sa.pl.regions(
                     <has_text_matching expression="group1 = '1'"/>
                 </assert_contents>
             </output>
-            <output name="anndata_out" location="https://zenodo.org/records/11260316/files/tl.diff_test.background_group.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
+            <output name="anndata_out" location="https://zenodo.org/records/12800783/files/tl.diff_test.background_group.pbmc_500_chr21.h5ad" ftype="h5ad" compare="sim_size" delta_frac="0.1" />
             <output name="diff_peaks" >
                 <assert_contents>
-                    <has_text_matching expression="chr21:13880000-13885000"/>
+                    <has_text_matching expression="chr21:5123633-5124134"/>
+                    <has_text_matching expression="chr21:32403055-32403556"/>
+                    <has_text_matching expression="chr21:36156247-36156748"/>
                 </assert_contents>
             </output>
-            <output name="out_png" location="https://zenodo.org/records/11260316/files/tl.diff_test.background_group.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.5"/>
+            <output name="out_png" location="https://zenodo.org/records/12800783/files/tl.diff_test.background_group.pbmc_500_chr21.png" ftype="png" compare="sim_size" delta_frac="0.5"/>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

Because of [this condition](https://github.com/galaxyproject/tools-iuc/blob/main/tools/snapatac2/peaks_and_motif_analysis.xml#L155) (which was accidentally added in the previous update) the updated anndata object is not written to the history. Fixed this bug and updated the test data. All the other tests that use the subsequent test data are also updated.
