### PR TITLE
Revert "ci.yaml and pr.yaml update"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -290,7 +290,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test


### PR DESCRIPTION
Reverts galaxyproject/tools-iuc#6218

With planemo 0.75.25 we should be getting pillow and tifffile, making this unnecessary.