### PR TITLE
Update LUCA version to be consistent with OMArk version

### DIFF
--- a/data_managers/data_manager_omamer/data_manager/omamer.py
+++ b/data_managers/data_manager_omamer/data_manager/omamer.py
@@ -15,7 +15,7 @@ OMAMER_DATASETS = {
     "Primates": "Primates-v2.0.0.h5",
     "Viridiplantae": "Viridiplantae-v2.0.0.h5",
     "Metazoa": "Metazoa-v2.0.0.h5",
-    "LUCA": "LUCA-v0.2.5.h5",
+    "LUCA": "LUCA-v2.0.0.h5",
 }
 
 DEFAULT_OUTPUT_DIR = "database_omamer"


### PR DESCRIPTION
Currently tool crashes if LUCA database is chosen due to clashing major versions of OMAmer and LUCA database

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
