### PR TITLE
Updating LUCA database version in Omamer data manager

### DIFF
--- a/data_managers/data_manager_omamer/data_manager/macros.xml
+++ b/data_managers/data_manager_omamer/data_manager/macros.xml
@@ -1,7 +1,7 @@
 
 <macros>
     <token name="@TOOL_VERSION@">2.0.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
 
     <xml name="requirements">
         <requirements>

--- a/data_managers/data_manager_omamer/data_manager/omamer.py
+++ b/data_managers/data_manager_omamer/data_manager/omamer.py
@@ -12,11 +12,17 @@ OMAMER_DATASETS_URL = "https://omabrowser.org/All/{dataset}"
 
 # List of OMAmer data sets with versions
 OMAMER_DATASETS = {
-    "Primates": "Primates-v2.0.0.h5",
-    "Viridiplantae": "Viridiplantae-v2.0.0.h5",
-    "Metazoa": "Metazoa-v2.0.0.h5",
+    "Primates": "Primates.h5",
+    "Primates_v2.0.0": "Primates-v2.0.0.h5",
+    "Viridiplantae": "Viridiplantae.h5",
+    "Viridiplantae_v2.0.0": "Viridiplantae-v2.0.0.h5",
+    "Metazoa": "Metazoa.h5",
+    "Metazoa_v2.0.0": "Metazoa-v2.0.0.h5",
+    "LUCA": "LUCA.h5",
     "LUCA_v0.2.5": "LUCA-v0.2.5.h5",
     "LUCA_v2.0.0": "LUCA-v2.0.0.h5",
+    "Saccharomyceta": "Saccharomyceta.h5",
+    "Homininae": "Homininae.h5",
 }
 
 DEFAULT_OUTPUT_DIR = "database_omamer"

--- a/data_managers/data_manager_omamer/data_manager/omamer.py
+++ b/data_managers/data_manager_omamer/data_manager/omamer.py
@@ -12,13 +12,9 @@ OMAMER_DATASETS_URL = "https://omabrowser.org/All/{dataset}"
 
 # List of OMAmer data sets with versions
 OMAMER_DATASETS = {
-    "Primates": "Primates.h5",
     "Primates_v2.0.0": "Primates-v2.0.0.h5",
-    "Viridiplantae": "Viridiplantae.h5",
     "Viridiplantae_v2.0.0": "Viridiplantae-v2.0.0.h5",
-    "Metazoa": "Metazoa.h5",
     "Metazoa_v2.0.0": "Metazoa-v2.0.0.h5",
-    "LUCA": "LUCA.h5",
     "LUCA_v0.2.5": "LUCA-v0.2.5.h5",
     "LUCA_v2.0.0": "LUCA-v2.0.0.h5",
     "Saccharomyceta": "Saccharomyceta.h5",

--- a/data_managers/data_manager_omamer/data_manager/omamer.py
+++ b/data_managers/data_manager_omamer/data_manager/omamer.py
@@ -15,7 +15,8 @@ OMAMER_DATASETS = {
     "Primates": "Primates-v2.0.0.h5",
     "Viridiplantae": "Viridiplantae-v2.0.0.h5",
     "Metazoa": "Metazoa-v2.0.0.h5",
-    "LUCA": "LUCA-v0.2.5.h5",
+    "LUCA_v0.2.5": "LUCA-v0.2.5.h5",
+    "LUCA_v2.0.0": "LUCA-v2.0.0.h5",
 }
 
 DEFAULT_OUTPUT_DIR = "database_omamer"

--- a/data_managers/data_manager_omamer/data_manager/omamer.xml
+++ b/data_managers/data_manager_omamer/data_manager/omamer.xml
@@ -12,13 +12,9 @@
     <inputs>
         <param name="output_dir" type="text" label="Output Directory" value=""/>
         <param name="name" type="select" label="Database">
-            <option value="Primates">Primates</option>
             <option value="Primates_v2.0.0">Primates_v2.0.0</option>
-            <option value="Viridiplantae">Viridiplantae</option>
             <option value="Viridiplantae_v2.0.0">Viridiplantae_v2.0.0</option>
-            <option value="Metazoa">Metazoa</option>
             <option value="Metazoa_v2.0.0">Metazoa_v2.0.0</option>
-            <option value="LUCA">LUCA</option>
             <option value="LUCA_v0.2.5">LUCA_v0.2.5</option>
             <option value="LUCA_v2.0.0">LUCA_v2.0.0</option>
             <option value="Saccharomyceta">Saccharomyceta</option>

--- a/data_managers/data_manager_omamer/data_manager/omamer.xml
+++ b/data_managers/data_manager_omamer/data_manager/omamer.xml
@@ -33,7 +33,7 @@
     <tests>
         <test>
             <param name="output_dir" value="test_galaxy"/>
-            <param name="name" value="Primates"/>
+            <param name="name" value="Primates_v2.0.0"/>
             <output name="output_file" file="out.json"/>
         </test>
     </tests>

--- a/data_managers/data_manager_omamer/data_manager/omamer.xml
+++ b/data_managers/data_manager_omamer/data_manager/omamer.xml
@@ -13,10 +13,16 @@
         <param name="output_dir" type="text" label="Output Directory" value=""/>
         <param name="name" type="select" label="Database">
             <option value="Primates">Primates</option>
+            <option value="Primates_v2.0.0">Primates_v2.0.0</option>
             <option value="Viridiplantae">Viridiplantae</option>
+            <option value="Viridiplantae_v2.0.0">Viridiplantae_v2.0.0</option>
             <option value="Metazoa">Metazoa</option>
+            <option value="Metazoa_v2.0.0">Metazoa_v2.0.0</option>
+            <option value="LUCA">LUCA</option>
             <option value="LUCA_v0.2.5">LUCA_v0.2.5</option>
             <option value="LUCA_v2.0.0">LUCA_v2.0.0</option>
+            <option value="Saccharomyceta">Saccharomyceta</option>
+            <option value="Homininae">Homininae</option>
         </param>
     </inputs>
 

--- a/data_managers/data_manager_omamer/data_manager/omamer.xml
+++ b/data_managers/data_manager_omamer/data_manager/omamer.xml
@@ -15,7 +15,8 @@
             <option value="Primates">Primates</option>
             <option value="Viridiplantae">Viridiplantae</option>
             <option value="Metazoa">Metazoa</option>
-            <option value="LUCA">LUCA</option>
+            <option value="LUCA_v0.2.5">LUCA_v0.2.5</option>
+            <option value="LUCA_v2.0.0">LUCA_v2.0.0</option>
         </param>
     </inputs>
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Based on the LUCA database update request by @tbrown91 for OMArk, this PR concerns with updating the data manager to install the latest version of the OMark databases while retaining the older databases version. 


