### PR TITLE
Fix bcftools cheetah section variable name

### DIFF
--- a/tools/bcftools/bcftools_call.xml
+++ b/tools/bcftools/bcftools_call.xml
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy4" profile="@PROFILE@">
+<tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy5" profile="@PROFILE@">
     <description>SNP/indel variant calling from VCF/BCF</description>
     <macros>
         <token name="@EXECUTABLE@">call</token>

--- a/tools/bcftools/bcftools_cnv.xml
+++ b/tools/bcftools/bcftools_cnv.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Call copy number variation from VCF B-allele frequency (BAF) and Log R Ratio intensity (LRR) values</description>
     <macros>

--- a/tools/bcftools/bcftools_convert_from_vcf.xml
+++ b/tools/bcftools/bcftools_convert_from_vcf.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@ from vcf" id="bcftools_@EXECUTABLE@_from_vcf" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Converts VCF/BCF to IMPUTE2/SHAPEIT formats</description>
     <macros>

--- a/tools/bcftools/bcftools_csq.xml
+++ b/tools/bcftools/bcftools_csq.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Haplotype aware consequence predictor</description>
     <macros>

--- a/tools/bcftools/bcftools_filter.xml
+++ b/tools/bcftools/bcftools_filter.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Apply fixed-threshold filters</description>
     <macros>

--- a/tools/bcftools/bcftools_gtcheck.xml
+++ b/tools/bcftools/bcftools_gtcheck.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Check sample identity</description>
     <macros>

--- a/tools/bcftools/bcftools_isec.xml
+++ b/tools/bcftools/bcftools_isec.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Create intersections, unions and complements of VCF files</description>
     <macros>

--- a/tools/bcftools/bcftools_mpileup.xml
+++ b/tools/bcftools/bcftools_mpileup.xml
@@ -207,7 +207,7 @@ ${pasted_data}
                     <options from_data_table="fasta_indexes"/>
                 </param>
             </when>
-            <when value="history"> 
+            <when value="history">
                 <param name="ref_file" type="data" format="fasta" label="Genome Reference" />
             </when>
             <when value="none"/>

--- a/tools/bcftools/bcftools_norm.xml
+++ b/tools/bcftools/bcftools_norm.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Left-align and normalize indels; check if REF alleles match the reference; split multiallelic sites into multiple rows; recover multiallelics from multiple rows</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_color_chrs.xml
+++ b/tools/bcftools/bcftools_plugin_color_chrs.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Color shared chromosomal segments, requires phased GTs</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_counts.xml
+++ b/tools/bcftools/bcftools_plugin_counts.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin  counts number of samples, SNPs, INDELs, MNPs and total sites</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_dosage.xml
+++ b/tools/bcftools/bcftools_plugin_dosage.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin genotype dosage</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_fill_an_ac.xml
+++ b/tools/bcftools/bcftools_plugin_fill_an_ac.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Fill INFO fields AN and AC</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_fill_tags.xml
+++ b/tools/bcftools/bcftools_plugin_fill_tags.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Set INFO tags AF, AN, AC, AC_Hom, AC_Het, AC_Hemi</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_fixploidy.xml
+++ b/tools/bcftools/bcftools_plugin_fixploidy.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin  Fix ploidy</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_frameshifts.xml
+++ b/tools/bcftools/bcftools_plugin_frameshifts.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Annotate frameshift indels</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_impute_info.xml
+++ b/tools/bcftools/bcftools_plugin_impute_info.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Add imputation information metrics to the INFO field</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_mendelian.xml
+++ b/tools/bcftools/bcftools_plugin_mendelian.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Count Mendelian consistent / inconsistent genotypes</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_missing2ref.xml
+++ b/tools/bcftools/bcftools_plugin_missing2ref.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Set missing genotypes</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_setgt.xml
+++ b/tools/bcftools/bcftools_plugin_setgt.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Sets genotypes</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_split_vep.xml
+++ b/tools/bcftools/bcftools_plugin_split_vep.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Extracts fields from structured annotations such as INFO/CSQ</description>
     <macros>

--- a/tools/bcftools/bcftools_plugin_tag2tag.xml
+++ b/tools/bcftools/bcftools_plugin_tag2tag.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_plugin_@PLUGIN_ID@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>plugin Convert between similar tags, such as GL and GP</description>
     <macros>

--- a/tools/bcftools/bcftools_query.xml
+++ b/tools/bcftools/bcftools_query.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Extracts fields from VCF/BCF file and prints them in user-defined format</description>
     <macros>

--- a/tools/bcftools/bcftools_roh.xml
+++ b/tools/bcftools/bcftools_roh.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>HMM model for detecting runs of homo/autozygosity</description>
     <macros>

--- a/tools/bcftools/bcftools_stats.xml
+++ b/tools/bcftools/bcftools_stats.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Parses VCF or BCF and produces stats which can be plotted using plot-vcfstats</description>
     <macros>

--- a/tools/bcftools/bcftools_view.xml
+++ b/tools/bcftools/bcftools_view.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <tool name="bcftools @EXECUTABLE@" id="bcftools_@EXECUTABLE@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>VCF/BCF conversion, view, subset and filter VCF/BCF files</description>
     <macros>

--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -436,7 +436,7 @@ $vcfs_list_file
     bgzip -c "$section.targets.targets_file" > $targets_path &&
     tabix -s 1 -b 2 -e 2 $targets_path &&
   #end if
-#elif $tgts_sec.targets_file:
+#elif $section.targets_file:
   #set $targets_path = 'targets_file.tab.gz'
   bgzip -c "$section.targets_file" > $targets_path &&
   tabix -s 1 -b 2 -e 2 $targets_path &&

--- a/tools/bcftools/macros.xml
+++ b/tools/bcftools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
   <token name="@TOOL_VERSION@">1.15.1</token>
-  <token name="@VERSION_SUFFIX@">3</token>
+  <token name="@VERSION_SUFFIX@">4</token>
   <token name="@PROFILE@">20.01</token>
   <xml name="bio_tools">
       <xrefs>


### PR DESCRIPTION
There's no tgts_secion defined anywhere in the bcftools wrappers. This fixed https://github.com/galaxyproject/tools-iuc/issues/6177#issuecomment-2255836399

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
