### PR TITLE
Bump gemini_load.xml wrapper version

### DIFF
--- a/tools/gemini/gemini_load.xml
+++ b/tools/gemini/gemini_load.xml
@@ -1,4 +1,4 @@
-<tool id="gemini_@BINARY@" name="GEMINI @BINARY@" version="@VERSION@+galaxy2">
+<tool id="gemini_@BINARY@" name="GEMINI @BINARY@" version="@VERSION@+galaxy3">
     <description>Loading a VCF file into GEMINI</description>
     <expand macro="bio_tools"/>
     <macros>


### PR DESCRIPTION
It looks like the last wrapper update to this tool did not bump the version as it should have.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
