### PR TITLE
Query tabular: add ability to inject variables

### DIFF
--- a/tools/query_tabular/macros.xml
+++ b/tools/query_tabular/macros.xml
@@ -131,6 +131,10 @@
             <validator type="regex" message="">(?ims)^\s*select\s+.*\s+from\s+.*$</validator>
         </param>
   </xml>
+  <xml name="variable_input">
+    <param name="variable" type="text" label="Name of the variable to introduce"/>
+    <param name="var_value" type="text" label="Value for the variable"/>
+  </xml>
   <xml name="macro_line_filters">
                 <repeat name="linefilters" title="Filter Tabular Input Lines">
                     <conditional name="filter">

--- a/tools/query_tabular/query_tabular.xml
+++ b/tools/query_tabular/query_tabular.xml
@@ -98,6 +98,9 @@ $sqlquery
 #for $i,$query in enumerate($addqueries.queries):
     #set $jquery = dict()
     #set $jquery['query'] = str($query.sqlquery)
+    #for $v,$var_i in enumerate($addvars.vars):
+        #set $jquery['query'] = $jquery['query'].replace('--' + str($var_i.variable) + '--', str($var_i.var_value))
+    #end for
     #set $jquery['result_file'] = 'results' + str($i) + '.tsv'
     #if $query.query_result.header == 'yes':
         #set $header_prefix = ''
@@ -173,6 +176,11 @@ $sqlquery
                 <expand macro="result_results_header_line" />
             </repeat>
         </section>
+        <section name="addvars" expanded="false" title="Variables" help="Variables added here will be replaced in the queries, where you insert --variable_name--.">
+            <repeat name="vars" title="Variable" min="0">
+                <expand macro="variable_input"/>
+            </repeat> 
+        </section>
     </inputs>
     <outputs>
         <data format="sqlite" name="sqlitedb" label="sqlite db of ${on_string}">
@@ -224,7 +232,13 @@ $sqlquery
                     <param name="col_names" value="CustomerID,Date,SaleAmount"/>
                 </section>
             </repeat>
-            <param name="sqlquery" value="SELECT FirstName,LastName,sum(SaleAmount) as &quot;TotalSales&quot; FROM customers join sales on customers.CustomerID = sales.CustomerID GROUP BY customers.CustomerID ORDER BY TotalSales DESC"/>
+            <section name="addvars">
+                <repeat name="vars">
+                    <param name="variable" value="FieldToUse"/>
+                    <param name="var_value" value="LastName"/>
+                </repeat>
+            </section>
+            <param name="sqlquery" value="SELECT FirstName, --FieldToUse--, sum(SaleAmount) as &quot;TotalSales&quot; FROM customers join sales on customers.CustomerID = sales.CustomerID GROUP BY customers.CustomerID ORDER BY TotalSales DESC"/>
             <output name="output" file="sales_results.tsv"/>
         </test>
 
@@ -674,6 +688,12 @@ Query Tabular
     In general, specifiy an index for table columns used in joins with other tables, 
     or on columns used in SQL query WHERE clauses or in GROUP BY clauses.
 
+**Variables**
+
+  Allows the user to introduce parameter variables (useful for workflow runs). Once 
+  a variable is created in the Variables section, say for instance a variable named
+  FieldToUse with a value 'LastName', then any appeareance of %%FieldToUse%% in any
+  of the queries will be replaced with the value LastName.
 
 **Outputs**
 

--- a/tools/query_tabular/query_tabular.xml
+++ b/tools/query_tabular/query_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="query_tabular" name="Query Tabular" version="3.3.2">
+<tool id="query_tabular" name="Query Tabular" version="3.3.2+galaxy1">
     <description>using sqlite sql</description>
 
     <macros>


### PR DESCRIPTION
Sometimes we have cases where we want to influence the query with some variables, this tries to achieve that, but I'm not sure if what I'm doing is somehow problematic for cheetah, as the error I'm getting is a bit hard to get:

```
Job in error state.. tool_id: query_tabular, exit_code: 1, stderr: JSON: {'tables': [{'file_path': '/tmp/tmpluhsl53u/files/9/d/0/dataset_9d037b44-5238-416a-a22b-d75ab0c83568.dat', 'table_name': 'customers', 'column_names': 'CustomerID,FirstName,LastName,Email,DOB,Phone', 'filters': [{'filter': 'regex', 'pattern': '^(#).*$', 'action': 'exclude_match'}]}, {'file_path': '/tmp/tmpluhsl53u/files/5/1/6/dataset_5161c295-48ea-4496-a202-efb755b8cb37.dat', 'table_name': 'sales', 'column_names': 'CustomerID,Date,SaleAmount', 'filters': [{'filter': 'regex', 'pattern': '^(#).*$', 'action': 'exclude_match'}]}]}
Error: incomplete input
.
```

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
