### PR TITLE
Correct PEAR --empirical-freqs param

### DIFF
--- a/tools/pear/pear.xml
+++ b/tools/pear/pear.xml
@@ -2,7 +2,7 @@
     <description>Paired-End read merger</description>
     <macros>
         <token name="@TOOL_VERSION@">0.9.6</token>
-        <token name="@VERSION_SUFFIX@">3</token>
+        <token name="@VERSION_SUFFIX@">4</token>
         <xml name="format_action">
             <actions>
                 <conditional name="library.type">
@@ -59,10 +59,10 @@
         --quality-theshold $quality_threshold
         --max-uncalled-base $max_uncalled_base
         --test-method $test_method
-        --empirical-freqs $empirical_freqs
         --threads "\${GALAXY_SLOTS:-8}"
         --score-method $score_method
         --cap $cap
+        $empirical_freqs
         $nbase
 ]]>
     </command>

--- a/tools/pear/pear.xml
+++ b/tools/pear/pear.xml
@@ -93,7 +93,7 @@
             <option value="1" selected="true">Given the minimum allowed overlap, test using the highest OES (1)</option>
             <option value="2">Use the acceptance probability (2)</option>
         </param>
-        <param name="empirical_freqs" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Disable empirical base frequencies" help="(--empirical-freqs)"/>
+        <param name="empirical_freqs" type="boolean" truevalue="--empirical-freqs" falsevalue="" checked="false" label="Disable empirical base frequencies" help="(--empirical-freqs)"/>
         <param name="nbase" type="boolean" truevalue="--nbase" falsevalue="" checked="false" label="Use N base if uncertain" help="When  merging a base-pair that consists of two non-equal bases out of which none is degenerate, set the merged base to N and use the highest quality score of the two bases. (--nbase)"/>
         <param name="score_method" type="select" label="Scoring method" help="(--score-method)">
             <option value="1">OES with +1 for match and -1 for mismatch</option>


### PR DESCRIPTION
Changes use of --empirical-freqs so that flag (in full, for clarity and avoiding misusing scoring method) is only included in the command if user chooses 'disable empirical frequencies==YES', restoring [default behaviour](https://cme.h-its.org/exelixis/web/software/pear/doc.html). Bumped version suffix.

FOR CONTRIBUTOR:
* [ x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
