### PR TITLE
Bug fix: update all_fasta columns in clair3 repo

### DIFF
--- a/tools/clair3/clair3.xml
+++ b/tools/clair3/clair3.xml
@@ -2,7 +2,7 @@
     <description>germline small variant caller for long-reads</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.8</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type='bio.tools'>clair3</xref>

--- a/tools/clair3/test-data/all_fasta.loc
+++ b/tools/clair3/test-data/all_fasta.loc
@@ -4,7 +4,7 @@
 #all_fasta.loc. This file has the format (white space characters are
 #TAB characters):
 #
-#<unique_build_id>	<display_name>	<file_path>
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
 #
 #So, all_fasta.loc could look something like this:
-test1	"Test Genome"	${__HERE__}/test1.fasta
+test1	test1	"Test Genome"	${__HERE__}/test1.fasta

--- a/tools/clair3/tool-data/all_fasta.loc.sample
+++ b/tools/clair3/tool-data/all_fasta.loc.sample
@@ -4,7 +4,7 @@
 #all_fasta.loc. This file has the format (white space characters are
 #TAB characters):
 #
-#<unique_build_id>	<display_name>	<file_path>
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
 #
 #So, all_fasta.loc could look something like this:
-#test1	Test-Genome	./test-data/test1.fa
+#test1	test1	Test-Genome	./test-data/test1.fa

--- a/tools/clair3/tool_data_table_conf.xml.sample
+++ b/tools/clair3/tool_data_table_conf.xml.sample
@@ -6,7 +6,7 @@
         <file path="tool-data/model.loc" />
     </table>
     <table name="all_fasta" comment_char="#">
-        <columns>value, name, path</columns>
+        <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>
 </tables>

--- a/tools/clair3/tool_data_table_conf.xml.test
+++ b/tools/clair3/tool_data_table_conf.xml.test
@@ -7,7 +7,7 @@
     </table>
     <!-- Locations of reference genome files in fasta format -->
     <table name="all_fasta" comment_char="#">
-        <columns>value, name, path</columns>
+        <columns>value, dbkey, name, path</columns>
         <file path="${__HERE__}/test-data/all_fasta.loc" />
     </table>
 </tables>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Update all_fasta files in clair3 repo to fix bug described in this issue: https://github.com/galaxyproject/tools-iuc/issues/6211

Should I bump the VERSION_SUFFIX for this change?