### PR TITLE
Sniffles: Add tool_data_table_conf file and tool-data loc sample file

### DIFF
--- a/tools/sniffles/sniffles.xml
+++ b/tools/sniffles/sniffles.xml
@@ -1,4 +1,4 @@
-<tool id="sniffles" name="sniffles" version="@TOOL_VERSION@+galaxy1" profile="23.0">
+<tool id="sniffles" name="sniffles" version="@TOOL_VERSION@+galaxy0" profile="23.0">
     <description>Structural variation caller using third generation sequencing</description>
     <macros>
         <token name="@TOOL_VERSION@">2.4</token>

--- a/tools/sniffles/sniffles.xml
+++ b/tools/sniffles/sniffles.xml
@@ -1,4 +1,4 @@
-<tool id="sniffles" name="sniffles" version="@TOOL_VERSION@+galaxy0" profile="23.0">
+<tool id="sniffles" name="sniffles" version="@TOOL_VERSION@+galaxy1" profile="23.0">
     <description>Structural variation caller using third generation sequencing</description>
     <macros>
         <token name="@TOOL_VERSION@">2.4</token>

--- a/tools/sniffles/tool-data/all_fasta.loc.sample
+++ b/tools/sniffles/tool-data/all_fasta.loc.sample
@@ -1,0 +1,10 @@
+#This file lists the locations and dbkeys of all the fasta files
+#under the "genome" directory (a directory that contains a directory
+#for each build). The script extract_fasta.py will generate the file
+#all_fasta.loc. This file has the format (white space characters are
+#TAB characters):
+#
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
+#
+#So, all_fasta.loc could look something like this:
+#test1	test1	Test-Genome	./test-data/test1.fa

--- a/tools/sniffles/tool_data_table_conf.xml.sample
+++ b/tools/sniffles/tool_data_table_conf.xml.sample
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<tables>
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+</tables>

--- a/tools/sniffles/tool_data_table_conf.xml.test
+++ b/tools/sniffles/tool_data_table_conf.xml.test
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<tables>
+    <!-- Locations of reference genome files in fasta format -->
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="${__HERE__}/test-data/all_fasta.loc" />
+    </table>
+</tables>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

After #6328, there seem to be issue with this tool. It is invalid on the ToolShed: https://toolshed.g2.bx.psu.edu/repository?repository_id=fd2e07886563dc35&changeset_revision=3f6f028f418f

```
sniffles.xml - This file requires an entry in the tool_data_table_conf.xml file. Upload a file named tool_data_table_conf.xml.sample to the repository that includes the required entry to correct this error.
```

Hopefully, this PR will fix the issue
