### PR TITLE
linter fixes for snpeff

### DIFF
--- a/tool_collections/snpeff/.lint_skip
+++ b/tool_collections/snpeff/.lint_skip
@@ -1,3 +1,0 @@
-InputsDataOptionsFilterAttribFiltersType
-InputsDataOptionsFiltersRef
-TestsExpectNumOutputs

--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -159,9 +159,6 @@
             </when>
             <when value="history">
                 <param name="snpeff_db" type="data" format="snpeffdb" label="@SNPEFF_VERSION@ Genome Data">
-                    <options options_filter_attribute="metadata.snpeff_version" >
-                        <filter type="add_value" value="@SNPEFF_VERSION@" />
-                    </options>
                     <validator type="expression" message="This version of SnpEff will only work with @SNPEFF_VERSION@ genome databases">value is not None and value.metadata.snpeff_version == "@SNPEFF_VERSION@"</validator>
                 </param>
                 <section name="reg_section" expanded="false" title="Regulation options">
@@ -181,9 +178,6 @@
             </when>
             <when value="custom">
                 <param name="snpeff_db" type="data" format="snpeffdb" label="@SNPEFF_VERSION@ Genome Data">
-                    <options options_filter_attribute="metadata.snpeff_version" >
-                        <filter type="add_value" value="@SNPEFF_VERSION@" />
-                    </options>
                     <validator type="expression" message="This version of SnpEff will only work with @SNPEFF_VERSION@ genome databases">value is not None and value.metadata.snpeff_version == "@SNPEFF_VERSION@"</validator>
                 </param>
                 <param name="codon_table" type="select" label="Select genetic code for this sequence" help="If this sequence uses non-standard genetic code, select one from these options">
@@ -364,30 +358,35 @@
             </change_format>
         </data>
         <data name="statsFile" format="html" label="${tool.name} on ${on_string} - HTML stats">
-            <filter>generate_stats == True</filter>
+            <filter>generate_stats</filter>
         </data>
         <data name="csvFile" format="csv" label="${tool.name} on ${on_string} - CSV stats">
-            <filter>csvStats == True</filter>
+            <filter>csvStats</filter>
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="input" ftype="vcf" value="input.vcf"/>
             <param name="inputFormat" value="vcf"/>
             <param name="outputFormat" value="vcf"/>
             <param name="genomeSrc" value="named"/>
             <param name="genome_version" value="ebola_zaire"/>
             <param name="udLength" value="0"/>
-            <param name="generate_stats" value="false"/>
+            <param name="generate_stats" value="true"/>
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text_matching expression="KJ660346\t572\t.*missense_variant" />
                     <has_text_matching expression="KJ660346\t1024\t.*synonymous_variant" />
                 </assert_contents>
             </output>
+            <output name="statsFile">
+                <assert_contents>
+                    <has_text text="&lt;b&gt;"/>
+                </assert_contents>
+            </output>
         </test>
         <!-- Test interval option-->
-        <test>
+        <test expect_num_outputs="2">
             <param name="input" ftype="vcf" value="input.vcf"/>
             <param name="inputFormat" value="vcf"/>
             <param name="outputFormat" value="vcf"/>
@@ -396,10 +395,17 @@
             <param name="genome_version" value="ebola_zaire"/>
             <param name="udLength" value="0"/>
             <param name="generate_stats" value="false"/>
+            <param name="csvStats" value="true"/>
             <output name="snpeff_output">
                 <assert_contents>
                     <has_text_matching expression="KJ660346\t572\t.*missense_variant" />
                     <has_text_matching expression="KJ660346\t1024\t.*synonymous_variant" />
+                </assert_contents>
+            </output>
+            <output name="csvFile">
+                <assert_contents>
+                    <has_n_lines n="185"/>
+                    <has_n_columns n="1" sep=","/>
                 </assert_contents>
             </output>
         </test>

--- a/tool_collections/snpeff/snpEff_create_db.xml
+++ b/tool_collections/snpeff/snpEff_create_db.xml
@@ -124,7 +124,7 @@
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gb"/>
             <param name="input" value="pBR322.gbk" />
@@ -135,7 +135,7 @@
             </output>
             <output name="output_fasta" value="pBR322_test1.fna"/>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gb"/>
             <param name="input" value="pBR322.gbk.gz" />
@@ -146,7 +146,7 @@
             </output>
             <output name="output_fasta" value="pBR322_test1.fna"/>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gff"/>
             <param name="reference_source_selector" value="history"/>
@@ -158,7 +158,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="genome_version" value="pBR322"/>
             <param name="input_type_selector" value="gff"/>
             <param name="reference_source_selector" value="history"/>
@@ -170,7 +170,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="genome_version" value="Saccharomyces_mito"/>
             <param name="input_type_selector" value="gtf"/>
             <param name="reference_source_selector" value="history"/>

--- a/tool_collections/snpeff/snpeff_get_chr_names.xml
+++ b/tool_collections/snpeff/snpeff_get_chr_names.xml
@@ -50,9 +50,6 @@
             <when value="history">
                 <param name="snpeff_db" type="data" format="snpeffdb" label="@SNPEFF_VERSION@ Genome Data">
                     <help>This can only be used on databases in your history that were downloaded using the snpEff download tool.</help>
-                    <options options_filter_attribute="metadata.snpeff_version" >
-                        <filter type="add_value" value="@SNPEFF_VERSION@" />
-                    </options>
                     <validator type="expression" message="This version of SnpEff will only work with @SNPEFF_VERSION@ genome databases">value is not None and value.metadata.snpeff_version == "@SNPEFF_VERSION@"</validator>
                 </param>
             </when>
@@ -65,9 +62,6 @@
             <when value="custom">
                 <param name="snpeff_db" type="data" format="snpeffdb" label="@SNPEFF_VERSION@ Genome Data">
                     <help>This can only be used on databases in your history that were created using the snpEff build tool.</help>
-                    <options options_filter_attribute="metadata.snpeff_version" >
-                        <filter type="add_value" value="@SNPEFF_VERSION@" />
-                    </options>
                     <validator type="expression" message="This version of SnpEff will only work with @SNPEFF_VERSION@ genome databases">value is not None and value.metadata.snpeff_version == "@SNPEFF_VERSION@"</validator>
                 </param>
             </when>


### PR DESCRIPTION
- remove deprecated and redundant filter_options_attribute
- add expect_num_outputs (and improve tests)

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
