### PR TITLE
linter fixes for fasttree

### DIFF
--- a/tools/fasttree/.lint_skip
+++ b/tools/fasttree/.lint_skip
@@ -1,1 +1,2 @@
+# the bool is used in a filter and an if statement of the command block which works
 InputsBoolDistinctValues

--- a/tools/fasttree/.lint_skip
+++ b/tools/fasttree/.lint_skip
@@ -1,4 +1,1 @@
 InputsBoolDistinctValues
-InputsNameRedundantArgument
-TestsExpectNumOutputs
-XMLOrder

--- a/tools/fasttree/fasttree.xml
+++ b/tools/fasttree/fasttree.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <tool id="fasttree" name="FASTTREE" version="@VERSION@+galaxy2" profile="18.01">
     <description>build maximum-likelihood phylogenetic trees</description>
-    <xrefs>
-        <xref type="bio.tools">fasttree</xref>
-    </xrefs>
     <macros>
         <token name="@VERSION@">2.1.10</token>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">fasttree</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="@VERSION@">fasttree</requirement>
     </requirements>
@@ -48,7 +48,7 @@ $model_selector.model
 #if $save_logfile:
     2> '$log'
 #end if
-
+&& echo $save_logfile
 ]]>
     </command>
     <inputs>
@@ -59,7 +59,7 @@ $model_selector.model
             </param>
             <when value="fasta">
                 <param format="fasta" name="input" type="data" multiple="false" label="FASTA file"/>
-                <param name="quote" argument="-quote" type="boolean" truevalue="-quote" falsevalue="" checked="false" label="Allow spaces and other restricted characters (but not ') in sequence and quote names in the output tree." help="This tool is only available for fasta input only; FastTree will not be able to read these trees back in." />
+                <param argument="-quote" type="boolean" truevalue="-quote" falsevalue="" checked="false" label="Allow spaces and other restricted characters (but not ') in sequence and quote names in the output tree." help="This tool is only available for fasta input only; FastTree will not be able to read these trees back in." />
                 <conditional name="intree_selector">
                     <param name="intree_format" type="select" label="Set starting tree(s)">
                         <option value="none" selected="true">No starting trees</option>
@@ -134,9 +134,9 @@ $model_selector.model
                 <param value="gamma" argument="-gamma" type="boolean" truevalue="-gamma" falsevalue="" checked="false" label="Use Gamma20" help="After optimizing the tree under the CAT approximation, rescale the lengths to optimize the Gamma20 likelihood." />
                 <param value="nosupport" argument="-nosupport" type="boolean" truevalue="-nosupport" falsevalue="" checked="false" label="Eliminates the support value computation. Support value computation is not recommended for wide alignments."/>
                 <param name="likelihood" argument="-noml" type="boolean" truevalue="-noml" falsevalue="" checked="false" label = "Turn off maximum-likelihood." />
-                <param name="fastest" argument="-fastest" type="boolean" truevalue="-fastest" falsevalue="" checked="false" label="Speed up the neighbor joining phase and reduce memory usage (recommended for >50,000 sequences)" />
-                <param name="pseudo" argument="-pseudo" type="boolean" truevalue="-pseudo" falsevalue="" checked="false" label="Use pseudocounts" help="Recommended for highly gapped/fragmentary sequences." />
-                <param name="mllen" argument="-mllen" type="boolean" truevalue="-mllen" falsevalue="" checked="false" label="Optimize branch lengths without ML NNIs." />
+                <param argument="-fastest" type="boolean" truevalue="-fastest" falsevalue="" checked="false" label="Speed up the neighbor joining phase and reduce memory usage (recommended for >50,000 sequences)" />
+                <param argument="-pseudo" type="boolean" truevalue="-pseudo" falsevalue="" checked="false" label="Use pseudocounts" help="Recommended for highly gapped/fragmentary sequences." />
+                <param argument="-mllen" type="boolean" truevalue="-mllen" falsevalue="" checked="false" label="Optimize branch lengths without ML NNIs." />
             </when>
         </conditional>
     </inputs>
@@ -147,7 +147,7 @@ $model_selector.model
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="select_format" value="fasta" />
             <param name="model" value="" />
             <param name="input" value="aligned.fasta" />

--- a/tools/fasttree/fasttree.xml
+++ b/tools/fasttree/fasttree.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<tool id="fasttree" name="FASTTREE" version="@VERSION@+galaxy2" profile="18.01">
+<tool id="fasttree" name="FASTTREE" version="@VERSION@+galaxy3" profile="23.1">
     <description>build maximum-likelihood phylogenetic trees</description>
     <macros>
         <token name="@VERSION@">2.1.10</token>
@@ -48,7 +47,6 @@ $model_selector.model
 #if $save_logfile:
     2> '$log'
 #end if
-&& echo $save_logfile
 ]]>
     </command>
     <inputs>


### PR DESCRIPTION
Leaving the `InputsBoolDistinctValues` skip: the boolean has no `truevalue` and `falsevalue`. It's used in a `filter` and an `if` statement of the command block .. and this works. 

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
