### PR TITLE
Scanpy add fa2 requirement and fix some bugs

### DIFF
--- a/tools/scanpy/cluster_reduce_dimension.xml
+++ b/tools/scanpy/cluster_reduce_dimension.xml
@@ -224,7 +224,7 @@ sc.tl.embedding_density(
 #end if
 
 @CMD_ANNDATA_WRITE_OUTPUTS@
-        ]]>     
+        ]]>
         </configfile>
     </configfiles>
     <inputs>
@@ -479,7 +479,7 @@ sc.tl.embedding_density(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 5 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -501,7 +501,7 @@ sc.tl.embedding_density(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 6 -->
         <test expect_num_outputs="2">
             <param name="adata" value="krumsiek11.h5ad"/>
@@ -529,7 +529,7 @@ sc.tl.embedding_density(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 7 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -581,7 +581,7 @@ sc.tl.embedding_density(
             <output name="anndata_out" ftype="h5ad">
                 <assert_contents>
                     <has_h5_keys keys="uns/draw_graph"/>
-                    <has_h5_keys keys="obsm/X_draw_graph_fr"/>
+                    <has_h5_keys keys="obsm/X_draw_graph_fa"/>
                 </assert_contents>
             </output>
         </test>
@@ -615,7 +615,7 @@ sc.tl.embedding_density(
         </test>
 
         <!-- test 10 -->
-        <test expect_num_outputs="2">    
+        <test expect_num_outputs="2">
             <param name="adata" value="pp.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad"/>
             <conditional name="method">
                 <param name="method" value="tl.paga"/>
@@ -665,7 +665,7 @@ sc.tl.embedding_density(
         </test>
     </tests>
     <help><![CDATA[
-        
+
 Cluster cells into subgroups (`tl.louvain`)
 ===========================================
 

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.10.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.09</token>
     <xml name="requirements">
         <requirements>
@@ -10,6 +10,7 @@
             <requirement type="package" version="2.2.2">pandas</requirement>
             <requirement type="package" version="1.14.1">scipy</requirement>
             <requirement type="package" version="0.14.2">statsmodels</requirement>
+            <requirement type="package" version="0.3.5">fa2</requirement>
             <yield />
         </requirements>
     </xml>

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -1205,9 +1205,6 @@ header=None
             <expand macro="sanitize_query"/>
         </param>
         <param argument="pos" type="data" format="tabular,csv,tsv" optional="true" label="Two-column tabular file storing the x and y coordinates for drawing"/>
-        <param argument="labels" type="text" value="" label="Comma-separated node labels" help="If none is provided, this defaults to the group labels stored in the categorical for which 'tl.paga' has been computed.">
-            <expand macro="sanitize_query"/>
-        </param>
         <expand macro="param_layout"/>
         <param argument="init_pos" type="data" format="tabular,csv,tsv" optional="true" label="Two-column tabular file storing the x and y coordinates for initializing the layout"/>
         <param argument="random_state" type="integer" value="0" label="For layouts with random initialization like 'fr', change this to use different intial states for the optimization. If 'None', the initial state is not reproducible."/>
@@ -1250,10 +1247,6 @@ header=None
         #end if
         #if $method.pos:
     pos=np.fromfile($method.pos, dtype=dt),
-        #end if
-        #if str($method.labels) != '':
-            #set $labels=([x.strip() for x in str($method.labels).split(',')])
-    labels=$labels,
         #end if
     layout='$method.layout',
         #if $method.init_pos:

--- a/tools/scanpy/macros.xml
+++ b/tools/scanpy/macros.xml
@@ -588,7 +588,7 @@ with open('anndata_info.txt','w', encoding='utf-8') as ainfo:
     ]]>
     </token>
     <token name="@CMD_SHOW_NONE@"><![CDATA[
-        show=None
+    show=None
         ]]>
     </token>
     <token name="@CMD_VAR_NAMES_HEADER_CHECK@"><![CDATA[
@@ -1198,7 +1198,9 @@ header=None
     </xml>
     <xml name="params_pl_paga">
         <param argument="threshold" type="float" min="0" value="" optional="true" label="Threshold to draw edges" help="Do not draw edges for weights below this threshold. Set to 0 if you want all edges. Discarding low-connectivity edges helps in getting a much clearer picture of the graph."/>
-        <expand macro="param_groups"/>
+        <param argument="labels" type="text" value="" optional="true" label="The node labels" help="This defaults to the group labels stored in the categorical for which paga() has been computed">
+            <expand macro="sanitize_query"/>
+        </param>
         <param argument="color" type="text" value="" label="The node colors" help="Gene name or obs. annotation, and also plots the degree of the abstracted graph when passing 'degree_dashed', 'degree_solid'.">
             <expand macro="sanitize_query"/>
         </param>
@@ -1238,9 +1240,9 @@ header=None
         #if str($method.threshold) != '':
     threshold=$method.threshold,
         #end if
-        #if str($method.groups) != '':
-            #set $groups=([x.strip() for x in str($method.groups).split(',')])
-    groups=$groups,
+        #if str($method.labels) != '':
+            #set $labels=([x.strip() for x in str($method.labels).split(',')])
+    labels=$labels,
         #end if
         #if str($method.color) != '':
             #set $color=([x.strip() for x in str($method.color).split(',')])
@@ -1270,7 +1272,9 @@ header=None
     dashed_edges='$method.dashed_edges',
         #end if
     single_component=$method.single_component,
+        #if str($method.fontsize) != '':
     fontsize=$method.fontsize,
+        #end if
     node_size_scale=$method.node_size_scale,
     node_size_power=$method.node_size_power,
     edge_width_scale=$method.edge_width_scale,

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -997,7 +997,7 @@ sc.pl.rank_genes_groups_tracksplot(
             <filter>advanced_common['show_log']</filter>
         </data>
         <data name="anndata_out" format="h5ad" from_work_dir="anndata.h5ad" label="${tool.name} (${method.method}) on ${on_string}: Annotated data matrix">
-            <filter>method['method'] != 'pl.paga'</filter>
+            <filter>method['method'] == 'pl.paga'</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -996,9 +996,9 @@ sc.pl.rank_genes_groups_tracksplot(
         <data name="hidden_output" format="txt" label="Log file" hidden="true" >
             <filter>advanced_common['show_log']</filter>
         </data>
-        <expand macro="anndata_outputs">
+        <data name="anndata_out" format="h5ad" from_work_dir="anndata.h5ad" label="${tool.name} (${method.method}) on ${on_string}: Annotated data matrix">
             <filter>method['method'] != 'pl.paga'</filter>
-        </expand>
+        </data>
     </outputs>
     <tests>
         <!-- test 1 -->

--- a/tools/scanpy/plot.xml
+++ b/tools/scanpy/plot.xml
@@ -75,7 +75,7 @@ sc.pl.scatter(
     legend_fontweight='$method.plot.legend_fontweight',
     #if $method.plot.color_map:
     color_map='$method.plot.color_map',
-    #end if   
+    #end if
     #if $method.plot.palette:
     palette=['$method.plot.palette'],
     #end if
@@ -98,7 +98,7 @@ sc.pl.heatmap(
 @CMD_VAR_NAMES_HEADER_CHECK@
 sc.pl.dotplot(
     @CMD_PARAM_PLOT_INPUTS@
-    @CMD_PARAMS_INPUTS@    
+    @CMD_PARAMS_INPUTS@
     @CMD_PARAM_GENE_SYMBOLS@
     @CMD_PARAMS_PLOTS@
     @CMD_PL_DOTPLOT@
@@ -259,7 +259,7 @@ sc.pl.pca_overview(
     @CMD_PARAM_GROUPS@
     @CMD_PARAMS_PL_ATTRIBUTE_SECTION@
     @CMD_SCATTER_OUTINE@
-    @CMD_SECTION_MATPLOTLIB_PYPLOT_SCATTER@    
+    @CMD_SECTION_MATPLOTLIB_PYPLOT_SCATTER@
     @CMD_SHOW_NONE@)
 
 #else if str($method.method) == 'pl.tsne':
@@ -274,7 +274,7 @@ sc.pl.tsne(
     @CMD_PARAM_GROUPS@
     @CMD_PARAMS_PL_ATTRIBUTE_SECTION@
     @CMD_SCATTER_OUTINE@
-    @CMD_SECTION_MATPLOTLIB_PYPLOT_SCATTER@    
+    @CMD_SECTION_MATPLOTLIB_PYPLOT_SCATTER@
     @CMD_PARAM_LAYER@
     @CMD_SHOW_NONE@)
 
@@ -366,6 +366,8 @@ sc.pl.paga(
     @CMD_PARAMS_PL_PAGA@
     @CMD_SHOW_NONE@)
 
+@CMD_ANNDATA_WRITE_OUTPUTS@
+
 #else if str($method.method) == 'pl.paga_compare':
 sc.pl.paga_compare(
     @CMD_PARAM_PLOT_INPUTS@
@@ -379,7 +381,7 @@ sc.pl.paga_compare(
     legend_fontweight='$method.plot.legend_fontweight',
     #if $method.plot.color_map:
     color_map='$method.plot.color_map',
-    #end if   
+    #end if
     #if $method.plot.palette:
     palette=['$method.plot.palette'],
     #end if
@@ -643,7 +645,7 @@ sc.pl.rank_genes_groups_tracksplot(
                     <expand macro="conditional_stripplot"/>
                     <conditional name="multi_panel">
                         <param argument="multi_panel" type="select" label="Display keys in multiple panels" help="Also when 'groupby is not provided">
-                            <option value="None" selected="true">No</option>                            
+                            <option value="None" selected="true">No</option>
                             <option value="True">Yes</option>
                         </param>
                         <when value="None"/>
@@ -994,6 +996,9 @@ sc.pl.rank_genes_groups_tracksplot(
         <data name="hidden_output" format="txt" label="Log file" hidden="true" >
             <filter>advanced_common['show_log']</filter>
         </data>
+        <expand macro="anndata_outputs">
+            <filter>method['method'] != 'pl.paga'</filter>
+        </expand>
     </outputs>
     <tests>
         <!-- test 1 -->
@@ -1036,7 +1041,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.scatter.umap.pbmc68k_reduced.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 2 -->
         <test expect_num_outputs="2">
             <param name="adata" value="krumsiek11.h5ad"/>
@@ -1076,7 +1081,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.scatter.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 3 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pbmc68k_reduced.h5ad"/>
@@ -1154,7 +1159,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.heatmap.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 5 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1200,7 +1205,7 @@ sc.pl.rank_genes_groups_tracksplot(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 6 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pbmc68k_reduced.h5ad"/>
@@ -1250,7 +1255,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.dotplot.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 7 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1262,7 +1267,7 @@ sc.pl.rank_genes_groups_tracksplot(
                     <param name="var_names" value="Fog1,EKLF,SCL"/>
                 </conditional>
                 <param name="gene_symbols" value="symbol"/>
-                <param name="groupby" value="cell_type"/>              
+                <param name="groupby" value="cell_type"/>
                 <param name="dendrogram" value="True"/>
                 <section name="matplotlib_pyplot_imshow">
                     <param name="cmap" value="YlGnBu"/>
@@ -1284,7 +1289,7 @@ sc.pl.rank_genes_groups_tracksplot(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 8 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1292,7 +1297,7 @@ sc.pl.rank_genes_groups_tracksplot(
             <conditional name="method">
                 <param name="method" value="pl.tracksplot"/>
                 <param name="gene_symbols" value="symbol"/>
-                <param name="groupby" value="cell_type"/>              
+                <param name="groupby" value="cell_type"/>
                 <param name="dendrogram" value="True"/>
                 <section name="matplotlib_pyplot_imshow">
                     <param name="cmap" value="YlGnBu"/>
@@ -1323,7 +1328,7 @@ sc.pl.rank_genes_groups_tracksplot(
                 <conditional name="key_variables">
                     <param name="type" value="custom"/>
                     <param name="keys" value="n_genes, percent_mito, n_counts"/>
-                </conditional>              
+                </conditional>
                 <section name="violin_plot">
                     <conditional name="multi_panel">
                         <param name="multi_panel" value="True"/>
@@ -1352,7 +1357,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.violin.pbmc68k_reduced_custom.png" ftype="png" compare="image_diff" eps="0.4"/>
         </test>
-        
+
         <!-- test 10 -->
         <test expect_num_outputs="2">
             <param name="adata" value="krumsiek11.h5ad"/>
@@ -1391,7 +1396,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.stacked_violin.krumsiek11.png" ftype="png" compare="image_diff" eps="1.1"/>
         </test>
-        
+
         <!-- test 11 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1425,7 +1430,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.stacked_violin_pp.filter_genes_dispersion.krumsiek11-seurat.png" compare="image_diff" eps="0.6"/>
         </test>
-        
+
         <!-- test 12 -->
         <test expect_num_outputs="2">
             <param name="adata" value="krumsiek11.h5ad"/>
@@ -1454,7 +1459,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.matrixplot.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 13 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1491,7 +1496,7 @@ sc.pl.rank_genes_groups_tracksplot(
                 </assert_contents>
             </output>
         </test>
-        
+
         <!-- test 14 -->
         <test expect_num_outputs="2">
             <param name="adata" value="krumsiek11.h5ad"/>
@@ -1520,7 +1525,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.clustermap.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 15 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.filter_genes_dispersion.krumsiek11-seurat.h5ad"/>
@@ -1547,13 +1552,13 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.highest_expr_genes.filter_genes_dispersion.krumsiek11-seurat.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 16 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.highly_variable_genes.seurat.blobs.h5ad"/>
             <param name="format" value="png"/>
             <conditional name="method">
-                <param name="method" value="pl.highly_variable_genes"/>                
+                <param name="method" value="pl.highly_variable_genes"/>
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true"/>
@@ -1568,13 +1573,13 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.highly_variable_genes.seurat.blobs.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 17 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.scrublet.krumsiek11.h5ad"/>
             <param name="format" value="png"/>
             <conditional name="method">
-                <param name="method" value="pl.scrublet_score_distribution"/>                
+                <param name="method" value="pl.scrublet_score_distribution"/>
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true"/>
@@ -1636,7 +1641,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_pdf" file="pl.pca.pbmc68k_reduced.CD3D_CD79A_components_2d.pdf" ftype="pdf" compare="sim_size"/>
         </test>
-        
+
         <!-- test 19 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.pca.krumsiek11.h5ad"/>
@@ -1656,7 +1661,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.pca_loadings.pp.pca.krumsiek11.png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 20 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.pca.krumsiek11.h5ad"/>
@@ -1675,7 +1680,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.pca_variance_ratio.pp.pca.krumsiek11.png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 21 -->
         <test expect_num_outputs="2">
             <param name="adata" value="pp.pca.krumsiek11.h5ad"/>
@@ -1709,7 +1714,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.pca_overview.pp.pca.krumsiek11.png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 22 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.tsne.krumsiek11.h5ad"/>
@@ -1745,7 +1750,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.tsne.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 23 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -1783,12 +1788,12 @@ sc.pl.rank_genes_groups_tracksplot(
                     <has_text_matching expression="ncols=4"/>
                     <has_text_matching expression="wspace=0.1"/>
                     <has_text_matching expression="hspace=0.25"/>
-                    
+
                 </assert_contents>
             </output>
             <output name="out_png" file="pl.umap.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 24 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -1820,12 +1825,12 @@ sc.pl.rank_genes_groups_tracksplot(
                     <has_text_matching expression="ncols=4"/>
                     <has_text_matching expression="wspace=0.1"/>
                     <has_text_matching expression="hspace=0.25"/>
-                    
+
                 </assert_contents>
             </output>
             <output name="out_png" file="pl.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 25 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.draw_graph.pp.neighbors_umap_euclidean.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -1865,7 +1870,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.draw_graph.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 26 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.embedding_density.umap.pbmc68k_reduced.h5ad"/>
@@ -1886,7 +1891,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.embedding_density.pbmc68k_reduced.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- This function is commented out because it is not compatible with pandas version. If the issue is not resolved in the next update, this should be removed. -->
         <!-- test 27 -->
         <!-- <test expect_num_outputs="2">
@@ -1894,7 +1899,7 @@ sc.pl.rank_genes_groups_tracksplot(
             <param name="format" value="png"/>
             <conditional name="method">
                 <param name="method" value="pl.dpt_groups_pseudotime"/>
-                
+
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true"/>
@@ -1907,7 +1912,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.dpt_groups_pseudotime.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="image_diff"/>
         </test> -->
-        
+
         <!-- test 28 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.h5ad"/>
@@ -1926,9 +1931,9 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.dpt_timeseries.dpt.diffmap.neighbors_gauss_braycurtis.recipe_weinreb17.paul15_subsample.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 29 -->
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="2">
             <param name="adata" value="tl.paga.neighbors.paul15_gauss_braycurtis.h5ad"/>
             <param name="format" value="png"/>
             <conditional name="method">
@@ -1940,8 +1945,13 @@ sc.pl.rank_genes_groups_tracksplot(
                 <param name="edge_width_scale" value="5"/>
             </conditional>
             <output name="out_png" file="pl.paga.paul15_gauss_braycurtis.png" ftype="png" compare="image_diff"/>
+            <output name="anndata_out" ftype="h5ad">
+                <assert_contents>
+                    <has_h5_keys keys="uns/paga"/>
+                </assert_contents>
+            </output>
         </test>
-        
+
         <!-- test 30 -->
         <test expect_num_outputs="1">
             <param name="adata" value="tl.paga.neighbors.paul15_gauss_braycurtis.h5ad"/>
@@ -1961,14 +1971,14 @@ sc.pl.rank_genes_groups_tracksplot(
         <!-- <test expect_num_outputs="2">
              test pl.paga_path
         </test> -->
-        
+
         <!-- test 32 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad"/>
             <param name="format" value="png"/>
             <conditional name="method">
                 <param name="method" value="pl.rank_genes_groups"/>
-                <param name="n_genes" value="10"/>                
+                <param name="n_genes" value="10"/>
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true"/>
@@ -1983,7 +1993,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.rank_genes_groups.rank_genes_groups.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 33 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad"/>
@@ -2018,7 +2028,7 @@ sc.pl.rank_genes_groups_tracksplot(
                 <element name="cell_type_progenitor" file="pl.rank_genes_groups_violin.progenitor.png" ftype="png" compare="image_diff" eps="3.5"/>
             </output_collection>
         </test>
-        
+
         <!-- test 34 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad"/>
@@ -2056,7 +2066,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.rank_genes_groups_stacked_violin.rank_genes_groups.krumsiek11.png" ftype="png" compare="image_diff" eps="1.5"/>
         </test>
-        
+
         <!-- test 35 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad"/>
@@ -2105,7 +2115,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.rank_genes_groups_dotplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 37 -->
         <test expect_num_outputs="2">
             <param name="adata" value="tl.rank_genes_groups.krumsiek11.h5ad"/>
@@ -2130,7 +2140,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.rank_genes_groups_matrixplot.rank_genes_groups.krumsiek11.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 38 pl.rank_genes_groups_dotplot with marker list-->
         <test expect_num_outputs="2">
             <param name="adata" value="cosg.rank_genes_groups.newton-cg.pbmc68k_highly_reduced_1.h5ad" />
@@ -2155,7 +2165,7 @@ sc.pl.rank_genes_groups_tracksplot(
             </output>
             <output name="out_png" file="pl.rank_genes_groups.newton-cg.pbmc68k_highly_reduced_marker_1.png" ftype="png" compare="image_diff"/>
         </test>
-        
+
         <!-- test 39: pl.rank_genes_groups_dotplot with marker list -->
         <test expect_num_outputs="2">
             <param name="adata" value="cosg.rank_genes_groups.newton-cg.pbmc68k_highly_reduced_1.h5ad" />


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

- If fa2 is missing, some functions fallback to 'fr' layout with a warning but the jobs were still passing. This PR adds fa2 and fix the test. 
- `pl.paga` adds `pos` under `adata.uns['paga']`. To subsequently run `tl.draw_graph` based on `paga`, the anndata object must be saved.
- Fixed a bug that failed check optional `fontsize` param in `pl.paga` function
- This update should not affect the upcoming GTA. 

@nomadscientist This should hopefully fix the trajectories tutorial.

