### PR TITLE
moabs: fix missing whens

### DIFF
--- a/tools/moabs/.lint_skip
+++ b/tools/moabs/.lint_skip
@@ -1,1 +1,0 @@
-ConditionalWhenMissing

--- a/tools/moabs/moabs.xml
+++ b/tools/moabs/moabs.xml
@@ -180,6 +180,7 @@
                     <option value="1">Set the mismatch rate</option>
                     <option value="2">Set the mismatch number</option>
                 </param>
+                <when value="0"/>
                 <when value="1">
                     <param argument="-v" type="float" value="0.08" min="0" max="1" label="Mismatch rate" help="The mismatch rate w.r.t to the read length"/>
                 </when>
@@ -249,6 +250,7 @@
                 <when value="0">
                     <param argument="-c" name="compFile" type="data" format="txt" label="Input comparison results" help="Previously generated comparison file from history"/>
                 </when>
+                <when value="1"/>
             </conditional>
             <param argument="-d" type="integer" value="3" min="0" label="Minimum depth for a site coverage" help="If a site has depth less than `d`, this site is ignored for statistical tests. This option affects much of nominal ratios but none of credible ratios. This option may be reset during later DMC/DMR rescan to filter sites with depth less than `d`. Default=3."/>
             <param argument="--filterCredibleDif" type="float" value="-10" label="Minimum absolute credible methylation difference (CDIF)" help="If absolute value of CDIF for a site less than filterCredibleDif, this site is ignored for regional calculation. Use a small value, such as 0.01, to filter all sites with no difference; use 0.20 (for example) to select DMCs. Any negative number means no filter. Default=-10."/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
