### PR TITLE
Use multithreaded pigz for compression in meryl

### DIFF
--- a/tools/meryl/arithmetic-kmers.xml
+++ b/tools/meryl/arithmetic-kmers.xml
@@ -12,14 +12,14 @@
     <command detect_errors="exit_code"><![CDATA[
     export GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-8192}/1024)) &&
     mkdir  -p ./temp_db/ &&
-    tar -zxf $input_meryldb_02 -C ./temp_db/ &&
+    tar -xmf $input_meryldb_02 --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" -C ./temp_db/ &&
     mv ./temp_db/* tmp.meryl &&
     meryl
     $arithmetic_operations
     $X
     tmp.meryl
     output read-db.meryl &&
-    tar -zcf read-db.meryldb read-db.meryl
+    tar -cf read-db.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" read-db.meryl
     ]]></command>
     <inputs>
         <param name="arithmetic_operations" type="select" label="Arithmetic operations" help="Select an operation to be executed">

--- a/tools/meryl/arithmetic-kmers.xml
+++ b/tools/meryl/arithmetic-kmers.xml
@@ -43,7 +43,7 @@
             <param name="arithmetic_operations" value="increase"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="59500" delta="1000"/>
+                    <has_size value="58946" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -54,7 +54,7 @@
             <param name="arithmetic_operations" value="decrease"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="42313" delta="1000"/>
+                    <has_size value="45595" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -65,7 +65,7 @@
             <param name="arithmetic_operations" value="multiply"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="60530" delta="1000"/>
+                    <has_size value="60645" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -76,7 +76,7 @@
             <param name="arithmetic_operations" value="divide"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="56200" delta="1000"/>
+                    <has_size value="58481" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -87,7 +87,7 @@
             <param name="arithmetic_operations" value="divide-round"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="56100" delta="1000"/>
+                    <has_size value="58236" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -98,7 +98,7 @@
             <param name="arithmetic_operations" value="modulo"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="37501" delta="1000"/>
+                    <has_size value="36971" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>

--- a/tools/meryl/count-kmers.xml
+++ b/tools/meryl/count-kmers.xml
@@ -63,7 +63,7 @@
             <param name="count_operation" value="count"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="22152" delta="1000"/>
+                    <has_size value="23404" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -80,7 +80,7 @@
             <param name="count_operation" value="count"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="22200" delta="1000"/>
+                    <has_size value="22700" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -97,7 +97,7 @@
             <param name="count_operation" value="count"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="22200" delta="1000"/>
+                    <has_size value="23155" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>

--- a/tools/meryl/count-kmers.xml
+++ b/tools/meryl/count-kmers.xml
@@ -27,7 +27,7 @@
     ./input.${input_reads.ext}
     output read-db.meryl &&
     echo 'K-mer size: ${size}' &&
-    tar -zcf read-db.meryldb read-db.meryl
+    tar -cf read-db.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" read-db.meryl
     ]]></command>
     <inputs>
         <param name="count_operation" type="select" label="Count operations" help="Select an operation to be executed">

--- a/tools/meryl/filter-kmers.xml
+++ b/tools/meryl/filter-kmers.xml
@@ -12,7 +12,7 @@
     <command detect_errors="exit_code"><![CDATA[
     export GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-8192}/1024)) &&
     mkdir  -p ./temp_db/ &&
-    tar -zxf $input_meryldb_02 -C ./temp_db/ &&
+    tar -xmf $input_meryldb_02 --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" -C ./temp_db/ &&
     mv ./temp_db/* tmp.meryl &&
     meryl
     $filter_operations
@@ -23,7 +23,7 @@
     #end if
     tmp.meryl
     output read-db.meryl &&
-    tar -zcf read-db.meryldb read-db.meryl
+    tar -cf read-db.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" read-db.meryl
     ]]></command>
     <inputs>
         <param name="filter_operations" type="select" label="Filter operations" help="Select an operation to be executed">

--- a/tools/meryl/filter-kmers.xml
+++ b/tools/meryl/filter-kmers.xml
@@ -58,7 +58,7 @@
             <param name="filter_operations" value="less-than"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="32077" delta="1000"/>
+                    <has_size value="32382" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -71,7 +71,7 @@
             <param name="filter_operations" value="greater-than"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="49643" delta="1000"/>
+                    <has_size value="50850" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -84,7 +84,7 @@
             <param name="filter_operations" value="greater-than"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="1634" delta="1000"/>
+                    <has_size value="1880" delta="1000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -97,7 +97,7 @@
             <param name="filter_operations" value="equal-to"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="2621" delta="1000"/>
+                    <has_size value="3073" delta="1000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -110,7 +110,7 @@
             <param name="filter_operations" value="not-equal-to"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="59100" delta="1000"/>
+                    <has_size value="59719" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>

--- a/tools/meryl/groups-kmers.xml
+++ b/tools/meryl/groups-kmers.xml
@@ -13,11 +13,11 @@
     export GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-8192}/1024)) &&
     #for $i,$mdb in enumerate($input_meryldb_02)
         mkdir -p ./tmp_folder_$i/ &&
-        tar -zxf $mdb -C ./tmp_folder_$i &&
+        tar -xmf $mdb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" -C ./tmp_folder_$i &&
         mv ./tmp_folder_$i/* db_'${i}'.meryl &&
     #end for
     meryl $groups_operations output read-db.meryl db_*  &&
-    tar -zcf read-db.meryldb read-db.meryl
+    tar -cf read-db.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" read-db.meryl
     ]]></command>
     <inputs>
         <param name="groups_operations" type="select" label="Operations on sets of k-mers" help="Select an operation to be executed">

--- a/tools/meryl/groups-kmers.xml
+++ b/tools/meryl/groups-kmers.xml
@@ -44,7 +44,7 @@
             <param name="groups_operations" value="union"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="36100" delta="1000"/>
+                    <has_size value="34918" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -54,7 +54,7 @@
             <param name="groups_operations" value="union-min"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="58925" delta="1000"/>
+                    <has_size value="59637" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -64,7 +64,7 @@
             <param name="groups_operations" value="union-max"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="58930" delta="1000"/>
+                    <has_size value="60705" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -74,7 +74,7 @@
             <param name="groups_operations" value="union-sum"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="58600" delta="1000"/>
+                    <has_size value="61311" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -84,7 +84,7 @@
             <param name="groups_operations" value="intersect"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="14951" delta="1000"/>
+                    <has_size value="16003" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -94,7 +94,7 @@
             <param name="groups_operations" value="intersect-min"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="14957" delta="1000"/>
+                    <has_size value="15413" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -104,7 +104,7 @@
             <param name="groups_operations" value="intersect-max"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="14956" delta="1000"/>
+                    <has_size value="15424" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -114,7 +114,7 @@
             <param name="groups_operations" value="intersect-sum"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="14953" delta="1000"/>
+                    <has_size value="15965" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -124,7 +124,7 @@
             <param name="groups_operations" value="subtract"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="23999" delta="1000"/>
+                    <has_size value="25728" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -134,7 +134,7 @@
             <param name="groups_operations" value="difference"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="24016" delta="1000"/>
+                    <has_size value="24666" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
@@ -144,7 +144,7 @@
             <param name="groups_operations" value="symmetric-difference"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="57455" delta="1000"/>
+                    <has_size value="60385" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>

--- a/tools/meryl/histogram-kmers.xml
+++ b/tools/meryl/histogram-kmers.xml
@@ -12,7 +12,7 @@
     <command detect_errors="exit_code"><![CDATA[
     export GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-8192}/1024)) &&
     mkdir  -p ./temp_db/ &&
-    tar -zxf $input_meryldb_02 -C ./temp_db/ &&
+    tar -xmf $input_meryldb_02 --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" -C ./temp_db/ &&
     mv ./temp_db/* tmp.meryl &&
     meryl histogram tmp.meryl > read-db.hist
     ]]></command>

--- a/tools/meryl/macros.xml
+++ b/tools/meryl/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.3</token>
     <token name="@GALAXY_TOOL_VERSION@">galaxy</token>
-    <token name="@SUFFIX_VERSION@">6</token>
+    <token name="@SUFFIX_VERSION@">7</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>                                                                                  
@@ -16,6 +16,7 @@
             <requirement type="package" version="1.1">merqury</requirement>
             <requirement type="package" version="@TOOL_VERSION@">meryl</requirement>
             <requirement type="package" version="1.34">tar</requirement>
+            <requirement type="package" version="2.8">pigz</requirement>
         </requirements>
     </xml>
     <xml name="meryldb_archive_assumptions">

--- a/tools/meryl/print.xml
+++ b/tools/meryl/print.xml
@@ -12,7 +12,7 @@
     <command detect_errors="exit_code"><![CDATA[
     export GALAXY_MEMORY_GB=\$((\${GALAXY_MEMORY_MB:-8192}/1024)) &&
     mkdir  -p ./temp_db/ &&
-    tar -zxf $input_meryldb_02 -C ./temp_db/ &&
+    tar -xmf $input_meryldb_02 --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" -C ./temp_db/ &&
     mv ./temp_db/* tmp.meryl &&
     meryl print tmp.meryl > read-db.tabular
     ]]></command>

--- a/tools/meryl/trio-mode.xml
+++ b/tools/meryl/trio-mode.xml
@@ -37,7 +37,7 @@
     #end for
     meryl union-sum child*.meryl output child.meryl &&
     meryl histogram child.meryl > read-db.hist &&                                          
-    tar -czf 'read-db.meryldb' child.meryl &&
+    tar -cf read-db.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" child.meryl &&
     
     ## mat specific kmers
     meryl difference mat.meryl pat.meryl output mat.only.meryl &&
@@ -62,7 +62,7 @@
     java -jar -Xmx1g \$MERQURY/eval/kmerHistToPloidyDepth.jar mat.inherited.hist > mat.inherited.ploidy &&
     VAR=`sed -n 2p mat.inherited.ploidy | awk '{print \$NF}'` &&
     meryl greater-than \$VAR output mat.hapmer.meryl mat.inherited.meryl &&
-    tar -czf 'mat.meryldb' mat.hapmer.meryl &&
+    tar -cf mat.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" mat.hapmer.meryl &&
 
     ## pat hapmers
     meryl intersect output pat.inherited.meryl child.meryl pat.only.filt.meryl &&
@@ -70,7 +70,7 @@
     java -jar -Xmx1g \$MERQURY/eval/kmerHistToPloidyDepth.jar pat.inherited.hist > pat.inherited.ploidy &&
     VAR=`sed -n 2p pat.inherited.ploidy | awk '{print \$NF}'` &&
     meryl greater-than \$VAR output pat.hapmer.meryl pat.inherited.meryl &&
-    tar -czf 'pat.meryldb' pat.hapmer.meryl &&
+    tar -cf pat.meryldb --use-compress-program="pigz -p \${GALAXY_SLOTS:-1}" pat.hapmer.meryl &&
 
     echo 'K-mer size: ${size}'
     ]]></command>

--- a/tools/meryl/trio-mode.xml
+++ b/tools/meryl/trio-mode.xml
@@ -111,21 +111,21 @@
             <param name="child_reads" value="child.fasta"/>
             <output name="read_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="3362942" delta="2000"/>
+                    <has_size value="3373562" delta="6000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
             <output name="read_db_hist" file="output_23.read-db.hist"/>
             <output name="pat_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="120610" delta="400"/>
+                    <has_size value="124859" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>
             <output name="pat_db_hist" file="output_23.pat.hist"/>
             <output name="mat_db" ftype="meryldb">
                 <assert_contents>
-                    <has_size value="67883" delta="300"/>
+                    <has_size value="71220" delta="3000"/>
                     <expand macro="meryldb_archive_assumptions"/>
                 </assert_contents>
             </output>


### PR DESCRIPTION
On very large meryldb archives, compressing the tar stream with a single-threaded zlib is the overwhelming amount of tool runtime. With 56 cores pigz decreased the compression runtime of a 24 GB meryldb from an estimated 30 hours to 9 minutes.

I also added `m` to the untar options so that mod times are not preserved. This can be useful when working with old datasets on HPC systems that have aggressive scratch cleanup.

Tested on the command line but not in the tools so I am relying on tool tests to catch my mistakes. =)

FOR CONTRIBUTOR:
* [x] This PR updates an existing tool or tool collection