### PR TITLE
hicexplorer buildmatrix

### DIFF
--- a/tools/hicexplorer/macros.xml
+++ b/tools/hicexplorer/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@THREADS@">\${GALAXY_SLOTS:-4}</token>
     <token name="@TOOL_VERSION@">3.7.5</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">23.0</token>
     <token name="@USE_RANGE@">
         #if $use_range.select_use_range == "yes_use_range":
@@ -48,7 +48,7 @@
     </xml>
 
     <xml name="restrictionCutFile">
-        <param argument="--restrictionCutFile" type="data" format="bed" optional="false" label="BED file with all restriction cut places" help="Should contaion only  mappable restriction sites. If given, the bins are set to match the restriction fragments
+        <param argument="--restrictionCutFile" type="data" format="bed" optional="true" label="BED file with all restriction cut places" help="Should contaion only  mappable restriction sites. If given, the bins are set to match the restriction fragments
                 (i.e. the region between one restriction site and the next)." />
     </xml>
 


### PR DESCRIPTION
Make bed file optional. It always was optional but if you had a bed in the history, it could not be removed.

