### PR TITLE
Do not lint R code in test-data

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -200,7 +200,7 @@ jobs:
     - name: lintr
       run: |
         set -eo pipefail
-        echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' -n 1 ./.github/styler.R --dry off
+        echo '${{ needs.setup.outputs.repository-list }}' | grep -v "test-data" | xargs -d '\n' -n 1 ./.github/styler.R --dry off
         git status
         git diff --exit-code | tee rlint_report.txt
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

Test data might include R or Rmd files for specific tools. Those tools might not follow R best-practices. Therefore, linting for the test-folder should be excluded.
