### PR TITLE
Update gtdb-tk DM - chunck extractall for memory efficiency

### DIFF
--- a/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
+++ b/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
@@ -2,7 +2,7 @@
     <description></description>
     <macros>
         <token name="@TOOL_VERSION@">202</token>
-        <token name="@VERSION_SUFFIX@">3</token>
+        <token name="@VERSION_SUFFIX@">4</token>
         <token name="@PROFILE@">20.09</token>
     </macros>
     <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Thanks to usegalaxy.eu and @bgruening we know that this DM exceeds 100 GB memory usage. Probably because the tar.gz of the full DB includes huge files: https://github.com/paulzierep/tools-iuc/blob/bc882c3b2f21b4d3bda7a6c584121c8e3f95eaf0/data_managers/data_manager_gtdbtk_database_installer/test-data/release220/readme.md

Hopefully by chunking the files it can be reduced. Cannot really test it locally, though. 
