### PR TITLE
Fix 2 bugs in SRST2

### DIFF
--- a/tools/srst2/macros.xml
+++ b/tools/srst2/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">0.2.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">20.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/srst2/srst2.xml
+++ b/tools/srst2/srst2.xml
@@ -103,9 +103,11 @@ srst2
 #if 'report_new_consensus' in str($output_files_selector) and $use_gene_db.selector == "yes" and $use_mlst_db.selector == "yes"
 && mkdir -p allelesOutput/ && cp *.output__input.*.pileup allelesOutput | true
 #end if
+
 #if $use_gene_db.selector == "yes" and  $use_gene_db.no_gene_details
-&& mkdir -p geneTypingOutput/ && cp output__genes__*__results.txt geneTypingOutput | true && cp output__fullgenes__*__results.txt geneTypingOutput | true
+&& mkdir -p geneTypingOutput/ geneTypingOutputFull/ && cp output__genes__*__results.txt geneTypingOutput | true && cp output__fullgenes__*__results.txt geneTypingOutputFull | true
 #end if
+
 #if 'save_scores' in str($output_files_selector)
     && mkdir -p scoresOutput/ && cp *.scores scoresOutput | true
 #end if
@@ -198,7 +200,11 @@ srst2
             <filter>use_mlst_db['selector'] == "yes"</filter>
         </data>  
         <collection name="gene_typing" type="list" label="${tool.name} on ${on_string}: Gene typing results files" >
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)" directory="geneTypingOutput" format="txt,tabular"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)" directory="geneTypingOutput" format="tabular"/>
+            <filter>use_gene_db['selector'] == "yes" and use_gene_db['no_gene_details'] is True</filter>
+        </collection>         
+        <collection name="gene_typing_full" type="list" label="${tool.name} on ${on_string}: Full Gene typing results files" >
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)" directory="geneTypingOutputFull" format="tabular"/>
             <filter>use_gene_db['selector'] == "yes" and use_gene_db['no_gene_details'] is True</filter>
         </collection>         
         <data name="Compiled_gene_and_mlst_output" format="tabular" from_work_dir="output__compiledResults.txt" label="${tool.name} on ${on_string}: Compiled MLST and Gene databases Results">
@@ -264,13 +270,15 @@ srst2
             </assert_contents>
         </output>
         <output_collection name="gene_typing" type="list">
-            <element name="output__fullgenes__0-gene_db__results.txt">
+            <element name="output__genes__0-gene_db__results.txt">
                 <assert_contents>
                     <has_text text="AmpC1_Ecoli_Bla"/>
                     <has_n_lines n="2"/>
                 </assert_contents>
             </element>
-            <element name="output__genes__0-gene_db__results.txt">
+        </output_collection>
+        <output_collection name="gene_typing_full" type="list">
+            <element name="output__fullgenes__0-gene_db__results.txt">
                 <assert_contents>
                     <has_text text="AmpC1_Ecoli_Bla"/>
                     <has_n_lines n="2"/>

--- a/tools/srst2/srst2.xml
+++ b/tools/srst2/srst2.xml
@@ -156,7 +156,7 @@ srst2
                             <add value="_" />    
                         </valid>
                     </sanitizer>
-                    <validator type="regex">[A-Za-z0-9 =-_/+]+</validator>
+                    <validator type="regex">[A-Za-z0-9 =_/+-]+</validator>
                 </param>
                 <param argument="--mlst_max_mismatch" type="integer" value="10" label="Maximum number of mismatches per read for MLST allele calling"/>
                 <param argument="--min_depth" type="integer" value="5" label="Minimum mean depth to flag as dubious allele call"/>

--- a/tools/srst2/srst2.xml
+++ b/tools/srst2/srst2.xml
@@ -233,7 +233,7 @@ srst2
         </data>             
     </outputs>
     <tests>
-    <test expect_num_outputs="9">
+    <test expect_num_outputs="10">
         <param name="prob_err" value="0.01"/>
         <param name="max_unaligned_overlap" value="10"/>
         <param name="mapq" value="1"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Fixes #6487 
Fixes #6459 

The collections are also separated because it made them very difficult to use in an automated way, especially with hamronize. 

Either they're a separate collection or you have to
- extract element identifiers (`txt,tabular` formatted output due to #6459 prevents this tool from selecting this collection weirdly)
- select matching element identifiers
- filter collection (because it won't let you just .. grep. you have to specify the precise list of identifiers. I get it, but the UX isn't great.)