### PR TITLE
Add bwa-mem2-idx

### DIFF
--- a/tools/bwa_mem2/bwa-mem2-idx.xml
+++ b/tools/bwa_mem2/bwa-mem2-idx.xml
@@ -1,0 +1,72 @@
+<tool id="bwa_mem2_idx" name="BWA-MEM2-INDEX"  version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+    <description>- creates indexes</description>
+    <macros>
+        <import>macros-index.xml</import>
+    </macros>
+    <expand macro="requirements"/>
+    <command><![CDATA[
+
+## Begin BWA-MEM command line
+echo "Index File runnin" > '$output' &&
+mkdir '$output.files_path' && 
+cd '$output.files_path' &&
+bwa-mem2 index -p 'index' '${input_fasta}'
+    ]]></command>
+
+    <inputs>
+        <param name="input_fasta" type="data" label="Select a genome to index" help="Build an index for this FASTA sequence." format="fasta,fasta.gz"/>
+    </inputs>
+
+    <outputs>
+        <data name="output" format="text" label="Test Testov"/>
+    </outputs>
+
+    <help><![CDATA[
+**What is does**
+BWA-MEM2 is the new version of the bwa-mem algorithm in bwa. It produces alignment identical to bwa and is ~1.3-3.1x faster depending on the use-case, dataset and the running machine.
+The algorithm is robust to sequencing errors and applicable to a wide range of sequence lengths from 70bp to a few megabases.
+
+The Galaxy implementation takes fastq files as input and produces output in BAM format, which can be further processed using various BAM utilities exiting in Galaxy (BAMTools, SAMTools, Picard).
+
+-----
+
+**Indices: Selecting reference genomes for BWA**
+
+Galaxy wrapper for BWA allows you select between precomputed and user-defined indices for reference genomes using **Will you select a reference genome from your history or use a built-in index?** flag. This flag has two options:
+
+  1. **Use a built-in genome index** - when selected (this is default), Galaxy provides the user with **Select reference genome index** dropdown. Genomes listed in this dropdown have been pre-indexed with bwa index utility and are ready to be mapped against.
+  2. **Use a genome from the history and build index** - when selected, Galaxy provides the user with **Select reference genome sequence** dropdown. This dropdown is populated by all FASTA formatted files listed in your current history. If your genome of interest is uploaded into history it will be shown there. Selecting a genome from this dropdown will cause Galaxy to first transparently index it using `bwa index` command, and then run mapping with `bwa mem`.
+
+If your genome of interest is not listed here you have two choices:
+
+  1. Contact galaxy team using **Help->Support** link at the top of the interface and let us know that an index needs to be added
+  2. Upload your genome of interest as a FASTA file to Galaxy history and selected **Use a genome from the history and build index** option.
+
+-----
+
+**Galaxy-specific option**
+
+Galaxy allows four levels of control over bwa-mem options provided by **Select analysis mode** menu option. These are:
+
+  1. *Simple Illumina mode*: The simplest possible bwa mem application in which it alignes single or paired-end data to reference using default parameters. It is equivalent to the following command: bwa mem <reference index> <fastq dataset1> [fastq dataset2]
+  2. *PacBio mode*: The mode adjusted specifically for mapping of long PacBio subreads. Equivalent to the following command: bwa mem -k17 -W40 -r10 -A1 -B1 -O1 -E1 -L0  <reference index> <PacBio dataset in fastq format>
+  3. *Full list of options*: Allows access to all options through Galaxy interface.
+
+-----
+
+**Bam sorting mode**
+
+The generated bam files can be sorted according to three criteria: coordinates, names and input order.
+
+In coordinate sorted mode the reads are sorted by coordinates. It means that the reads from the beginning of the first chromosome are first in the file. 
+
+When sorted by read name, the file is sorted by the reference ID (i.e., the QNAME field). 
+
+Finally, the *No sorted (sorted as input)* option yield a BAM file in which the records are sorted in an order corresponding to the order of the reads in the original input file. This option requires using a single thread to perform the conversion from SAM to BAM format, so the runtime is extended.
+
+
+@RG@
+
+@info@
+    ]]></help>
+</tool>

--- a/tools/bwa_mem2/macros-index.xml
+++ b/tools/bwa_mem2/macros-index.xml
@@ -1,0 +1,13 @@
+<macros>
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="@TOOL_VERSION@">bwa-mem2</requirement>
+        </requirements>
+    </xml>
+
+
+
+    <token name="@TOOL_VERSION@">2.2.1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">21.05</token>
+</macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Often we use bwa in workflows for multiple samples, where the same index is created repeatedly—-hundreds or even thousands of times. This tool will allow the creation of an index before running bwa-mem2, so multiple bwa-mem2 instances can use the same index without creating it over and over again. This will require a modification to bwa-mem2 as well to be able to take advantage of the index. 
