### PR TITLE
Update tools/freyja to 1.5.2

### DIFF
--- a/tools/freyja/macros.xml
+++ b/tools/freyja/macros.xml
@@ -39,7 +39,7 @@ ln -s '$variants_file' 'variants_file.vcf' &&
     --meta '${meta}'
 #end if
 $confirmedonly
-$pathogen
+--pathogen $pathogen
 ]]></token>
     <token name="@CUSTOM_BARCODES_COMMAND@"><![CDATA[
 #if $usher_update_option.choice == 'custom'

--- a/tools/freyja/macros.xml
+++ b/tools/freyja/macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">1.5.1</token>
+    <token name="@TOOL_VERSION@">1.5.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biotools">

--- a/tools/freyja/macros.xml
+++ b/tools/freyja/macros.xml
@@ -39,6 +39,7 @@ ln -s '$variants_file' 'variants_file.vcf' &&
     --meta '${meta}'
 #end if
 $confirmedonly
+$pathogen
 ]]></token>
     <token name="@CUSTOM_BARCODES_COMMAND@"><![CDATA[
 #if $usher_update_option.choice == 'custom'
@@ -138,6 +139,17 @@ freyja plot
                checked="false"
                label="Use larger library with non-public lineages"
                help="Allows to use larger UShER barcodes library extended with GISAID non-public lineages"/>
+        <param argument="--pathogen" type="select" label="Pathogen of interest">
+            <option value="SARS-CoV-2" selected="true">SARS-CoV-2</option>
+            <option value="MPXV" selected="true">MPXV</option>
+            <option value="H5NX" selected="true">H5NX</option>
+            <option value="H1N1pdm" selected="true">H1N1pdm</option>
+            <option value="FLU-B-VIC" selected="true">FLU-B-VIC</option>
+            <option value="MEASLESN450" selected="true">MEASLESN450</option>
+            <option value="MEASLES" selected="true">MEASLES</option>
+            <option value="RSVa" selected="true">RSVa</option>
+            <option value="RSVb" selected="true">RSVb</option>
+        </param> 
     </xml>
     <xml name="plot_lineages">
         <param argument="--lineages" type="boolean" truevalue="--lineages" falsevalue=""

--- a/tools/freyja/macros.xml
+++ b/tools/freyja/macros.xml
@@ -39,7 +39,7 @@ ln -s '$variants_file' 'variants_file.vcf' &&
     --meta '${meta}'
 #end if
 $confirmedonly
---pathogen $pathogen
+--pathogen '$pathogen'
 ]]></token>
     <token name="@CUSTOM_BARCODES_COMMAND@"><![CDATA[
 #if $usher_update_option.choice == 'custom'


### PR DESCRIPTION
This PR updates the freyja tool to 1.5.2 and adds new `--pathogen` option.

Fixes: #6513

---
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
