### PR TITLE
bbtools: use aggressive error detection

### DIFF
--- a/tools/bbtools/bbduk.xml
+++ b/tools/bbtools/bbduk.xml
@@ -6,7 +6,7 @@
     <expand macro="edam_ontology"/>
     <expand macro="bio.tools"/>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #import os
 
 #if str($input_type_cond.input_type) in ['single', 'pair']:

--- a/tools/bbtools/bbmap.xml
+++ b/tools/bbtools/bbmap.xml
@@ -8,7 +8,7 @@
         <xref type="bio.tools">bbmap</xref>
     </xrefs>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #if str($ref_source_cond.ref_source) == 'cached'
     #set ref = str($ref_source_cond.reference.fields.path)
 #else:

--- a/tools/bbtools/bbmerge.xml
+++ b/tools/bbtools/bbmerge.xml
@@ -6,7 +6,7 @@
     <expand macro="edam_ontology"/>
     <expand macro="bio.tools"/>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #if str($input_type_cond.input_type) in ['single', 'pair']:
     #set read1 = $input_type_cond.read1
     ## bbmerge uses the file extension to determine the input format.

--- a/tools/bbtools/callvariants.xml
+++ b/tools/bbtools/callvariants.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="bio.tools"/>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #import os
 
 #if str($ref_source_cond.ref_source) == 'cached'

--- a/tools/bbtools/macros.xml
+++ b/tools/bbtools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">39.08</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>

--- a/tools/bbtools/tadpole.xml
+++ b/tools/bbtools/tadpole.xml
@@ -6,7 +6,7 @@
     <expand macro="edam_ontology"/>
     <expand macro="bio.tools"/>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 #import os
 
 #if str($input_type_cond.input_type) in ['single', 'pair']:


### PR DESCRIPTION
had a `Exception in thread "Thread-0" java.lang.OutOfMemoryError: Java heap space` in bbnorm. 

I could also implement a separate stdio rule foe this. 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
