### PR TITLE
correctly embed reference in bam/cram

### DIFF
--- a/tools/minimap2/minimap2.xml
+++ b/tools/minimap2/minimap2.xml
@@ -16,11 +16,6 @@
     <version_command>minimap2 --version</version_command>
     <command>
 <![CDATA[
-    #if $reference_source.reference_source_selector == 'history':
-        ln -f -s '$reference_source.ref_file' reference.fa &&
-    #else:
-        ln -f -s '$reference_source.ref_file.fields.path' reference.fa &&
-    #end if
     minimap2
     #if str($fastq_input.analysis_type_selector) == 'self-homology':
         -DP -k19 -w19 -m200
@@ -142,7 +137,11 @@
         -K $io_options.K
     #end if
     -t \${GALAXY_SLOTS:-4}
-    reference.fa
+    #if $reference_source.reference_source_selector == 'history':
+        '$reference_source.ref_file'
+    #else:
+        '$reference_source.ref_file.fields.path'
+    #end if
     #if $fastq_input.fastq_input_selector in ['single', 'paired_iv']:
         '$fastq_input.fastq_input1'
     #else if $fastq_input.fastq_input_selector == 'paired':
@@ -151,7 +150,12 @@
          '$fastq_input.fastq_input1.forward' '$fastq_input.fastq_input1.reverse'
     #end if
     #if str($io_options.output_format) in ('BAM', 'CRAM'):
-        -a | samtools view --no-PG -hT reference.fa
+        -a | samtools view --no-PG -hT 
+        #if $reference_source.reference_source_selector == 'history':
+            '$reference_source.ref_file'
+        #else:
+            '$reference_source.ref_file.fields.path'
+        #end if
     #end if
     #if $io_options.output_format == 'BAM':
         | samtools sort
@@ -165,7 +169,12 @@
         -@\${GALAXY_SLOTS:-2}
         -O $io_options.output_format
         $io_options.eqx
-        --reference reference.fa
+        --reference 
+        #if $reference_source.reference_source_selector == 'history':
+            '$reference_source.ref_file'
+        #else:
+            '$reference_source.ref_file.fields.path'
+        #end if
         --output-fmt-option no_ref
         -o '$alignment_output'
     #else:


### PR DESCRIPTION
currently minimap2's bam/cram output stores a tmp file as the reference fasta. This prevents other galaxy tools from using it as the spec expects that the stored reference is a real file. This patch simply copies existing code over to ensure the real full path to the reference is used. It won't solve all cases (e.g. when reference file is deleted) but it will solve the other cases.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
