### PR TITLE
Fix fasttree tool

### DIFF
--- a/tools/fasttree/.lint_skip
+++ b/tools/fasttree/.lint_skip
@@ -1,2 +1,0 @@
-# the bool is used in a filter and an if statement of the command block which works
-InputsBoolDistinctValues

--- a/tools/fasttree/fasttree.xml
+++ b/tools/fasttree/fasttree.xml
@@ -90,7 +90,7 @@ $model_selector.model
                 </conditional>
             </when>
         </conditional>
-        <param name="save_logfile" type="boolean" truevalue="" falsevalue="" checked="false" label="Save log file output" />
+        <param name="save_logfile" type="boolean" checked="false" label="Save log file output" />
         <conditional name="model_selector">
             <param name="format" type="select" label="Protein or nucleotide alignment" help="Specify if the aligned sequences are nucleotide or protein sequences">
                 <option value="-nt">Nucleotide</option>
@@ -153,6 +153,13 @@ $model_selector.model
             <param name="save_logfile" value="true" />
             <output name="output" file="tree.nhx" ftype="nhx" lines_diff="2" />
             <output name="log" file="log.txt" ftype="txt" compare="contains" />
+        </test>
+        <test expect_num_outputs="1">
+            <param name="select_format" value="fasta" />
+            <param name="model" value="" />
+            <param name="input" value="aligned.fasta" />
+            <param name="format" value="-nt" />
+            <output name="output" file="tree.nhx" ftype="nhx" lines_diff="2" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tools-iuc/pull/6389#issuecomment-2545001051, broken by the addition of a newer profile version in that PR. We should probably not make it possible to skip error-level linting.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
