### PR TITLE
Fix glimmer tools error handling

### DIFF
--- a/tools/glimmer/.lint_skip
+++ b/tools/glimmer/.lint_skip
@@ -1,5 +1,1 @@
 CommandTODO
-InputsBoolDistinctValues
-OutputsLabelDuplicatedNoFilter
-TestsExpectNumOutputs
-XMLOrder

--- a/tools/glimmer/glimmer_acgt_content.xml
+++ b/tools/glimmer/glimmer_acgt_content.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_acgt_content" name="ACGT Content" version="@WRAPPER_VERSION@">
+<tool id="glimmer_acgt_content" name="ACGT Content" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>of windows in each sequence</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         window-acgt

--- a/tools/glimmer/glimmer_build_icm.xml
+++ b/tools/glimmer/glimmer_build_icm.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_build_icm" name="Glimmer ICM builder" version="@WRAPPER_VERSION@">
+<tool id="glimmer_build_icm" name="Glimmer ICM builder" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description></description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         build-icm

--- a/tools/glimmer/glimmer_extract.xml
+++ b/tools/glimmer/glimmer_extract.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_extract" name="Extract sequence regions" version="@WRAPPER_VERSION@">
+<tool id="glimmer_extract" name="Extract sequence regions" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>from a genome</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         extract

--- a/tools/glimmer/glimmer_gbk_to_orf.xml
+++ b/tools/glimmer/glimmer_gbk_to_orf.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_gbk_to_orf" name="Extract ORF" version="@WRAPPER_VERSION@">
+<tool id="glimmer_gbk_to_orf" name="Extract ORF" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>from a GenBank file</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         python '$__tool_directory__/glimmer_gbk_to_orf.py'
@@ -16,8 +16,8 @@
         <param name="infile" type='data' format="genbank" label="gene bank file"/>
     </inputs>
     <outputs>
-        <data name="aa_output" format="fasta" />
-        <data name="nc_output" format="fasta" />
+        <data name="aa_output" format="fasta" label="${tool.name}: Amino acids"/>
+        <data name="nc_output" format="fasta" label="{tool.name}: Nucleotides"/>
     </outputs>
     <tests>
         <test>

--- a/tools/glimmer/glimmer_glimmer_to_gff.xml
+++ b/tools/glimmer/glimmer_glimmer_to_gff.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_glimmer_to_gff" name="Convert Glimmer to GFF" version="@WRAPPER_VERSION@+galaxy1">
+<tool id="glimmer_glimmer_to_gff" name="Convert Glimmer to GFF" version="@WRAPPER_VERSION@+galaxy1" profile="@PROFILE_VERSION@">
     <description></description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         python '$__tool_directory__/glimmer_glimmer_to_gff.py'

--- a/tools/glimmer/glimmer_long_orfs.xml
+++ b/tools/glimmer/glimmer_long_orfs.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_long_orfs" name="Glimmer long ORFs" version="@WRAPPER_VERSION@">
+<tool id="glimmer_long_orfs" name="Glimmer long ORFs" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>identify long, non-overlapping ORFs</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         long-orfs

--- a/tools/glimmer/glimmer_w_icm.xml
+++ b/tools/glimmer/glimmer_w_icm.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_knowledge_based" name="Glimmer3" version="@WRAPPER_VERSION@">
+<tool id="glimmer_knowledge_based" name="Glimmer3" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>Predict ORFs in prokaryotic genomes (knowlegde-based)</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command detect_errors="aggressive"><![CDATA[
     glimmer3
@@ -87,20 +87,20 @@
             </when>
         </conditional>
 
-        <param name="report" type="boolean" truevalue="" falsevalue="" checked="false" label="Report the classic glimmer table output"/>
-        <param name="detailed_report" type="boolean" truevalue="" falsevalue="" checked="false" label="Output a detailed gene prediction report as separate file"/>
+        <param name="report" type="boolean" checked="false" label="Report the classic glimmer table output"/>
+        <param name="detailed_report" type="boolean" checked="false" label="Output a detailed gene prediction report as separate file"/>
     </inputs>
     <outputs>
         <data name="genes_output" format="fasta" label="Glimmer3 on ${on_string} (Gene Prediction FASTA)" />
         <data name="report_output" format="txt" label="Glimmer3 on ${on_string} (Gene Prediction table)">
-            <filter>report == True</filter>
+            <filter>report</filter>
         </data>
         <data name="detailed_output" format="txt" label="Glimmer3 on ${on_string} (detailed report)">
-            <filter>detailed_report == True</filter>
+            <filter>detailed_report</filter>
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="3">
             <param name="seq_input" value='streptomyces_Tue6071_plasmid_genomic.fasta' />
             <param name="icm_input" value='streptomyces_Tu6071_plasmid_genes.icm' ftype="tar" />
             <param name="max_olap" value="50" />
@@ -117,6 +117,20 @@
             <output name="genes_output" file='glimmer_w_icm_trans-table-11_genomic.fasta' ftype="fasta" />
             <output name="report_output" file='glimmer_w_icm_trans-table-11_genomic.out' ftype="txt" />
             <output name="detailed_output" file='glimmer_w_icm_trans-table-11_genomic.dout' ftype="txt" lines_diff="6" />
+        </test>
+        <test expect_num_outputs="1">
+            <param name="seq_input" value='streptomyces_Tue6071_plasmid_genomic.fasta' />
+            <param name="icm_input" value='streptomyces_Tu6071_plasmid_genes.icm' ftype="tar" />
+            <param name="max_olap" value="50" />
+            <param name="gene_len" value="90" />
+            <param name="threshold" value="30" />
+            <param name="gc_percent" value="0.0" />
+            <param name="linear" value="--linear" />
+            <param name="no_indep" value="" />
+            <param name="extend" value="" />
+            <param name="start_codons" value="atg,gtg,ttg" />
+            <param name="genbank_gencode" value="11" />
+            <output name="genes_output" file='glimmer_w_icm_trans-table-11_genomic.fasta' ftype="fasta" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/glimmer/glimmer_wo_icm.xml
+++ b/tools/glimmer/glimmer_wo_icm.xml
@@ -1,9 +1,9 @@
-<tool id="glimmer_not_knowledge_based" name="Glimmer3" version="@WRAPPER_VERSION@">
+<tool id="glimmer_not_knowledge_based" name="Glimmer3" version="@WRAPPER_VERSION@" profile="@PROFILE_VERSION@">
     <description>Predict ORFs in prokaryotic genomes (not knowlegde-based)</description>
-    <expand macro="bio_tools"/>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="bio_tools"/>
     <expand macro="requirements"/>
     <command><![CDATA[
         python '$__tool_directory__/glimmer_wo_icm.py'
@@ -31,20 +31,20 @@
         <param name="threshold" type="integer" value="30" label="Set threshold score for calling as gene. If the in-frame score >= N, then the region is given a number and considered a potential gene." />
         <param name="linear" type="boolean" truevalue="true" falsevalue="false" checked="true" label="Assume linear rather than circular genome, i.e., no wraparound" />
 
-        <param name="detailed_report" type="boolean" truevalue="" falsevalue="" checked="false" label="Output a detailed gene prediction report as separate file" />
-        <param name="report" type="boolean" truevalue="" falsevalue="" checked="false" label="Report the classic glimmer table output" />
+        <param name="detailed_report" type="boolean" checked="false" label="Output a detailed gene prediction report as separate file" />
+        <param name="report" type="boolean" checked="false" label="Report the classic glimmer table output" />
     </inputs>
     <outputs>
         <data name="genes_output" format="fasta" label="Glimmer3 on ${on_string} (Gene Prediction FASTA)" />
         <data name="prediction" format="txt" label="Glimmer3 on ${on_string} (Gene Prediction table)">
-            <filter>report == True</filter>
+            <filter>report</filter>
         </data>
         <data name="detailed" format="txt" label="Glimmer3 on ${on_string} (detailed report)">
-            <filter>detailed_report == True</filter>
+            <filter>detailed_report</filter>
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="streptomyces_Tue6071_plasmid_genomic.fasta" />
             <param name="overlap" value="0" />
             <param name="gene_length" value="110" />
@@ -52,6 +52,16 @@
             <param name="linear" value="true" />
             <param name="detailed_report" value="" />
             <param name="report" value="" />
+            <output name="genes_output" file="glimmer_wo_icm_trans-table-11_plasmid_genomic.fasta" ftype="fasta" />
+        </test>
+        <test expect_num_outputs="3">
+            <param name="input" value="streptomyces_Tue6071_plasmid_genomic.fasta" />
+            <param name="overlap" value="0" />
+            <param name="gene_length" value="110" />
+            <param name="threshold" value="30" />
+            <param name="linear" value="true" />
+            <param name="detailed_report" value="true" />
+            <param name="report" value="true" />
             <output name="genes_output" file="glimmer_wo_icm_trans-table-11_plasmid_genomic.fasta" ftype="fasta" />
         </test>
     </tests>

--- a/tools/glimmer/macros.xml
+++ b/tools/glimmer/macros.xml
@@ -19,4 +19,5 @@
             <citation type="doi">10.1093/bioinformatics/btm009</citation>
         </citations>
     </xml>
+    <token name="@PROFILE_VERSION@">23.1</token>
 </macros>


### PR DESCRIPTION
All the tools that call into python scripts wouldn't fail on non-zero exit codes. They also didn't write to stderr, so in fact they could never fail. Also fixes the remaining lint errors.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
