### PR TITLE
Add data manager for clair3 models

### DIFF
--- a/data_managers/data_manager_clair3_models/.shed.yml
+++ b/data_managers/data_manager_clair3_models/.shed.yml
@@ -1,0 +1,11 @@
+categories:
+- Data Managers
+description: Install Clair3 models from the Oxford Nanopore Rerio repository
+long_description: |
+  This data manager downloads the Clair3 models from the Oxford Nanopore Rerio repository and installs
+  them in the Galaxy instance. Note that these models are licensed according to the terms of the
+  "Oxford Nanopore Technologies, Ltd. Public License Version 1.0"
+name: data_manager_clair3_models
+owner: iuc
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/main/data_managers/data_manager_clair3_models
+type: unrestricted

--- a/data_managers/data_manager_clair3_models/data_manager/install_clair3_models.xml
+++ b/data_managers/data_manager_clair3_models/data_manager/install_clair3_models.xml
@@ -1,6 +1,6 @@
-<tool id="data_manager_clair3_models" name="Clair3 model downloader" version="0.0.1" tool_type="manage_data" profile="23.2" />
+<tool id="data_manager_clair3_models" name="Clair3 model downloader" version="0.0.1" tool_type="manage_data" profile="23.2">
     <requirements>
-        <requirement type="package">python</requirement>
+        <requirement type="package" version="3.12">python</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$tool_directory/model_fetcher.py'
@@ -17,12 +17,14 @@
                 <option value="latest">Latest models from rerio page</option>
                 <option value="chosen">User provided list of models</option>
             </param>
-        <when value="latest">
-        </when>
-        <when value="chosen">
-            <param name="model_list" type="text" label="List of models to download" help="A space separated list of model to download, e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430'">
-                <validator type="regex" message="Invalid model list. Format is a space separated list of model names (e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430')" value="^[a-z_0-9,]+$"/>
-            </param>
+            <when value="latest">
+            </when>
+            <when value="chosen">
+                <param name="model_list" type="text" label="List of models to download" help="A space separated list of model to download, e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430'">
+                    <validator type="regex" message="Invalid model list. Format is a space separated list of model names (e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430')">^[a-z_0-9,]+$</validator>
+                </param>
+            </when>
+        </conditional>
     </inputs>
     <outputs>
         <data name="output_file" format="data_manager_clair3_models" label="Downloaded models" />
@@ -49,5 +51,27 @@
                     <has_text text='data_tables' />  
                 </assert_contents>
             </output>
+        </test>
     </tests>
+    <help><![CDATA[
+    Clair3_ is a variant caller for long read data developed at the University of Hong Kong. This tool makes use of models trained to match particular
+    sequencing technologies and basecallers. Oxford Nanopore provides a set of models for Clair3 on their Rerio_ page. These tools are designed for
+    "research release" under the terms of the "Oxford Nanopore Technologies, Ltd. Public License Version 1.0" license_. This data manager allows
+    downloading model files from the Rerio page and installing them on a Galaxy server.
+
+    .. _Clair3: https://github.com/HKU-BAL/Clair3
+    .. _Rerio: https://github.com/nanoporetech/rerio
+    .. _license: https://github.com/nanoporetech/rerio/blob/master/LICENCE.txt
+    ]]>
+    </help>
+    <citations>
+        <citation type="doi">10.1101/2021.12.29.474431v2</citation>
+        <citation type="bibtex"><![CDATA[@misc{ONT2024,
+            title        = {Rerio},
+            author       = {Oxford Nanopore Technologies},
+            year         = 2024,
+            howpublished = {\url{https://github.com/nanoporetech/rerio}},
+            commit       = {c0c8ce6}
+    }]]></citation>
+    </citations>
 </tool>

--- a/data_managers/data_manager_clair3_models/data_manager/install_clair3_models.xml
+++ b/data_managers/data_manager_clair3_models/data_manager/install_clair3_models.xml
@@ -1,0 +1,53 @@
+<tool id="data_manager_clair3_models" name="Clair3 model downloader" version="0.0.1" tool_type="manage_data" profile="23.2" />
+    <requirements>
+        <requirement type="package">python</requirement>
+    </requirements>
+    <command detect_errors="exit_code"><![CDATA[
+        python '$tool_directory/model_fetcher.py'
+            '{output_file}'
+            #if $model_selection.source == 'latest'
+                --download_latest
+            #elif $model_selection.source == 'chosen'
+                --model_list '$model_selection.model_list'
+            #end if
+    ]]></command>
+    <inputs>
+        <conditional name="model_selection">
+            <param name="source" label="Select the source of the list of models to download" type="select">
+                <option value="latest">Latest models from rerio page</option>
+                <option value="chosen">User provided list of models</option>
+            </param>
+        <when value="latest">
+        </when>
+        <when value="chosen">
+            <param name="model_list" type="text" label="List of models to download" help="A space separated list of model to download, e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430'">
+                <validator type="regex" message="Invalid model list. Format is a space separated list of model names (e.g. 'r1041_e82_400bps_sup_v430,r1041_e82_400bps_hac_v430')" value="^[a-z_0-9,]+$"/>
+            </param>
+    </inputs>
+    <outputs>
+        <data name="output_file" format="data_manager_clair3_models" label="Downloaded models" />
+    </outputs>
+    <tests>
+        <test> <!-- test1 -->
+            <conditional name="model_selection">
+                <param name="source" value="chosen"/>
+                <param name="model_list" value="r1041_e82_400bps_sup_v500,r1041_e82_400bps_hac_v500" />
+            </conditional>
+            <output name="output_file">
+                <assert_contents>
+                    <has_text text='r1041_e82_400bps_sup_v500' />
+                </assert_contents>
+            </output>
+        </test>
+        <test> <!-- test2 -->
+            <conditional name="model_selection">
+                <param name="source" value="latest"/>
+            </conditional>
+            <output name="output_file">
+                <assert_contents>
+                    <!-- because we don't know what the names of the latest models are we can only test to see if the data table output is created -->
+                    <has_text text='data_tables' />  
+                </assert_contents>
+            </output>
+    </tests>
+</tool>

--- a/data_managers/data_manager_clair3_models/data_manager/model_fetcher.py
+++ b/data_managers/data_manager_clair3_models/data_manager/model_fetcher.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+import tarfile
+
+
+from io import StringIO, BytesIO
+from pathlib import Path
+from urllib.request import urlopen, Request
+
+DATA_TABLE_NAME = 'clair3_models'
+
+
+def find_latest_models():
+    # based on the README.rst of the rerio repository as of 7 January 2025
+    url = 'https://raw.githubusercontent.com/nanoporetech/rerio/refs/heads/master/README.rst'
+    httprequest = Request(url)
+    with urlopen(httprequest) as response:
+        if response.status != 200:
+            raise IOError(f'Failed to fetch the latest models: {response.status}')
+        data = response.read().decode('utf-8')
+        init_line_seen = False
+        config_line_seen = False
+        read_lines = False
+        models = []
+        for line in StringIO(data):
+            if read_lines:
+                if line.startswith('=========================='):
+                    read_lines = False
+                    break
+                model = line[:break1-1]
+                models.append(model)
+            if config_line_seen and line.startswith('=========================='):
+                break1 = line.find(' ')
+                read_lines = True
+                continue
+            if init_line_seen and line.startswith('Config'):
+                config_line_seen = True
+                continue
+            if line.startswith('Clair3 models for the following configurations are available:'):
+                init_line_seen = True
+                continue
+        return models
+
+
+def fetch_model(model_name):
+    # the model files are tar gzipped, with a structure like:
+    # model_name/pileup.index
+    # model_name/full_alignment.index
+    # and other files, with the key point being that the model_name becoomes the model_directory
+
+    url = f'https://raw.githubusercontent.com/nanoporetech/rerio/refs/heads/master/clair3_models/{model_name}_model'
+    httprequest = Request(url)
+    with urlopen(httprequest) as response:
+        if response.status != 200:
+            raise IOError(f'Failed to fetch the model {model_name}: {response.status}')
+        final_url = response.read().decode('utf-8').strip()
+    httprequest = Request(final_url)
+    with urlopen(httprequest) as response:
+        if response.status != 200:
+            raise IOError(f'Failed to fetch the model {model_name} from CDN URL {final_url}: {response.status}')
+        data = response.read()
+    return data
+
+
+def unpack_model(data, outdir):
+    with tarfile.open(fileobj=BytesIO(data), mode='r:*') as tar:
+        tar.extractall(outdir)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dm_filename', type=str, help='The filename of the data manager file to read parameters from and write outputs to')
+    parser.add_argument('--download_latest', action='store_true', default=False, help='Download the latest models as per the rerio repository')
+    parser.add_argument('--download_models', type=str, help='Comma separated list of models to download')
+    args = parser.parse_args()
+
+    # parameters to a data manager are passed in a JSON file (see https://docs.galaxyproject.org/en/latest/dev/data_managers.html) and
+    # similarily a JSON file is created to pass the output back to Galaxy
+    models = []
+    if args.download_latest:
+        models.extend(find_latest_models())
+    if args.download_models:
+        models.extend(args.download_models.split(','))
+    
+    if not models:
+        sys.exit('No models to download, please specify either --download_latest or --download_models')
+
+    with open(args.galaxy_datamanager_filename) as fh:
+        config = json.load(fh)
+    if 'extra_files_path' not in config.get('output_data', [{}])[0]:
+        sys.exit('Please specify the output directory in the data manager configuration (the extra_files_path)')
+    output_directory = config["output_data"]["extra_files_path"]
+    if not Path(output_directory).exists():
+        Path(output_directory).mkdir(parents=True)
+    
+    data_manager_dict = {}
+    data_manager_dict["data_tables"] = config.get("data_tables", {})
+    data_manager_dict["data_tables"][DATA_TABLE_NAME] = []
+
+    for model in models:
+        model_dir = Path(output_directory) / model
+        # In the test below we assume that the contents of the model are uniquely identified by the model name. It is possible
+        # that Oxford Nanopore will change the contents of the model tarball without changing the name. Hopefully this will never
+        # happen.
+        if model_dir.exists():
+            print(f'Model {model} already exists, skipping', file=sys.stderr)
+            continue
+        data = fetch_model(model)
+        unpack_model(data, output_directory)
+
+        data_manager_dict["data_tables"][DATA_TABLE_NAME].append(
+            dict(
+                value=model,
+                path=str(model_dir)
+            )
+        )
+
+        with open(args.output_dm_filename, 'w') as fh:
+            json.dump(data_manager_dict, fh, sort_keys=True, indent=4)

--- a/data_managers/data_manager_clair3_models/data_manager/model_fetcher.py
+++ b/data_managers/data_manager_clair3_models/data_manager/model_fetcher.py
@@ -25,12 +25,13 @@ def find_latest_models():
         config_line_seen = False
         read_lines = False
         models = []
+        break1 = 0
         for line in StringIO(data):
             if read_lines:
                 if line.startswith('=========================='):
                     read_lines = False
                     break
-                model = line[:break1-1]
+                model = line[:break1 - 1]
                 models.append(model)
             if config_line_seen and line.startswith('=========================='):
                 break1 = line.find(' ')
@@ -84,7 +85,7 @@ if __name__ == '__main__':
         models.extend(find_latest_models())
     if args.download_models:
         models.extend(args.download_models.split(','))
-    
+
     if not models:
         sys.exit('No models to download, please specify either --download_latest or --download_models')
 
@@ -95,7 +96,7 @@ if __name__ == '__main__':
     output_directory = config["output_data"]["extra_files_path"]
     if not Path(output_directory).exists():
         Path(output_directory).mkdir(parents=True)
-    
+
     data_manager_dict = {}
     data_manager_dict["data_tables"] = config.get("data_tables", {})
     data_manager_dict["data_tables"][DATA_TABLE_NAME] = []

--- a/data_managers/data_manager_clair3_models/data_manager_conf.xml
+++ b/data_managers/data_manager_clair3_models/data_manager_conf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<data_managers>    
+    <data_manager tool_file="data_manager/clair3_models.xml" id="data_manager_clair3_models">
+        <data_table name="clair3_models">
+            <output>
+                <column name="value" />
+                <column name="path" output_ref="output_file" >
+                    <!-- note: the Python script sanitises the possibly user-supplied scheme name ('value') -->
+                    <move type="directory">
+                        <source>${path}</source>
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">clair3_models/#echo str($value)#</target>
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/clair3_models/#echo str($value)#</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+    </data_manager>    
+</data_managers>

--- a/data_managers/data_manager_clair3_models/test-data/clair3_models.loc
+++ b/data_managers/data_manager_clair3_models/test-data/clair3_models.loc
@@ -1,4 +1,4 @@
-# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Revio site and provided as directories)
+# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Rerio site and provided as directories)
 #
 # the columns are:
 # 1. value

--- a/data_managers/data_manager_clair3_models/test-data/clair3_models.loc
+++ b/data_managers/data_manager_clair3_models/test-data/clair3_models.loc
@@ -1,0 +1,8 @@
+# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Revio site and provided as directories)
+#
+# the columns are:
+# 1. value
+# 2. path (path to directory containing model)
+# for example
+#
+# r1041_e82_400bps_hac_v500	/data/galaxy/tool_data/clair3_models/r1041_e82_400bps_hac_v500

--- a/data_managers/data_manager_clair3_models/tool-data/clair3_models.loc.sample
+++ b/data_managers/data_manager_clair3_models/tool-data/clair3_models.loc.sample
@@ -1,4 +1,4 @@
-# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Revio site and provided as directories)
+# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Rerio site and provided as directories)
 #
 # the columns are:
 # 1. value

--- a/data_managers/data_manager_clair3_models/tool-data/clair3_models.loc.sample
+++ b/data_managers/data_manager_clair3_models/tool-data/clair3_models.loc.sample
@@ -1,0 +1,8 @@
+# this is a table separated file describing the locations of Clair3 models (which are download from Oxford Nanopore's Revio site and provided as directories)
+#
+# the columns are:
+# 1. value
+# 2. path (path to directory containing model)
+# for example
+#
+# r1041_e82_400bps_hac_v500	/data/galaxy/tool_data/clair3_models/r1041_e82_400bps_hac_v500

--- a/data_managers/data_manager_clair3_models/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_clair3_models/tool_data_table_conf.xml.sample
@@ -1,0 +1,6 @@
+<tables>
+    <table name="clair3_models" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, path</columns>
+        <file path="tool-data/clair3_models.loc" />
+    </table>
+</tables>

--- a/data_managers/data_manager_clair3_models/tool_data_table_conf.xml.test
+++ b/data_managers/data_manager_clair3_models/tool_data_table_conf.xml.test
@@ -1,0 +1,6 @@
+<tables>
+    <table name="clair3_models" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, path</columns>
+        <file path="${__HERE__}/clair3_models.loc" />
+    </table>
+</tables>


### PR DESCRIPTION
As noted in #6547 the clair3 tool does not come with models for newer Oxford Nanopore flow cells (the R10 flow cells). These are provided by Oxford Nanopore on their Rerio page. This data manager fetches Clair3 models from that page.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
