### PR TITLE
hicBuildMatrix SAM inputs changed from repeat to plain params

### DIFF
--- a/tools/hicexplorer/hicBuildMatrix.xml
+++ b/tools/hicexplorer/hicBuildMatrix.xml
@@ -1,4 +1,4 @@
-<tool id="hicexplorer_hicbuildmatrix" name="@BINARY@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="hicexplorer_hicbuildmatrix" name="@BINARY@" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>create a contact matrix</description>
     <macros>
         <token name="@BINARY@">hicBuildMatrix</token>
@@ -10,10 +10,7 @@
         mkdir ./QCfolder &&
         mkdir '$qc.files_path' &&
         @BINARY@
-            --samFiles
-            #for $repeat in $samFiles:
-                '${repeat.samFile}'
-            #end for
+            --samFiles '$samFile1' '$samFile2'
 
             --restrictionCutFile '$restrictionCutFile'
 
@@ -43,7 +40,7 @@
             #if $dbKey:
                 --genomeAssembly '$dbKey'
             #else
-                --genomeAssembly '$samFiles[0].samFile.metadata.dbkey'
+                --genomeAssembly '$samFile1.metadata.dbkey'
             #end if
 
             #if $region:
@@ -79,12 +76,7 @@
 ]]>
     </command>
     <inputs>
-        <!-- can we use multiple=True here with min="2" and max="2" ? -->
-        <repeat max="2" min="2" name="samFiles" title="Sam/Bam files to process (forward/reverse)" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
-            <param name="samFile" type="data" format="sam,qname_input_sorted.bam">
-            </param>
-        </repeat>
-
+        <expand macro="samFiles" />
         <expand macro="restrictionCutFile" />
         <expand macro="restrictionSequence" />
         <expand macro="danglingSequence" />
@@ -142,12 +134,8 @@
     </outputs>
     <tests>
         <test expect_num_outputs="4">
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R1_unsorted.sam" dbkey="hg38" />
-            </repeat>
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R2_unsorted.sam" dbkey="hg38" />
-            </repeat>
+            <param name="samFile1" value="small_test_R1_unsorted.sam" dbkey="hg38" />
+            <param name="samFile2" value="small_test_R2_unsorted.sam" dbkey="hg38" />
             <param name="outputFormat" value="h5" />
             <repeat name="binSizes">
                 <param name="binSize" value="5000" />
@@ -165,12 +153,8 @@
             <output name="raw_qc" file="raw_qc_report" compare="diff" lines_diff="2" />
         </test>
         <test expect_num_outputs="4">
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R1_unsorted.sam" dbkey="hg38" />
-            </repeat>
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R2_unsorted.sam" dbkey="hg38" />
-            </repeat>
+            <param name="samFile1" value="small_test_R1_unsorted.sam" dbkey="hg38" />
+            <param name="samFile2" value="small_test_R2_unsorted.sam" dbkey="hg38" />
             <repeat name="binSizes">
                 <param name="binSize" value="5000" />
             </repeat>

--- a/tools/hicexplorer/hicBuildMatrixMicroC.xml
+++ b/tools/hicexplorer/hicBuildMatrixMicroC.xml
@@ -1,4 +1,4 @@
-<tool id="hicexplorer_hicbuildmatrixmicroc" name="@BINARY@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="hicexplorer_hicbuildmatrixmicroc" name="@BINARY@" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>create a contact matrix</description>
     <macros>
         <token name="@BINARY@">hicBuildMatrixMicroC</token>
@@ -10,10 +10,7 @@
         mkdir ./QCfolder &&
         mkdir '$qc.files_path' &&
         @BINARY@
-            --samFiles
-            #for $repeat in $samFiles:
-                '${repeat.samFile}'
-            #end for
+            --samFiles '$samFile1' '$samFile2'
 
             #if $maxLibraryInsertSize:
                 --maxLibraryInsertSize $maxLibraryInsertSize
@@ -32,7 +29,7 @@
             #if $dbKey:
                 --genomeAssembly '$dbKey'
             #else
-                --genomeAssembly '$samFiles[0].samFile.metadata.dbkey'
+                --genomeAssembly '$samFile1.metadata.dbkey'
             #end if
 
             #if $region:
@@ -67,11 +64,7 @@
 ]]>
     </command>
     <inputs>
-        <!-- can we use multiple=True here with min="2" and max="2" ? -->
-        <repeat max="2" min="2" name="samFiles" title="Sam/Bam files to process (forward/reverse)" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
-            <param name="samFile" type="data" format="sam,qname_input_sorted.bam">
-            </param>
-        </repeat>
+        <expand macro="samFiles" />
 
         <param argument="--maxLibraryInsertSize" type="integer" optional="true" value="" label="Maximum library insert size defines different cut offs based on the maximum expected library size" help="*This is not the average fragment size* but the higher end of the fragment size distribution (obtained using for example Fragment Analyzer)
                         which usually is between 800 to 1500 bp. If this value if not known use the default of 1000. The insert value is used to decide if two mates
@@ -123,12 +116,8 @@
     </outputs>
     <tests>
         <test expect_num_outputs="4">
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R1_unsorted.sam" dbkey="hg38" />
-            </repeat>
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R2_unsorted.sam" dbkey="hg38" />
-            </repeat>
+            <param name="samFile1" value="small_test_R1_unsorted.sam" dbkey="hg38" />
+            <param name="samFile2" value="small_test_R2_unsorted.sam" dbkey="hg38" />
             <param name="outputFormat" value="h5" />
             <repeat name="binSizes">
                 <param name="binSize" value="5000" />
@@ -143,12 +132,8 @@
             <output name="raw_qc" file="raw_qc_report_micro-c" compare="diff" lines_diff="2" />
         </test>
         <test expect_num_outputs="4">
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R1_unsorted.sam" dbkey="hg38" />
-            </repeat>
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R2_unsorted.sam" dbkey="hg38" />
-            </repeat>
+            <param name="samFile1" value="small_test_R1_unsorted.sam" dbkey="hg38" />
+            <param name="samFile2" value="small_test_R2_unsorted.sam" dbkey="hg38" />
             <repeat name="binSizes">
                 <param name="binSize" value="5000" />
             </repeat>
@@ -169,7 +154,7 @@ Creation of the contact matrix
 ===============================
 
 
-**hicBuildMatrixMicroC** generates a contact matrix from Micro-C read pairs, using paired-end Hi-C reads mapped to a reference genome. This process requires two SAM or BAM files: one for the first mate and one for the second mate of the paired-end reads. These files must be unaligned by position (i.e., not sorted). Unlike traditional Hi-C data, where restriction enzyme cut sites determine resolution, Micro-C does not rely on such sites. Instead, the contact matrix is created using a fixed bin size (e.g., 10,000 bp). 
+**hicBuildMatrixMicroC** generates a contact matrix from Micro-C read pairs, using paired-end Hi-C reads mapped to a reference genome. This process requires two SAM or BAM files: one for the first mate and one for the second mate of the paired-end reads. These files must be unaligned by position (i.e., not sorted). Unlike traditional Hi-C data, where restriction enzyme cut sites determine resolution, Micro-C does not rely on such sites. Instead, the contact matrix is created using a fixed bin size (e.g., 10,000 bp).
 
 Additionally, **hicBuildMatrixMicroC** produces a quality control report to evaluate the quality of the Hi-C reads, aiding in determining the success of both the experimental protocol and sequencing process.
 

--- a/tools/hicexplorer/hicCorrectMatrix.xml
+++ b/tools/hicexplorer/hicCorrectMatrix.xml
@@ -121,16 +121,20 @@
     <tests>
         <test expect_num_outputs="1">
             <param name="matrix_h5_cooler" value="small_test_matrix.h5" />
-            <param name="mode_selector" value="correct" />
-            <param name="correctionMethod_selector" value="ice" />
+            <conditional name="mode">
+                <param name="mode_selector" value="correct" />
+                <conditional name="correctionMethod">
+                    <param name="correctionMethod_selector" value="ice" />
+                    <param name="filterThreshold_low" value="-2.0" />
+                    <param name="filterThreshold_large" value="4" />
+                </conditional>
+            </conditional>
             <repeat name="chromosomes">
                 <param name="chromosome" value="chrUextra" />
             </repeat>
             <repeat name="chromosomes">
                 <param name="chromosome" value="chr3LHet" />
             </repeat>
-            <param name="filterThreshold_low" value="-2.0" />
-            <param name="filterThreshold_large" value="4" />
             <output name="outFileName" ftype="h5">
                 <assert_contents>
                     <has_h5_keys keys="correction_factors,intervals,matrix,nan_bins" />
@@ -139,8 +143,12 @@
         </test>
         <test expect_num_outputs="1">
             <param name="matrix_h5_cooler" value="small_test_matrix.h5" />
-            <param name="mode_selector" value="correct" />
-            <param name="correctionMethod_selector" value="kr" />
+            <conditional name="mode">
+                <param name="mode_selector" value="correct" />
+                <conditional name="correctionMethod">
+                    <param name="correctionMethod_selector" value="kr" />
+                </conditional>
+            </conditional>
             <output name="outFileName" ftype="h5">
                 <assert_contents>
                     <has_h5_keys keys="correction_factors,intervals,matrix" />
@@ -149,8 +157,12 @@
         </test>
         <test expect_num_outputs="1">
             <param name="matrix_h5_cooler" value="small_test_matrix.cool" />
-            <param name="mode_selector" value="correct" />
-            <param name="correctionMethod_selector" value="kr" />
+            <conditional name="mode">
+                <param name="mode_selector" value="correct" />
+                <conditional name="correctionMethod">
+                    <param name="correctionMethod_selector" value="kr" />
+                </conditional>
+            </conditional>
             <output name="outFileName" ftype="cool">
                 <assert_contents>
                     <has_h5_keys keys="bins,chroms,indexes,pixels" />
@@ -159,17 +171,20 @@
         </test>
         <test expect_num_outputs="1">
             <param name="matrix_h5_cooler" value="small_test_matrix.h5" />
-
-            <param name="mode_selector" value="correct" />
-            <param name="correctionMethod_selector" value="ice" />
+            <conditional name="mode">
+                <param name="mode_selector" value="correct" />
+                <conditional name="correctionMethod">
+                    <param name="correctionMethod_selector" value="ice" />
+                    <param name="filterThreshold_low" value="-2.0" />
+                    <param name="filterThreshold_large" value="4" />
+                </conditional>
+            </conditional>
             <repeat name="chromosomes">
                 <param name="chromosome" value="chrUextra" />
             </repeat>
             <repeat name="chromosomes">
                 <param name="chromosome" value="chr3LHet" />
             </repeat>
-            <param name="filterThreshold_low" value="-2.0" />
-            <param name="filterThreshold_large" value="4" />
             <output name="outFileName" ftype="h5">
                 <assert_contents>
                     <has_h5_keys keys="correction_factors,intervals,matrix,nan_bins" />
@@ -178,7 +193,9 @@
         </test>
         <test expect_num_outputs="1">
             <param name="matrix_h5_cooler" value="small_test_matrix.h5" />
-            <param name="mode_selector" value="diagnostic_plot" />
+            <conditional name="mode">
+                <param name="mode_selector" value="diagnostic_plot" />
+            </conditional>
             <repeat name="chromosomes">
                 <param name="chromosome" value="chrUextra" />
             </repeat>

--- a/tools/hicexplorer/hicNormalize.xml
+++ b/tools/hicexplorer/hicNormalize.xml
@@ -54,7 +54,9 @@
     <tests>
         <test>
             <param name="matrix_h5_cooler_multiple" value="small_test_matrix.cool" />
-            <param name="normalize" value="norm_range" />
+            <conditional name="normalize_conditional">
+                <param name="normalize" value="norm_range" />
+            </conditional>
             <output name="normalize_matrix">
                 <discovered_dataset designation="0_norm_small_test_matrix" ftype="cool">
                     <assert_contents>
@@ -65,7 +67,9 @@
         </test>
         <test>
             <param name="matrix_h5_cooler_multiple" value="small_test_matrix.cool,small_test_matrix.cool" />
-            <param name="normalize" value="smallest" />
+            <conditional name="normalize_conditional">
+                <param name="normalize" value="smallest" />
+            </conditional>
             <output name="normalize_matrix">
                 <discovered_dataset designation="0_norm_small_test_matrix" ftype="cool">
                     <assert_contents>
@@ -81,7 +85,9 @@
         </test>
         <test>
             <param name="matrix_h5_cooler_multiple" value="small_test_matrix.h5,small_test_matrix.h5" />
-            <param name="normalize" value="smallest" />
+            <conditional name="normalize_conditional">
+                <param name="normalize" value="smallest" />
+            </conditional>
             <output name="normalize_matrix">
                 <discovered_dataset designation="0_norm_small_test_matrix" ftype="h5">
                     <assert_contents>

--- a/tools/hicexplorer/hicPCA.xml
+++ b/tools/hicexplorer/hicPCA.xml
@@ -232,7 +232,7 @@ Two files are outputed by **hicPCA**, one with the first (pca1) and one with the
 For example, below you can find a ``hicPlotMatrix`` of the Pearson correlation matrix derived from a contact matrix for chromosome 6 in mouse computed with ``hicTransform`` (which is part of A/B compartments computation). The optional data track at the bottom shows the first eigenvector for A/B compartment obtained using **hicPCA**.
 
 .. image:: $PATH_TO_IMAGES/hicPCA.png
-   :scale: 35 %
+   :width: 35 %
 
 _________________
 

--- a/tools/hicexplorer/hicPlotDistVsCounts.xml
+++ b/tools/hicexplorer/hicPlotDistVsCounts.xml
@@ -119,7 +119,7 @@ them. If the ``--perchr`` option is given, each chromosome is plotted independen
 Below can be found an example output:
 
 .. image:: $PATH_TO_IMAGES/hicPlotDistVsCounts.png
-   :scale: 50 %
+   :width: 50 %
 
 Here, we see that the samples from the first condition are not so well correlated, but they follow the same tendancies and are distinct from the two samples of the second condition. The later are well correlated and display enriched long-range contacts compared to the first condition samples.
 
@@ -127,7 +127,7 @@ Here, we see that the samples from the first condition are not so well correlate
 On the second graph below, the distance vs. Hi-C contact counts is computed and plotted per chromosome:
 
 .. image:: $PATH_TO_IMAGES/hicPlotDistVsCounts_result2.png
-   :scale: 50 %
+   :width: 50 %
 
 _________________
 

--- a/tools/hicexplorer/hicQuickQC.xml
+++ b/tools/hicexplorer/hicQuickQC.xml
@@ -1,4 +1,4 @@
-<tool id="hicexplorer_hicquickqc" name="@BINARY@" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="hicexplorer_hicquickqc" name="@BINARY@" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>get a first quality estimate of Hi-C data</description>
     <macros>
         <token name="@BINARY@">hicQuickQC</token>
@@ -11,13 +11,10 @@
         mkdir $qc.files_path &&
         @BINARY@
 
-            --samFiles
-            #for $repeat in $samFiles:
-                '${repeat.samFile}'
-            #end for
+            --samFiles '$samFile1' '$samFile2'
 
             --restrictionCutFile '$restrictionCutFile'
-            
+
             #if $restrictionSequence:
                 --restrictionSequence $restrictionSequence
             #end if
@@ -34,10 +31,7 @@
         && mv $qc.files_path/*.log raw_qc
     ]]>    </command>
     <inputs>
-        <!-- can we use multiple="true" with min="2" and max="2" ? -->
-        <repeat max="2" min="2" name="samFiles" title="Sam/Bam files to process (forward/reverse)" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
-            <param name="samFile" type="data" format="sam,qname_input_sorted.bam" />
-        </repeat>
+        <expand macro="samFiles" />
         <expand macro="restrictionCutFile" />
         <expand macro="restrictionSequence" />
         <expand macro="danglingSequence" />
@@ -49,12 +43,8 @@
     </outputs>
     <tests>
         <test expect_num_outputs="2">
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R1_unsorted.sam" />
-            </repeat>
-            <repeat name="samFiles">
-                <param name="samFile" value="small_test_R2_unsorted.sam" />
-            </repeat>
+            <param name="samFile1" value="small_test_R1_unsorted.sam" />
+            <param name="samFile2" value="small_test_R2_unsorted.sam" />
             <param name="restrictionCutFile" value="DpnII_10k.bed" />
             <param name="restrictionSequence" value="GATC" />
             <param name="danglingSequence" value="GATC" />

--- a/tools/hicexplorer/hicQuickQC.xml
+++ b/tools/hicexplorer/hicQuickQC.xml
@@ -43,8 +43,8 @@
     </outputs>
     <tests>
         <test expect_num_outputs="2">
-            <param name="samFile1" value="small_test_R1_unsorted.sam" />
-            <param name="samFile2" value="small_test_R2_unsorted.sam" />
+            <param name="samFile1" value="small_test_R1_unsorted.sam" dbkey="hg38"/>
+            <param name="samFile2" value="small_test_R2_unsorted.sam" dbkey="hg38"/>
             <param name="restrictionCutFile" value="DpnII_10k.bed" />
             <param name="restrictionSequence" value="GATC" />
             <param name="danglingSequence" value="GATC" />

--- a/tools/hicexplorer/macros.xml
+++ b/tools/hicexplorer/macros.xml
@@ -47,6 +47,11 @@
         <param argument='--dpi' type='integer' optional='true' min="10" max="1000" label='DPI for image' help='Change the default resolution of the plot.' />
     </xml>
 
+    <xml name="samFiles">
+        <param name="samFile1" type="data" format="sam,qname_input_sorted.bam" label="Forward SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file."/>
+        <param name="samFile2" type="data" format="sam,qname_input_sorted.bam" label="Reverse SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file."/>
+    </xml>
+
     <xml name="restrictionCutFile">
         <param argument="--restrictionCutFile" type="data" format="bed" optional="false" label="BED file with all restriction cut places" help="Should contaion only mappable restriction sites. If given, the bins are set to match the restriction fragments
                 (i.e. the region between one restriction site and the next)." />

--- a/tools/hicexplorer/macros.xml
+++ b/tools/hicexplorer/macros.xml
@@ -48,8 +48,12 @@
     </xml>
 
     <xml name="samFiles">
-        <param name="samFile1" type="data" format="sam,qname_input_sorted.bam" label="Forward SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file."/>
-        <param name="samFile2" type="data" format="sam,qname_input_sorted.bam" label="Reverse SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file."/>
+        <param name="samFile1" type="data" format="sam,qname_input_sorted.bam" label="Forward SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
+            <validator type="unspecified_build" />
+        </param>
+        <param name="samFile2" type="data" format="sam,qname_input_sorted.bam" label="Reverse SAM/BAM file to process" help="Please use the special BAM datatype: qname_input_sorted.bam and use for 'bowtie2' the '--reorder' option to create a BAM file.">
+            <validator type="unspecified_build" />
+        </param>
     </xml>
 
     <xml name="restrictionCutFile">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

A repeat with exactly 2 params can be replaced with two params. With two params, at least the labels are better.

version bump only for the affected tools.