### PR TITLE
IRMA update: Add amended consensus output and run info

### DIFF
--- a/tools/irma/createMissingFiles.py
+++ b/tools/irma/createMissingFiles.py
@@ -3,8 +3,8 @@ import os
 import subprocess
 
 dirPrefix = "resultDir/"
-expectedSegments = ["A_MP", "A_NP", "A_HA", "A_PB1",
-                    "A_PB2", "A_NA", "A_PA", "A_NS"]
+expectedSegments = {"A_MP": 7, "A_NP": 5, "A_HA": 4, "A_PB1": 2,
+                    "A_PB2": 1, "A_NA": 6, "A_PA": 3, "A_NS": 8}
 
 
 def renameSubtypeFiles(identifier):
@@ -19,7 +19,7 @@ def getMissingSegments():
     for file in os.listdir(dirPrefix):
         if file.endswith(".fasta"):
             presentSegments.append(file.split('.')[0])
-    return [segment for segment in expectedSegments
+    return [segment for segment in expectedSegments.keys()
             if segment not in presentSegments]
 
 
@@ -56,8 +56,13 @@ def writeEmptyVcf(identifier, vcfHeader):
         f.write(vcfHeader)
 
 
+def writeEmptyAmendedFasta(identifier):
+    #  irma names these files like: resultDir/amended_consensus/resultDir_<segNr>.fa
+    open(dirPrefix + "amended_consensus/resultDir_" + str(expectedSegments[identifier]) + ".fa", 'x').close()
+
+
 def samtoolsSortAllBam():
-    for segment in expectedSegments:
+    for segment in expectedSegments.keys():
         os.rename(dirPrefix + segment + ".bam",
                   dirPrefix + segment + "_unsorted.bam")
         cmd = ['samtools', 'sort', dirPrefix + segment + "_unsorted.bam"]
@@ -76,4 +81,5 @@ if __name__ == "__main__":
         writeEmptyBam(segment, bamHeader)
         writeEmptyFasta(segment)
         writeEmptyVcf(segment, vcfHeader)
+        writeEmptyAmendedFasta(segment)
     samtoolsSortAllBam()

--- a/tools/irma/irma.xml
+++ b/tools/irma/irma.xml
@@ -413,6 +413,11 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
                     <param name="INCL_CHIM" value="false"/>
                     <param name="ADAPTER" value="AGATGTGTATAAGAGACAG"/>
                     <param name="ENFORCE_CLIPPED_LENGTH" value="true"/>
+                    <param name="MERGE_SECONDARY" value="false"/>
+                    <param name="RESIDUAL_ASSEMBLY_FACTOR" value="0"/>
+                </conditional>
+                <conditional name="match_step">
+                    <param name="customize" value="yes"/>
                     <param name="MIN_RP" value="15"/>
                     <param name="MIN_RC" value="15"/>
                     <param name="MIN_BLAT_MATCH" value="0"/>
@@ -465,9 +470,6 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
             <output_collection name="bam_collection" type="list" count="8" />
             <output_collection name="vcf_collection" type="list" count="8" />
         </test>
-
-        <!--New test, for new outputs-->
-        
         <test expect_num_outputs="19">
             <conditional name="input_type_conditional">
                 <param name="fastq_input1" value="test_reads.fq" />

--- a/tools/irma/irma.xml
+++ b/tools/irma/irma.xml
@@ -2,7 +2,7 @@
     <description>Construct robust assemblies of highly variable RNA viruses</description>
     <macros>
         <token name="@TOOL_VERSION@">1.2.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">irma-virus</xref> 
@@ -126,8 +126,10 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
             <option value="FLU-pacbio">FLU-pacbio</option>
         </param>
         <param name="optional_outputs" type="select" display="checkboxes" multiple="true" optional="true" label="Select additional IRMA outputs">
+            <option value="amended_consensus" selected="false">Amended consensus files: Include ambiguity codes for alleles, with second allele frequency greater 0.25</option>
             <option value="bam" selected="false">Bam: Alignment files of fastq against polished reference</option>
             <option value="vcf" selected="false">Vcf: Variation calling file per segment</option>
+            <option value="run_info" selected="false">Run info: Text file with run metadata</option>
         </param>
         <conditional name="advanced_config">
             <param name="customize" type="select" label="Customize Advanced Settings?" help="Choosing Yes here, lets you overwrite advanced settings defined in IRMA's default configuration file.">
@@ -267,8 +269,8 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
     </inputs>
     <outputs>
         <collection name="consensus_collection" type="list" label="Fasta Consensus Sequences">
-            <data name="PB1" format="fasta" from_work_dir="resultDir/A_PB1.fasta" label="PB1"/>
             <data name="PB2" format="fasta" from_work_dir="resultDir/A_PB2.fasta" label="PB2"/>
+            <data name="PB1" format="fasta" from_work_dir="resultDir/A_PB1.fasta" label="PB1"/>
             <data name="PA" format="fasta" from_work_dir="resultDir/A_PA.fasta" label="PA"/>
             <data name="HA" format="fasta" from_work_dir="resultDir/A_HA.fasta" label="HA"/>
             <data name="NP" format="fasta" from_work_dir="resultDir/A_NP.fasta" label="NP"/>
@@ -277,6 +279,17 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
             <data name="NS" format="fasta" from_work_dir="resultDir/A_NS.fasta" label="NS"/>
         </collection>
         <!-- optional outputs-->
+        <collection name="amended_collection" type="list" label="Amended Fasta Consensus">
+            <filter>optional_outputs and 'amended_consensus' in optional_outputs</filter>
+            <data name="PB1" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_1.fa" label="PB1"/>
+            <data name="PB2" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_2.fa"  label="PB2"/>
+            <data name="PA" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_3.fa"  label="PA"/>
+            <data name="HA" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_4.fa"  label="HA"/>
+            <data name="NP" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_5.fa"  label="NP"/>
+            <data name="NA" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_6.fa"  label="NA"/>
+            <data name="MP" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_7.fa" label="MP"/>
+            <data name="NS" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_8.fa"  label="NS"/>
+        </collection>
         <collection name="bam_collection" type="list" label="Alignment files (bam)">
             <filter>optional_outputs and 'bam' in optional_outputs</filter>
             <data name="PB1" format="bam" from_work_dir="resultDir/A_PB1.bam" label="PB1"/>
@@ -299,6 +312,9 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
             <data name="MP" format="vcf" from_work_dir="resultDir/A_MP.vcf" label="MP"/>
             <data name="NS" format="vcf" from_work_dir="resultDir/A_NS.vcf" label="NS"/>
         </collection>
+        <data name="run_info" label="IRMA run info" format="txt" from_work_dir="resultDir/logs/run_info.txt"> 
+            <filter>optional_outputs and 'run_info' in optional_outputs</filter>
+        </data>
     </outputs>
     <tests>
         <test expect_num_outputs="27">
@@ -397,11 +413,6 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
                     <param name="INCL_CHIM" value="false"/>
                     <param name="ADAPTER" value="AGATGTGTATAAGAGACAG"/>
                     <param name="ENFORCE_CLIPPED_LENGTH" value="true"/>
-                    <param name="MERGE_SECONDARY" value="false"/>
-                    <param name="RESIDUAL_ASSEMBLY_FACTOR" value="0"/>
-                </conditional>
-                <conditional name="match_step">
-                    <param name="customize" value="yes"/>
                     <param name="MIN_RP" value="15"/>
                     <param name="MIN_RC" value="15"/>
                     <param name="MIN_BLAT_MATCH" value="0"/>
@@ -453,6 +464,34 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
             </output_collection>
             <output_collection name="bam_collection" type="list" count="8" />
             <output_collection name="vcf_collection" type="list" count="8" />
+        </test>
+
+        <!--New test, for new outputs-->
+        
+        <test expect_num_outputs="19">
+            <conditional name="input_type_conditional">
+                <param name="fastq_input1" value="test_reads.fq" />
+                <param name="input_type" value="single" />
+            </conditional>
+            <conditional name="advanced_config">
+                <param name="customize" value="no" />
+            </conditional>
+            <param name="module" value="FLU-utr" />
+            <param name="optional_outputs" value="amended_consensus,run_info"/>
+            <output_collection name="consensus_collection" type="list">
+                <element name="HA">
+                  <assert_contents>
+                    <has_n_lines n="2"/>
+                  </assert_contents>
+                </element>
+            </output_collection>
+            <output_collection name="amended_collection" type="list">
+                <element name="HA">
+                  <assert_contents>
+                    <has_n_lines n="2"/>
+                  </assert_contents>
+                </element>
+            </output_collection>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/irma/irma.xml
+++ b/tools/irma/irma.xml
@@ -281,8 +281,8 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
         <!-- optional outputs-->
         <collection name="amended_collection" type="list" label="Amended Fasta Consensus">
             <filter>optional_outputs and 'amended_consensus' in optional_outputs</filter>
-            <data name="PB1" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_1.fa" label="PB1"/>
-            <data name="PB2" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_2.fa"  label="PB2"/>
+            <data name="PB2" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_1.fa"  label="PB2"/>
+            <data name="PB1" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_2.fa" label="PB1"/>
             <data name="PA" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_3.fa"  label="PA"/>
             <data name="HA" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_4.fa"  label="HA"/>
             <data name="NP" format="fasta" from_work_dir="resultDir/amended_consensus/resultDir_5.fa"  label="NP"/>
@@ -292,8 +292,8 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
         </collection>
         <collection name="bam_collection" type="list" label="Alignment files (bam)">
             <filter>optional_outputs and 'bam' in optional_outputs</filter>
-            <data name="PB1" format="bam" from_work_dir="resultDir/A_PB1.bam" label="PB1"/>
             <data name="PB2" format="bam" from_work_dir="resultDir/A_PB2.bam" label="PB2"/>
+            <data name="PB1" format="bam" from_work_dir="resultDir/A_PB1.bam" label="PB1"/>
             <data name="PA" format="bam" from_work_dir="resultDir/A_PA.bam" label="PA"/>
             <data name="HA" format="bam" from_work_dir="resultDir/A_HA.bam" label="HA"/>
             <data name="NP" format="bam" from_work_dir="resultDir/A_NP.bam" label="NP"/>
@@ -303,8 +303,8 @@ SIG_LEVEL=$advanced_config.variant_calling.SIG_LEVEL
         </collection>
         <collection name="vcf_collection" type="list" label="Variant calling files (VCF)">
             <filter>optional_outputs and 'vcf' in optional_outputs</filter>
-            <data name="PB1" format="vcf" from_work_dir="resultDir/A_PB1.vcf" label="PB1"/>
             <data name="PB2" format="vcf" from_work_dir="resultDir/A_PB2.vcf" label="PB2"/>
+            <data name="PB1" format="vcf" from_work_dir="resultDir/A_PB1.vcf" label="PB1"/>
             <data name="PA" format="vcf" from_work_dir="resultDir/A_PA.vcf" label="PA"/>
             <data name="HA" format="vcf" from_work_dir="resultDir/A_HA.vcf" label="HA"/>
             <data name="NP" format="vcf" from_work_dir="resultDir/A_NP.vcf" label="NP"/>


### PR DESCRIPTION
Adds IRMAs output: amended consensus fasta as optional output & logs/run_info.txt, which includes meta data for the IRMA run (optional aswell).
Added a new test, that covers these 2 new outputs.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
