### PR TITLE
Update MultiQC to version 1.27

### DIFF
--- a/tools/multiqc/bamtools_plugin.xml
+++ b/tools/multiqc/bamtools_plugin.xml
@@ -28,7 +28,7 @@
             <output name="stats">
                 <assert_contents>
                     <has_text text="bamtools_txt"/>
-                    <has_text text="Bamtools"/>
+                    <has_text text="bamtools-duplicates_pct"/>
                     <has_n_lines n="2"/>
                     <has_n_columns n="3"/>
                 </assert_contents>

--- a/tools/multiqc/bcftools_plugin.xml
+++ b/tools/multiqc/bcftools_plugin.xml
@@ -28,8 +28,8 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="Stats_mqc_generalstats_bcftools_stats_number_of_records"/>
-                    <has_text text="Stats_mqc_generalstats_bcftools_stats_number_of_SNPs"/>
+                    <has_text text="bcftools_stats-number_of_records"/>
+                    <has_text text="bcftools_stats-number_of_SNPs"/>
                     <has_text text="Test1"/>
                     <has_text text="72330"/>
                     <has_n_lines n="2"/>

--- a/tools/multiqc/cutadapt_plugin.xml
+++ b/tools/multiqc/cutadapt_plugin.xml
@@ -34,10 +34,9 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="Cutadapt"/>
-                    <has_text text="Cutadapt_mqc_generalstats_cutadapt_percent_trimmed"/>
+                    <has_text text="Sample"/>
+                    <has_text text="cutadapt-percent_trimmed"/>
                     <has_text text="10"/>
-                    <has_text text="Cutadapt_mqc_generalstats_cutadapt_percent_trimmed"/>
                     <has_n_lines n="2"/>
                     <has_n_columns n="2"/>
                 </assert_contents>

--- a/tools/multiqc/fastp_plugin.xml
+++ b/tools/multiqc/fastp_plugin.xml
@@ -33,9 +33,9 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="fastp_mqc_generalstats_fastp_pct_duplication"/>
+                    <has_text text="fastp-pct_duplication"/>
                     <has_text text="R1_fq"/>
-                    <has_text text="fastp_mqc_generalstats_fastp_after_filtering_q30_rate"/>
+                    <has_text text="fastp-after_filtering_q30_rate"/>
                     <has_text text="bwa-mem-fastq1_fq"/>
                     <has_n_lines n="3"/>
                     <has_n_columns n="8"/>

--- a/tools/multiqc/fastqc_plugin.xml
+++ b/tools/multiqc/fastqc_plugin.xml
@@ -58,7 +58,7 @@
             <assert_contents>
                 <has_text text="poulet5_1"/>
                 <has_text text="poulet5_2"/>
-                <has_text text="FastQC_mqc_generalstats_fastqc_median_sequence_length"/>
+                <has_text text="fastqc-median_sequence_length"/>
                 <has_n_lines n="3"/>
                 <has_n_columns n="7"/>
             </assert_contents>

--- a/tools/multiqc/featurecounts_plugin.xml
+++ b/tools/multiqc/featurecounts_plugin.xml
@@ -36,10 +36,10 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="featureCounts_mqc_generalstats_featurecounts_Assigned"/>
+                    <has_text text="featurecounts-Assigned"/>
                     <has_text text="accepted_hits"/>
                     <has_text text="TopHat"/>
-                    <has_text text="featureCounts_mqc_generalstats_featurecounts_percent_assigned"/>
+                    <has_text text="featurecounts-percent_assigned"/>
                     <has_n_lines n="7"/>
                     <has_n_columns n="3"/>
                 </assert_contents>

--- a/tools/multiqc/flexbar_plugin.xml
+++ b/tools/multiqc/flexbar_plugin.xml
@@ -28,7 +28,7 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="Flexbar_mqc_generalstats_flexbar_removed_bases_pct"/>
+                    <has_text text="flexbar-removed_bases_pct"/>
                     <has_text text="result_right"/>
                     <has_n_lines n="2"/>
                     <has_n_columns n="2"/>

--- a/tools/multiqc/macros.xml
+++ b/tools/multiqc/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.24.1</token>
+    <token name="@TOOL_VERSION@">1.27</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="bio_tools">
         <xrefs>
@@ -180,7 +180,7 @@ sp:
                     <has_text text="result_right"/>
                     <has_text text="bwa-mem-fastq1_fq"/>
                     <has_text text="25839_merged"/>
-                    <has_text text="Slamdunk_mqc_generalstats_slamdunk_retained"/>
+                    <has_text text="slamdunk-retained"/>
                     <has_text text="C2"/>
                     <has_n_lines n="11"/>
                     <has_n_columns n="22"/>
@@ -275,7 +275,7 @@ sp:
                     <has_text text="hisat2_2_txt"/>
                     <has_text text="HS002-PE-R00059_BD0U5YACXX.RHM067_CAGATC_L002_R1"/>
                     <has_text text="treat2"/>
-                    <has_text text="Cutadapt"/>
+                    <has_text text="cutadapt-percent_trimmed"/>
                     <has_text text="star_log_txt"/>
                     <has_text text="tophat_txtalign"/>
                     <has_n_lines n="17"/>
@@ -488,7 +488,7 @@ sp:
                 <assert_contents>
                     <has_text text="bamtools_txt"/>
                     <has_text text="Test1"/>
-                    <has_text text="Prokka_mqc_generalstats_prokka_contigs"/>
+                    <has_text text="prokka-contigs"/>
                     <has_text text="5: TopHat on data 1, data 14, and data 13"/>
                     <has_text text="gatk_varianteval_txt"/>
                     <has_text text="x_bam"/>
@@ -500,12 +500,13 @@ sp:
                     <has_text text="14892_1#15"/>
                     <has_text text="samtools_flagstat_txt"/>
                     <has_text text="mapped_passed"/>
-                    <has_text text="stats_mqc_generalstats_samtools_stats_error_rate"/>
+                    <has_text text="samtools_stats-error_rate"/>
                     <has_text text="samtools_stats_txt"/>
                     <has_text text="snpeff_csv"/>
-                    <has_text text="Bamtools"/>
+                    <has_text text="bamtools-mapped_reads_pct"/>
+                    <has_text text="bamtools-duplicates_pct"/>
                     <has_n_lines n="22"/>
-                    <has_n_columns n="46"/>
+                    <has_n_columns n="50"/>
                 </assert_contents>
             </output>
         </test>
@@ -525,7 +526,7 @@ sp:
             </repeat>
             <output name="html_report" ftype="html">
                 <assert_contents>
-                    <has_size value="4594258" delta="500"/>
+                    <has_size value="4766687" delta="500"/>
                 </assert_contents>
             </output>
             <!--output name="stats" ftype="tabular">
@@ -560,7 +561,7 @@ sp:
             <output name="stats" ftype="tabular">
                 <assert_contents>
                     <has_text text="poulet5_2"/>
-                    <has_text text="FastQC"/>
+                    <has_text text="fastqc-percent_gc"/>
                     <has_n_lines n="3"/>
                     <has_n_columns n="7"/>
                 </assert_contents>
@@ -596,7 +597,7 @@ sp:
             </output>
             <output name="stats" ftype="tabular">
                 <assert_contents>
-                    <has_text text="pycoQC_mqc_generalstats_pycoqc_passed_median_read_length"/>
+                    <has_text text="pycoqc-passed_median_read_length"/>
                     <has_text text="pycoqc_json"/>
                 </assert_contents>
             </output>

--- a/tools/multiqc/picard_plugin.xml
+++ b/tools/multiqc/picard_plugin.xml
@@ -105,9 +105,9 @@
             <output name="stats">
                 <assert_contents>
                     <has_text text="picard_CollectRnaSeqMetrics_bam"/>
-                    <has_text text="InsertSizeMetrics_mqc_generalstats_picard_insertsizemetrics_summed_median"/>
+                    <has_text text="picard_insertsizemetrics-summed_median"/>
                     <has_text text="picard_CollectRnaSeqMetrics_bam"/>
-                    <has_text text="RnaSeqMetrics_mqc_generalstats_picard_rnaseqmetrics_PCT_MRNA_BASES"/>
+                    <has_text text="picard_rnaseqmetrics-PCT_MRNA_BASES"/>
                     <has_text text="NA"/>
                     <has_n_lines n="4"/>
                     <has_n_columns n="6"/>

--- a/tools/multiqc/pycoqc_plugin.xml
+++ b/tools/multiqc/pycoqc_plugin.xml
@@ -30,7 +30,7 @@
             </output>
             <output name="stats" ftype="tabular">
                 <assert_contents>
-                    <has_text text="pycoQC_mqc_generalstats_pycoqc_passed_median_read_length"/>
+                    <has_text text="pycoqc-passed_median_read_length"/>
                     <has_text text="pycoqc_json"/>
                 </assert_contents>
             </output>

--- a/tools/multiqc/qualimap_plugin.xml
+++ b/tools/multiqc/qualimap_plugin.xml
@@ -47,13 +47,13 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="BamQC_mqc_generalstats_qualimap_bamqc_mean_coverage"/>
-                    <has_text text="BamQC_mqc_generalstats_qualimap_bamqc_mapped_reads"/>
-                    <has_text text="BamQC_mqc_generalstats_qualimap_bamqc_total_reads"/>
+                    <has_text text="qualimap_bamqc-mean_coverage"/>
+                    <has_text text="qualimap_bamqc-mapped_reads"/>
+                    <has_text text="qualimap_bamqc-total_reads"/>
                     <has_text text="x_bam"/>
                     <has_text text="0.98"/>
                     <has_n_lines n="2"/>
-                    <has_n_columns n="6"/>
+                    <has_n_columns n="9"/>
                 </assert_contents>
             </output>
             <output_collection name="plots" type="list" count="0"/>

--- a/tools/multiqc/samtools_plugin.xml
+++ b/tools/multiqc/samtools_plugin.xml
@@ -85,10 +85,10 @@
                 <assert_contents>
                     <has_text text="samtools_flagstat_txt"/>
                     <has_text text="mapped_passed"/>
-                    <has_text text="stats_mqc_generalstats_samtools_stats_error_rate"/>
+                    <has_text text="samtools_stats-error_rate"/>
                     <has_text text="samtools_stats_txt"/>
                     <has_n_lines n="3"/>
-                    <has_n_columns n="11"/>
+                    <has_n_columns n="12"/>
                 </assert_contents>
             </output>
             <output_collection name="plots" type="list" count="5"/>

--- a/tools/multiqc/star_plugin.xml
+++ b/tools/multiqc/star_plugin.xml
@@ -65,7 +65,7 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="STAR_mqc_generalstats_star_uniquely_mapped_percent"/>
+                    <has_text text="star-mapped_percent"/>
                     <has_text text="star_log_txt"/>
                     <has_n_lines n="2"/>
                     <has_n_columns n="7"/>

--- a/tools/multiqc/trimmomatic_plugin.xml
+++ b/tools/multiqc/trimmomatic_plugin.xml
@@ -28,7 +28,7 @@
             </output>
             <output name="stats">
                 <assert_contents>
-                    <has_text text="Trimmomatic_mqc_generalstats_trimmomatic_dropped_pct"/>
+                    <has_text text="trimmomatic-dropped_pct"/>
                     <has_text text="C2"/>
                     <has_n_lines n="2"/>
                     <has_n_columns n="2"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)


Bump MultiQC to version 1.27, because the current version 1.24.1 had a [bug](https://github.com/MultiQC/MultiQC/issues/2810) in calculating the average read length.