### PR TITLE
Changed assembler from SSW to minimap2

### DIFF
--- a/tools/irma/irma.xml
+++ b/tools/irma/irma.xml
@@ -2,7 +2,7 @@
     <description>Construct robust assemblies of highly variable RNA viruses</description>
     <macros>
         <token name="@TOOL_VERSION@">1.2.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">irma-virus</xref> 
@@ -52,6 +52,7 @@ cat irma_config.sh
 SINGLE_LOCAL_PROC=\${GALAXY_SLOTS:-1}
 DOUBLE_LOCAL_PROC=\$((SINGLE_LOCAL_PROC/2 + (SINGLE_LOCAL_PROC==1)))
 TMP=\$TMPDIR
+ASSEM_PROG="MINIMAP2"
 #if $advanced_config.customize == 'yes':
   #if $advanced_config.reference == 'yes':
 SKIP_E=$advanced_config.reference.SKIP_E


### PR DESCRIPTION
Due to excessive I/O usage of SSW, the assembler used in IRMA is changed to minimap2.

The used modified version of SSW opens the reference for every read. This leads to excessive I/O workload in the assembling process (opening the ref files more than 10.000 times). To avoid this, the assembler is now set to minimap2 (fixed). It has a constant number of reference file accesses (32 per assembled segment). 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
