### PR TITLE
Update deeparg : remove suite information into DM .shed.yaml

### DIFF
--- a/data_managers/data_manager_deeparg/.shed.yml
+++ b/data_managers/data_manager_deeparg/.shed.yml
@@ -8,6 +8,3 @@ remote_repository_url: "https://github.com/galaxyproject/tools-iuc/tree/master/d
 type: unrestricted
 categories:
 - Data Managers
-suite:
-  name: "suite_deeparg"
-  description: "DeepARG is a deep learning based approach to predict Antibiotic Resistance Genes (ARGs) from metagenomes with short or long sequences"


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Error from deploy : 
```
+ planemo shed_update --shed_target toolshed --shed_key *** --force_repository_creation data_managers/data_manager_deeparg
cd '/home/runner/work/tools-iuc/tools-iuc/data_managers/data_manager_deeparg' && git rev-parse HEAD
galaxy.util.commands WARNING: Passing program arguments as a string may be a security hazard if combined with untrusted input
git diff --quiet
Could not update suite_deeparg
Failed to find repository for owner/name iuc/suite_deeparg
Could not update suite_deeparg
Unexpected HTTP status code: 500: {"err_msg": "Revision <b>92aff5b00830<\/b> includes no Galaxy utilities for which metadata can be defined so this revision cannot be automatically installed into a local Galaxy instance."}
Repository metadata updated successfully for repository 'suite_deeparg' on the main Tool Shed.
Failed to update repository contents for repository 'suite_deeparg' on the main Tool Shed.
```

So I removed suite information into DM .shed.yaml