### PR TITLE
fix muon params

### DIFF
--- a/tools/muon/macros.xml
+++ b/tools/muon/macros.xml
@@ -177,7 +177,7 @@ with open('mudata_info.txt','w', encoding='utf-8') as ainfo:
                     <param name="mod_name" type="text" label="Modality name" optional="true">
                         <expand macro="sanitize_string" />
                     </param>
-                    <param name="resolution" type="float" label="Resolution for the above modality" help="Higher values -> more clusters"/>
+                    <param name="resolution" type="float" optional="true" label="Resolution for the above modality" help="Higher values -> more clusters"/>
                 </repeat>
             </when>
         </conditional>
@@ -196,7 +196,7 @@ with open('mudata_info.txt','w', encoding='utf-8') as ainfo:
                     <param name="mod_name" type="text" label="Modality name" optional="true">
                         <expand macro="sanitize_string" />
                     </param>
-                    <param name="mod_weights" type="float" label="Weight for the above modality" help="Higher values -> more important"/>
+                    <param name="mod_weights" type="float" optional="true" label="Weight for the above modality" help="Higher values -> more important"/>
                 </repeat>
             </when>
         </conditional>

--- a/tools/muon/macros.xml
+++ b/tools/muon/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.1.6</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">23.0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

Failed on toolshed because non-optional params have no value set. It was not caught in linting. 
 