### PR TITLE
Add missing required_files to run remotely

### DIFF
--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -2,7 +2,7 @@
     <description>computes operations on table data</description>
     <macros>
         <token name="@VERSION@">1.2.4</token>
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
         <token name="@COPEN@"><![CDATA[<code>]]></token>
         <token name="@CCLOSE@"><![CDATA[</code>]]></token>
         <import>allowed_functions.xml</import>

--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -97,6 +97,10 @@
         <requirement type="package" version="1.19.2">numpy</requirement>
     </requirements>
 
+    <required_files>
+        <include path="scripts/safety.py" />
+    </required_files>
+
     <version_command><![CDATA[
         python '$__tool_directory__/scripts/table_compute.py' --version
     ]]></version_command>


### PR DESCRIPTION
Fix the following error:

```
cp: can't stat '/jetstream2/scratch/main/jobs/65014985/tool_files/scripts/safety.py': No such file or directory
```

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
