### PR TITLE
Changing datatype of FASTK tool from tar to fastk_ktab_tar

### DIFF
--- a/tools/fastk/fastk.xml
+++ b/tools/fastk/fastk.xml
@@ -1,4 +1,4 @@
-<tool id="fastk_fastk" name="FastK" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.2">
+<tool id="fastk_fastk" name="FastK" version="@TOOL_VERSION@+galaxy2" profile="23.2">
     <description>A k-mer counter for high-quality assembly datasets</description>
     <macros>
         <import>macros.xml</import>
@@ -54,7 +54,7 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="fastk_out" format="tar" from_work_dir="fastk.tar" label="${tool.name} on ${on_string}: FastK files"/>
+        <data name="fastk_out" format="fastk_ktab_tar" from_work_dir="fastk.tar" label="${tool.name} on ${on_string}: FastK files"/>
         <data name="fastk_hist_out" format="fastk_hist" from_work_dir="output.hist" label="${tool.name} on ${on_string}: FastK hist"/>
         <data name="fastk_ktab_out" format="fastk_ktab" from_work_dir="ktabfiles/output.ktab" label="${tool.name} on ${on_string}: FastK ktab">
             <filter> sorted_table['sorted_table_option'] != 'no' </filter> 
@@ -69,7 +69,7 @@
             <param name="infile" value="input01.fasta.gz"/>
             <param name="kmer_size" value="40"/>
             <output name="fastk_hist_out" file="test01.hist" ftype="fastk_hist"/>
-            <output name="fastk_out" ftype="tar">
+            <output name="fastk_out" ftype="fastk_ktab_tar">
                 <assert_contents>
                     <has_archive_member path="ktabfiles"/>
                 </assert_contents>
@@ -82,7 +82,7 @@
                 <param name="sorted_table_option" value="yes_with_default"/>
             </conditional>
             <output name="fastk_hist_out" file="test02.hist" ftype="fastk_hist"/>
-            <output name="fastk_out" ftype="tar">
+            <output name="fastk_out" ftype="fastk_ktab_tar">
                 <assert_contents>
                     <has_archive_member path="ktabfiles/output.ktab"/>
                 </assert_contents>
@@ -97,7 +97,7 @@
                 <param name="sorted_table_cutoff" value="5"/>
             </conditional>
             <output name="fastk_hist_out" file="test03.hist" ftype="fastk_hist"/>
-            <output name="fastk_out" ftype="tar">
+            <output name="fastk_out" ftype="fastk_ktab_tar">
                 <assert_contents>
                     <has_archive_member path="ktabfiles/output.ktab"/>
                 </assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

---
Based on https://github.com/galaxyproject/galaxy/pull/19615 this PR replaces the tar dataype with fastk_ktab_tar for fastk_fastk tool