### PR TITLE
Udate checkm2 DM

### DIFF
--- a/data_managers/data_manager_checkm2/data_manager/checkm2_datamanager.xml
+++ b/data_managers/data_manager_checkm2/data_manager/checkm2_datamanager.xml
@@ -13,7 +13,8 @@
     <command detect_errors="exit_code"><![CDATA[
         mkdir -p '$out_file.extra_files_path' &&
         #if $test != "true"
-            checkm2 database --download --path  '$out_file.extra_files_path'/ &&
+            wget 'https://zenodo.org/records/5571251/files/checkm2_database.tar.gz' &&
+            tar -xf 'checkm2_database.tar.gz' -C '$out_file.extra_files_path' &&
             mv '$out_file.extra_files_path'/CheckM2_database/uniref100.KO.1.dmnd '$out_file.extra_files_path' &&
         #else
             touch '$out_file.extra_files_path'/uniref100.KO.1.dmnd &&


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

This PR should fix the CheckM2 DM without using CheckM2 downlaod function since this function doesnt work yet. https://github.com/galaxyproject/tools-iuc/issues/6717 to read more about the issue.

I change the DM since it is build simple and with the DM FAIRyMAG can use CheckM2 and Binette without any donwlaod and input the DB manually.

The devs from CheckM2 did saw the issue and try to fix it but it is unknow when they will publish a release with the fix and till then with using wget and tar we can make the DM functional and change it back when CheckM2 download option work.