### PR TITLE
Fix spades CLI

### DIFF
--- a/tools/spades/macros.xml
+++ b/tools/spades/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.15.5</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">spades</requirement>
@@ -385,16 +385,16 @@ export OMP_THREAD_LIMIT=\${GALAXY_SLOTS:-4} &&
 
 <token name="@STATS@"><![CDATA[
 #if 'cs' in $optional_output
-    && test -f 'output/contigs.fasta' && python '$__tool_directory__/write_tsv_script.py' < 'output/contigs.fasta' > '$out_cs' || echo 'No contigs.fasta.'
+    && (test -f 'output/contigs.fasta' && python '$__tool_directory__/write_tsv_script.py' < 'output/contigs.fasta' > '$out_cs' || echo 'No contigs.fasta.')
 #end if
 #if 'ss' in $optional_output
-    && test -f 'output/scaffolds.fasta' && python '$__tool_directory__/write_tsv_script.py' < 'output/scaffolds.fasta' > '$out_ss' || echo 'No scaffolds.fasta.'
+    && (test -f 'output/scaffolds.fasta' && python '$__tool_directory__/write_tsv_script.py' < 'output/scaffolds.fasta' > '$out_ss' || echo 'No scaffolds.fasta.')
 #end if
 ]]></token>
 
 <token name="@CORRECTED@"><![CDATA[
     #if 'corrected' in $optional_output
-        && test -d 'output/corrected' && zip -q -r 'corrected.zip' 'output/corrected/*.fastq.gz' || echo 'No output files for corrected reads.'
+        && (test -d 'output/corrected' && zip -q -r 'corrected.zip' 'output/corrected/*.fastq.gz' || echo 'No output files for corrected reads.')
     #end if
 ]]></token>
 


### PR DESCRIPTION
Since `false && ... && false || true` is `true` the spades tools using these macros never fail

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
