### PR TITLE
Lowered required galaxy tool version

### DIFF
--- a/tools/autobigs/autobigs-cli.xml
+++ b/tools/autobigs/autobigs-cli.xml
@@ -1,9 +1,9 @@
-<tool id="autobigs-cli" name="autoBIGS.cli" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
+<tool id="autobigs-cli" name="autoBIGS.cli" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="19.05">
     <description>Automated MLST typing</description>
     <macros>
         <import>macros.xml</import>
         <token name="@TOOL_VERSION@">0.6.2</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <expand macro="bio_tools"/>
     </macros>
 


### PR DESCRIPTION
Simply lowers the minimum Galaxy version that should be required to run this tool.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
