### PR TITLE
Funannotate: more consistent tool names

### DIFF
--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -1,5 +1,5 @@
-<tool id="funannotate_annotate" name="Funannotate functional" profile="20.01" version="@TOOL_VERSION@+galaxy5">
-    <description>annotation</description>
+<tool id="funannotate_annotate" name="Funannotate annotate" profile="20.01" version="@TOOL_VERSION@+galaxy5">
+    <description>functions"</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/funannotate/funannotate_annotate.xml
+++ b/tools/funannotate/funannotate_annotate.xml
@@ -1,5 +1,5 @@
 <tool id="funannotate_annotate" name="Funannotate annotate" profile="20.01" version="@TOOL_VERSION@+galaxy5">
-    <description>functions"</description>
+    <description>functions</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/funannotate/funannotate_clean.xml
+++ b/tools/funannotate/funannotate_clean.xml
@@ -1,5 +1,5 @@
-<tool id="funannotate_clean" name="Funannotate assembly clean" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
-    <description></description>
+<tool id="funannotate_clean" name="Funannotate clean" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <description>assembly</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/funannotate/funannotate_predict.xml
+++ b/tools/funannotate/funannotate_predict.xml
@@ -1,5 +1,5 @@
-<tool id="funannotate_predict" name="Funannotate predict annotation" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
-    <description></description>
+<tool id="funannotate_predict" name="Funannotate predict" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <description>annotation</description>
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/funannotate/funannotate_sort.xml
+++ b/tools/funannotate/funannotate_sort.xml
@@ -1,5 +1,5 @@
-<tool id="funannotate_sort" name="Sort assembly" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
-    <description></description>
+<tool id="funannotate_sort" name="Funannotate sort" profile="20.01" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <description>assembly</description>
     <macros>
         <import>macros.xml</import>
     </macros>


### PR DESCRIPTION
We can skip deployment (just want to have this in the next release), but I also do not mind bumping versions.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
