### PR TITLE
Remove conflicting URL from tools/recentrifuge causing linting failure

### DIFF
--- a/tools/recentrifuge/macro.xml
+++ b/tools/recentrifuge/macro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-  <token name="@TOOL_VERSION@">1.15.0</token>
+  <token name="@TOOL_VERSION@">1.15.1</token>
   <token name="@VERSION_SUFFIX@">0</token>
   <token name="@PROFILE@">21.05</token>
   <xml name="version_command">

--- a/tools/recentrifuge/recentrifuge.xml
+++ b/tools/recentrifuge/recentrifuge.xml
@@ -388,8 +388,6 @@ rcf - Release 1.8.1 - Mar 2022
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU Affero General Public License for more details.
 
-  You should have received a copy of the GNU Affero General Public License
-  along with this program.
   ]]></help>
     <expand macro="citations"/>
 </tool>

--- a/tools/recentrifuge/recentrifuge.xml
+++ b/tools/recentrifuge/recentrifuge.xml
@@ -389,7 +389,7 @@ rcf - Release 1.8.1 - Mar 2022
   GNU Affero General Public License for more details.
 
   You should have received a copy of the GNU Affero General Public License
-  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  along with this program.
   ]]></help>
     <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Fixes: #6832 