### PR TITLE
update version omamer

### DIFF
--- a/data_managers/data_manager_omamer/data_manager/macros.xml
+++ b/data_managers/data_manager_omamer/data_manager/macros.xml
@@ -1,7 +1,7 @@
 
 <macros>
-    <token name="@TOOL_VERSION@">2.0.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.1.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
 
     <xml name="requirements">
         <requirements>

--- a/data_managers/data_manager_omamer/test-data/out.json
+++ b/data_managers/data_manager_omamer/test-data/out.json
@@ -5,7 +5,7 @@
         "name": "Primates-v2.0.0",
         "path": "Primates-v2.0.0.h5",
         "value": "Primates-v2.0.0.h5",
-        "version": "2.0.2"
+        "version": "2.1.0"
       }
     ]
   }

--- a/data_managers/data_manager_omamer/tool-data/omamer.loc.sample
+++ b/data_managers/data_manager_omamer/tool-data/omamer.loc.sample
@@ -5,4 +5,4 @@
 # value name version path
 #
 # for example
-# Primates-v2.0.0	Primates	2.0.2	/tmp/database/omamer/database_omamer/Primates-v2.0.0
+# Primates-v2.0.0	Primates	2.1.0	/tmp/database/omamer/database_omamer/Primates-v2.0.0


### PR DESCRIPTION
Hi, I'm opening this PR to correct an error from this PR (https://github.com/galaxyproject/iwc/pull/748).
 I got this error message: 

`Inserting taxids:       2655000 WARNING: Database version mismatch: DB 2.0.0 / OMAmer 2.1.0
Traceback (most recent call last):
  File "/usr/local/bin/omark", line 52, in <module>
    omark.launcher(arg)
  File "/usr/local/lib/python3.9/site-packages/omark/omark.py", line 269, in launcher
    get_omamer_qscore(omamerfile, dbpath, outdir, taxid, original_FASTA_file = original_fasta, isoform_file=isoform_file, taxonomic_rank=taxonomic_rank)
  File "/usr/local/lib/python3.9/site-packages/omark/omark.py", line 116, in get_omamer_qscore
    closest_corr = spd.get_sampled_taxa(likely_clade, 5 , tax_tab, sp_tab, tax_buff, taxonomic_rank)
  File "/usr/local/lib/python3.9/site-packages/omark/species_determination.py", line 403, in get_sampled_taxa
    ranks = ncbi.get_rank(lineage_ncbi)
  File "/usr/local/lib/python3.9/site-packages/ete3/ncbi_taxonomy/ncbiquery.py", line 201, in get_rank
    result = self.db.execute(cmd)
sqlite3.OperationalError: no such column: "6656" - should this be a string literal in single-quotes?
/usr/local/lib/python3.9/site-packages/tables/file.py:113: UnclosedFileWarning: Closing remaining open file: /cvmfs/data.galaxyproject.org/byhand/omamer/LUCA-v2.0.0.h5
  warnings.warn(UnclosedFileWarning(msg))`

I'm not sure if this will correct the problem. 
Thank you! Have a nice day!
Romane