### PR TITLE
[Quicktree] fix output label

### DIFF
--- a/tools/quicktree/quicktree.xml
+++ b/tools/quicktree/quicktree.xml
@@ -65,7 +65,7 @@ input.quicktree
         </param>
     </inputs>
     <outputs>
-        <data name="output_file" format="newick" label="${tool.name} on ${on_string}: stockholm format">
+        <data name="output_file" format="newick" label="${tool.name} on ${on_string}: Tree">
             <change_format>
                 <when input="output_type" value="dist_out" format="mothur.dist" />
             </change_format>


### PR DESCRIPTION
The output of Quicktree was labelled as "Stockholm Format", but this isn't true and rather confusing, so updated the label of the output dataset