### PR TITLE
Updating and fixing outdated links in tools/arriba

### DIFF
--- a/tools/arriba/arriba.xml
+++ b/tools/arriba/arriba.xml
@@ -507,7 +507,7 @@ It is based on chimeric alignments found by the STAR RNA-Seq aligner.
 
 **INPUTS**
 
-See:  https://arriba.readthedocs.io/en/latest/input-files/
+See:  https://github.com/suhrig/arriba/wiki/04-Input-files
 
   - Alignments
 
@@ -672,14 +672,14 @@ See:  https://arriba.readthedocs.io/en/latest/input-files/
 
 **OPTIONS**
 
-  - Arriba: https://arriba.readthedocs.io/en/latest/command-line-options/#arriba
-  - Visualization: https://arriba.readthedocs.io/en/latest/command-line-options/#draw_fusionsr
-  - RNA STAR: https://arriba.readthedocs.io/en/latest/workflow/
+  - Arriba: https://github.com/suhrig/arriba/wiki/07-Command-line-options#arriba
+  - Visualization: https://github.com/suhrig/arriba/wiki/07-Command-line-options#draw_fusionsr
+  - RNA STAR: https://github.com/suhrig/arriba/wiki/03-Workflow
 
 
 **OUTPUTS**
 
-See:  https://arriba.readthedocs.io/en/latest/output-files/
+See: https://github.com/suhrig/arriba/wiki/05-Output-files
 
   - fusions.tsv
 
@@ -732,7 +732,7 @@ See:  https://arriba.readthedocs.io/en/latest/output-files/
 
 **VISUALIZATION**
 
-See: https://arriba.readthedocs.io/en/latest/visualization/
+See: https://github.com/suhrig/arriba/wiki/06-Visualization
 
   - fusions.pdf
 
@@ -743,11 +743,11 @@ See: https://arriba.readthedocs.io/en/latest/visualization/
   :height: 467
 
 
-.. _Arriba: https://arriba.readthedocs.io/en/latest/
-.. _INPUTS: https://arriba.readthedocs.io/en/latest/input-files/
-.. _OUTPUTS: https://arriba.readthedocs.io/en/latest/output-files/
-.. _VISUALIZATION: https://arriba.readthedocs.io/en/latest/visualization/
-.. _OPTIONS: https://arriba.readthedocs.io/en/latest/command-line-options/
+.. _Arriba: https://github.com/suhrig/arriba/wiki/01-Home
+.. _INPUTS: https://github.com/suhrig/arriba/wiki/04-Input-files
+.. _OUTPUTS: https://github.com/suhrig/arriba/wiki/05-Output-files
+.. _VISUALIZATION: https://github.com/suhrig/arriba/wiki/06-Visualization
+.. _OPTIONS: https://github.com/suhrig/arriba/wiki/07-Command-line-options
 
     ]]></help>
     <expand macro="citations" />

--- a/tools/arriba/arriba_draw_fusions.xml
+++ b/tools/arriba/arriba_draw_fusions.xml
@@ -89,7 +89,7 @@ Arriba_Draw_Fusions_ (draw_fusions.R) renders publication-quality visualizations
 
 **INPUTS**
 
-See: https://arriba.readthedocs.io/en/latest/command-line-options/#draw_fusionsr
+See: https://github.com/suhrig/arriba/wiki/07-Command-line-options#draw_fusionsr
 
   - Fusions  
 
@@ -122,12 +122,12 @@ See: https://arriba.readthedocs.io/en/latest/command-line-options/#draw_fusionsr
 
 **OPTIONS**
 
-  See: https://arriba.readthedocs.io/en/latest/command-line-options/#draw_fusionsr
+  See: https://github.com/suhrig/arriba/wiki/07-Command-line-options#draw_fusionsr
 
 
 **OUTPUTS**
 
-See: https://arriba.readthedocs.io/en/latest/visualization/
+See: https://github.com/suhrig/arriba/wiki/06-Visualization
 
   - fusions.pdf
 
@@ -140,8 +140,8 @@ See: https://arriba.readthedocs.io/en/latest/visualization/
 
 
 
-.. _Arriba_Draw_Fusions: https://arriba.readthedocs.io/en/latest/visualization/
-.. _Arriba: https://arriba.readthedocs.io/en/latest/
+.. _Arriba_Draw_Fusions: https://github.com/suhrig/arriba/wiki/06-Visualization
+.. _Arriba: https://github.com/suhrig/arriba/wiki/01-Home
 
     ]]></help>
     <expand macro="citations" />

--- a/tools/arriba/arriba_get_filters.xml
+++ b/tools/arriba/arriba_get_filters.xml
@@ -65,8 +65,8 @@ The **Arriba Get Filters** tool adds the following Arriba distribution input_fil
   - cytobands
 
 
-.. _Arriba: https://arriba.readthedocs.io/en/latest/
-.. _input_files: https://arriba.readthedocs.io/en/latest/input-files/
+.. _Arriba: https://github.com/suhrig/arriba/wiki/01-Home
+.. _input_files: https://github.com/suhrig/arriba/wiki/04-Input-files
 
 ]]></help>
     <expand macro="citations" />

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.4.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.5.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@TOOL_VERSION@">arriba</requirement>

--- a/tools/arriba/macros.xml
+++ b/tools/arriba/macros.xml
@@ -238,6 +238,7 @@
                         </help>
                         <validator type="regex" message="">^\d+(,\d+)?$</validator>
                     </param>
+                    <param argument="--plotPanels" type="boolean" label="Plot panels" truevalue="TRUE" falsevalue="FALSE" help="The output will contain a panel for each fusion partner"/>
                 </section>
     </xml>
     <token name="@DRAW_FUSIONS@">
@@ -300,6 +301,9 @@ draw_fusions.R
     #end if
     #if str($visualization.options.fontSize)
         --fontSize=$visualization.options.fontSize
+    #end if
+    #if $visualization.options.plotPanels
+        --plotPanels=$visualization.options.plotPanels
     #end if
 </token>
 </macros>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

---

This PR updates outdated documentation links, replacing them with the new GitHub Wiki links as per the latest update.
Fixes: https://github.com/galaxyproject/tools-iuc/pull/6892