### PR TITLE
Revert "Sort with max-memory per thread"

### DIFF
--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -116,9 +116,9 @@ bwa-mem2 mem
 #end if
 
 #if str( $output_sort ) == "coordinate":
-        | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -m "\${GALAXY_MEMORY_MB_PER_SLOT:-768}M" -O bam -o '$bam_output'
+        | samtools sort -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$bam_output'
 #elif str( $output_sort ) == "name":
-        | samtools sort -n -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -m "\${GALAXY_MEMORY_MB_PER_SLOT:-768}M" -O bam -o '$bam_output'
+        | samtools sort -n -@\${GALAXY_SLOTS:-2} -T "\${TMPDIR:-.}" -O bam -o '$bam_output'
 #else
         | samtools view -@ \${GALAXY_SLOTS:-2} -bS - -o '$bam_output'
 #end if

--- a/tools/bwa_mem2/macros.xml
+++ b/tools/bwa_mem2/macros.xml
@@ -2,7 +2,7 @@
     <import>read_group_macros.xml</import>
 
     <token name="@TOOL_VERSION@">2.2.1</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@VERSION_SUFFIX@">4</token>
     <token name="@PROFILE_VERSION@">20.01</token>
 
     <xml name="xrefs">


### PR DESCRIPTION
Causes more problems than it solves. Fixes https://github.com/galaxyproject/tools-iuc/issues/6898

This reverts commit c5a57522f74771171525db6902c055393014f1cc.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
