### PR TITLE
bakta: make amrfinder db mandatory

### DIFF
--- a/tools/bakta/bakta.xml
+++ b/tools/bakta/bakta.xml
@@ -98,7 +98,7 @@ $annotation.compliant
                     <validator message="No bakta database is available" type="no_options"/>
                 </options>
             </param>
-            <param name="amrfinder_db_select" type="select" optional="true" label="AMRFinderPlus database" help="The selection of this database is not needed if Bakta database version is higher 5.0">
+            <param name="amrfinder_db_select" type="select" optional="false" label="AMRFinderPlus database" help="The selection of this database is not needed if Bakta database version is higher 5.0">
                 <options from_data_table="amrfinderplus_versioned_database">
                     <filter type="static_value" value="3.12" column="db_version"/>
                     <validator message="No AMRFinderPlus database is available" type="no_options"/>

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -2,7 +2,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.9.4</token>
     <token name="@COMPATIBLE_BAKTA_VERSION@">1.7</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">
         <version_command><![CDATA[bakta --version]]></version_command>


### PR DESCRIPTION
the tool currently requires the value. otherwise the symlinks created in the beginning will not work

not sure if the DB is really needed.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
