### PR TITLE
Hardening linter skipping

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -123,6 +123,15 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+
+    - name: Set skip version check for push event (i.e. merge to main)
+      if: ${{ github.event_name != 'pull_request' }}
+      run:
+        echo "EXTRA_SKIP=--skip version_bumped" >> "$GITHUB_ENV"
+    - name: Set no skip vor pull_request events
+      if: ${{ github.event_name == 'pull_request' }}
+      run:
+        echo "EXTRA_SKIP=" >> "$GITHUB_ENV"
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -131,6 +140,7 @@ jobs:
         fail-level: warn
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: ${{ env.EXTRA_SKIP }}
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
@@ -352,7 +362,7 @@ jobs:
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
-    needs: [setup, combine_outputs]
+    needs: [setup, lint, combine_outputs]
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
make use of `planemo lint` again when merging to main but skip version check.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
