### PR TITLE
Add threads option to miniprot_index

### DIFF
--- a/tools/miniprot/miniprot_index.xml
+++ b/tools/miniprot/miniprot_index.xml
@@ -1,4 +1,4 @@
-<tool id="miniprot_index" name="Miniprot index" version="@TOOL_VERSION@+galaxy0" profile="21.05">
+<tool id="miniprot_index" name="Miniprot index" version="@TOOL_VERSION@+galaxy1" profile="21.05">
     <description>build a genome index for miniprot</description>
     <macros>
         <import>macros.xml</import>
@@ -6,7 +6,7 @@
     <expand macro="xrefs"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-        miniprot -d '$output_index' '$input_genome'
+        miniprot -t \${GALAXY_SLOTS:-1} -d '$output_index' '$input_genome'
     ]]></command>
     <inputs>
         <param name="input_genome" type="data" format="fasta,fasta.gz" label="Genomic sequence (FASTA)" help="Genomic contigs / scaffolds in FASTA format" />


### PR DESCRIPTION
Unlike most indexing steps, multi-threading is supported ([and recommended](https://github.com/lh3/miniprot/blob/4aaf71d03a229ec62fcfef379328103843da9511/README.md#L18)).

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
