### PR TITLE
fix shed.yaml for data_manager_fetch_busco_options

### DIFF
--- a/data_managers/data_manager_fetch_busco/data_manager/busco_fetcher.xml
+++ b/data_managers/data_manager_fetch_busco/data_manager/busco_fetcher.xml
@@ -1,4 +1,4 @@
-<tool id="busco_fetcher" name="Busco" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="20.01">
+<tool id="busco_fetcher" name="Busco" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="23.1">
     <description>dataset dowloader</description>
         <macros>
         <token name="@TOOL_VERSION@">5.8.0</token>

--- a/data_managers/data_manager_fetch_busco_options/.shed.yml
+++ b/data_managers/data_manager_fetch_busco_options/.shed.yml
@@ -5,7 +5,7 @@ description: Contains a data manager that defines and populates the busco
 homepage_url: https://github.com/galaxyproject/tools-iuc/
 long_description: |
     Download BUSCO reference datasets and add their paths to a data table
-name: data_manager_fetch_busco
+name: data_manager_fetch_busco_options
 owner: iuc
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/data_managers/data_manager_fetch_busco/
 type: unrestricted

--- a/data_managers/data_manager_fetch_busco_options/data_manager/busco_options.xml
+++ b/data_managers/data_manager_fetch_busco_options/data_manager/busco_options.xml
@@ -1,4 +1,4 @@
-<tool id="busco_fetcher_options" name="Busco options" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="20.01">
+<tool id="busco_fetcher_options" name="Busco options" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="23.1">
     <description></description>
         <macros>
         <token name="@TOOL_VERSION@">5.8.0</token>


### PR DESCRIPTION
and update profile for both DMs to trigger re-deployment

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
