### PR TITLE
fastx toolkit: remove URL that is long gone

### DIFF
--- a/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
+++ b/tool_collections/fastx_toolkit/fasta_clipping_histogram/fasta_clipping_histogram.xml
@@ -109,11 +109,6 @@ The first sequence counts as 2, the second as 10, the third as 3, to produce the
 
 Use the **FASTA Collapser** tool to create FASTA files with multiplicity counts.
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
-.. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
+++ b/tool_collections/fastx_toolkit/fasta_formatter/fasta_formatter.xml
@@ -81,11 +81,6 @@ Output FASTA file (with width=0 => single line)::
     >Scaffold9299
     CAGCATCTACATAATATGATCGCTATTAAACTTAAATCTCCTTGACGGAGTCTTCGGTCATAACACAAACCCAGACCTACGTATATGACAAAGCTAATAGaactggtctttacctTTAAGTTG
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/fasta_nucleotide_changer.xml
@@ -64,12 +64,6 @@ Output DNA FASTA file (with RNA-to-DNA mode)::
     >cel-miR-1 MIMAT0000003 Caenorhabditis elegans miR-1
     TGGAATGTAAAGAAGTATGTA
 
-
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_boxplot/fastq_quality_boxplot.xml
@@ -57,11 +57,6 @@ A low quality library (median drops quickly):
 
 .. image:: fastq_quality_boxplot_3.png
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTQ-Quality-Boxplot is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_converter/fastq_quality_converter.xml
@@ -93,11 +93,6 @@ FASTQ with ASCII quality scores::
     +CSHL__2_FC042AGWWWXX:8:1:103:1185
     hhhhhca_hhh`^Vh@IVQNHdObVLWCJ@HBDY^B
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTQ-Quality-Converter is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/fastq_quality_filter.xml
@@ -73,11 +73,6 @@ Using **percent = 90** and **cut-off = 30** - This read will be discarded (90% o
 
 Using **percent = 100** and **cut-off = 20** - This read will be discarded (not all cycles have quality equal to / higher than 20).
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTQ-Quality-Filter is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/fastq_to_fasta.xml
@@ -116,11 +116,6 @@ Will be converted to FASTA (with 'rename sequence names' = YES)::
     >1
     GGTCAATGATGAGTTGGCACTGTAGGCACCATCAAT
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTQ-to-FASTA is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/fastx_artifacts_filter.xml
@@ -83,11 +83,6 @@ This tool filters sequencing artifacts (reads with all but 3 identical bases).
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAA
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAA
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTX-Artifacts-filter is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
+++ b/tool_collections/fastx_toolkit/fastx_barcode_splitter/fastx_barcode_splitter.xml
@@ -145,11 +145,6 @@ The output of this tool is an HTML file, displaying the split counts and the fil
 
 .. image:: barcode_splitter_output_example.png
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTX-barcode-splitter is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/fastx_clipper.xml
@@ -95,11 +95,6 @@ This tool clips adapters from the 3'-end of the sequences in a FASTA/FASTQ file.
 * Sequence no. 1 was discarded since it wasn't clipped (i.e. didn't contain the adapter sequence). (**Output** parameter).
 * Sequence no. 5 was discarded --- it's length (after clipping) was shorter than 15 nt (**Minimum Sequence Length** parameter).
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
+++ b/tool_collections/fastx_toolkit/fastx_collapser/fastx_collapser.xml
@@ -77,12 +77,6 @@ The following output::
     ATAT
 
 means that the sequence "ATAT" is the second sequence in the file, and it appeared 4 times in the input FASTA file.
-
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
+++ b/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/fastx_nucleotides_distribution.xml
@@ -51,11 +51,6 @@ But most of the time, the chart will look rather random:
 
 .. image:: fastq_nucleotides_distribution_4.png
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
     <!-- FASTQ-Nucleotides-Distribution is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
+++ b/tool_collections/fastx_toolkit/fastx_quality_statistics/fastx_quality_statistics.xml
@@ -61,11 +61,6 @@ For example::
      4  6362991 -4 40 248214827 39.01 40 40 40  0 40 40 2536861 1167423 1248968 1409739   0
     36  6362991 -5 40 117158566 18.41  7 15 30 23 -5 40 4074444 1402980   63287  822035 245
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTQ-Statistics is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->

--- a/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/fastx_renamer.xml
@@ -67,11 +67,6 @@ Renamed to **numeric counter**::
     +1
     40 40 40 40 40 40 40 40 40 40 38 40 40 40 40 40 14 40 40 40 40 40 36 40 13 14 24 24 9 24 9 40 10 10 15 40
 
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/fastx_reverse_complement.xml
@@ -53,12 +53,6 @@ Output FASTQ file::
     TACCNNCTTTGAATTACAAGGANGAGGCTACAGACA
     +CSHL_1_FC42AGWWWXX:8:1:3:740
     26 27 17 15 5 5 24 26 29 31 32 33 27 21 27 33 33 33 33 33 33 27 5 27 33 33 33 33 33 33 33 33 34 33 33 33
-
-------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
+++ b/tool_collections/fastx_toolkit/fastx_trimmer/fastx_trimmer.xml
@@ -82,11 +82,6 @@ Trimming with First=6 and Last=10, will generate a FASTA file with 5 bases (base
     >2-1
     AGGCT
 
-    ------
-
-This tool is based on `FASTX-toolkit`__ by Assaf Gordon.
-
- .. __: http://hannonlab.cshl.edu/fastx_toolkit/
     ]]></help>
     <expand macro="citations" />
 <!-- FASTX-Trimmer is part of the FASTX-toolkit, by A.Gordon (gordon@cshl.edu) -->


### PR DESCRIPTION
I intentionally do not bump :)

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
