### PR TITLE
Logex tool Patch : Add missing collection type

### DIFF
--- a/tools/fastk/logex.xml
+++ b/tools/fastk/logex.xml
@@ -1,4 +1,4 @@
-<tool id="fastk_logex" name="FastK Logex" version="@TOOL_VERSION@+galaxy3" profile="24.2" license="MIT">
+<tool id="fastk_logex" name="FastK Logex" version="@TOOL_VERSION@+galaxy4" profile="24.2" license="MIT">
     <description>Performs binary operations on the generated Ktab files from FASTK suite</description>
     <macros>
         <import>macros.xml</import>
@@ -86,7 +86,7 @@
             </when>
             <when value="collection">
                 <param name="input_ktab_collection" type="data_collection" collection_type="list" format="fastk_ktab" label="Input FastK ktab Collection"/>
-                <param name="input_ktab_collection_tar" type="data_collection" format="fastk_ktab_tar" label="Associated FastK TAR file consisting of intermediate .ktab files"/>
+                <param name="input_ktab_collection_tar" type="data_collection" collection_type="list" format="fastk_ktab_tar" label="Associated FastK TAR file consisting of intermediate .ktab files"/>
                 <conditional name="operation_sel">
                     <param name="operation_selector_collection" type="select" label="Select Operation to Perform" help="Select the operation to be performed on the input ktab files.">
                         <option value="and">AND</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

---
This PR is a small patch that add missing collection type to Logex tool. 