### PR TITLE
Bump ncbi_datasets deps to 18.1.0

### DIFF
--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">17.1.0</token>
+    <token name="@TOOL_VERSION@">18.1.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">23.0</token>
     <token name="@LICENSE@">MIT</token>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)


The current version of ncbi-datasets-cli seems to no more be compatible with the current NCBI server (API?)

```
dataformat doesn't recognize this input!
Error:  unknown field "atgcCount"

Use dataformat tsv genome <command> --help for detailed help about a command.
```