### PR TITLE
Add bracken fix and kraken note

### DIFF
--- a/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
+++ b/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
@@ -38,15 +38,6 @@
                 <validator type="no_options" message="No Kraken2 databases are available" />
             </options>
         </param>
-        <param name="read_len" type="select" label="Read length" help="The read length of the bracken DB should be the same as the length of the reads to be analysis (one read in case of paired reads). The prebuilt DBs where built using the same K-mer length as the kraken2 DB.">
-            <option value="50">50</option>
-            <option value="75">75</option>
-            <option value="100" selected="true">100</option>
-            <option value="150">150</option>
-            <option value="200">200</option>
-            <option value="250">250</option>
-            <option value="300">300</option>
-        </param>
         <conditional name="check_prebuilt">
             <param name="prebuilt" type="select" label="Use Pre-built DB" help="Use existing pre-built DB. This only works for kraken DBs, that already contain additional bracken DBs. This is the case for DBs downloaded from https://benlangmead.github.io/aws-indexes/k2.">
                 <option value="no">No</option>

--- a/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
+++ b/data_managers/data_manager_build_bracken_database/data_manager/bracken_build_database.xml
@@ -3,7 +3,7 @@
     <description>bracken database builder</description>
     <macros>
         <token name="@TOOL_VERSION@">2.8</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">22.01</token>
     </macros>
     <requirements>
@@ -15,7 +15,7 @@
         #set db_dir = os.path.basename($kraken_db.fields.path)
 
         mkdir '$db_dir' &&
-        ln -s '${kraken_db.fields.path}/*' '$db_dir/' &&
+        ln -s '${kraken_db.fields.path}'/* '$db_dir/' &&
         python '$__tool_directory__/bracken_build_database.py'
           '${out_file}'
           
@@ -37,6 +37,15 @@
             <options from_data_table="kraken2_databases">
                 <validator type="no_options" message="No Kraken2 databases are available" />
             </options>
+        </param>
+        <param name="read_len" type="select" label="Read length" help="The read length of the bracken DB should be the same as the length of the reads to be analysis (one read in case of paired reads). The prebuilt DBs where built using the same K-mer length as the kraken2 DB.">
+            <option value="50">50</option>
+            <option value="75">75</option>
+            <option value="100" selected="true">100</option>
+            <option value="150">150</option>
+            <option value="200">200</option>
+            <option value="250">250</option>
+            <option value="300">300</option>
         </param>
         <conditional name="check_prebuilt">
             <param name="prebuilt" type="select" label="Use Pre-built DB" help="Use existing pre-built DB. This only works for kraken DBs, that already contain additional bracken DBs. This is the case for DBs downloaded from https://benlangmead.github.io/aws-indexes/k2.">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -2,14 +2,14 @@
     <description>database builder</description>
     <macros>
         <token name="@TOOL_VERSION@">2.1.3</token>
-        <token name="@VERSION_SUFFIX@">6</token>
+        <token name="@VERSION_SUFFIX@">7</token>
         <token name="@PROFILE@">22.01</token>
         <xml name="common_params">
             <param name="kmer_len" type="integer" value="35" label="K-mer length in BP" />
             <param name="minimizer_len" type="integer" value="31" label="Minimizer length" />
             <param name="minimizer_spaces" type="integer" value="7" label="Minimizer spaces" />
             <param name="load_factor" type="float" value="0.7" min="0" max="1" label="Load factor" help="Proportion of the hash table to be populated" />
-            <param name="clean" type="boolean" truevalue="--clean" falsevalue="" checked="true" label="Clean up extra files" />
+            <param name="clean" type="boolean" truevalue="--clean" falsevalue="" checked="false" label="Clean up extra files. Note: If the extra files are removed this DB cannot be used to build a bracken DB!" />
         </xml>
         <xml name="viral">
             <option value="viral">Viral (viral; ~0.5 GB)</option>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

While following a problem from GTA I realized, the bracken option `prebuilt == "no"` does not work, first due to:
`ln -s '${kraken_db.fields.path}/*' '$db_dir/' &&` 
This is fixed now, the DB builds. But this never worked still, since the DB is only built in the working dir.
I am not really sure how to fix it properly, since: (a) Bracken cannot write in the kraken DB folder. So to really fix it we probably have to make a copy of the kraken2 DB, and add the Bracken part. But this will also add a lot of extra code, since 
in the data_manager_conf.xml, we can either move the path or not, but here it would be conditional.
Any suggestions @bernt-matthias @bebatut 

