### PR TITLE
Fix input order in TRANSIT resampling tool and bump version to 3.2.3

### DIFF
--- a/tools/transit/macros.xml
+++ b/tools/transit/macros.xml
@@ -17,7 +17,7 @@
 			<yield />
 		</requirements>
 	</xml>
-	<token name="@TOOL_VERSION@">3.0.2</token>
+	<token name="@TOOL_VERSION@">3.2.3</token>
 	<token name="@VERSION_SUFFIX@">1</token>
 	<xml name="outputs">
         <yield />

--- a/tools/transit/transit_resampling.xml
+++ b/tools/transit/transit_resampling.xml
@@ -12,7 +12,7 @@
         #for idx, filename in enumerate(str($controls).split(',')):
             ln -s '$filename' control_file_${idx}.wig &&
         #end for
-        transit resampling $input_files $control_files annotation.dat transit_out.txt
+        transit resampling $control_files $input_files annotation.dat transit_out.txt
         @STANDARD_OPTIONS@
         -s $samples $histogram $adaptive $exclude_zero $pseudo $loess
         ]]>


### PR DESCRIPTION
Fixes the input order of control and experimental files in the `transit_resampling` tool.  
Also bumps the version to `3.2.3`.

- [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
- [x] License permits unrestricted use (educational + commercial)
- [ ] This PR adds a new tool or tool collection
- [x] This PR updates an existing tool or tool collection
- [ ] This PR does something else (explain below)

