### PR TITLE
Fix  ``required_files`` in Table Compute

### DIFF
--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -2,7 +2,7 @@
     <description>computes operations on table data</description>
     <macros>
         <token name="@VERSION@">1.2.4</token>
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">2</token>
         <token name="@COPEN@"><![CDATA[<code>]]></token>
         <token name="@CCLOSE@"><![CDATA[</code>]]></token>
         <import>allowed_functions.xml</import>
@@ -99,6 +99,7 @@
 
     <required_files>
         <include path="scripts/safety.py" />
+        <include path="scripts/table_compute.py" />
     </required_files>
 
     <version_command><![CDATA[


### PR DESCRIPTION
If `<required_files/>` is used it must include all tool files to be transferred. Fixes part of https://github.com/galaxyproject/pulsar/issues/392

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
