### PR TITLE
Fix bug in output formats of Squirrel-Phylo

### DIFF
--- a/tools/squirrel/macros.xml
+++ b/tools/squirrel/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
   <token name="@TOOL_VERSION@">1.0.13</token>
-  <token name="@VERSION_SUFFIX@">0</token>
+  <token name="@VERSION_SUFFIX@">1</token>
   <xml name="requirements">
   <requirements>
     <requirement type="package" version="@TOOL_VERSION@">squirrel</requirement>

--- a/tools/squirrel/squirrel-phylo.xml
+++ b/tools/squirrel/squirrel-phylo.xml
@@ -139,10 +139,10 @@
       <data name="png" format="png" label="${tool.name} - phylotree png image"> 
         <filter>apobec3</filter>
       </data>
-      <data name="aa_recon" format="png" label="${tool.name} - aa mutations ancestral reconstruction">
+      <data name="aa_recon" format="csv" label="${tool.name} - aa mutations ancestral reconstruction">
         <filter>apobec3</filter>
       </data>
-      <data name="branch_snps" format="png" label="${tool.name} - apobec3 nt mutations">
+      <data name="branch_snps" format="csv" label="${tool.name} - apobec3 nt mutations">
         <filter>apobec3</filter>
       </data>
     </outputs>

--- a/tools/squirrel/squirrel-phylo.xml
+++ b/tools/squirrel/squirrel-phylo.xml
@@ -130,7 +130,7 @@
 
     <outputs>
       <!-- standard outputs-->
-      <data name="tree" format="newick" label="${tool.name} - phylogenetic tree" />
+      <data name="tree" format="nexus" label="${tool.name} - phylogenetic tree" />
       <data name="alignment" format="fasta" label="${tool.name} - aligned sequences" />
       <!-- apobec3 outputs-->
       <data name="svg" format="svg" label="${tool.name} - phylotree svg image">


### PR DESCRIPTION
outputs `aa_recon` and `branch_snps` are `csv` not `png` files. I think a transposition error results in the outputs of these two files being tagged as `png`.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
