### PR TITLE
STARSolo add --outBAMsortingBinsN an add a param to force samtools sort

### DIFF
--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -5,7 +5,7 @@
     the index versions in sync, but you should manually update @IDX_VERSION_SUFFIX@ -->
     <!-- STAR version to be used -->
     <token name="@TOOL_VERSION@">2.7.11b</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <!-- STAR index version compatible with this version of STAR
     This is the STAR version that introduced the index structure expected
@@ -584,4 +584,30 @@
             #end if
     ]]></token>
 
+    <xml name="perf_params">
+        <section name="perf" title="Performance tweaks / Troubleshooting" expanded="false">
+            <param argument="--outBAMsortingBinsN" type="integer" value="50" min="1" label="Number of genome bins for coordinate-sorting" help="Higher values result in lower RAM requirements during the sorting step. The default value is 50. Tweak this if you are facing memory-related errors." />
+            <param argument="--winAnchorMultimapNmax" type="integer" value="50" min="50" label="Maximum number of loci anchors are allowed to map to" help="Higher value can increase the runtime singificantly. This value should be set greater or equal to --outFilterMultimapNmax" />
+        </section>
+    </xml>
+    <token name="@PERF@"><![CDATA[
+        --outBAMsortingBinsN $perf.outBAMsortingBinsN
+        --winAnchorMultimapNmax $perf.winAnchorMultimapNmax
+    ]]></token>
+
+    <token name="@SAMTOOLS_SORT@"><![CDATA[
+        ## BAM sorting (logic copied from samtools_sort wrapper)
+        ## choosing BAM SortedByCoord appeared once to give fewer reads
+        ## than BAM Unsorted followed by a samtools sort
+        ## so better go with the latter?
+
+        &&
+        ##compute the number of ADDITIONAL threads to be used by samtools (-@)
+        addthreads=\${GALAXY_SLOTS:-2} && (( addthreads-- )) &&
+        ##compute the number of memory available to samtools sort (-m)
+        ##use only 75% of available: https://github.com/samtools/samtools/issues/831
+        addmemory=\${GALAXY_MEMORY_MB_PER_SLOT:-768} &&
+        ((addmemory=addmemory*75/100)) &&
+        samtools sort -@ \$addthreads -m \$addmemory"M" -T "\${TMPDIR:-.}" -O bam -o '$output_BAM' Aligned.out.bam
+    ]]></token>
 </macros>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -176,8 +176,7 @@
         @ALGO_DEFAULT@
         #end if
         --outBAMsortingThreadN \${GALAXY_SLOTS:-4}
-        --outBAMsortingBinsN $perf.outBAMsortingBinsN
-        --winAnchorMultimapNmax $perf.winAnchorMultimapNmax
+        @PERF@
         --limitBAMsortRAM \$((\${GALAXY_MEMORY_MB:-0}*1000000))
 
         #if $oformat.wasp_conditional.waspOutputMode == "wasp_mode":
@@ -402,10 +401,7 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
                 </when>
             </conditional>
         </section>
-        <section name="perf" title="Performance tweaks / Troubleshooting" expanded="false">
-            <param argument="--outBAMsortingBinsN" type="integer" value="50" min="1" label="Number of genome bins for coordinate-sorting" help="Higher values result in lower RAM requirements during the sorting step. The default value is 50. Tweak this if you are facing memory-related errors." />
-            <param argument="--winAnchorMultimapNmax" type="integer" value="50" min="50" label="Maximum number of loci anchors are allowed to map to" help="Higher value can increase the runtime singificantly. This value should be set greater or equal to --outFilterMultimapNmax" />
-        </section>
+        <expand macro="perf_params"/>
         <expand macro="outWig"/>
     </inputs>
 

--- a/tools/rgrnastar/rg_rnaStarSolo.xml
+++ b/tools/rgrnastar/rg_rnaStarSolo.xml
@@ -108,7 +108,11 @@
     --quantMode TranscriptomeSAM $solo.quantModeGene
     #set $tag_names = str($solo.outSAMattributes).replace(',', ' ')
     --outSAMattributes $tag_names
-    #if "CB" in $tag_names or "UB" in $tag_names or str($outWig.outWigType) != 'None':
+
+    ## force unsorted BAM output and later use samtools sort
+    #if $use_samtools_sort
+        --outSAMtype BAM Unsorted
+    #elif "CB" in $tag_names or "UB" in $tag_names or str($outWig.outWigType) != 'None':
         --outSAMtype BAM SortedByCoordinate
     #else:
         --outSAMtype BAM Unsorted
@@ -137,6 +141,9 @@
     #else:
     @ALGO_DEFAULT@
     #end if
+    --outBAMsortingThreadN \${GALAXY_SLOTS:-4}
+    @PERF@
+    --limitBAMsortRAM \$((\${GALAXY_MEMORY_MB:-0}*1000000))
 
     ##outWig:
     @OUTWIG@
@@ -149,23 +156,14 @@
     ## put the barcodes and features stats into a single file
     && cat <(echo "Barcodes:") Solo.out/Barcodes.stats <(echo "Genes:") Solo.out/soloFeatures/Features.stats > '${output_stats}'
 
-    #if "CB" in $tag_names or "UB" in $tag_names or str($outWig.outWigType) != 'None':
+    ## force samtools sort regardless of other params
+    #if $use_samtools_sort
+        @SAMTOOLS_SORT@
+    #elif "CB" in $tag_names or "UB" in $tag_names or str($outWig.outWigType) != 'None'
         ## recompress BAM output for smaller file size
         && samtools view -b -o '$output_BAM' Aligned.sortedByCoord.out.bam
     #else:
-        ## BAM sorting (logic copied from samtools_sort wrapper)
-        ## choosing BAM SortedByCoord appeared once to give fewer reads
-        ## than BAM Unsorted followed by a samtools sort
-        ## so better go with the latter?
-
-        &&
-        ##compute the number of ADDITIONAL threads to be used by samtools (-@)
-        addthreads=\${GALAXY_SLOTS:-2} && (( addthreads-- )) &&
-        ##compute the number of memory available to samtools sort (-m)
-        ##use only 75% of available: https://github.com/samtools/samtools/issues/831
-        addmemory=\${GALAXY_MEMORY_MB_PER_SLOT:-768} &&
-        ((addmemory=addmemory*75/100)) &&
-        samtools sort -@ \$addthreads -m \$addmemory"M" -T "\${TMPDIR:-.}" -O bam -o '$output_BAM' Aligned.out.bam
+        @SAMTOOLS_SORT@
     #end if
     ##outWig:
     @OUTWIGOUTPUTS@
@@ -432,7 +430,9 @@
             </conditional>
         </section>
         <expand macro="chim_params"/>
+        <expand macro="perf_params"/>
         <expand macro="outWig"/>
+        <param name="use_samtools_sort" type="boolean" checked="false" label="Use Samtools to sort the BAM file" help="Otherwise, use options in 'Performance tweaks / Troubleshooting' section"/>
     </inputs>
     <outputs>
         <data format="txt" name="output_log" label="${tool.name} on ${on_string}: log" from_work_dir="Log.final.out">


### PR DESCRIPTION
Quick fix to https://github.com/galaxyproject/tools-iuc/issues/7043

- This PR does NOT export `--outSAMtype`. This patch should still keep the existing functionality of the tool. It adds an extra boolean param `use_samtools_sort` which forces `--outSAMtype BAM Unsorted` and uses `samtools sort` to sort the BAM file.
- It also exposes `--outBAMsortingBinsN` and `--winAnchorMultimapNmax` params which already exist in STAR.  
