### PR TITLE
un-quotes the region list so chr1 chr2 will not be passed as an inval…

### DIFF
--- a/tool_collections/samtools/samtools_view/samtools_view.xml
+++ b/tool_collections/samtools/samtools_view/samtools_view.xml
@@ -104,7 +104,7 @@
                 #if str($mode.filter_config.cond_region.select_region) == 'bed':
                     #set std_filters = $std_filters + " -L '%s'" % str($mode.filter_config.cond_region.bedfile)
                 #elif str($mode.filter_config.cond_region.select_region) == 'text':
-                    #set $reg_filters = "'%s'" % str($mode.filter_config.cond_region.regions).strip()
+                    #set $reg_filters = "'%s'" % "' '".join(str($mode.filter_config.cond_region.regions).strip().split())
                 #end if
 
                #if $mode.filter_config.cond_rg.select_rg == 'text':
@@ -282,7 +282,9 @@
                         </param>
                         <when value="no"/>
                         <when value="text">
-                            <param name="regions" type="text" optional="false" label="Filter by regions" help="One or more space-separated region specifications to restrict output to only those alignments which overlap the specified region(s)."/>
+                            <param name="regions" type="text" optional="false" label="Filter by regions" help="One or more space-separated region specifications to restrict output to only those alignments which overlap the specified region(s).">
+                                <validator type="regex" message="Invalid characters in regions. Only letters, numbers, periods, underscores, hyphens, colons, asterixes, and spaces are allowed.">^[A-Za-z0-9._\-:\*\s]+$</validator>
+                            </param>
                         </when>
                         <when value="bed">
                             <param name="bedfile" format="bed" argument="-L" optional="false" type="data" label="Filter by intervals in a bed file" help="Only output alignments overlapping the intervals in the input bed file." />
@@ -640,7 +642,7 @@
             </conditional>
             <output name="outputsam" file="test_17.bam" ftype="bam" lines_diff="4" />
         </test>
-        <!-- 18) -->
+        <!-- 18) region filtering with multiple regions -> cram -->
         <test expect_num_outputs="1">
             <param name="input" value="in_test_14.bam" ftype="bam" />
             <conditional name="mode">
@@ -648,7 +650,7 @@
                 <section name="filter_config">
                     <conditional name="cond_region">
                         <param name="select_region" value="text"/>
-                        <param name="regions" value="CHROMOSOME_I" />
+                        <param name="regions" value="CHROMOSOME_I:1-1 CHROMOSOME_I:2" />
                     </conditional>
                 </section>
                 <conditional name="output_options">


### PR DESCRIPTION
…id region 'chr1 chr2', instead quotes each whitespace separated block and validates user input

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
