### PR TITLE
deeparg DM: fix .loc file name in sample file

### DIFF
--- a/data_managers/data_manager_deeparg/tool_data_table_conf.xml.sample
+++ b/data_managers/data_manager_deeparg/tool_data_table_conf.xml.sample
@@ -1,6 +1,6 @@
 <tables>
     <table name="deeparg" comment_char="#">
         <columns>value, name, path, db_version</columns>
-        <file path="tool-data/deeparg.loc.sample"/>
+        <file path="tool-data/deeparg.loc"/>
     </table>
 </tables>


### PR DESCRIPTION
Had to fix the .loc files manually on .eu to make this DM work and chances are this is the root of the problem.
