### PR TITLE
mapDamage : add value to non-optional parameters (for deployment)

### DIFF
--- a/tools/map_damage/map_damage.xml
+++ b/tools/map_damage/map_damage.xml
@@ -143,13 +143,13 @@
                 </param>
                 <when value="no_downsampling"/>
                 <when value="p">
-                    <param argument="--downsample" type="float" min="0" max="1" label="Percentage of reads to sample" help="Must be between 0 and 1 (0 and 1 not included)">
+                    <param argument="--downsample" type="float" min="0" max="1" value="0.8" label="Percentage of reads to sample" help="Must be between 0 and 1 (0 and 1 not included)">
                         <validator type="in_range" min="0" exclude_min="true" max="1" exclude_max="true" message="Percentage of reads to downsample must be > 0 and &lt; 1"/>
                     </param>
                     <param argument="--downsample-seed" type="integer" optional="true" label="Downsampling seed" help="Seed (integer) used to randomly select reads for downsampling. Useful for reproducibility."/>
                 </when>
                 <when value="n">
-                    <param argument="--downsample" type="integer" min="1" label="Number of reads to sample" help="Must be superior or equal to 1"/>
+                    <param argument="--downsample" type="integer" min="1" value="1000" label="Number of reads to sample" help="Must be superior or equal to 1"/>
                     <param argument="--downsample-seed" type="integer" optional="true" label="Downsampling seed" help="Seed (integer) used to randomly select reads for downsampling. Useful for reproducibility."/>
                 </when>
             </conditional>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

As discussed in #7081, here's a new PR in order to give a value to the non-optional params which didn't have one.
If successful, this would close issue #7076

Thanks! 