### PR TITLE
kma: remove .lint-skip file

### DIFF
--- a/tools/kma/.lint_skip
+++ b/tools/kma/.lint_skip
@@ -1,3 +1,0 @@
-TestsCaseValidation
-ValidDatatypes
-XSD


### PR DESCRIPTION
We can skip the version bump here (which is the reason of the failing lint)

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
