### PR TITLE
velvet: linter and test fixes

### DIFF
--- a/tools/velvet/.lint_skip
+++ b/tools/velvet/.lint_skip
@@ -1,3 +1,0 @@
-XMLOrder
-TestsCaseValidation
-TestsParamInInputs

--- a/tools/velvet/macros.xml
+++ b/tools/velvet/macros.xml
@@ -6,6 +6,7 @@
       </requirements>
   </xml>
   <token name="@WRAPPER_VERSION@">1.2.10</token>
+  <token name="@PROFILE@">24.0</token>
   <xml name="stdio">
     <stdio>
       <!-- Anything other than zero is an error -->

--- a/tools/velvet/velvetg.xml
+++ b/tools/velvet/velvetg.xml
@@ -1,11 +1,11 @@
-<tool id="velvetg" name="velvetg" version="@WRAPPER_VERSION@.2">
+<tool id="velvetg" name="velvetg" version="@WRAPPER_VERSION@.3" profile="@PROFILE@">
   <description>Velvet sequence assembler for very short reads</description>
-  <xrefs>
-      <xref type="bio.tools">velvet</xref>
-  </xrefs>
   <macros>
     <import>macros.xml</import>
   </macros>
+  <xrefs>
+      <xref type="bio.tools">velvet</xref>
+  </xrefs>
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <version_command><![CDATA[
@@ -201,11 +201,19 @@
         <composite_data value='velvetg_paired/Log'/>
       </param>
       <param name="add_out" value="amos,unused,lastgraph" />
-      <param name="read_trkg" value="-read_trkg no" />
-      <param name="cutoff" value="auto" />
-      <param name="coverage" value="auto" />
-      <param name="use_contig_lgth" value="no" />
-      <param name="paired" value="no" />
+      <param name="read_trkg" value="false" />
+      <conditional name="coverage">
+        <param name="cutoff" value="auto" />
+      </conditional>
+      <conditional name="expected">
+        <param name="coverage" value="auto" />
+      </conditional>
+      <conditional name="contig_lgth">
+        <param name="use_contig_lgth" value="no" />
+      </conditional>
+      <conditional name="reads">
+        <param name="paired" value="no" />
+      </conditional>
       <output name="velvet_asm" file="velvetg_paired/velvet_asm.afg" compare="diff"/>
       <output name="unused_reads_fasta" file="velvetg_paired/UnusedReads.fa" compare="diff"/>
       <output name="LastGraph" file="velvetg_paired/lastgraph.txt" compare="diff"/>

--- a/tools/velvet/velveth.xml
+++ b/tools/velvet/velveth.xml
@@ -1,11 +1,11 @@
-<tool id="velveth" name="velveth" version="@WRAPPER_VERSION@.3">
+<tool id="velveth" name="velveth" version="@WRAPPER_VERSION@.4" profile="@PROFILE@">
   <description>Prepare a dataset for the Velvet velvetg Assembler</description>
-  <xrefs>
-      <xref type="bio.tools">velvet</xref>
-  </xrefs>
   <macros>
     <import>macros.xml</import>
   </macros>
+  <xrefs>
+      <xref type="bio.tools">velvet</xref>
+  </xrefs>
   <expand macro="requirements"/>
   <expand macro="stdio"/>
   <version_command><![CDATA[
@@ -84,14 +84,22 @@
         <conditional name="input_type">
           <param name="input_type_selector" value="paireds" />
           <param name="read_type" value="-shortPaired" />
-          <param name="input1" value="R1.fastq" ftype="fastqsanger" />
+          <param name="input" value="R1.fastq" ftype="fastqsanger" />
           <param name="input2" value="R2.fastq" ftype="fastqsanger" />
         </conditional>
       </repeat>
-      <param name="strand_specific" value="" />
+      <param name="strand_specific" value="false" />
       <output name="outfile" file="velveth_paireds.out">
-        <extra_files type="file" name='Sequences' value="velveth_paireds/Sequences" compare="diff" />
-        <extra_files type="file" name='Roadmaps' value="velveth_paireds/Roadmaps" compare="diff" />
+        <extra_files type="file" name='Sequences' value="velveth_paireds/Sequences" compare="sim_size">
+          <assert_contents>
+            <has_line_matching expression="^>mutant-no_snps.gff.*"/>
+          </assert_contents>
+        </extra_files>
+        <extra_files type="file" name='Roadmaps' value="velveth_paireds/Roadmaps" compare="sim_size">
+          <assert_contents>
+            <has_text text="ROADMAP"/>
+          </assert_contents>
+        </extra_files>
       </output>
     </test>
     <test>
@@ -103,10 +111,14 @@
           <param name="input" value="R1.fastq" ftype="fastqillumina" />
         </conditional>
       </repeat>
-      <param name="strand_specific" value="" />
+      <param name="strand_specific" value="false" />
       <output name="outfile" file="velveth_single.out">
         <extra_files type="file" name='Sequences' value="velveth_single/Sequences" compare="diff" />
-        <extra_files type="file" name='Roadmaps' value="velveth_single/Roadmaps" compare="diff" />
+        <extra_files type="file" name='Roadmaps' value="velveth_single/Roadmaps" compare="sim_size">
+          <assert_contents>
+            <has_text text="ROADMAP"/>
+          </assert_contents>
+        </extra_files>
       </output>
     </test>
     <test>
@@ -119,17 +131,20 @@
         </conditional>
       </repeat>
       <repeat name="inputs">
-        <param name="file_format" value="fastq" />
         <conditional name="input_type">
           <param name="input_type_selector" value="single" />
           <param name="read_type" value="-short2" />
           <param name="input" value="R2.fastq" ftype="fastq" />
         </conditional>
       </repeat>
-      <param name="strand_specific" value="" />
+      <param name="strand_specific" value="false" />
       <output name="outfile" file="velveth_single.out">
         <extra_files type="file" name='Sequences' value="velveth_single2/Sequences" compare="diff" />
-        <extra_files type="file" name='Roadmaps' value="velveth_single2/Roadmaps" compare="diff" />
+        <extra_files type="file" name='Roadmaps' value="velveth_single2/Roadmaps" compare="sim_size">
+          <assert_contents>
+            <has_text text="ROADMAP"/>
+          </assert_contents>
+        </extra_files>
       </output>
     </test>
   </tests>


### PR DESCRIPTION
tool tests fail for a long time because CI now uses 2 cores and test-data has been generated with 1 core. this is because velvet is not deterministic for multiple cores

https://www.biostars.org/p/86907/
https://github.com/dzerbino/velvet/issues/56

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
