### PR TITLE
fastplong: fixed max value for quality params

### DIFF
--- a/tools/fastplong/fastplong.xml
+++ b/tools/fastplong/fastplong.xml
@@ -6,7 +6,7 @@
     </creator>
     <macros>
         <token name="@TOOL_VERSION@">0.3.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">3</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">fastplong</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

I was initially going to make a remark on the changes made in #7222 (the change of the max value from quality from 60 to 36) as that was not a typo of me but intentionally :) (we regularly see Qvalues above 36 with modern day data&basecalling in ONT) but before doing so I made the good decision to run some tests on those parameters.
It thus turned out that, though the doc say 36 as max, the actual max values is 30! above it tool will fail with complaint.