### PR TITLE
bakta, fix for local DB usage

### DIFF
--- a/tools/bakta/bakta.xml
+++ b/tools/bakta/bakta.xml
@@ -10,7 +10,7 @@
     <expand macro="version_command"/>
     <command detect_errors="aggressive"><![CDATA[
 mkdir -p ./database_path/amrfinderplus-db &&
-ln -s '$(input_option.bakta_db_select.fields.path)'/* database_path &&
+for file in '$(input_option.bakta_db_select.fields.path)'/*; do [ -f "\$file" ] && ln -s "\$file" database_path; done &&
 ln -s '$(input_option.amrfinder_db_select.fields.path)/' database_path/amrfinderplus-db/latest &&
 
 bakta 

--- a/tools/bakta/macro.xml
+++ b/tools/bakta/macro.xml
@@ -2,7 +2,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.9.4</token>
     <token name="@COMPATIBLE_BAKTA_VERSION@">1.7</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">
         <version_command><![CDATA[bakta --version]]></version_command>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

When trying to use a local installed bakta DB the command block cmdline used in the wrapper failed, so this is an 'extension' of the command block to allow using local installed bakta databases.
(briefly: changed linking by a for loop linking approach).
I'm available to provide more elaborate explanation if need-be 