### PR TITLE
Add required_files to addName

### DIFF
--- a/tools/add_input_name_as_column/add_input_name_as_column.xml
+++ b/tools/add_input_name_as_column/add_input_name_as_column.xml
@@ -3,8 +3,11 @@
     <requirements>
         <requirement type="package" version="3.7">python</requirement>
     </requirements>
+    <required_files>
+        <include path="add_input_name_as_column.py"/>
+    </required_files>
     <command><![CDATA[
-python '$__tool_directory__/'add_input_name_as_column.py
+python '$__tool_directory__/add_input_name_as_column.py'
 --input '$input'
 --label '$input.element_identifier'
 --output '$output'


### PR DESCRIPTION
Although the quoting is valid, I think the way it's done prevents Pulsar from implicitly copying the wrapper script? On .org we're getting:

```
python: can't open file '/jetstream2/scratch/main/jobs-vgp/70483536/tool_files/add_input_name_as_column.py': [Errno 2] No such file or directory
```

This adjusts the quoting _and_ adds required_files for good measure. No tool version change because there's no change in functionality, just a fix for running with Pulsar.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
