### PR TITLE
update samples file for lexicmap indexes

### DIFF
--- a/tools/lexicmap/tool-data/lexicmap_index.loc.sample
+++ b/tools/lexicmap/tool-data/lexicmap_index.loc.sample
@@ -1,0 +1,8 @@
+#This is a sample file distributed with Galaxy that enables tools
+#to use a pre-built lexicmap indexes. You will need to create these
+#indexes and then create a lexicmap_index.loc file similar to this
+#one (store it in this directory) that points to pre-built indexes.
+#The lexicmap_index.loc file has this format 
+#(longer white space characters are TAB characters):
+#
+#<unique_build_id>   <display_name>   <file_path>

--- a/tools/lexicmap/tool-data/lexicmap_index.loc.xml
+++ b/tools/lexicmap/tool-data/lexicmap_index.loc.xml
@@ -1,6 +1,0 @@
-<tables>
-    <table name="lexicmap_index" comment_char="#" allow_duplicate_entries="False">
-        <columns>value, name, path</columns>
-        <file path="tool-data/lexicmap_index.loc"/>
-    </table>
-</tables>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

@bgruening @bernt-matthias The deploy step failed for lexicmap. I looked at how bwa and blast had their tool-data configured and tried to mimic it. The question if I should have named the sample file like this instead `tool-data/lexicmap_index.loc` instead of `tool-data/lexicmap_index.loc.sample`