### PR TITLE
Pairtools - fix typo causing problem down the line

### DIFF
--- a/tools/pairtools/dedup.xml
+++ b/tools/pairtools/dedup.xml
@@ -7,7 +7,7 @@
     <command detect_errors="exit_code"><![CDATA[
         #if $pairs_path.is_of_type('4dn_pairs.gz') or $pairs_path.is_of_type('4dn_pairsam.gz'):
             #set $input_link = "input.gz"
-            #set $output_dedup_pairs_link = "output_dedup_pairs.ga"
+            #set $output_dedup_pairs_link = "output_dedup_pairs.gz"
             #set $output_dups_pairs_link = "output_dups_pairs.gz"
         #else
             #set $input_link = "input"

--- a/tools/pairtools/macros.xml
+++ b/tools/pairtools/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.1.3</token>
-    <token name="@SUFFIX_VERSION@">5</token>
+    <token name="@SUFFIX_VERSION@">6</token>
     <token name="@PROFILE_VERSION@">25.0</token>
     <xml name="edam_ontology">
         <edam_datas>


### PR DESCRIPTION
Fixing the error `Exception: Input file is not valid .pairs, has no header or is empty.` when using split after dedup

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
