### PR TITLE
Mash paste - fix file name in toolshed file that was pointing to a different tool 

### DIFF
--- a/tools/mash/.shed.yml
+++ b/tools/mash/.shed.yml
@@ -35,6 +35,6 @@ repositories:
   mash_paste:
     description: "mash paste: Create a single sketch file from multiple sketch files."
     include:
-      - mash_sketch.xml
+      - mash_paste.xml
       - macros.xml
       - test-data


### PR DESCRIPTION
Sorry about the mistake!

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
