### PR TITLE
Seqkit Split2 patch for mishandling of paired collection

### DIFF
--- a/tools/seqkit/seqkit_split2.xml
+++ b/tools/seqkit/seqkit_split2.xml
@@ -79,7 +79,10 @@
     #end if
     -o seqkit_split2
     -O out
-    -j "\${GALAXY_SLOTS:-4}"
+    -j "\${GALAXY_SLOTS:-4}" 
+    #if $paired:
+        && (find out/ -type f -name "seqkit_split2_*.*" | while read -r file; do mv "\$file" "\$(echo \$file | sed -E 's/(seqkit_split2)_(R1|R2)_([0-9]+)(\..+)/\1_\3_\2\4/' | sed -E 's/_R1/_forward/; s/_R2/_reverse/')"; done)
+    #end if
     ]]></command>
     <inputs>
         <conditional name="input_file_type">
@@ -118,9 +121,9 @@
             <discover_datasets pattern="(?P&lt;designation&gt;seqkit_split2\.part_\d+)\.(?P&lt;ext&gt;.+)" directory="out"/>
             <filter>input_file_type['type'] == 'single' </filter>
         </collection>
-        <collection name="outputs_paired_files" type="list" label="${tool.name} on ${on_string}: Paired-End Splitted files">
-            <discover_datasets pattern="(?P&lt;designation&gt;seqkit_split2_R[12]_\d+)\.(?P&lt;ext&gt;.+)" directory="out"/>
+        <collection name="outputs_paired_files" type="list:paired" label="${tool.name} on ${on_string}: Paired-End Splitted files">
             <filter>input_file_type['type'] == 'paired_collection' </filter>
+                <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_(?P&lt;identifier_1&gt;forward|reverse)\.(?P&lt;ext&gt;.+)" directory="out"/>
         </collection>
     </outputs>
     <tests>
@@ -163,16 +166,30 @@
                 <param name="split_selector" value="by_part"/>
                 <param name="by_part" value="2"/>
             </conditional>
-            <output_collection name="outputs_paired_files" type="list" count="4">
-                <element name="seqkit_split2_R1_001" ftype="fastqsanger.gz">
-                    <assert_contents>
-                        <has_n_lines n="4958"/>
-                    </assert_contents>
+            <output_collection name="outputs_paired_files" type="list:paired" count="2">
+                <element name="seqkit_split2_001">
+                    <element name="forward" ftype="fastqsanger.gz">
+                        <assert_contents>
+                            <has_n_lines n="4958"/>
+                        </assert_contents>
+                    </element>
+                    <element name="reverse" ftype="fastqsanger.gz">
+                        <assert_contents>
+                            <has_n_lines n="3792"/>
+                        </assert_contents>
+                    </element>    
                 </element>
-                <element name="seqkit_split2_R2_001" ftype="fastqsanger.gz">
-                    <assert_contents>
-                        <has_n_lines n="3792"/>
-                    </assert_contents>
+                <element name="seqkit_split2_002">
+                    <element name="forward" ftype="fastqsanger.gz">
+                        <assert_contents>
+                            <has_n_lines n="4949"/>
+                        </assert_contents>
+                    </element>
+                    <element name="reverse" ftype="fastqsanger.gz">
+                        <assert_contents>
+                            <has_n_lines n="3657"/>
+                        </assert_contents>  
+                    </element>
                 </element>
             </output_collection>
         </test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
