### PR TITLE
snpEff , now capturse .genes.txt file, fixes #6688

### DIFF
--- a/tool_collections/snpeff/snpEff.xml
+++ b/tool_collections/snpeff/snpEff.xml
@@ -98,7 +98,8 @@
             #end if
             #set $genes_file_name = os.path.split($genes_file)[-1]
             mkdir '$statsFile.files_path' &&
-            mv '$genes_file' '#echo os.path.join($statsFile.files_path, $genes_file_name)#'
+            cp '$genes_file' $genesFile &&
+            mv '$genes_file' '#echo os.path.join($statsFile.files_path, $genes_file_name)#' 
         #end if
     ]]></command>
     <inputs>
@@ -331,12 +332,15 @@
         <data name="statsFile" format="html" label="${tool.name} on ${on_string} - HTML stats">
             <filter>generate_stats</filter>
         </data>
+        <data name="genesFile" format="tabular" label="${tool.name} on ${on_string} - Tabular stats">
+            <filter>generate_stats</filter>
+        </data>
         <data name="csvFile" format="csv" label="${tool.name} on ${on_string} - CSV stats">
             <filter>csvStats</filter>
         </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="input" ftype="vcf" value="input.vcf"/>
             <param name="inputFormat" value="vcf"/>
             <param name="outputFormat" value="vcf"/>
@@ -353,6 +357,12 @@
             <output name="statsFile">
                 <assert_contents>
                     <has_text text="&lt;b&gt;"/>
+                </assert_contents>
+            </output>
+            <output name="genesFile">
+                <assert_contents>
+                    <has_text text="The following table is formatted as tab separated values." />
+                    <has_text_matching expression="GeneName\tGeneId\tTranscriptId\tBioType\tvariants_impact_LOW.+" />
                 </assert_contents>
             </output>
         </test>

--- a/tool_collections/snpeff/snpEff_macros.xml
+++ b/tool_collections/snpeff/snpEff_macros.xml
@@ -1,6 +1,6 @@
 <macros>
   <token name="@TOOL_VERSION@">5.2</token>
-  <token name="@VERSION_SUFFIX@">0</token>
+  <token name="@VERSION_SUFFIX@">1</token>
   <token name="@SNPEFF_VERSION@">SnpEff5.2</token>
   <xml name="requirement">
       <requirement type="package" version="@TOOL_VERSION@">snpeff</requirement>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

The file mentioned in #6688 was generated and present but not captured in the output set. Now the file is added to the output and available in the history 