### PR TITLE
Fix CI workflow: use find

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -354,7 +354,8 @@ jobs:
         mode: check
     - name: Check if all test chunks succeeded
       run: |
-        NFILES=$(ls artifacts/ | grep "Tool test output" | wc -l)
+        ls artifacts/
+        NFILES=$(find artifacts/ -name "tool_test_output.json" | wc -l)
         if [[ "${{ needs.setup.outputs.chunk-count }}" != "$NFILES" ]]; then
           exit 1
         fi


### PR DESCRIPTION
seems that https://github.com/galaxyproject/tools-iuc/pull/7293 introduced some problem if there is only one artifact

tested here https://github.com/galaxyproject/tools-iuc/pull/7314

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
