### PR TITLE
Salmon DM: add missing loc.sample file

### DIFF
--- a/data_managers/data_manager_salmon_index_builder/tool-data/transcriptomes.loc.sample
+++ b/data_managers/data_manager_salmon_index_builder/tool-data/transcriptomes.loc.sample
@@ -1,0 +1,4 @@
+#This file has the format (white space characters are
+#TAB characters):
+#
+#<unique_build_id>	<dbkey>		<display_name>	<file_path>


### PR DESCRIPTION
Current TS version contains only an uninstalled invalid tool which is due to the missing loc file.  I guess we can skip the bump, since the last version is not installable anyway.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
