### PR TITLE
Salmon DM: use transcriptome ID and name

### DIFF
--- a/data_managers/data_manager_salmon_index_builder/data_manager/salmon_index_builder.xml
+++ b/data_managers/data_manager_salmon_index_builder/data_manager/salmon_index_builder.xml
@@ -36,10 +36,10 @@
     <configfiles>
         <configfile name="dmjson"><![CDATA[{
 #if str($sequence_id).strip() == ""
-    #set sequence_id = $all_fasta_source.fields.dbkey
+    #set sequence_id = $transcriptome.fields.value
 #end if
 #if str($sequence_name).strip() == ""
-    #set sequence_name = $all_fasta_source.fields.dbkey
+    #set sequence_name = $transcriptome.fields.name
 #end if
 
   "data_tables":{


### PR DESCRIPTION
While doing the first run I realized that this would be a better default than the dbkey

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
