### PR TITLE
Run tests against release_25.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     types: [run-all-tool-tests-command]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_25.0
+  GALAXY_BRANCH: release_25.1
   MAX_CHUNKS: 40
 jobs:
   setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_25.0
+  GALAXY_BRANCH: release_25.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:


### PR DESCRIPTION
Release testing looks good: github.com/galaxyproject/tools-iuc/actions/runs/18426959794

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

Updates for new release 25.1
