### PR TITLE
Modify illuminapairedend input options to use paired data collections instead of two data collections

### DIFF
--- a/tools/obitools/illuminapairedend.xml
+++ b/tools/obitools/illuminapairedend.xml
@@ -87,11 +87,9 @@ illuminapairedend aims at aligning the two reads of a pair-end library sequenced
 \* If the two reads overlap, it returns the consensus sequence together with its quality
 \* Otherwise, it concatenates sequence merging the forward read and the reversed-complemented reverse read.
 
-The program uses as input one or two fastq sequences reads files.
+The program uses as input a pair of fastq sequences read datasets.
 
-\* If two files are used one of them must be specified using the -r option. Sequence records corresponding to the  same read pair must be in the same order in the two files.
-\* If just one file is provided, sequence records are supposed to be all of the same length. The first half of the sequence is used as forward read, the second half is used as the reverse read.
-illuminapairedend align the forward sequence record with the reverse complement of the reverse sequence record. The alignment algorithm takes into account the base qualities.
+illuminapairedend aligns the forward sequence record with the reverse complement of the reverse sequence record. The alignment algorithm takes into account the base qualities.
 
 @OBITOOLS_LINK@
 
@@ -100,6 +98,7 @@ illuminapairedend align the forward sequence record with the reverse complement 
     <expand macro="citation" />
 
 </tool>
+
 
 
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

I changed the illuminapairedend xml to be compatible with paired data collections as discussed here: https://github.com/galaxyproject/tools-iuc/issues/7403
