### PR TITLE
send deployment report in any case

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -403,7 +403,7 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && needs.deploy.result != 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ always() (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
     steps:
     # report to the PR if deployment failed
@@ -418,7 +418,7 @@ jobs:
         token: ${{ secrets.PAT }}
         issue-number: ${{ steps.getpr.outputs.number }}
         body: |
-          Attention: deployment ${{ needs.deploy.result }}!
+          Deployment status: **${{ needs.deploy.result }}**
 
           https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
then we don't need to check manually if deployment succeeded

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
