### PR TITLE
Syncronize tool test timeout between PR tests and weekly tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -305,7 +305,7 @@ jobs:
         chunk-count: ${{ needs.setup.outputs.chunk-count }}
         galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
         # Limit each test to 15 minutes
-        test_timeout: 1800
+        test_timeout: 900
     - uses: actions/upload-artifact@v5
       with:
         name: 'Tool test output ${{ matrix.chunk }}'


### PR DESCRIPTION
- the value is then again the same as in the weekly test
- having a single tool test running more that 15min seems wrong. (note that the timeout is only the accumulated sleep time when Galaxy waits for the job to finish, i.e. the actual time from start to end may be significantly larger). if really needed we should comeup with a way to specify larger test time outs on a per-tool basis

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
