### PR TITLE
Changed obiclean help section text to the actual obiclean documentation

### DIFF
--- a/tools/obitools/obiclean.xml
+++ b/tools/obitools/obiclean.xml
@@ -95,5 +95,3 @@ Finally, each sequence record is annotated with three new attributes head, inter
     </help>
     <expand macro="citation"/>
     </tool>
-
-


### PR DESCRIPTION
Changed help description to actual obiclean documentation

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
