### PR TITLE
Hifiasm — fix nosseq output pattern

### DIFF
--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -2,7 +2,7 @@
     <description>haplotype-resolved de novo assembler for PacBio Hifi reads</description>
     <macros>
         <token name="@TOOL_VERSION@">0.25.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@FORMATS@">fasta,fasta.gz,fastq,fastq.gz</token>
         <xml name="reads">
             <param name="reads" type="data" format="@FORMATS@" multiple="true" label="Input reads"/>
@@ -175,7 +175,7 @@
             2> output.log
         #end if
 	    
-        && mkdir noseq_files && mv *.noseq.gfa noseq_files
+        && mkdir noseq_files && mv *noseq*gfa noseq_files
 
         #if $bins_out:
             && mkdir bin_files && mv *.bin bin_files


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

As described in the [docs](https://hifiasm.readthedocs.io/en/latest/interpreting-output.html) the noseq output files do not follow the strict pattern of  `*.noseq.gfa`. The correct pattern is `*noseq*gfa`.
This was causing `No such file or directory` error for some users.
