### PR TITLE
Comment out sample filename / fix error

### DIFF
--- a/tools/bbgbigwig/tool-data/dbkeys.loc.sample
+++ b/tools/bbgbigwig/tool-data/dbkeys.loc.sample
@@ -1,2 +1,2 @@
 #<dbkey>	<display_name>	<len_file_path>
-hg38	hg38	testing.len
+#hg38	hg38	testing.len


### PR DESCRIPTION
Fixes error:  tool execution causes galaxy to look for nonexistant `testing.len` file.
```
Error: The requested genome file (/cvmfs/.../len/ucsc/hg38.len,testing.len) could not be opened. Exiting!
```

Also ref: https://github.com/galaxyproject/galaxy/issues/21448

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
