### PR TITLE
Fix gtdbtk reference data compatibility

### DIFF
--- a/tools/gtdbtk/gtdbtk_classify_wf.xml
+++ b/tools/gtdbtk/gtdbtk_classify_wf.xml
@@ -37,7 +37,7 @@ $full_tree
     ]]></command>
     <inputs>
         <param name="input" type="data" format="fasta,fasta.gz" multiple="true" label="Fasta (Genome) files"/>
-        <param name="gtdbtk_db" type="select" label="GTDB-Tk database" help="This version of GTDB-Tk requires GTDB version 220. Please contact your service administrator if this version is not available to select.">
+        <param name="gtdbtk_db" type="select" label="GTDB-Tk database" help="This version of GTDB-Tk requires GTDB version 226. Please contact your service administrator if this version is not available to select.">
             <options from_data_table="gtdbtk_database_versioned">
                 <filter type="regexp" column="version" value="^226$"/>
                 <validator type="no_options" message="No locally cached GTDB-Tk database is available"/>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/7561

I would suggest not to bump -- will overwrite the old version on Galaxy servers. 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
