### PR TITLE
Fix numeric columns as factor level in deseq2

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -244,7 +244,8 @@ if (!is.null(opt$sample_sheet_mode)) {
             # Find matching row in sample sheet
             matching_row <- which(sample_sheet[[sample_id_col]] == element_id)
             if (length(matching_row) > 0) {
-                level <- sample_sheet[[factor_name]][matching_row[1]]
+                # Convert level to character to ensure consistent list indexing
+                level <- as.character(sample_sheet[[factor_name]][matching_row[1]])
                 if (!(level %in% names(level_to_files))) {
                     level_to_files[[level]] <- character(0)
                     level_order <- c(level_order, level) # Record order of first appearance

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -983,6 +983,44 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </assert_contents>
             </output>
         </test>
+        <!--Test sample_sheet_contrasts with numeric factor column in design formula -->
+        <test expect_num_outputs="2">
+            <param name="select_data|how" value="sample_sheet_contrasts"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="GSM461179_treat_single.counts" value="GSM461179_treat_single.counts"/>
+                    <element name="GSM461180_treat_paired.counts" value="GSM461180_treat_paired.counts"/>
+                    <element name="GSM461181_treat_paired.counts" value="GSM461181_treat_paired.counts"/>
+                    <element name="GSM461176_untreat_single.counts" value="GSM461176_untreat_single.counts"/>
+                    <element name="GSM461177_untreat_paired.counts" value="GSM461177_untreat_paired.counts"/>
+                    <element name="GSM461178_untreat_paired.counts" value="GSM461178_untreat_paired.counts"/>
+                    <element name="GSM461182_untreat_single.counts" value="GSM461182_untreat_single.counts"/>
+                </collection>
+            </param>
+            <param name="select_data|sample_sheet" value="sample_sheet_numeric.tab"/>
+            <param name="select_data|design_formula_mode|mode" value="custom"/>
+            <param name="select_data|design_formula_mode|design_formula" value="~ replicate + treatment"/>
+            <param name="select_data|design_formula_mode|reference_level" value="Untreated"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="1"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="counts_out">
+                <assert_contents>
+                    <has_text_matching expression="FBgn0000003\t0\t0\t0\t0\t0\t0\t0"/>
+                    <has_n_columns n="8"/>
+                </assert_contents>
+            </output>
+            <output name="deseq_out">
+                <assert_contents>
+                    <!-- Multi-factor design with numeric replicate column -->
+                    <has_text_matching expression="FBgn0003360\t1933\.950.*"/>
+                    <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 .. class:: infomark

--- a/tools/deseq2/macros.xml
+++ b/tools/deseq2/macros.xml
@@ -39,7 +39,7 @@
     </xml>
     <token name="@TOOL_VERSION@">2.11.40.8</token>
     <token name="@DESEQ2_VERSION@">1.40.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>

--- a/tools/deseq2/test-data/sample_sheet_numeric.tab
+++ b/tools/deseq2/test-data/sample_sheet_numeric.tab
@@ -1,0 +1,8 @@
+sample	treatment	replicate
+GSM461179_treat_single.counts	Treated	1
+GSM461180_treat_paired.counts	Treated	2
+GSM461181_treat_paired.counts	Treated	3
+GSM461176_untreat_single.counts	Untreated	1
+GSM461177_untreat_paired.counts	Untreated	2
+GSM461178_untreat_paired.counts	Untreated	3
+GSM461182_untreat_single.counts	Untreated	4


### PR DESCRIPTION
When the Replicate column contains numeric values (1, 2, 3), R treats them as numbers rather than strings when indexing lists. This causes the level_to_files list to use numeric indices instead of named elements, which then breaks when checking level %in% names(level_to_files).

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
