### PR TITLE
CI: skip URL check when merging

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -128,7 +128,7 @@ jobs:
     - name: Set skip version check for push event (i.e. merge to main)
       if: ${{ github.event_name != 'pull_request' }}
       run:
-        echo "EXTRA_SKIP=--skip version_bumped" >> "$GITHUB_ENV"
+        echo "EXTRA_SKIP=--skip version_bumped,tool_urls" >> "$GITHUB_ENV"
     - name: Set no skip vor pull_request events
       if: ${{ github.event_name == 'pull_request' }}
       run:


### PR DESCRIPTION
- this way we still see possibly dysfunctional URLs
- but we can still merge after a manual check and the tool will get deployed

note that since https://github.com/galaxyproject/planemo/pull/1598 we will see the servers response. please open issues at planemo if there is something in the response that we can check for and allow some URLs to fail

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
