### PR TITLE
PAGE (XML) output option for tesseract

### DIFF
--- a/tools/tesseract/macros.xml
+++ b/tools/tesseract/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">5.5.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@TOOL_VERSION_PDFIMAGES@">25.07.0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/tesseract/tesseract.xml
+++ b/tools/tesseract/tesseract.xml
@@ -199,6 +199,7 @@
             <option value="tessedit_create_hocr">HOCR</option>
             <option value="tessedit_create_tsv">TSV</option>
             <option value="tessedit_create_alto">ALTO</option>
+            <option value="tessedit_create_page_xml">PAGE</option>
         </param>
         <param argument="--psm" type="select" label="Page Segmentation Mode (PSM)" help="How the page layout is interpreted." optional="true">
             <option value="0">Orientation and script detection only</option>
@@ -234,9 +235,12 @@
         <data name="output_alto" format="xml" from_work_dir="output.xml" label="${tool.name} on ${on_string}: ALTO">
             <filter>'tessedit_create_alto' in output_formats</filter>
         </data>
+        <data name="output_page" format="xml" from_work_dir="output.xml" label="${tool.name} on ${on_string}: PAGE">
+            <filter>'tessedit_create_page_xml' in output_formats</filter>
+        </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="3">
+        <test expect_num_outputs="4">
             <conditional name="models">
                 <param name="models_select" value="official"/>
                 <param name="tessdata" value="test_tessdata"/>
@@ -245,11 +249,16 @@
             <param name="input_file" value="eurotext.png"/>
             <param name="user_patterns" value="eng.user-patterns"/>
             <param name="user_words" value="eng.user-words"/>
-            <param name="output_formats" value="tessedit_create_txt,tessedit_create_pdf,tessedit_create_alto"/>
+            <param name="output_formats" value="tessedit_create_txt,tessedit_create_pdf,tessedit_create_alto,tessedit_create_page_xml"/>
             <param name="psm" value="3"/>
             <output name="output_text" file="image_output.txt"/>
             <output name="output_pdf" file="image_output.pdf"/>
             <output name="output_alto">
+                <assert_contents>
+                    <is_valid_xml/>
+                </assert_contents>
+            </output>
+            <output name="output_page">
                 <assert_contents>
                     <is_valid_xml/>
                 </assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Adds the output option for [PAGE](https://de.wikipedia.org/wiki/PAGE_(XML)) which is used in some OCR workflows and software. It is used for [ground truth data](https://ocr-d.de/de/gt-guidelines/trans/) by the [ocr-d](https://ocr-d.de/) project as well.