### PR TITLE
Correction for 2025-07-14 prebuilt_db slugs in kraken2_build_database…

### DIFF
--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -2,7 +2,7 @@
     <description>database builder</description>
     <macros>
         <token name="@TOOL_VERSION@">2.1.6</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
         <token name="@PROFILE@">24.0</token>
         <xml name="common_params">
             <param name="kmer_len" type="integer" value="35" label="K-mer length in BP" />
@@ -23,8 +23,14 @@
         <xml name="standard_08gb">
             <option value="standard_08gb">Standard-8 (Standard with DB capped at 8 GB)</option>
         </xml>
+        <xml name="standard_08_gb">
+            <option value="standard_08_GB">Standard-8 (Standard with DB capped at 8 GB)</option>
+        </xml>
         <xml name="standard_16gb">
             <option value="standard_16gb">Standard-16 (Standard with DB capped at 16 GB)</option>
+        </xml>
+        <xml name="standard_16_gb">
+            <option value="standard_16_GB">Standard-16 (Standard with DB capped at 16 GB)</option>
         </xml>
         <xml name="pluspf">
             <option value="pluspf">PlusPF (Standard plus protozoa and fungi; ~50 GB)</option>
@@ -32,8 +38,14 @@
         <xml name="pluspf_08gb">
             <option value="pluspf_08gb">PlusPF-8 (PlusPF with DB capped at 8 GB; ~7.5 GB)</option>
         </xml>
+        <xml name="pluspf_08_gb">
+            <option value="plus_08_GB">PlusPF-8 (PlusPF with DB capped at 8 GB; ~7.5 GB)</option>
+        </xml>
         <xml name="pluspf_16gb">
             <option value="pluspf_16gb">PlusPF-16 (PlusPF with DB capped at 16 GB; ~15 GB)</option>
+        </xml>
+        <xml name="pluspf_16_gb">
+            <option value="pluspf_16_GB">PlusPF-16 (PlusPF with DB capped at 16 GB; ~15 GB)</option>
         </xml>
         <xml name="pluspfp">
             <option value="pluspfp">PlusPFP (Standard plus protozoa, fungi and plant; ~129 GB)</option>
@@ -41,8 +53,14 @@
         <xml name="pluspfp_08gb">
             <option value="pluspfp_08gb">PlusPFP-8 (PlusPFP with DB capped at 8 GB; ~7.5 GB)</option>
         </xml>
+        <xml name="pluspfp_08_gb">
+            <option value="pluspfp_08_GB">PlusPFP-8 (PlusPFP with DB capped at 8 GB; ~7.5 GB)</option>
+        </xml>
         <xml name="pluspfp_16gb">
             <option value="pluspfp_16gb">PlusPFP-16 (PlusPFP with DB capped at 16 GB; ~15 GB)</option>
+        </xml>
+        <xml name="pluspfp_16_gb">
+            <option value="pluspfp_16_GB">PlusPFP-16 (PlusPFP with DB capped at 16 GB; ~7.5 GB)</option>
         </xml>
     </macros>
     <xrefs>
@@ -67,12 +85,18 @@ mkdir '$out_file.extra_files_path' &&
         'standard': "Standard-Full (archaea, bacteria, viral, plasmid, human,UniVec_Core)",
         'standard_08gb': "Standard-8 (Standard with DB capped at 8 GB)",
         'standard_16gb': "Standard-16 (Standard with DB capped at 16 GB)",
+        'standard_08_gb': "Standard-8 (Standard with DB capped at 8 GB)",
+        'standard_16_gb': "Standard-16 (Standard with DB capped at 16 GB)",
         'pluspf': "PlusPF (Standard plus protozoa and fungi)",
         'pluspf_08gb': "PlusPF-8 (PlusPF with DB capped at 8 GB)",
         'pluspf_16gb': "PlusPF-16 (PlusPF with DB capped at 16 GB)",
+        'pluspf_08_gb': "PlusPF-8 (PlusPF with DB capped at 8 GB)",
+        'pluspf_16_gb': "PlusPF-16 (PlusPF with DB capped at 16 GB)",
         'pluspfp': "PlusPFP (Standard plus protozoa, fungi and plant)",
         'pluspfp_08gb': "PlusPFP-8 (PlusPFP with DB capped at 8 GB)",
         'pluspfp_16gb': "PlusPFP-16 (PlusPFP with DB capped at 16 GB)",
+        'pluspfp_08_gb': "PlusPFP-8 (PlusPFP with DB capped at 8 GB)",
+        'pluspfp_16_gb': "PlusPFP-16 (PlusPFP with DB capped at 16 GB)",
     }
     #set special_name = {
         "core_nt_20250609": "Very large collection, inclusive of GenBank, RefSeq, TPA and PDB (July, 2025)",
@@ -102,7 +126,7 @@ mkdir '$out_file.extra_files_path' &&
     #set database_value = "_".join([now, "standard_prebuilt", str($database_type.prebuilt.prebuilt_db), str($database_type.prebuilt.prebuilt_date)])
     #set database_name = " ".join(["Prebuilt Refseq indexes: ", display_name, "(Version: ", str($database_type.prebuilt.prebuilt_date), "- Downloaded:", now + ")"])
 
-    ## the 16S dbs have a different link and file name 
+    ## the 16S dbs have a different link and file name
     ## and are stored in a subfolder
     #if $database_type.database_type == "amplicon_prebuilt"
         #silent commands.append("wget https://genome-idx.s3.amazonaws.com/kraken/" + str($database_type.prebuilt.prebuilt_db) + "_" + date_url_str + ".tgz")
@@ -208,6 +232,7 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
             <when value="standard_prebuilt">
                 <conditional name="prebuilt">
                     <param name="prebuilt_date" type="select" label="Select index build date">
+                        <option value="2025-10-15">October 15, 2025</option>
                         <option value="2025-07-14">July 14, 2025</option>
                         <option value="2024-12-28">December 28, 2024</option>
                         <option value="2024-09-04">September 4, 2024</option>
@@ -220,19 +245,34 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                         <option value="2020-12-02">December 2, 2020</option>
                         <option value="2020-09-19">September 19, 2020</option>
                     </param>
+                    <when value="2025-10-15">
+                        <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
+                            <expand macro="viral"/>
+                            <expand macro="minusb"/>
+                            <expand macro="standard"/>
+                            <expand macro="standard_08_gb"/>
+                            <expand macro="standard_16_gb"/>
+                            <expand macro="pluspf"/>
+                            <expand macro="pluspf_08_gb"/>
+                            <expand macro="pluspf_16_gb"/>
+                            <expand macro="pluspfp"/>
+                            <expand macro="pluspfp_08_gb"/>
+                            <expand macro="pluspfp_16_gb"/>
+                        </param>
+                    </when>
                     <when value="2025-07-14">
                         <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
                             <expand macro="viral"/>
                             <expand macro="minusb"/>
                             <expand macro="standard"/>
-                            <expand macro="standard_08_GB"/>
-                            <expand macro="standard_16_GB"/>
+                            <expand macro="standard_08_gb"/>
+                            <expand macro="standard_16_gb"/>
                             <expand macro="pluspf"/>
-                            <expand macro="pluspf_08_GB"/>
-                            <expand macro="pluspf_16_GB"/>
+                            <expand macro="pluspf_08_gb"/>
+                            <expand macro="pluspf_16_gb"/>
                             <expand macro="pluspfp"/>
-                            <expand macro="pluspfp_08_GB"/>
-                            <expand macro="pluspfp_16_GB"/>
+                            <expand macro="pluspfp_08_gb"/>
+                            <expand macro="pluspfp_16_gb"/>
                         </param>
                     </when>
                     <when value="2024-12-28">
@@ -416,9 +456,9 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                 <conditional name="prebuilt">
                     <param name="xyz" type="select" multiple="false" label="Select pre-built database to download">
                         <option value="16S_Greengenes13.5_20200326">Greengenes 13.5</option>
-                        <option value="16S_RDP11.5_20200326">RDP 11.5</option> 
-                        <option value="16S_Silva132_20200326">Silva 132</option> 
-                        <option value="16S_Silva138_20200326">Silva 138</option> 
+                        <option value="16S_RDP11.5_20200326">RDP 11.5</option>
+                        <option value="16S_Silva132_20200326">Silva 132</option>
+                        <option value="16S_Silva138_20200326">Silva 138</option>
                     </param>
                     <when value="16S_Greengenes13.5_20200326">
                         <param name="prebuilt_db" type="hidden" value="16S_Greengenes13.5"/>
@@ -568,7 +608,7 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                     <has_text text="Created"/>
                 </assert_contents>
             </output>
-        </test> 
+        </test>
 
         <!-- special_prebuilt -->
 
@@ -592,7 +632,7 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                     <has_text text="Downloaded"/>
                 </assert_contents>
             </output>
-        </test> 
+        </test>
 
         <!-- amplicon_prebuilt -->
 
@@ -613,7 +653,7 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                     <has_text text="16S_Greengenes13.5"/>
                 </assert_contents>
             </output>
-        </test> 
+        </test>
 
         <!-- special -->
 

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -225,14 +225,14 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                             <expand macro="viral"/>
                             <expand macro="minusb"/>
                             <expand macro="standard"/>
-                            <expand macro="standard_08gb"/>
-                            <expand macro="standard_16gb"/>
+                            <expand macro="standard_08_GB"/>
+                            <expand macro="standard_16_GB"/>
                             <expand macro="pluspf"/>
-                            <expand macro="pluspf_08gb"/>
-                            <expand macro="pluspf_16gb"/>
+                            <expand macro="pluspf_08_GB"/>
+                            <expand macro="pluspf_16_GB"/>
                             <expand macro="pluspfp"/>
-                            <expand macro="pluspfp_08gb"/>
-                            <expand macro="pluspfp_16gb"/>
+                            <expand macro="pluspfp_08_GB"/>
+                            <expand macro="pluspfp_16_GB"/>
                         </param>
                     </when>
                     <when value="2024-12-28">

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -2,7 +2,7 @@
     <description>database builder</description>
     <macros>
         <token name="@TOOL_VERSION@">2.1.6</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">24.0</token>
         <xml name="common_params">
             <param name="kmer_len" type="integer" value="35" label="K-mer length in BP" />

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -85,18 +85,18 @@ mkdir '$out_file.extra_files_path' &&
         'standard': "Standard-Full (archaea, bacteria, viral, plasmid, human,UniVec_Core)",
         'standard_08gb': "Standard-8 (Standard with DB capped at 8 GB)",
         'standard_16gb': "Standard-16 (Standard with DB capped at 16 GB)",
-        'standard_08_gb': "Standard-8 (Standard with DB capped at 8 GB)",
-        'standard_16_gb': "Standard-16 (Standard with DB capped at 16 GB)",
+        'standard_08_GB': "Standard-8 (Standard with DB capped at 8 GB)",
+        'standard_16_GB': "Standard-16 (Standard with DB capped at 16 GB)",
         'pluspf': "PlusPF (Standard plus protozoa and fungi)",
         'pluspf_08gb': "PlusPF-8 (PlusPF with DB capped at 8 GB)",
         'pluspf_16gb': "PlusPF-16 (PlusPF with DB capped at 16 GB)",
-        'pluspf_08_gb': "PlusPF-8 (PlusPF with DB capped at 8 GB)",
-        'pluspf_16_gb': "PlusPF-16 (PlusPF with DB capped at 16 GB)",
+        'pluspf_08_GB': "PlusPF-8 (PlusPF with DB capped at 8 GB)",
+        'pluspf_16_GB': "PlusPF-16 (PlusPF with DB capped at 16 GB)",
         'pluspfp': "PlusPFP (Standard plus protozoa, fungi and plant)",
         'pluspfp_08gb': "PlusPFP-8 (PlusPFP with DB capped at 8 GB)",
         'pluspfp_16gb': "PlusPFP-16 (PlusPFP with DB capped at 16 GB)",
-        'pluspfp_08_gb': "PlusPFP-8 (PlusPFP with DB capped at 8 GB)",
-        'pluspfp_16_gb': "PlusPFP-16 (PlusPFP with DB capped at 16 GB)",
+        'pluspfp_08_GB': "PlusPFP-8 (PlusPFP with DB capped at 8 GB)",
+        'pluspfp_16_GB': "PlusPFP-16 (PlusPFP with DB capped at 16 GB)",
     }
     #set special_name = {
         "core_nt_20250609": "Very large collection, inclusive of GenBank, RefSeq, TPA and PDB (July, 2025)",
@@ -133,10 +133,7 @@ mkdir '$out_file.extra_files_path' &&
         #silent commands.append("mkdir -p '" + $out_file.extra_files_path + "/" + database_value + "'/tmp_extract")
         #silent commands.append("tar -xzf " + str($database_type.prebuilt.prebuilt_db) + "_" + date_url_str + ".tgz -C '" + $out_file.extra_files_path + "/" + database_value + "'/tmp_extract")
         #silent commands.append("topdir=$(find '" + $out_file.extra_files_path + "/" + database_value + "/tmp_extract' -mindepth 1 -maxdepth 1 -type d | head -n 1)")
-        #silent commands.append("if [ -n \"$topdir\" ]")
-        #silent commands.append("then")
-        #silent commands.append("    mv \"$topdir\"/* '" + $out_file.extra_files_path + "/" + database_value + "/'")
-        #silent commands.append("fi")
+        #silent commands.append("if [ -n \"$topdir\" ]; then mv \"$topdir\"/* '" + $out_file.extra_files_path + "/" + database_value + "/'; fi")
         #silent commands.append("rm -rf '" + $out_file.extra_files_path + "/" + database_value + "/tmp_extract'")
     #else
         #silent commands.append("wget https://genome-idx.s3.amazonaws.com/kraken/k2_" + str($database_type.prebuilt.prebuilt_db) + "_" + date_url_str + ".tar.gz")

--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -227,7 +227,7 @@
             <option value="assminfo-grouping-method">Assembly Grouping Method</option>
             <option value="assminfo-level">Assembly Level</option>
             <option value="assminfo-linked-assmaccession">Assembly Linked Assembly Accession</option>
-            <option value="assminfo-linked-assmtype">Assembly Linked Assembly Type</option>
+            <option value="assminfo-linked-assm-type">Assembly Linked Assembly Type</option>
             <option value="assminfo-long-name">Assembly LongName</option>
             <option value="assminfo-name">Assembly Name</option>
             <option value="assminfo-notes">Assembly Notes</option>

--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -146,7 +146,7 @@
             <option value="annotinfo-busco-missing">Annotation BUSCO Missing</option>
             <option value="annotinfo-busco-singlecopy">Annotation BUSCO Single Copy</option>
             <option value="annotinfo-busco-totalcount">Annotation BUSCO Total Count</option>
-            <option value="annotinfo-busco-ver">Annotation BUSCO Version</option>
+            <option value="annotinfo-busco-version">Annotation BUSCO Version</option>
             <option value="annotinfo-featcount-gene-non-coding">Annotation Count Gene Non-coding</option>
             <option value="annotinfo-featcount-gene-other">Annotation Count Gene Other</option>
             <option value="annotinfo-featcount-gene-protein-coding">Annotation Count Gene Protein-coding</option>
@@ -226,7 +226,7 @@
             <option value="assminfo-description">Assembly Description</option>
             <option value="assminfo-grouping-method">Assembly Grouping Method</option>
             <option value="assminfo-level">Assembly Level</option>
-            <option value="assminfo-linked-assmaccession">Assembly Linked Assembly Accession</option>
+            <option value="assminfo-linked-assm-accession">Assembly Linked Assembly Accession</option>
             <option value="assminfo-linked-assm-type">Assembly Linked Assembly Type</option>
             <option value="assminfo-long-name">Assembly LongName</option>
             <option value="assminfo-name">Assembly Name</option>


### PR DESCRIPTION
The path format to https://benlangmead.github.io/aws-indexes/k2 indexes changed slightly between April and July 2025. This impacts the constructed paths created from `prebuilt_db`. 

Example
> https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16_GB_20251015.tar.gz
> https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16_GB_20250714.tar.gz
> https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16gb_20250402.tar.gz

Reported at https://help.galaxyproject.org/t/kraken2-build-databases-download-fails-with-not-found-path/17400

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
