### PR TITLE
minor text changes used to trigger deployment

### DIFF
--- a/tools/kmindex/kmindex_build.xml
+++ b/tools/kmindex/kmindex_build.xml
@@ -1,5 +1,5 @@
 <tool id="kmindex_build" name="kmindex build" version="@VERSION@" profile="@PROFILE@">
-    <description>wrapper used to build k-mer index from sequencing samples</description>
+    <description>build k-mer index from sequencing samples</description>
     <macros>
         <import>macros.xml</import>
     </macros>


### PR DESCRIPTION
The previous deployment attempt failed because it depended on a new data type that was not included in the then-latest release. This data type is now available in version 25.1.1, and the tool should deploy successfully.

Link to the pull request with the failed deployment: https://github.com/galaxyproject/tools-iuc/pull/7535

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
