### PR TITLE
CI: only show warn and error messages in linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,7 @@ jobs:
       with:
         mode: lint
         fail-level: warn
+        report_level: warn
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: --biocontainers --skip version_bumped

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,7 +124,6 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-
     - name: Set skip version check for push event (i.e. merge to main)
       if: ${{ github.event_name != 'pull_request' }}
       run:
@@ -139,6 +138,7 @@ jobs:
       with:
         mode: lint
         fail-level: warn
+        report_level: warn
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: ${{ env.EXTRA_SKIP }}


### PR DESCRIPTION
Can't remember a case where check / info messages from the linter were useful for a PR review (or for me as a tool developer).

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
