### PR TITLE
Run fallback workflow only when main workflow does not run

### DIFF
--- a/.github/workflows/pr_without_tool_change.yaml
+++ b/.github/workflows/pr_without_tool_change.yaml
@@ -11,7 +11,6 @@ on:
     - '*'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   determine-success:
     name: Check workflow success


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)
