### PR TITLE
small fixes for integron finder

### DIFF
--- a/tools/integron_finder/.lint_skip
+++ b/tools/integron_finder/.lint_skip
@@ -1,2 +1,0 @@
-TestsCaseValidation
-ValidDatatypes

--- a/tools/integron_finder/integron_finder.xml
+++ b/tools/integron_finder/integron_finder.xml
@@ -65,16 +65,16 @@
         <param name="no_logfile" type="boolean" truevalue="true" falsevalue="false" label="Remove log file"/>
     </inputs>
     <outputs>
-        <collection type="list" label="Genbank files from [$tool.name] on $[on_string]" name="genbank_out">
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.gbk" format="gbk" visible="false" directory="Results_Integron_Finder/" />
+        <collection type="list" label="${tool.name} on ${on_string}: Genbank " name="genbank_out">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.gbk" format="genbank" visible="false" directory="Results_Integron_Finder/" />
             <filter>gbk</filter>
         </collection>
-	      <data format="txt" name="integron_log" from_work_dir="Results_Integron_Finder/integron_finder.out" label="Log from [$tool.name] on $[on_string]">
+	    <data format="txt" name="integron_log" from_work_dir="Results_Integron_Finder/integron_finder.out" label="${tool.name} on ${on_string}: Log">
             <filter> no_logfile == False</filter>
         </data>
-        <data format="tsv" name="integrons_table" from_work_dir="Results_Integron_Finder/*.integrons" label="Integrons annotations from [$tool.name] on $[on_string]"/>
-        <data format="tsv" name="summary" from_work_dir="Results_Integron_Finder/*.summary" label="Summary from [$tool.name] on $[on_string]"/>
-        <collection type="list" label="Graphic from [$tool.name] on $[on_string]" name="pdf_out">
+        <data format="tsv" name="integrons_table" from_work_dir="Results_Integron_Finder/*.integrons" label="${tool.name} on ${on_string}: Integron annotations"/>
+        <data format="tsv" name="summary" from_work_dir="Results_Integron_Finder/*.summary" label="${tool.name} on ${on_string}: Summary"/>
+        <collection name="pdf_out" type="list" label="${tool.name} on ${on_string}: Graphic">
             <discover_datasets pattern="(?P&lt;designation&gt;.+)\.pdf" format="pdf" visible="false" directory="Results_Integron_Finder/" />
             <filter>pdf</filter>
         </collection>
@@ -146,7 +146,7 @@
                     <param name="calin_threshold" value="3"/>
                     <param name="max_attc_size" value="188"/>
                     <param name="min_attc_size" value="30"/>
-                    <param name="keep_palindromes" value=""/>
+                    <param name="keep_palindromes" value="false"/>
                 </section>
             </section>
             <output name="integrons_table" value="test7_integrons_table.tsv" lines_diff="3" />

--- a/tools/integron_finder/macro.xml
+++ b/tools/integron_finder/macro.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">2.0.5</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">22.05</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">24.2</token>
     <token name="@THREADS@">\${GALAXY_SLOTS:-2}</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
