### PR TITLE
Fix deployment for haltools

### DIFF
--- a/tools/haltools/hal_halAddToBranch.xml
+++ b/tools/haltools/hal_halAddToBranch.xml
@@ -35,8 +35,8 @@
         </param>
         <param name="topAlignmentFile" type="data" format="hal" label="Top alignment file" help="HAL file defining the connection between the parent and the new insert. A tree containing the insert, its parent, and its siblings"/>
         <param name="botAlignmentFile" type="data" format="hal" label="Bottom alignment file" help="HAL file defining the subtree starting from the new insert node. A tree containing the insert, its children, and its new leaf genome"/>
-        <param name="upperBranchLength" type="float" min="0" label="Upper branch length" help="Length of branch from parent to insert"/>
-        <param name="leafBranchLength" type="float" min="0" label="Leaf branch length" help="Leaf branch length"/>
+        <param name="upperBranchLength" type="float" value="1" min="0" label="Upper branch length" help="Length of branch from parent to insert"/>
+        <param name="leafBranchLength" type="float" value="1" min="0" label="Leaf branch length" help="Leaf branch length"/>
         <expand macro="params_noMarkAncestors"/>
     </inputs>
     <outputs>


### PR DESCRIPTION
Fixes deployment for https://github.com/galaxyproject/tools-iuc/pull/7659
---
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
