### PR TITLE
Hifiasm - Add findutils to reqs

### DIFF
--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -177,7 +177,7 @@
         #end if
 	    
         && mkdir noseq_files
-        && find ./ -maxdepth 1 -type f -name "*noseq*gfa" -exec mv {} ./noseq_files +
+        && find ./ -maxdepth 1 -type f -name "*noseq*gfa" -exec mv {} noseq_files ';'
 
         #if $bins_out:
             && mkdir bin_files && mv *.bin bin_files


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Hopefully this will solve the `find: missing argument to '-exec'` error