### PR TITLE
Allow unsorted.bam in samtools fixmate

### DIFF
--- a/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
+++ b/tool_collections/samtools/samtools_fixmate/samtools_fixmate.xml
@@ -1,4 +1,4 @@
-<tool id="samtools_fixmate" name="Samtools fixmate" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="samtools_fixmate" name="Samtools fixmate" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>fill mate coordinates, ISIZE and mate related flags</description>
     <macros>
         <import>macros.xml</import>
@@ -31,7 +31,7 @@
             '$output'
     ]]></command>
     <inputs>
-        <param name="bamfile" type="data" format="sam,bam,cram" optional="false" label="Select alignment" help="Set of aligned reads." />
+        <param name="bamfile" type="data" format="sam,unsorted.bam,cram" optional="false" label="Select alignment" help="Set of aligned reads." />
         <param name="remsec" type="boolean" argument="-r" truevalue="-r" falsevalue="" checked="false" label="Remove secondary and unmapped reads" />
         <param name="noprop" type="boolean" argument="-p" truevalue="-p" falsevalue="" checked="false" label="Disable FR proper pair check" />
         <param name="tempcigar" type="boolean" argument="-c" truevalue="-c" falsevalue="" checked="false" label="Add template cigar ct tag" />


### PR DESCRIPTION
The command section did this correctly but the input forced conversion in the (coordinate sorted) bam first.
Tests are covering this already, they passed because of implicit conversion.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
