### PR TITLE
Cutadapt - Fix --minimum-length param default

### DIFF
--- a/tools/cutadapt/cutadapt.xml
+++ b/tools/cutadapt/cutadapt.xml
@@ -1,4 +1,4 @@
-<tool id="cutadapt" name="Cutadapt" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
+<tool id="cutadapt" name="Cutadapt" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="25.1">
     <description>Remove adapter sequences from FASTQ/FASTA</description>
     <macros>
         <import>macros.xml</import>
@@ -352,7 +352,7 @@ $read_mod_options.zero_cap
         <section name="filter_options" title="Read Filtering Options">
             <param argument="--discard-trimmed" type="boolean" checked="false" truevalue="--discard-trimmed" falsevalue="" label="Discard Trimmed Reads" help="Discard reads that contain the adapter instead of trimming them. Use the 'Minimum overlap length' option in order to avoid throwing away too many randomly matching reads!" />
             <param argument="--discard_untrimmed" type="boolean" checked="false" truevalue="--discard-untrimmed" falsevalue="" label="Discard Untrimmed Reads" help="Discard reads that do not contain the adapter." />
-            <param argument="--minimum-length" type="integer" min="0" value="1" label="Minimum length (R1)" help="Discard reads that, after processing, are shorter than LENGTH. Note: You can set this parameter to zero to keep empty reads (with zero-length sequence and quality string) in the output, but some downstream tools may have problems with these. Default: 1" />
+            <param argument="--minimum-length" type="integer" min="0" value="0" label="Minimum length (R1)" help="Discard reads that, after processing, are shorter than LENGTH. Note: You can set this parameter to zero to keep empty reads (with zero-length sequence and quality string) in the output, but some downstream tools may have problems with these. Default: 0" />
             <param name="minimum_length2" type="integer" min="0" value="" optional="true" label="Minimum length (R2)" help="For paired-end data, you can specify here a separate minimum length cutoff to apply to R2 reads. Leave empty to reuse the R1 cutoff set above. Ignored for single-end data." />
             <param argument="--maximum-length" type="integer" min="0" optional="true" value="" label="Maximum length (R1)" help="Discard trimmed reads that are longer than LENGTH. Reads that are too long even before adapter removal are also discarded." />
             <param name="maximum_length2" type="integer" min="0" value="" optional="true" label="Maximum length (R2)" help="For paired-end data, you can specify here a separate maximum length cutoff to apply to R2 reads. Leave empty to reuse the R1 cutoff set above. Ignored for single-end data." />

--- a/tools/cutadapt/macros.xml
+++ b/tools/cutadapt/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">5.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@FASTQ_TYPES@">fastq.bz2,fastq.gz,fastq,fasta.bz2,fasta.gz,fasta</token>
     <xml name="edam_ontology">
         <edam_topics>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

As mentioned in the [docs](https://cutadapt.readthedocs.io/en/stable/guide.html#filtering) the default of this param should be set to zero:
> If you do not use this option, reads that have a length of zero (empty reads) are kept in the output.