### PR TITLE
Fix hyphy relax GALAXY_SLOTS escaping

### DIFF
--- a/tools/hyphy/hyphy_relax.xml
+++ b/tools/hyphy/hyphy_relax.xml
@@ -1,4 +1,4 @@
-<tool id="hyphy_relax" name="HyPhy-RELAX" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="hyphy_relax" name="HyPhy-RELAX" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>Detect relaxed selection in a codon-based
     phylogenetic framework</description>
     <macros>
@@ -9,7 +9,7 @@
     <command detect_errors="exit_code"><![CDATA[
         #if $input_type_cond.input_type == "single":
             @SYMLINK_FILES@
-            export OMP_NUM_THREADS="\\${GALAXY_SLOTS:-1}" &&
+            export OMP_NUM_THREADS="\${GALAXY_SLOTS:-1}" &&
             hyphy relax
                 --alignment 'input.$input_type_cond.input_file.ext'
                 @INPUT_TREE@
@@ -21,7 +21,7 @@
                 #end if
                 echo "input_${i}.$input_data.input_file.ext" >> filelist.txt &&
             #end for
-            export OMP_NUM_THREADS="\\${GALAXY_SLOTS:-1}" &&
+            export OMP_NUM_THREADS="\${GALAXY_SLOTS:-1}" &&
             hyphy relax
                 --multiple-files Yes
                 --filelist filelist.txt


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
