### PR TITLE
Update Bowtie2 to 2.5.5 and add new option

### DIFF
--- a/tools/bowtie2/bowtie2_macros.xml
+++ b/tools/bowtie2/bowtie2_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.5.4</token>
+    <token name="@TOOL_VERSION@">2.5.5</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">23.0</token>
     <!-- Import this at the top of your command block and then

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -228,6 +228,7 @@ bowtie2
     #if str( $analysis_type.effort_options.effort_options_selector ) == "yes":
         -D ${analysis_type.effort_options.D}
         -R ${analysis_type.effort_options.R}
+        ${analysis_type.effort_options.d}
     #end if
     #if str( $analysis_type.other_options.other_options_selector ) == "yes":
         ${analysis_type.other_options.non_deterministic}
@@ -422,6 +423,7 @@ bowtie2
                     <when value="yes">
                         <param name="D" type="integer" value="15" min="0" label="Attempt that many consecutive seed extension attempts to `fail` before Bowtie 2 moves on, using the alignments found so far" help="-D; A seed extension `fails` if it does not yield a new best or a new second-best alignment.  This limit is automatically adjusted up when -k or -a are specified. Default=15"/>
                         <param name="R" type="integer" value="2" min="0" label="Set the maximum number of times Bowtie 2 will `re-seed` reads with repetitive seeds" help="When `re-seeding`, Bowtie 2 simply chooses a new set of reads (same length, same number of mismatches allowed) at different offsets and searches for more alignments.  A read is considered to have repetitive seeds if the total number of seed hits divided by the number of seeds that aligned at least once is greater than 300.  Default=2"/>
+                        <param argument="-d" type="boolean" truevalue="-d" falsevalue="" label="Consider all seeds in order (no subsampling)" help="Can be used to augment -a or -k with deterministic behavior. This option significantly speeds up -a while also reducing memory consumption."/>
                     </when>
                     <when value="no">
                         <!-- do nothing -->
@@ -1187,8 +1189,14 @@ Bowtie 2 accepts files in Sanger FASTQ format (single or paired-end). Paired-end
             (same length, same number of mismatches allowed) at different offsets and
             searches for more alignments.  A read is considered to have repetitive seeds if
             the total number of seed hits divided by the number of seeds that aligned at
-            least once is greater than 300.  Default: 2.
-
+            least once is greater than 300.  Default: 2.3
+    
+    -d/--deterministic-seeds
+            Consider all seeds in order (no subsampling). Can be used to augment -a or -k with 
+            deterministic behavior. This option significantly speeds up -a while also reducing memory consumption. 
+            It is not however always strictly better than standalone [-a] when considering the 
+            number of repeated alignments found.    
+            
 -----
 
 **Paired-end options**::


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
