### PR TITLE
Fix fixed hyphy version

### DIFF
--- a/tools/hyphy/hyphy_relax.xml
+++ b/tools/hyphy/hyphy_relax.xml
@@ -1,4 +1,4 @@
-<tool id="hyphy_relax" name="HyPhy-RELAX" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="hyphy_relax" name="HyPhy-RELAX" version="@TOOL_VERSION@+galaxy4" profile="@PROFILE@">
     <description>Detect relaxed selection in a codon-based
     phylogenetic framework</description>
     <macros>


### PR DESCRIPTION
I had +galaxy1 locally, but them bump should have been to +4 in https://github.com/galaxyproject/tools-iuc/pull/7744

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
