### PR TITLE
Drop wrong help text on bwa-mem / bwa-mem2 output sorting

### DIFF
--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -265,7 +265,7 @@ bwa mem
                 </conditional>
             </when>
         </conditional>
-        <param name="output_sort" type="select" label="BAM sorting mode" help="The 'Not sorted' option can extend the run time of the tool significantly (cause it requires running on only a single thread).">
+        <param name="output_sort" type="select" label="BAM sorting mode">
             <option value="coordinate" selected="True">Sort by chromosomal coordinates</option>
             <option value="name">Sort by read names  (i.e., the QNAME field) </option>
             <option value="unsorted">Not sorted (sorted as input)</option>

--- a/tools/bwa_mem2/bwa-mem2.xml
+++ b/tools/bwa_mem2/bwa-mem2.xml
@@ -265,7 +265,7 @@ bwa-mem2 mem
                 </conditional>
             </when>
         </conditional>
-        <param name="output_sort" type="select" label="BAM sorting mode" help="The 'Not sorted' option can extend the run time of the tool significantly (cause it requires running on only a single thread).">
+        <param name="output_sort" type="select" label="BAM sorting mode">
             <option value="coordinate" selected="True">Sort by chromosomal coordinates</option>
             <option value="name">Sort by read names  (i.e., the QNAME field) </option>
             <option value="unsorted">Not sorted (sorted as input)</option>


### PR DESCRIPTION
Just saw this. I don't know what this refers to (conversion on next input if next input requires coordinate sorting?) but that's also not true, that just depends on what the admin has assigned as cores to the converter. Not sorted in fact is the fastest way to run the tool. Not bumping the version, I think we can skip deployment and push with the next update.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
