### PR TITLE
Update ncbi_datasets macros.xml to clarify accepted list format

### DIFF
--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">18.14.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">23.0</token>
     <token name="@LICENSE@">MIT</token>
     <token name="@PROFILE_AND_LICENSE@">profile="@PROFILE@" license="@LICENSE@"</token>
@@ -45,7 +45,7 @@
         <conditional name="text_or_file" label="How do you want to specify the @WHAT@(s) to download">
             <param name="text_or_file" type="select" label="Enter @WHAT@ or read from file ?">
                 <option value="text">Enter @WHAT@s</option>
-                <option value="file">Read a list of @WHAT_EXTENDED@s from a dataset</option>
+                <option value="file">Read a list of @WHAT_EXTENDED@s from a dataset, one per line</option>
             </param>
             <when value="text">
                 <!-- command section also allows spaces as separator for backward compatibility


### PR DESCRIPTION
Replicating what we used on other list inputs sent to NCBI. Example: fasterq_dump sra accession list format.

Users are submitting comma separated lists in a text file after the query gets too long on the direct form entry. Let's clarify the list is one identifier per line here too.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
