### PR TITLE
Adjust Liftoff wrapper error detection

### DIFF
--- a/tools/liftoff/liftoff.xml
+++ b/tools/liftoff/liftoff.xml
@@ -2,7 +2,7 @@
     <description>Lift gene annotations between genome assemblies</description>
     <macros>
         <token name="@TOOL_VERSION@">1.6.3</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">24.2</token>
     </macros>
     <xrefs>


### PR DESCRIPTION
recently saw it fail for a warning, which id like to try to change

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
