### PR TITLE
trigger psauron deployment

### DIFF
--- a/tools/psauron/psauron.xml
+++ b/tools/psauron/psauron.xml
@@ -5,9 +5,7 @@
     </macros>
     <expand macro="requirements"/>
     <version_command>psauron --version</version_command>
-    <command detect_errors="exit_code">
-
-        <![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         psauron
         -i '$i' 
         -c


### PR DESCRIPTION
fixes hopefully: https://github.com/galaxyproject/tools-iuc/issues/7774

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
