### PR TITLE
Fix folder and version handling of snpEff data manager

### DIFF
--- a/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
+++ b/data_managers/data_manager_snpeff/data_manager/data_manager_snpEff_download.py
@@ -101,26 +101,41 @@ def download_database(data_manager_dict, target_directory, genome_version, organ
     genome_path = os.path.join(data_dir, genome_version)
     snpeff_version = getSnpeffVersion()
     key = snpeff_version + '_' + genome_version
+    db_version = None
+    genomedb_name = regulationdb_name = ""
+
     if os.path.isdir(genome_path):
         for dirpath, _, files in os.walk(genome_path):
             for fname in files:
                 if fname.startswith('snpEffectPredictor'):
                     # if snpEffectPredictor.bin download succeeded
-                    name = genome_version + (' : ' + organism if organism else '')
-                    data_table_entry = dict(
-                        key=key,
-                        version=getSnpeffDbVersion(os.path.join(dirpath, fname)) or snpeff_version,
-                        value=genome_version,
-                        name=name,
-                        path=data_dir
-                    )
-                    _add_data_table_entry(data_manager_dict, 'snpeffv_genomedb', data_table_entry)
+                    genomedb_name = genome_version + (' : ' + organism if organism else '')
+                    db_version = getSnpeffDbVersion(os.path.join(dirpath, fname)) or snpeff_version
                 else:
                     m = re.match(regulation_pattern, fname)
                     if m:
-                        name = m.groups()[0]
-                        data_table_entry = dict(key=key, version=snpeff_version, genome=genome_version, value=name, name=name)
-                        _add_data_table_entry(data_manager_dict, 'snpeffv_regulationdb', data_table_entry)
+                        regulationdb_name = m.groups()[0]
+
+        if db_version:
+            data_table_entry = dict(
+                key=key,
+                version=db_version,
+                value=genome_version,
+                name=genomedb_name,
+                path=f"snpEff/{db_version}/data"
+            )
+            _add_data_table_entry(data_manager_dict, 'snpeffv_genomedb', data_table_entry)
+
+        if regulationdb_name:
+            data_table_entry = dict(
+                key=key,
+                version=db_version or snpeff_version,
+                genome=genome_version,
+                value=regulationdb_name,
+                name=regulationdb_name
+            )
+            _add_data_table_entry(data_manager_dict, 'snpeffv_regulationdb', data_table_entry)
+
     return data_manager_dict
 
 

--- a/data_managers/data_manager_snpeff/data_manager_conf.xml
+++ b/data_managers/data_manager_snpeff/data_manager_conf.xml
@@ -19,9 +19,9 @@
         <column name="name" />  <!-- columns that are going to be specified by the Data Manager Tool -->
         <column name="path" output_ref="out_file" >
           <move type="directory" relativize_symlinks="True">
-            <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">snpEff/v4_3/data</target>
+            <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${path}</target>
           </move>
-          <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/snpEff/v4_3/data</value_translation>
+          <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${path}</value_translation>
           <value_translation type="function">abspath</value_translation>
         </column>
       </output>


### PR DESCRIPTION
- Record the donwloaded DB version as the compatibility version also in the regulationdb table
- Move version-specific output folder choice into the download logic instead of hard-coding it in the data manager conf file where it's easily overlooked when updating the wrapper.
- This change also now allows to store dbs in folders named after their compatibility version instead of after the snpEff version used to download them.


There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
