### PR TITLE
update default zvalue for kmindex

### DIFF
--- a/tools/kmindex/kmindex_query.xml
+++ b/tools/kmindex/kmindex_query.xml
@@ -83,6 +83,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output" type="list" count="1">
                 <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
             </output_collection>
@@ -95,6 +96,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta.gz"/>
             <param name="format" value="matrix"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output_matrix" type="list" count="1">
                 <element name="abundance_test" ftype="tabular" value="expected_query2_index1.tsv" />
             </output_collection>
@@ -121,6 +123,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output" type="list" count="1">
                 <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
             </output_collection>
@@ -133,6 +136,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output" type="list" count="1">
                 <element name="test_index" ftype="json" value="expected_query_t6.json" />
             </output_collection>
@@ -145,6 +149,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output" type="list" count="2">
                 <element name="index1" ftype="json" value="expected_query2_index1.json" />
                 <element name="index2" ftype="json" value="expected_query2_index2.json" />
@@ -158,6 +163,7 @@
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="matrix"/>
+            <param name="zvalue" value="0"/>
             <output_collection name="output_matrix" type="list" count="2">
                 <element name="index1" ftype="tabular" value="expected_query2_index1_register.tsv" />
                 <element name="index2" ftype="tabular" value="expected_query2_index2_register.tsv" />


### PR DESCRIPTION
update default zvalue after getting recommendation from the developer to use 6 as default

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
