### PR TITLE
Column Maker tool: Add help text for basic arithmetic expressions

### DIFF
--- a/tools/column_maker/column_maker.xml
+++ b/tools/column_maker/column_maker.xml
@@ -1,4 +1,4 @@
-<tool id="Add_a_column1" name="Compute" version="2.1" profile="23.0">
+<tool id="Add_a_column1" name="Compute" version="2.1+galaxy0" profile="23.0">
     <description>on rows</description>
     <macros>
         <xml name="compute_repeat">
@@ -318,10 +318,10 @@ Several expressions can be specified and will be applied sequentially to each ro
 
 - The following built-in Python functions are available for use in expressions::
 
-    abs | all | any | ascii | bin | bool | chr | complex | divmod | float | format | hex | int | len | list 
+    abs | all | any | ascii | bin | bool | chr | complex | divmod | float | format | hex | int | len | list
     map | max | min | oct | ord | pow | range | reversed | round | set | sorted | str | sum | type
 
-    acos | acosh | asin | asinh | atan | atan2 | atanh | cbrt | ceil | comb | copysign | cos | cosh | degrees 
+    acos | acosh | asin | asinh | atan | atan2 | atanh | cbrt | ceil | comb | copysign | cos | cosh | degrees
     dist | erf | erfc | exp | exp2 | expm1 | fabs | factorial | floor | fmod | frexp | fsum | gamma | gcd
     hypot | inf | isclose | isfinite | isinf | isnan | isqrt | ldexp | lgamma | log | log10 | log1p | log2
     modf | nextafter | perm | pow | prod | remainder | sin | sqrt | tan | tanh | tau | trunc | ulp


### PR DESCRIPTION
Just a small addition to the help text, mainly for the tutorial I am writing. Explicitly mention the basic arithmetic operations that are availeble.


FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
