### PR TITLE
Update spatialdata

### DIFF
--- a/tools/spatialdata/macros.xml
+++ b/tools/spatialdata/macros.xml
@@ -14,6 +14,7 @@
             <requirement type="package" version="2.3.3">pandas</requirement>
             <requirement type="package" version="0.20.0">rioxarray</requirement>
             <requirement type="package" version="3.0">zip</requirement>
+            <requirement type="package" version="6.0">unzip</requirement>
         </requirements>
     </xml>
     <xml name="creator">

--- a/tools/spatialdata/macros.xml
+++ b/tools/spatialdata/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.7.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -84,11 +84,23 @@
                 #end if
             #end for
             ln -s '$method_condi.input_micron_to_mosaic' 'input/region/images/micron_to_mosaic_pixel_transform.csv' &&
-            ln -s '$method_condi.cell_by_gene' 'input/region/vpt_outputs/cell_by_gene.csv' &&
-            ln -s '$method_condi.cell_meta' 'input/region/vpt_outputs/cell_metadata.csv' &&
-            ## the tool checks the file name, so the name is hardcoded here, but it does not necessarily have to be from cellpose
-            ln -s '$method_condi.cells_boundaries' 'input/region/vpt_outputs/cellpose_micron_space.parquet' &&
-            ln -s '$method_condi.transcripts' 'input/region/detected_transcripts.csv' &&
+            #for $vpt in $method_condi.vpt_output:
+                #if 'cell_by_gene' in str($vpt.element_identifier):
+                    ln -s '$vpt' 'input/region/vpt_outputs/cell_by_gene.csv' &&
+                #end if
+                #if 'cell_metadata' in str($vpt.element_identifier):
+                    ln -s '$vpt' 'input/region/vpt_outputs/cell_metadata.csv' &&
+                #end if
+                #if 'detected_transcripts' in str($vpt.element_identifier):
+                    ln -s '$vpt' 'input/region/detected_transcripts.csv' &&
+                #end if
+            #end for
+            #for $parquet in $method_condi.cells_boundaries:
+                #if 'micron_space' in str($parquet.element_identifier):
+                    ## the tool checks the file name, so the name is hardcoded here, but it does not necessarily have to be from cellpose
+                    ln -s '$parquet' 'input/region/vpt_outputs/cellpose_micron_space.parquet' &&
+                #end if
+            #end for
 
         ## Visium
         #else if $method_condi.method == 'visium':
@@ -482,10 +494,8 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 </param>
                 <param argument="--mosaic-images" type="data" format="tiff" multiple="true" label="MEROSCOPE tiff images"/>
                 <param name="input_micron_to_mosaic" type="data" format="csv" label="Micron to mosaic mapping file"/>
-                <param name="cell_by_gene" type="data" format="csv" label="Cell by gene table" help="Cells as rows and Genes as columns"/>
-                <param name="cell_meta" type="data" format="csv" label="Cell metadata table"/>
-                <param name="cells_boundaries" type="data" format="parquet" label="Cell boundaries (micron_space)"/>
-                <param name="transcripts" type="data" format="csv" label="Detected transcripts"/>
+                <param name="vpt_output" type="data_collection" collection_type="list" format="csv" label="VPT output" help="This should include cell_by_gene, cell_metadata, and detected_transcripts data."/>
+                <param name="cells_boundaries" type="data_collection" collection_type="list" format="parquet" label="Cell boundaries" help="Only micron_space will be used."/>
                 <param name="transcripts_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load transcripts information?"/>
                 <param name="cells_boundaries_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells boundaries?"/>
                 <param name="cells_table_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells table?"/>
@@ -653,10 +663,8 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="mosaic_images" location="https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z3.tif"/>
                 <param name="z_layers" value="3"/>
                 <param name="input_micron_to_mosaic" location="https://zenodo.org/records/18746346/files/merscope_micron_to_mosaic_pixel_transform.csv"/>
-                <param name="cell_by_gene" location="https://zenodo.org/records/18746346/files/merscope_cell_by_gene.csv"/>
-                <param name="cell_meta" location="https://zenodo.org/records/18746346/files/merscope_cell_metadata.csv"/>
+                <param name="vpt_output" location="https://zenodo.org/records/18746346/files/merscope_cell_by_gene.csv,https://zenodo.org/records/18746346/files/merscope_cell_metadata.csv,https://zenodo.org/records/18746346/files/merscope_detected_transcripts.csv"/>
                 <param name="cells_boundaries" location="https://zenodo.org/records/18746346/files/merscope_cellpose2_micron_space.parquet"/>
-                <param name="transcripts" location="https://zenodo.org/records/18746346/files/merscope_detected_transcripts.csv"/>
             </conditional>
             <assert_stdout>
                 <has_text text="z_layers=[3]"/>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -231,7 +231,7 @@
         cat 'spdata_io.py' &&
         python3 'spdata_io.py' &&
         ## zip the output spatialdata folder
-        cd output && zip -r ../spatialdata.spatialdata.zip spatialdata/ && cd ..
+        cd output && zip -r ../spatialdata.spatialdata.zip spatialdata.zarr/ && cd ..
     ]]></command>
     <configfiles>
         <configfile name="spdata_config" filename="spdata_io.py">
@@ -401,7 +401,7 @@ spdata["he_image"] = xenium_aligned_image(
 #end if
 
 print(spdata)
-spdata.write("./output/spatialdata", overwrite=True)
+spdata.write("./output/spatialdata.zarr", overwrite=True)
         </configfile>
     </configfiles>
     <inputs>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -663,8 +663,18 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="mosaic_images" location="https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z3.tif"/>
                 <param name="z_layers" value="3"/>
                 <param name="input_micron_to_mosaic" location="https://zenodo.org/records/18746346/files/merscope_micron_to_mosaic_pixel_transform.csv"/>
-                <param name="vpt_output" location="https://zenodo.org/records/18746346/files/merscope_cell_by_gene.csv,https://zenodo.org/records/18746346/files/merscope_cell_metadata.csv,https://zenodo.org/records/18746346/files/merscope_detected_transcripts.csv"/>
-                <param name="cells_boundaries" location="https://zenodo.org/records/18746346/files/merscope_cellpose2_micron_space.parquet"/>
+                <param name="cells_boundaries">
+                    <collection type="list">
+                        <element name="cellpose2_micron_space" location="https://zenodo.org/records/18746346/files/merscope_cellpose2_micron_space.parquet"/>
+                    </collection>
+                </param>
+                <param name="vpt_output">
+                    <collection type="list">
+                        <element name="cell_by_gene" location="https://zenodo.org/records/18746346/files/merscope_cell_by_gene.csv"/>
+                        <element name="cell_metadata" location="https://zenodo.org/records/18746346/files/merscope_cell_metadata.csv"/>
+                        <element name="detected_transcripts" location="https://zenodo.org/records/18746346/files/merscope_detected_transcripts.csv"/>
+                    </collection>
+                </param>
             </conditional>
             <assert_stdout>
                 <has_text text="z_layers=[3]"/>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -673,7 +673,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="&quot;label&quot;: &quot;DAPI&quot;"/>
                     </has_archive_member>
@@ -695,7 +695,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </conditional>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/1_image"/>
                     </has_archive_member>
@@ -716,7 +716,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/Galaxy_image"/>
                     </has_archive_member>
@@ -735,7 +735,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/input_image"/>
                     </has_archive_member>
@@ -761,7 +761,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/Test_Visium_full_image"/>
                     </has_archive_member>
@@ -823,7 +823,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                     </has_archive_member>
                 </assert_contents>
@@ -852,7 +852,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/morphology_focus"/>
                     </has_archive_member>
@@ -884,7 +884,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/morphology_focus"/>
                     </has_archive_member>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -9,7 +9,7 @@
         mkdir -p input output &&
         unzip -q '$input_spatialdata' -d input &&
 
-        ## Rename directory to spatialdata if it has a different name
+        ## Rename directory to spatialdata.zarr if it has a different name
         dir_name=\$(ls -d input/*/ | head -1 | xargs basename) &&
         if [ "\$dir_name" != "spatialdata.zarr" ]; then
             mv "input/\$dir_name" input/spatialdata.zarr;

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -11,15 +11,15 @@
 
         ## Rename directory to spatialdata if it has a different name
         dir_name=\$(ls -d input/*/ | head -1 | xargs basename) &&
-        if [ "\$dir_name" != "spatialdata" ]; then
-            mv "input/\$dir_name" input/spatialdata;
+        if [ "\$dir_name" != "spatialdata.zarr" ]; then
+            mv "input/\$dir_name" input/spatialdata.zarr;
         fi &&
 
         ## run the operation pipeline
         cat 'spdata_operation.py' &&
         python3 'spdata_operation.py'
         #if $operation_condi.operation in ['bounding_box_query', 'polygon_query', 'concatenate', 'transform', 'aggregate', 'to_circles', 'to_polygons', 'get_centroids', 'join_spatialelement_table', 'match_element_to_table', 'match_table_to_element', 'match_sdata_to_table', 'filter_by_table_query', 'rasterize', 'rasterize_bins', 'rasterize_bins_link_table_to_labels', 'map_raster', 'unpad_raster', 'relabel_sequential', 'sanitize_table', 'import_table', 'add_shape']:
-            && cd output && zip -r ../spatialdata.spatialdata.zip spatialdata/ && cd ..
+            && cd output && zip -r ../spatialdata.spatialdata.zip spatialdata.zarr/ && cd ..
         #end if
     ]]></command>
     <configfiles>
@@ -27,7 +27,7 @@
 import spatialdata as sd
 
 ## Load the SpatialData object
-sdata = sd.read_zarr("./input/spatialdata")
+sdata = sd.read_zarr("./input/spatialdata.zarr")
 
 print("Input SpatialData object:")
 print(sdata)
@@ -542,7 +542,7 @@ print(result)
 
 ## Save the result
 #if $operation_condi.operation in ['bounding_box_query', 'polygon_query', 'concatenate', 'transform', 'aggregate', 'to_circles', 'to_polygons', 'get_centroids', 'join_spatialelement_table', 'match_element_to_table', 'match_table_to_element', 'match_sdata_to_table', 'filter_by_table_query', 'rasterize', 'rasterize_bins', 'rasterize_bins_link_table_to_labels', 'map_raster', 'unpad_raster', 'relabel_sequential', 'sanitize_table', 'import_table', 'add_shape']:
-result.write("./output/spatialdata", overwrite=True)
+result.write("./output/spatialdata.zarr", overwrite=True)
 
 #else if $operation_condi.operation in ['get_values']:
 import pandas as pd

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -1010,7 +1010,7 @@ print("\nOperation completed successfully!")
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_size value="55000" delta="1000"/>
+                    <has_size value="56000" delta="1000"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -1111,7 +1111,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7500000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="points/cell_centroids"/>
                     </has_archive_member>
@@ -1135,7 +1135,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7600000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="tables/filtered_table"/>
                         <has_text text="tables/filtered_filtered_table"/>
@@ -1159,7 +1159,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="85000000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/matched_Test_Visium"/>
                     </has_archive_member>
@@ -1182,7 +1182,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="144000000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="tables/matched_table"/>
                     </has_archive_member>
@@ -1243,7 +1243,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="93000000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="/images/he_image"/>
                         <has_text text="/images/Test_Visium_full_image"/>
@@ -1274,7 +1274,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7500000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="labels/transformed_labels"/>
                     </has_archive_member>
@@ -1300,7 +1300,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7400000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/rasterized_cell_labels"/>
                     </has_archive_member>
@@ -1326,7 +1326,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="29000000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/rasterized_Test_VisiumHD_square_002um"/>
                     </has_archive_member>
@@ -1352,7 +1352,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="29000000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="labels/rasterized_Test_VisiumHD_square_002um"/>
                     </has_archive_member>
@@ -1374,7 +1374,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="29700000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="labels/rasterized_Test_VisiumHD_square_002um"/>
                     </has_archive_member>
@@ -1396,7 +1396,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7480000" delta="20000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/cell_circles"/>
                     </has_archive_member>
@@ -1418,7 +1418,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7600000" delta="100000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/cell_polygons"/>
                     </has_archive_member>
@@ -1443,7 +1443,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="1100000" delta="50000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/nucleus_boundaries"/>
                     </has_archive_member>
@@ -1466,7 +1466,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="13000000" delta="1000000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/mapped_morphology_focus"/>
                     </has_archive_member>
@@ -1487,7 +1487,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="13200000" delta="300000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="images/unpadded_morphology_focus"/>
                     </has_archive_member>
@@ -1600,7 +1600,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7800000" delta="200000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="tables/imported_table"/>
                     </has_archive_member>
@@ -1621,7 +1621,7 @@ print("\nOperation completed successfully!")
             <output name="spatialdata_output">
                 <assert_contents>
                     <has_size value="7560000" delta="30000"/>
-                    <has_archive_member path="spatialdata/zarr.json">
+                    <has_archive_member path="spatialdata.zarr/zarr.json">
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/new_shapes"/>
                     </has_archive_member>

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -10,8 +10,8 @@
 
         ## Rename directory to spatialdata if it has a different name
         dir_name=\$(ls -d input/*/ | head -1 | xargs basename) &&
-        if [ "\$dir_name" != "spatialdata" ]; then
-            mv "input/\$dir_name" input/spatialdata;
+        if [ "\$dir_name" != "spatialdata.zarr" ]; then
+            mv "input/\$dir_name" input/spatialdata.zarr;
         fi &&
 
         ## run the plotting pipeline
@@ -24,7 +24,7 @@ import spatialdata as sd
 import spatialdata_plot
 
 ## Load the SpatialData object
-spdata = sd.read_zarr("./input/spatialdata")
+spdata = sd.read_zarr("./input/spatialdata.zarr")
 
 print(spdata)
 

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -8,7 +8,7 @@
     <command detect_errors="exit_code"><![CDATA[
         unzip -q '$input_spatialdata' -d input &&
 
-        ## Rename directory to spatialdata if it has a different name
+        ## Rename directory to spatialdata.zarr if it has a different name
         dir_name=\$(ls -d input/*/ | head -1 | xargs basename) &&
         if [ "\$dir_name" != "spatialdata.zarr" ]; then
             mv "input/\$dir_name" input/spatialdata.zarr;


### PR DESCRIPTION
Updates:

* Added unzip to requirements as it failed to do unzip on usegalaxy
* Add `.zarr` extension to the output. napari-spatialdata checks this extension
* Make MERSCOPE importer compatible with VPT outputs

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
