### PR TITLE
Fix output file name in shovill.xml

### DIFF
--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -1,8 +1,9 @@
-<tool id="shovill" name="Shovill" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="shovill" name="Shovill" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Faster SPAdes assembly of Illumina reads</description>
     <macros>
         <token name="@TOOL_VERSION@">1.4.2</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@PROFILE@">25.1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">shovill</xref>

--- a/tools/shovill/shovill.xml
+++ b/tools/shovill/shovill.xml
@@ -136,7 +136,7 @@
             <filter>log == True</filter>
         </data>
         <data name="contigs" format="fasta" label="${tool.name} on ${on_string}: Contigs" from_work_dir="out/contigs.fa"/>
-        <data name="contigs_graph" format="txt"  label="${tool.name} on ${on_string}: Contig Graph" from_work_dir="out/contigs.gfa">
+        <data name="contigs_graph" format="txt"  label="${tool.name} on ${on_string}: Contig Graph" from_work_dir="out/spades.gfa">
             <filter> assembler_type['assembler'] != 'skesa' </filter>
         </data>
         <data name="bamfiles" format="unsorted.bam" from_work_dir="out/shovill.bam" label="Bam file for ${tool.name} on ${on_string}">


### PR DESCRIPTION
Galaxy Australia has had an issue with a blank graph output file from shovill. Jenna has raised an issue in this repo. The wrapper expects ‘out/contigs.gfa’ which does not exist. The .gfa output is ‘out/spades.gfa’.

For issue #7704 

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
