### PR TITLE
Add limits for STAR at index generataion

### DIFF
--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -126,7 +126,7 @@
             --runThreadN \${GALAXY_SLOTS:-4}
             ## in bytes
             --limitGenomeGenerateRAM \$((\${GALAXY_MEMORY_MB:-31000} * 1000000))
-            ## Limits - useful to generate indices from a large genomes with a lot of annotations
+            ## Limits - useful to generate indices from large genomes with a lot of annotations
             @LIMITS@
         &&
     #end if

--- a/tools/rgrnastar/macros.xml
+++ b/tools/rgrnastar/macros.xml
@@ -5,7 +5,7 @@
     the index versions in sync, but you should manually update @IDX_VERSION_SUFFIX@ -->
     <!-- STAR version to be used -->
     <token name="@TOOL_VERSION@">2.7.11b</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <!-- STAR index version compatible with this version of STAR
     This is the STAR version that introduced the index structure expected
@@ -126,6 +126,8 @@
             --runThreadN \${GALAXY_SLOTS:-4}
             ## in bytes
             --limitGenomeGenerateRAM \$((\${GALAXY_MEMORY_MB:-31000} * 1000000))
+            ## Limits - useful to generate indices from a large genomes with a lot of annotations
+            @LIMITS@
         &&
     #end if
     ]]></token>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -1053,12 +1053,14 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
                 <conditional name="params">
                     <param name="settingsType" value="full" />
                         <section name="junction_limits">
+                            <param name="limitOutSJoneRead" value="100" />
+                            <param name="limitOutSJcollapsed" value="5000" />
                             <param name="limitSjdbInsertNsj" value="5000" />
                         </section>
                 </conditional>
             </section>
             <assert_stdout>
-                <has_line_matching expression=".*genomeGenerate.*limitSjdbInsertNsj\s+5000" />
+                <has_line_matching expression=".*genomeGenerate.*--limitOutSJoneRead\s+100.\s+--limitOutSJcollapsed\s+5000\s+--limitSjdbInsertNsj\s+5000" />
             </assert_stdout>
         </test>
       </tests>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -1037,6 +1037,30 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
             <output name="splice_junctions" file="rnastar_test_splicejunctions_diploid.bed"/>
             <output name="mapped_reads" file="rnastar_test_mapped_reads_diploid.bam" compare="sim_size" delta="634" />
         </test>
+        <!-- test limits during the index generation -->
+        <test expect_num_outputs="3">
+            <conditional name="singlePaired">
+                <param name="sPaired" value="paired" />
+                <param name="input1" value="pbmc_1k_v2_L001.R1.10k.fastq.gz" ftype="fastqsanger.gz" />
+                <param name="input2" value="pbmc_1k_v2_L001.R2.10k.fastq.gz" ftype="fastqsanger.gz" />
+            </conditional>
+            <conditional name="refGenomeSource">
+                <param name="geneSource" value="history" />
+                <param name="genomeFastaFiles" value="filtered3.Homo_sapiens.GRCh38.dna.chromosome.21.fa.gz" />
+                <param name="genomeSAindexNbases" value="5" />
+            </conditional>
+            <section name="algo">
+                <conditional name="params">
+                    <param name="settingsType" value="full" />
+                        <section name="junction_limits">
+                            <param name="limitSjdbInsertNsj" value="5000" />
+                        </section>
+                </conditional>
+            </section>
+            <assert_stdout>
+                <has_line_matching expression=".*genomeGenerate.*limitSjdbInsertNsj\s+5000" />
+            </assert_stdout>
+        </test>
       </tests>
     <help><![CDATA[
 **What it does**

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -1060,7 +1060,7 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
                 </conditional>
             </section>
             <assert_stdout>
-                <has_line_matching expression=".*genomeGenerate.*--limitOutSJoneRead\s+100.\s+--limitOutSJcollapsed\s+5000\s+--limitSjdbInsertNsj\s+5000" />
+                <has_line_matching expression=".*genomeGenerate.*--limitOutSJoneRead\s+100\s+--limitOutSJcollapsed\s+5000\s+--limitSjdbInsertNsj\s+5000" />
             </assert_stdout>
         </test>
       </tests>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

We had a user on EU server using a human+mouse fused genome. The index generation failed because of the default `--limitSjdbInsertNsj 1000000`. 