### PR TITLE
kraken2 builder: Fix Python compatibility

### DIFF
--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -56,7 +56,7 @@
 #import datetime
 #import re
 
-#set now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H%M%SZ")
+#set now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
 #set commands = []
 mkdir '$out_file.extra_files_path' &&
 


### PR DESCRIPTION
This fixes the data manager so it runs on Python 3.10 and below.

Commit 797b5fc changed data_managers/data_manager_build_kraken2_database/ data_manager/kraken2_build_database.xml#59 from the deprecated datetime.utcnow() to datetime.now(datetime.UTC). However, datetime.UTC was introduced in Python 3.11, making this tool break on systems with earlier Python versions.

This fix should behave identically and support back to Python 3.2, long before Galaxy's minimum Python version of 3.9

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [X] This PR does something else (explain below)

This is a compatibility fix for an existing tool.