### PR TITLE
Fix: kraken2 builder: update URLs

### DIFF
--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -100,6 +100,19 @@ mkdir '$out_file.extra_files_path' &&
         #set display_name = amplicon_name.get(str($database_type.prebuilt.prebuilt_db)+"_"+date_url_str)
     #end if
 
+    #set download_db = str($database_type.prebuilt.prebuilt_db)
+    #if download_db.endswith("_08gb")
+        #if date_url_str < "20220607"
+            #set download_db = download_db.replace("_08gb", "_8gb")
+        #else if date_url_str >= "20250714"
+            #set download_db = download_db.replace("_08gb", "_08_GB")
+        #end if
+    #else if download_db.endswith("_16gb")
+        #if date_url_str >= "20250714"
+            #set download_db = download_db.replace("_16gb", "_16_GB")
+        #end if
+    #end if
+
     #set database_value = "_".join([now, "standard_prebuilt", str($database_type.prebuilt.prebuilt_db), str($database_type.prebuilt.prebuilt_date)])
     #set database_name = " ".join(["Prebuilt Refseq indexes: ", display_name, "(Version: ", str($database_type.prebuilt.prebuilt_date), "- Downloaded:", now + ")"])
 
@@ -116,9 +129,9 @@ mkdir '$out_file.extra_files_path' &&
         #silent commands.append("fi")
         #silent commands.append("rm -rf '" + $out_file.extra_files_path + "/" + database_value + "/tmp_extract'")
     #else
-        #silent commands.append("wget https://genome-idx.s3.amazonaws.com/kraken/k2_" + str($database_type.prebuilt.prebuilt_db) + "_" + date_url_str + ".tar.gz")
+        #silent commands.append("wget https://genome-idx.s3.amazonaws.com/kraken/k2_" + download_db + "_" + date_url_str + ".tar.gz")
         #silent commands.append("mkdir -p '" + $out_file.extra_files_path + "/" + database_value + "'")
-        #silent commands.append("tar -xzf k2_" + str($database_type.prebuilt.prebuilt_db) + "_" + date_url_str + ".tar.gz -C '" + $out_file.extra_files_path + "/" + database_value + "'")
+        #silent commands.append("tar -xzf k2_" + download_db + "_" + date_url_str + ".tar.gz -C '" + $out_file.extra_files_path + "/" + database_value + "'")
     #end if
 
 #else if $database_type.database_type == "minikraken"
@@ -205,8 +218,10 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
             <when value="standard_prebuilt">
                 <conditional name="prebuilt">
                     <param name="prebuilt_date" type="select" label="Select index build date">
+                        <option value="2026-02-26">February 26, 2026</option>
                         <option value="2025-10-15">October 15, 2025</option>
                         <option value="2025-07-14">July 14, 2025</option>
+                        <option value="2025-04-02">April 2, 2025</option>
                         <option value="2024-12-28">December 28, 2024</option>
                         <option value="2024-09-04">September 4, 2024</option>
                         <option value="2024-06-05">June 5, 2024</option>
@@ -218,6 +233,21 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                         <option value="2020-12-02">December 2, 2020</option>
                         <option value="2020-09-19">September 19, 2020</option>
                     </param>
+                    <when value="2026-02-26">
+                        <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
+                            <expand macro="viral"/>
+                            <expand macro="minusb"/>
+                            <expand macro="standard"/>
+                            <expand macro="standard_08gb"/>
+                            <expand macro="standard_16gb"/>
+                            <expand macro="pluspf"/>
+                            <expand macro="pluspf_08gb"/>
+                            <expand macro="pluspf_16gb"/>
+                            <expand macro="pluspfp"/>
+                            <expand macro="pluspfp_08gb"/>
+                            <expand macro="pluspfp_16gb"/>
+                        </param>
+                    </when>
                     <when value="2025-10-15">
                         <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
                             <expand macro="viral"/>
@@ -234,6 +264,21 @@ echo '{"data_tables": {"kraken2_databases": [{"value": "$database_value", "name"
                         </param>
                     </when>
                     <when value="2025-07-14">
+                        <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
+                            <expand macro="viral"/>
+                            <expand macro="minusb"/>
+                            <expand macro="standard"/>
+                            <expand macro="standard_08gb"/>
+                            <expand macro="standard_16gb"/>
+                            <expand macro="pluspf"/>
+                            <expand macro="pluspf_08gb"/>
+                            <expand macro="pluspf_16gb"/>
+                            <expand macro="pluspfp"/>
+                            <expand macro="pluspfp_08gb"/>
+                            <expand macro="pluspfp_16gb"/>
+                        </param>
+                    </when>
+                    <when value="2025-04-02">
                         <param name="prebuilt_db" type="select" label="Select a prebuilt Refseq index to download">
                             <expand macro="viral"/>
                             <expand macro="minusb"/>

--- a/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
+++ b/data_managers/data_manager_build_kraken2_database/data_manager/kraken2_build_database.xml
@@ -2,7 +2,7 @@
     <description>database builder</description>
     <macros>
         <token name="@TOOL_VERSION@">2.17.1</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">24.0</token>
         <xml name="common_params">
             <param name="kmer_len" type="integer" value="35" label="K-mer length in BP" />
@@ -56,7 +56,7 @@
 #import datetime
 #import re
 
-#set now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H%M%SZ")
+#set now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
 #set commands = []
 mkdir '$out_file.extra_files_path' &&
 


### PR DESCRIPTION
This change fixes the kraken2 builder with two changes:

## Fix generated URLs
The generated URLs does not correspond to the actual URLs where the data is stored. This makes building about 21 of the databases fail, e.g. the standard 8 GB from 2025-10-15.

In this fix, I used the webpage https://benlangmead.github.io/aws-indexes/k2 to check the actual URLs, and verified each of them responds (but did not download every database to check it actually contains the correct file).

## Fix Python compat
Commit 797b5fc changed data_managers/data_manager_build_kraken2_database/
data_manager/kraken2_build_database.xml#59 from the deprecated
datetime.utcnow() to datetime.now(datetime.UTC). However, datetime.UTC was
introduced in Python 3.11, making this tool break on systems with earlier
Python versions.

This fix should behave identically and support back to Python 3.2, long before
Galaxy's minimum Python version of 3.9

Note that local tests fail due to what I think are unrelated reasons - flaky networking not related to the URLs updated in this PR.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [X] This PR does something else (explain below)

Fixes broken URL for existing tool