### PR TITLE
metabat2: fix linter issues

### DIFF
--- a/tools/metabat2/.lint_skip
+++ b/tools/metabat2/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/metabat2/macros.xml
+++ b/tools/metabat2/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">2.17</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">21.01</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">24.2</token>
     <xml name="biotools">
         <xrefs>
             <xref type="bio.tools">MetaBAT_2</xref>

--- a/tools/metabat2/metabat2.xml
+++ b/tools/metabat2/metabat2.xml
@@ -90,16 +90,19 @@ metabat2
             <discover_datasets pattern="bin\.(?P&lt;designation&gt;\d*)" format="tabular" directory="bins"/>
         </collection>
         <data name="lowDepth" format="fasta" from_work_dir="bins/bin.lowDepth.fa" label="${tool.name} on ${on_string}: Low depth bins">
-            <filter>not out['saveCls'] and not out['onlyLabel'] and 'lowDepth' in out['extra_outputs']</filter>
+            <filter>not out['saveCls'] and not out['onlyLabel']</filter>
+            <filter>out['extra_outputs'] and 'lowDepth' in out['extra_outputs']</filter>
         </data>
         <data name="tooShort" format="fasta" from_work_dir="bins/bin.tooShort.fa" label="${tool.name} on ${on_string}: Too short bins">
-            <filter>not out['saveCls'] and not out['onlyLabel'] and 'tooShort' in out['extra_outputs']</filter>
+            <filter>not out['saveCls'] and not out['onlyLabel']</filter>
+            <filter>out['extra_outputs'] and 'tooShort' in out['extra_outputs']</filter>
         </data>
         <data name="unbinned" format="fasta" from_work_dir="bins/bin.unbinned.fa" label="${tool.name} on ${on_string}: Unbinned sequences">
-            <filter>not out['saveCls'] and not out['onlyLabel'] and 'unbinned' in out['extra_outputs']</filter>
+            <filter>not out['saveCls'] and not out['onlyLabel']</filter>
+            <filter>out['extra_outputs'] and 'unbinned' in out['extra_outputs']</filter>
         </data>
         <data name="process_log" format="txt" label="${tool.name} on ${on_string}: Process log">
-            <filter>'log' in out['extra_outputs']</filter>
+            <filter>out['extra_outputs'] and 'log' in out['extra_outputs']</filter>
         </data>
     </outputs>
     <tests>
@@ -165,7 +168,7 @@ metabat2
             <section name="out">
                 <param name="onlyLabel" value="false"/>
                 <param name="saveCls" value="false"/>
-                <param name="extra_outputs" value=""/>
+                <param name="extra_outputs" value_json="null"/>
             </section>
             <output_collection name="bins" type="list" count="0"/>
         </test>
@@ -180,7 +183,7 @@ metabat2
             <section name="out">
                 <param name="onlyLabel" value="false"/>
                 <param name="saveCls" value="true"/>
-                <param name="extra_outputs" value=""/>
+                <param name="extra_outputs" value_json="null"/>
             </section>
             <output name="bin_saveCls" ftype="tabular">
                 <assert_contents>
@@ -201,7 +204,7 @@ metabat2
             <section name="out">
                 <param name="onlyLabel" value="true"/>
                 <param name="saveCls" value="false"/>
-                <param name="extra_outputs" value=""/>
+                <param name="extra_outputs" value_json="null"/>
             </section>
             <output_collection name="bin_onlyLabel" type="list" count="2">
                 <element name="1" ftype="tabular">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
