### PR TITLE
Updating tools/pimento from version 1.0.2 to 1.0.3

### DIFF
--- a/tools/pimento/macros.xml
+++ b/tools/pimento/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.0.2</token>
+    <token name="@TOOL_VERSION@">1.0.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@LICENSE@">Apache-2.0</token>
     <xml name="requirements">

--- a/tools/pimento/std.xml
+++ b/tools/pimento/std.xml
@@ -9,9 +9,9 @@
         #if $primers:
             mkdir primers &&
             cp '$primers' primers &&
-            pimento std -i '$input_reads' -p primers --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads \${GALAXY_SLOTS:-1}
+            pimento std -i '$input_reads' -p primers --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads "\${GALAXY_SLOTS:-1}"
         #else
-            pimento std -i '$input_reads' --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads \${GALAXY_SLOTS:-1}
+            pimento std -i '$input_reads' --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads "\${GALAXY_SLOTS:-1}"
         #end if
     ]]></command>
     <inputs>

--- a/tools/pimento/std.xml
+++ b/tools/pimento/std.xml
@@ -9,9 +9,9 @@
         #if $primers:
             mkdir primers &&
             cp '$primers' primers &&
-            pimento std -i '$input_reads' -p primers --minimum_primer_threshold $minimum_primer_threshold $merged -o sample
+            pimento std -i '$input_reads' -p primers --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads \${GALAXY_SLOTS:-1}
         #else
-            pimento std -i '$input_reads' --minimum_primer_threshold $minimum_primer_threshold $merged -o sample
+            pimento std -i '$input_reads' --minimum_primer_threshold $minimum_primer_threshold $merged -o sample --threads \${GALAXY_SLOTS:-1}
         #end if
     ]]></command>
     <inputs>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.



Closes #7863 