### PR TITLE
update ppanggolin suite

### DIFF
--- a/tools/ppanggolin/macros.xml
+++ b/tools/ppanggolin/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.3.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="citation">
         <citations>
             <citation type="doi">10.1371/journal.pcbi.1007732</citation> 

--- a/tools/ppanggolin/ppanggolin_msa.xml
+++ b/tools/ppanggolin/ppanggolin_msa.xml
@@ -74,7 +74,7 @@
             <option value="dna">DNA</option>
         </param>
         
-        <param argument="--phylo" name="do_phylo" type="boolean" checked="true" label="Writes a whole genome msa file for additional phylogenetic analysis (recommended)" truevalue="--phylo" falsevalue=""/>
+        <param argument="--phylo" name="do_phylo" type="boolean" checked="true" label="Writes a whole genome msa file (fasta format) for additional phylogenetic analysis (recommended)" truevalue="--phylo" falsevalue=""/>
 
         <param argument="--single_copy" name="do_single_copy" type="boolean" checked="false" label="Report gene families that are considered 'single copy'" truevalue="--single_copy" falsevalue=""/>
 
@@ -84,7 +84,7 @@
 
     <outputs>
         <data name="archive_msa_partition_source" format="tar.gz" label="PPanGGOLiN msa on ${on_string}: archive msa ${choice_partition} ${choice_source}" />
-        <data name="partition_genome_alignment" format="maf" label="PPanGGOLiN msa on ${on_string}: ${choice_partition} genome alignment" >
+        <data name="partition_genome_alignment" format="fasta" label="PPanGGOLiN msa on ${on_string}: ${choice_partition} genome alignment" >
           <filter>do_phylo is True</filter>
         </data>
     </outputs>


### PR DESCRIPTION
changed output file partition_genome_alignment format to fasta in order to improve interoperability with other tools (i.e. fasttree)

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
