### PR TITLE
Diamond: disable blastdb sorting

### DIFF
--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -209,7 +209,6 @@
             <when value="blast">
                 <param name="reference_database" type="select" label="Reference database" help="If your database of interest is not listed, contact your Galaxy admin">
                     <options from_data_table="blastdb_p">
-                        <filter type="sort_by" column="2"/>
                         <validator type="no_options" message="No indexes are available for the selected input dataset"/>
                     </options>
                 </param>

--- a/tools/diamond/macros.xml
+++ b/tools/diamond/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.1.22</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">diamond</requirement>


### PR DESCRIPTION
sort column was wrong. this makes it analogous to the BLAST wrapper (i.e. we will have the same sort order)

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
