### PR TITLE
Lint fix: Adapter Removal

### DIFF
--- a/tools/adapter_removal/.lint_skip
+++ b/tools/adapter_removal/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/adapter_removal/adapter_removal.xml
+++ b/tools/adapter_removal/adapter_removal.xml
@@ -244,9 +244,11 @@ $fastq_merging_options.collapse_conservatively
         </data>
     </outputs>
     <tests>
-        <!-- Single dataset input, all defaults -->
+        <!-- Test 01: Single dataset input, all defaults -->
         <test expect_num_outputs="2">
-            <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+            <conditional name="input_type_cond">
+                <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+            </conditional>
             <output name="output_settings" ftype="txt">
                 <assert_contents>
                     <has_size value="2117" delta="10"/>
@@ -264,11 +266,13 @@ $fastq_merging_options.collapse_conservatively
                 </assert_contents>
             </output>
        </test>
-        <!-- Dataset pair input, all defaults -->
+        <!-- Test 02: Dataset pair input, all defaults -->
         <test expect_num_outputs="3">
-            <param name="input_type" value="pair"/>
-            <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
-            <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+            <conditional name="input_type_cond">
+                <param name="input_type" value="pair"/>
+                <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+                <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+            </conditional>
             <section name="fastq_options">
                 <param name="convert_uracils" value="false"/>
                 <param name="mask_degenerate_bases" value="true"/>
@@ -298,12 +302,14 @@ $fastq_merging_options.collapse_conservatively
                 </assert_contents>
             </output>
        </test>
-        <!-- Dataset pair input, all defaults, interleaved output -->
+        <!-- Test 03: Dataset pair input, all defaults, interleaved output -->
         <test expect_num_outputs="2">
-            <param name="input_type" value="pair"/>
-            <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
-            <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
-            <param name="interleaved_output" value="yes"/>
+            <conditional name="input_type_cond">
+                <param name="input_type" value="pair"/>
+                <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+                <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+                <param name="interleaved_output" value="yes"/>
+            </conditional>
             <output name="output_settings" ftype="txt">
                 <assert_contents>
                     <has_size value="2593" delta="10"/>
@@ -321,15 +327,17 @@ $fastq_merging_options.collapse_conservatively
                 </assert_contents>
             </output>
        </test>
-        <!-- Collection of dataset pairs input, all defaults -->
+        <!-- Test 04: Collection of dataset pairs input, all defaults -->
         <test expect_num_outputs="3">
-            <param name="input_type" value="paired"/>
-            <param name="reads_collection">
-                <collection type="paired">
-                    <element name="forward" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
-                    <element name="reverse" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
-                </collection>
-            </param>
+            <conditional name="input_type_cond">
+                <param name="input_type" value="paired"/>
+                <param name="reads_collection">
+                    <collection type="paired">
+                        <element name="forward" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+                        <element name="reverse" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+                    </collection>
+                </param>
+            </conditional>
             <output name="output_settings" ftype="txt">
                 <assert_contents>
                     <has_size value="2594" delta="10"/>
@@ -355,11 +363,13 @@ $fastq_merging_options.collapse_conservatively
                 </assert_contents>
             </output>
        </test>
-        <!-- Dataset pair input, all defaults, all optional outputs checked -->
+        <!-- Test 05: Dataset pair input, all defaults, all optional outputs checked -->
         <test expect_num_outputs="7">
-            <param name="input_type" value="pair"/>
-            <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
-            <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+            <conditional name="input_type_cond">
+                <param name="input_type" value="pair"/>
+                <param name="read1" ftype="fastqsanger.gz" value="reads1.fastq.gz"/>
+                <param name="read2" ftype="fastqsanger.gz" value="reads2.fastq.gz"/>
+            </conditional>
             <param name="output_select" value="output_singleton,output_collapsed,output_collapsed_truncated,output_discarded"/>
             <output name="output_settings" ftype="txt">
                 <assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
