### PR TITLE
alphagenome: vectorize post-processing across scoring tools

### DIFF
--- a/tools/alphagenome/alphagenome_interval_predictor.py
+++ b/tools/alphagenome/alphagenome_interval_predictor.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 import numpy as np
+import pandas as pd
 from alphagenome.data import genome
 from alphagenome.models import dna_client
 
@@ -79,6 +80,71 @@ def extract_region_slice(values, interval_start, region_start, region_end):
     offset_start = max(0, offset_start)
     offset_end = min(values.shape[0], offset_end)
     return values[offset_start:offset_end]
+
+
+def metadata_column(metadata, column, size):
+    if metadata is not None and column in metadata.columns:
+        values = metadata[column].astype(str).to_numpy()
+        if len(values) >= size:
+            return values[:size]
+        padded = np.full(size, "", dtype=object)
+        padded[:len(values)] = values
+        return padded
+    return np.full(size, "", dtype=object)
+
+
+def as_2d(values):
+    values = np.asarray(values)
+    if values.ndim == 1:
+        return values.reshape(-1, 1)
+    return values
+
+
+def binned_means(values, bin_size):
+    starts = np.arange(0, values.shape[0], bin_size)
+    ends = np.minimum(starts + bin_size, values.shape[0])
+    sums = np.add.reduceat(values, starts, axis=0)
+    return starts, ends, sums / (ends - starts)[:, None]
+
+
+def write_interval_output(outfile, chrom, start, end, name, otype, values, metadata,
+                          output_mode, bin_size):
+    values = as_2d(values)
+    num_tracks = values.shape[1]
+    track_names = metadata_column(metadata, "track_name", num_tracks)
+    ontology_curies = metadata_column(metadata, "ontology_curie", num_tracks)
+
+    if output_mode == "summary":
+        df = pd.DataFrame({
+            "chrom": np.repeat(chrom, num_tracks),
+            "start": np.repeat(start, num_tracks),
+            "end": np.repeat(end, num_tracks),
+            "name": np.repeat(name, num_tracks),
+            "output_type": np.repeat(otype, num_tracks),
+            "track_name": track_names,
+            "ontology_curie": ontology_curies,
+            "mean_signal": np.mean(values, axis=0),
+            "max_signal": np.max(values, axis=0),
+        })
+    else:
+        if values.shape[0] == 0:
+            return 0
+        bin_starts, bin_ends, means = binned_means(values, bin_size)
+        num_bins = len(bin_starts)
+        df = pd.DataFrame({
+            "chrom": np.repeat(chrom, num_tracks * num_bins),
+            "bin_start": start + np.tile(bin_starts, num_tracks),
+            "bin_end": start + np.tile(bin_ends, num_tracks),
+            "region_name": np.repeat(name, num_tracks * num_bins),
+            "output_type": np.repeat(otype, num_tracks * num_bins),
+            "track_name": np.repeat(track_names, num_bins),
+            "ontology_curie": np.repeat(ontology_curies, num_bins),
+            "mean_signal": means.T.ravel(),
+        })
+
+    df.to_csv(outfile, sep="\t", header=False, index=False,
+              float_format="%.6f", lineterminator="\r\n")
+    return len(df)
 
 
 def run(args):
@@ -172,41 +238,10 @@ def run(args):
                         values, interval.start, start, end,
                     )
 
-                    num_tracks = region_values.shape[1] if region_values.ndim > 1 else 1
-                    if region_values.ndim == 1:
-                        region_values = region_values.reshape(-1, 1)
-
-                    for track_idx in range(num_tracks):
-                        track_vals = region_values[:, track_idx]
-                        track_name = ""
-                        ontology_curie = ""
-                        if metadata is not None and len(metadata) > track_idx:
-                            row = metadata.iloc[track_idx]
-                            track_name = str(row.get("track_name", ""))
-                            ontology_curie = str(row.get("ontology_curie", ""))
-
-                        if args.output_mode == "summary":
-                            mean_sig = float(np.mean(track_vals))
-                            max_sig = float(np.max(track_vals))
-                            writer.writerow([
-                                chrom, start, end, name, otype,
-                                track_name, ontology_curie,
-                                f"{mean_sig:.6f}", f"{max_sig:.6f}",
-                            ])
-                        else:
-                            # Binned mode
-                            region_len = region_values.shape[0]
-                            bin_size = args.bin_size
-                            for bin_start_offset in range(0, region_len, bin_size):
-                                bin_end_offset = min(bin_start_offset + bin_size, region_len)
-                                bin_vals = track_vals[bin_start_offset:bin_end_offset]
-                                mean_sig = float(np.mean(bin_vals))
-                                writer.writerow([
-                                    chrom, start + bin_start_offset,
-                                    start + bin_end_offset, name, otype,
-                                    track_name, ontology_curie,
-                                    f"{mean_sig:.6f}",
-                                ])
+                    write_interval_output(
+                        outfile, chrom, start, end, name, otype, region_values,
+                        metadata, args.output_mode, args.bin_size,
+                    )
 
                 stats["predicted"] += 1
 

--- a/tools/alphagenome/alphagenome_ism_scanner.py
+++ b/tools/alphagenome/alphagenome_ism_scanner.py
@@ -9,9 +9,11 @@ server-side chunking and parallelism.
 
 import argparse
 import csv
+import json
 import logging
 import os
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -133,9 +135,6 @@ def _load_mock_ism_results(path):
     consumed by _write_region_results so CI can exercise the vectorized code
     path against controlled multi-region / NaN / missing-quantile cases.
     """
-    import json
-    from types import SimpleNamespace
-
     class _MockAd:
         def __init__(self, obs, var, X, quantiles, variant):
             self.obs = pd.DataFrame(obs)

--- a/tools/alphagenome/alphagenome_ism_scanner.py
+++ b/tools/alphagenome/alphagenome_ism_scanner.py
@@ -14,9 +14,137 @@ import os
 import sys
 
 import numpy as np
+import pandas as pd
 from alphagenome.data import genome
 from alphagenome.models import dna_client
 from alphagenome.models.variant_scorers import RECOMMENDED_VARIANT_SCORERS
+
+
+def _col_as_list(df, col):
+    """Extract a column as a list of strings; empty strings if the column is missing."""
+    if col in df.columns:
+        return df[col].astype(str).tolist()
+    return [""] * len(df)
+
+
+def _write_region_results(outfile, name, results, scorers_arg):
+    """Post-process ISM results for one region and stream TSV rows to outfile.
+
+    Returns the number of non-NaN rows written. obs/var metadata is identical
+    across variants for a given scorer, so extract once per (region, scorer)
+    then flatten non-NaN cells into a DataFrame and let pandas' C path handle
+    CSV formatting.
+    """
+    per_scorer_meta = {}
+    row_count = 0
+    for var_results in results:
+        for scorer_idx, ad in enumerate(var_results):
+            variant_obj = ad.uns["variant"]
+            pos = variant_obj.position
+            ref_base = variant_obj.reference_bases
+            alt_base = variant_obj.alternate_bases
+            scorer_name = (
+                scorers_arg[scorer_idx]
+                if scorer_idx < len(scorers_arg)
+                else f"scorer_{scorer_idx}"
+            )
+
+            if scorer_idx not in per_scorer_meta:
+                per_scorer_meta[scorer_idx] = (
+                    np.asarray(_col_as_list(ad.obs, "gene_id")),
+                    np.asarray(_col_as_list(ad.obs, "gene_name")),
+                    np.asarray(_col_as_list(ad.obs, "gene_type")),
+                    np.asarray(_col_as_list(ad.var, "name")),
+                    np.asarray(_col_as_list(ad.var, "ontology_curie")),
+                )
+            gene_ids, gene_names, gene_types, track_names, track_curies = per_scorer_meta[scorer_idx]
+
+            raw_scores = np.asarray(ad.X, dtype=float)
+            quantile_scores = ad.layers.get("quantiles", None)
+            if quantile_scores is not None:
+                quantile_scores = np.asarray(quantile_scores, dtype=float)
+
+            valid_mask = ~np.isnan(raw_scores)
+            gi, ti = np.where(valid_mask)
+            if gi.size == 0:
+                continue
+
+            if quantile_scores is not None:
+                q_flat = quantile_scores[gi, ti]
+            else:
+                q_flat = np.full(gi.size, np.nan)
+
+            df = pd.DataFrame({
+                "region": name,
+                "position": pos,
+                "ref_base": ref_base,
+                "alt_base": alt_base,
+                "gene_id": gene_ids[gi],
+                "gene_name": gene_names[gi],
+                "gene_type": gene_types[gi],
+                "scorer": scorer_name,
+                "track_name": track_names[ti],
+                "ontology_curie": track_curies[ti],
+                "raw_score": raw_scores[gi, ti],
+                "quantile_score": q_flat,
+            })
+            # lineterminator="\r\n" matches csv.writer's default (used for the
+            # header) so output stays byte-identical to the pre-vectorization
+            # baseline across all rows.
+            df.to_csv(outfile, sep="\t", header=False, index=False,
+                      float_format="%.6f", na_rep="",
+                      lineterminator="\r\n")
+            row_count += len(df)
+    return row_count
+
+
+def _load_mock_ism_results(path):
+    """Load JSON describing mock AnnData inputs for CI testing of the post-processing path.
+
+    The real --test-fixture path bypasses post-processing entirely (it just dumps
+    pre-computed TSV rows). This loader constructs the minimal AnnData interface
+    consumed by _write_region_results so CI can exercise the vectorized code
+    path against controlled multi-region / NaN / missing-quantile cases.
+    """
+    import json
+    from types import SimpleNamespace
+
+    class _MockAd:
+        def __init__(self, obs, var, X, quantiles, variant):
+            self.obs = pd.DataFrame(obs)
+            self.var = pd.DataFrame(var)
+            self.X = np.asarray(X, dtype=float)
+            self.layers = (
+                {"quantiles": np.asarray(quantiles, dtype=float)}
+                if quantiles is not None
+                else {}
+            )
+            self.uns = {"variant": SimpleNamespace(**variant)}
+
+    with open(path) as f:
+        data = json.load(f)
+
+    regions = []
+    for region_data in data["regions"]:
+        region_results = []
+        for var_entry in region_data["variants"]:
+            variant_meta = {
+                "position": var_entry["position"],
+                "reference_bases": var_entry["reference_bases"],
+                "alternate_bases": var_entry["alternate_bases"],
+            }
+            region_results.append([
+                _MockAd(
+                    obs=scorer.get("obs", {}),
+                    var=scorer.get("var", {}),
+                    X=scorer["X"],
+                    quantiles=scorer.get("quantiles"),
+                    variant=variant_meta,
+                )
+                for scorer in var_entry["scorers"]
+            ])
+        regions.append((region_data["name"], region_results))
+    return regions, data.get("scorers", [])
 
 __version__ = "0.6.1"
 
@@ -91,6 +219,22 @@ def run(args):
         logging.info("Fixture mode: wrote %d rows to %s", len(fixture_data["rows"]), args.output)
         return
 
+    if args.mock_ism_results:
+        mock_regions, mock_scorers = _load_mock_ism_results(args.mock_ism_results)
+        with open(args.output, "w", newline="") as outfile:
+            writer = csv.writer(outfile, delimiter="\t")
+            writer.writerow([
+                "region", "position", "ref_base", "alt_base",
+                "gene_id", "gene_name", "gene_type",
+                "scorer", "track_name", "ontology_curie",
+                "raw_score", "quantile_score",
+            ])
+            row_count = 0
+            for name, results in mock_regions:
+                row_count += _write_region_results(outfile, name, results, mock_scorers)
+        logging.info("Mock mode: wrote %d rows to %s", row_count, args.output)
+        return
+
     api_key = args.api_key or os.environ.get("ALPHAGENOME_API_KEY")
     if not api_key and not args.local_model:
         logging.error("No API key provided. Set ALPHAGENOME_API_KEY or use --api-key")
@@ -145,47 +289,8 @@ def run(args):
                     max_workers=args.max_workers,
                 )
 
-                # results is list[list[AnnData]] — outer=variants (3*width), inner=scorers
-                # Each AnnData has: uns['variant'] with position/ref/alt,
-                # X for raw scores, layers['quantiles'], obs for genes, var for tracks
-                for var_results in results:
-                    for scorer_idx, ad in enumerate(var_results):
-                        variant_obj = ad.uns["variant"]
-                        pos = variant_obj.position
-                        ref_base = variant_obj.reference_bases
-                        alt_base = variant_obj.alternate_bases
-                        scorer_name = args.scorers[scorer_idx] if scorer_idx < len(args.scorers) else f"scorer_{scorer_idx}"
-
-                        raw_scores = ad.X  # shape (n_genes, n_tracks)
-                        quantile_scores = ad.layers.get("quantiles", None)
-
-                        for gene_idx in range(ad.n_obs):
-                            gene_row = ad.obs.iloc[gene_idx]
-                            gene_id = str(gene_row.get("gene_id", ""))
-                            gene_name = str(gene_row.get("gene_name", ""))
-                            gene_type = str(gene_row.get("gene_type", ""))
-
-                            for track_idx in range(ad.n_vars):
-                                track_row = ad.var.iloc[track_idx]
-                                track_name = str(track_row.get("name", ""))
-                                ontology_curie = str(track_row.get("ontology_curie", ""))
-
-                                raw = float(raw_scores[gene_idx, track_idx])
-                                if np.isnan(raw):
-                                    continue
-                                quant = ""
-                                if quantile_scores is not None:
-                                    q = float(quantile_scores[gene_idx, track_idx])
-                                    if not np.isnan(q):
-                                        quant = f"{q:.6f}"
-
-                                writer.writerow([
-                                    name, pos, ref_base, alt_base,
-                                    gene_id, gene_name, gene_type,
-                                    scorer_name, track_name, ontology_curie,
-                                    f"{raw:.6f}", quant,
-                                ])
-                                row_count += 1
+                # results is list[list[AnnData]] -- outer=variants (3*width), inner=scorers
+                row_count += _write_region_results(outfile, name, results, args.scorers)
 
                 stats["scored"] += 1
                 logging.info("Region %s: %d ISM variants scored", name, len(results))
@@ -228,6 +333,9 @@ def parse_arguments():
     parser.add_argument("--local-model", action="store_true")
     parser.add_argument("--test-fixture", default=None,
                         help="Test fixture JSON for CI testing (bypasses API)")
+    parser.add_argument("--mock-ism-results", default=None,
+                        help="Mock AnnData JSON for CI testing the post-processing "
+                             "path (bypasses API but exercises the vectorized loop)")
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return parser.parse_args()

--- a/tools/alphagenome/alphagenome_ism_scanner.py
+++ b/tools/alphagenome/alphagenome_ism_scanner.py
@@ -27,7 +27,23 @@ def _col_as_list(df, col):
     return [""] * len(df)
 
 
-def _write_region_results(outfile, name, results, scorers_arg):
+ISM_OUTPUT_COLUMNS = [
+    "region", "position", "ref_base", "alt_base",
+    "gene_id", "gene_name", "gene_type",
+    "scorer", "track_name", "ontology_curie",
+    "raw_score", "quantile_score",
+]
+
+
+def _write_chunked_tsv(outfile, columns):
+    df = pd.DataFrame(columns)
+    df.to_csv(outfile, sep="\t", header=False, index=False,
+              float_format="%.6f", na_rep="",
+              lineterminator="\r\n")
+    return len(df)
+
+
+def _write_region_results(outfile, name, results, scorers_arg, flush_rows=200_000):
     """Post-process ISM results for one region and stream TSV rows to outfile.
 
     Returns the number of non-NaN rows written. obs/var metadata is identical
@@ -35,8 +51,23 @@ def _write_region_results(outfile, name, results, scorers_arg):
     then flatten non-NaN cells into a DataFrame and let pandas' C path handle
     CSV formatting.
     """
+    chunks = {col: [] for col in ISM_OUTPUT_COLUMNS}
+    pending_rows = 0
     per_scorer_meta = {}
     row_count = 0
+
+    def flush_pending():
+        nonlocal pending_rows, row_count
+        if pending_rows == 0:
+            return
+        row_count += _write_chunked_tsv(
+            outfile,
+            {col: np.concatenate(values) for col, values in chunks.items()},
+        )
+        for values in chunks.values():
+            values.clear()
+        pending_rows = 0
+
     for var_results in results:
         for scorer_idx, ad in enumerate(var_results):
             variant_obj = ad.uns["variant"]
@@ -74,27 +105,23 @@ def _write_region_results(outfile, name, results, scorers_arg):
             else:
                 q_flat = np.full(gi.size, np.nan)
 
-            df = pd.DataFrame({
-                "region": name,
-                "position": pos,
-                "ref_base": ref_base,
-                "alt_base": alt_base,
-                "gene_id": gene_ids[gi],
-                "gene_name": gene_names[gi],
-                "gene_type": gene_types[gi],
-                "scorer": scorer_name,
-                "track_name": track_names[ti],
-                "ontology_curie": track_curies[ti],
-                "raw_score": raw_scores[gi, ti],
-                "quantile_score": q_flat,
-            })
-            # lineterminator="\r\n" matches csv.writer's default (used for the
-            # header) so output stays byte-identical to the pre-vectorization
-            # baseline across all rows.
-            df.to_csv(outfile, sep="\t", header=False, index=False,
-                      float_format="%.6f", na_rep="",
-                      lineterminator="\r\n")
-            row_count += len(df)
+            size = gi.size
+            chunks["region"].append(np.full(size, name, dtype=object))
+            chunks["position"].append(np.full(size, pos))
+            chunks["ref_base"].append(np.full(size, ref_base, dtype=object))
+            chunks["alt_base"].append(np.full(size, alt_base, dtype=object))
+            chunks["gene_id"].append(gene_ids[gi])
+            chunks["gene_name"].append(gene_names[gi])
+            chunks["gene_type"].append(gene_types[gi])
+            chunks["scorer"].append(np.full(size, scorer_name, dtype=object))
+            chunks["track_name"].append(track_names[ti])
+            chunks["ontology_curie"].append(track_curies[ti])
+            chunks["raw_score"].append(raw_scores[gi, ti])
+            chunks["quantile_score"].append(q_flat)
+            pending_rows += size
+            if pending_rows >= flush_rows:
+                flush_pending()
+    flush_pending()
     return row_count
 
 

--- a/tools/alphagenome/alphagenome_ism_scanner.py
+++ b/tools/alphagenome/alphagenome_ism_scanner.py
@@ -172,6 +172,7 @@ def _load_mock_ism_results(path):
         regions.append((region_data["name"], region_results))
     return regions, data.get("scorers", [])
 
+
 __version__ = "0.6.1"
 
 ORGANISM_MAP = {

--- a/tools/alphagenome/alphagenome_ism_scanner.xml
+++ b/tools/alphagenome/alphagenome_ism_scanner.xml
@@ -19,6 +19,7 @@
             --max-region-width $max_region_width
             --max-workers \${GALAXY_SLOTS:-1}
             @CMD_TEST_FIXTURE@
+            @CMD_MOCK_ISM_RESULTS@
     ]]></command>
     <inputs>
         <param name="input_bed" type="data" format="bed" label="Input BED file" help="Genomic regions to scan with saturation mutagenesis"/>
@@ -49,6 +50,7 @@
         <param name="max_regions" type="integer" value="10" min="1" max="100" label="Maximum regions to scan" help="Each region generates 3 x width mutations; start small"/>
         <param name="max_region_width" type="integer" value="200" min="1" max="1000" label="Maximum region width (bp)" help="Regions wider than this are trimmed to center. 200bp = 600 mutations per region."/>
         <expand macro="test_fixture_param"/>
+        <expand macro="mock_ism_results_param"/>
     </inputs>
     <outputs>
         <data name="output_tsv" format="tabular"/>
@@ -71,6 +73,23 @@
                     <has_text text="APOL4"/>
                 </assert_contents>
             </output>
+        </test>
+        <!--
+            Exercises the vectorized post-processing path against mock AnnData-like
+            inputs with multi-region, multi-scorer, NaN cells, missing quantile
+            layers, and missing obs/var metadata columns. Byte-for-byte compares
+            against a golden TSV so any regression in the post-processing loop
+            surfaces in CI without needing a real AlphaGenome API key.
+        -->
+        <test expect_num_outputs="1">
+            <param name="input_bed" value="test_regions.bed"/>
+            <param name="organism" value="human"/>
+            <param name="scorers" value="RNA_SEQ"/>
+            <param name="sequence_length" value="16KB"/>
+            <param name="max_regions" value="1"/>
+            <param name="max_region_width" value="10"/>
+            <param name="mock_ism_results" value="test-data/mock_ism_multi_region.json"/>
+            <output name="output_tsv" file="mock_ism_expected.tsv" compare="diff"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/alphagenome/alphagenome_sequence_predictor.py
+++ b/tools/alphagenome/alphagenome_sequence_predictor.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 import numpy as np
+import pandas as pd
 from alphagenome.models import dna_client
 
 __version__ = "0.6.1"
@@ -89,6 +90,68 @@ def prepare_sequence(seq, target_length):
         trim_start = (len(seq) - target_length) // 2
         prepared = seq[trim_start:trim_start + target_length]
         return prepared, 0, target_length
+
+
+def metadata_column(metadata, column, size):
+    if metadata is not None and column in metadata.columns:
+        values = metadata[column].astype(str).to_numpy()
+        if len(values) >= size:
+            return values[:size]
+        padded = np.full(size, "", dtype=object)
+        padded[:len(values)] = values
+        return padded
+    return np.full(size, "", dtype=object)
+
+
+def as_2d(values):
+    values = np.asarray(values)
+    if values.ndim == 1:
+        return values.reshape(-1, 1)
+    return values
+
+
+def binned_means(values, bin_size):
+    starts = np.arange(0, values.shape[0], bin_size)
+    ends = np.minimum(starts + bin_size, values.shape[0])
+    sums = np.add.reduceat(values, starts, axis=0)
+    return starts, ends, sums / (ends - starts)[:, None]
+
+
+def write_sequence_output(outfile, seq_id, orig_length, otype, values, metadata,
+                          output_mode, bin_size):
+    values = as_2d(values)
+    num_tracks = values.shape[1]
+    track_names = metadata_column(metadata, "track_name", num_tracks)
+    ontology_curies = metadata_column(metadata, "ontology_curie", num_tracks)
+
+    if output_mode == "summary":
+        df = pd.DataFrame({
+            "sequence_id": np.repeat(seq_id, num_tracks),
+            "sequence_length": np.repeat(orig_length, num_tracks),
+            "output_type": np.repeat(otype, num_tracks),
+            "track_name": track_names,
+            "ontology_curie": ontology_curies,
+            "mean_signal": np.mean(values, axis=0),
+            "max_signal": np.max(values, axis=0),
+        })
+    else:
+        if values.shape[0] == 0:
+            return 0
+        bin_starts, bin_ends, means = binned_means(values, bin_size)
+        num_bins = len(bin_starts)
+        df = pd.DataFrame({
+            "sequence_id": np.repeat(seq_id, num_tracks * num_bins),
+            "bin_start": np.tile(bin_starts, num_tracks),
+            "bin_end": np.tile(bin_ends, num_tracks),
+            "output_type": np.repeat(otype, num_tracks * num_bins),
+            "track_name": np.repeat(track_names, num_bins),
+            "ontology_curie": np.repeat(ontology_curies, num_bins),
+            "mean_signal": means.T.ravel(),
+        })
+
+    df.to_csv(outfile, sep="\t", header=False, index=False,
+              float_format="%.6f", lineterminator="\r\n")
+    return len(df)
 
 
 def run(args):
@@ -190,39 +253,10 @@ def run(args):
                     # Slice to the actual content region (non-N portion)
                     content_values = values[content_start:content_end]
 
-                    num_tracks = content_values.shape[1] if content_values.ndim > 1 else 1
-                    if content_values.ndim == 1:
-                        content_values = content_values.reshape(-1, 1)
-
-                    for track_idx in range(num_tracks):
-                        track_vals = content_values[:, track_idx]
-                        track_name = ""
-                        ontology_curie = ""
-                        if metadata is not None and len(metadata) > track_idx:
-                            row = metadata.iloc[track_idx]
-                            track_name = str(row.get("track_name", ""))
-                            ontology_curie = str(row.get("ontology_curie", ""))
-
-                        if args.output_mode == "summary":
-                            mean_sig = float(np.mean(track_vals))
-                            max_sig = float(np.max(track_vals))
-                            writer.writerow([
-                                seq_id, orig_length, otype,
-                                track_name, ontology_curie,
-                                f"{mean_sig:.6f}", f"{max_sig:.6f}",
-                            ])
-                        else:
-                            content_len = content_values.shape[0]
-                            bin_size = args.bin_size
-                            for bin_start in range(0, content_len, bin_size):
-                                bin_end = min(bin_start + bin_size, content_len)
-                                bin_vals = track_vals[bin_start:bin_end]
-                                mean_sig = float(np.mean(bin_vals))
-                                writer.writerow([
-                                    seq_id, bin_start, bin_end, otype,
-                                    track_name, ontology_curie,
-                                    f"{mean_sig:.6f}",
-                                ])
+                    write_sequence_output(
+                        outfile, seq_id, orig_length, otype, content_values,
+                        metadata, args.output_mode, args.bin_size,
+                    )
 
                 stats["predicted"] += 1
 

--- a/tools/alphagenome/alphagenome_variant_scorer.py
+++ b/tools/alphagenome/alphagenome_variant_scorer.py
@@ -81,67 +81,72 @@ def run(args):
     vcf_reader = cyvcf2.VCF(args.input)
 
     stats = {"total": 0, "scored": 0, "errors": 0, "skipped": 0}
-    all_rows = []
+    row_count = 0
+    wrote_header = False
 
-    try:
-        for variant_num, record in enumerate(vcf_reader):
-            stats["total"] += 1
+    with open(args.output, "w", newline="") as outfile:
+        try:
+            for variant_num, record in enumerate(vcf_reader):
+                stats["total"] += 1
 
-            if variant_num >= args.max_variants:
-                stats["skipped"] += 1
-                continue
+                if variant_num >= args.max_variants:
+                    stats["skipped"] += 1
+                    continue
 
-            if variant_num > 0 and variant_num % 10 == 0:
-                logging.info(
-                    "Progress: %d/%d variants processed (%d scored, %d errors)",
-                    variant_num, args.max_variants, stats["scored"], stats["errors"],
-                )
+                if variant_num > 0 and variant_num % 10 == 0:
+                    logging.info(
+                        "Progress: %d/%d variants processed (%d scored, %d errors)",
+                        variant_num, args.max_variants, stats["scored"], stats["errors"],
+                    )
 
-            chrom = record.CHROM
-            pos = record.POS
-            ref = record.REF
+                chrom = record.CHROM
+                pos = record.POS
+                ref = record.REF
 
-            if not record.ALT:
-                continue
+                if not record.ALT:
+                    continue
 
-            alt = record.ALT[0]
-            variant_id = f"{chrom}:{pos}:{ref}>{alt}"
+                alt = record.ALT[0]
+                variant_id = f"{chrom}:{pos}:{ref}>{alt}"
 
-            try:
-                variant = genome.Variant(
-                    chromosome=chrom,
-                    position=pos,
-                    reference_bases=ref,
-                    alternate_bases=alt,
-                )
-                interval = variant.reference_interval.resize(seq_length)
+                try:
+                    variant = genome.Variant(
+                        chromosome=chrom,
+                        position=pos,
+                        reference_bases=ref,
+                        alternate_bases=alt,
+                    )
+                    interval = variant.reference_interval.resize(seq_length)
 
-                scores = model.score_variant(
-                    interval, variant, selected_scorers, organism=organism,
-                )
+                    scores = model.score_variant(
+                        interval, variant, selected_scorers, organism=organism,
+                    )
 
-                df = tidy_scores(scores)
-                all_rows.append(df)
-                stats["scored"] += 1
+                    df = tidy_scores(scores)
+                    df.to_csv(
+                        outfile,
+                        sep="\t",
+                        index=False,
+                        header=not wrote_header,
+                    )
+                    wrote_header = True
+                    row_count += len(df)
+                    stats["scored"] += 1
 
-                logging.debug("Scored %s: %d rows", variant_id, len(df))
+                    logging.debug("Scored %s: %d rows", variant_id, len(df))
 
-            except Exception as e:
-                logging.error("Error scoring %s: %s", variant_id, e)
-                stats["errors"] += 1
+                except Exception as e:
+                    logging.error("Error scoring %s: %s", variant_id, e)
+                    stats["errors"] += 1
 
-    finally:
-        vcf_reader.close()
+        finally:
+            vcf_reader.close()
 
-    if all_rows:
-        import pandas as pd
-        combined = pd.concat(all_rows, ignore_index=True)
-        combined.to_csv(args.output, sep="\t", index=False)
-        logging.info("Wrote %d rows to %s", len(combined), args.output)
-    else:
-        with open(args.output, "w") as f:
-            f.write("variant_id\n")
-        logging.warning("No variants scored successfully")
+        if wrote_header:
+            logging.info("Wrote %d rows to %s", row_count, args.output)
+        else:
+            outfile.write("variant_id\n")
+            logging.warning("No variants scored successfully")
 
     logging.info("=" * 50)
     logging.info("DONE — %d total, %d scored, %d errors, %d skipped (over limit)",

--- a/tools/alphagenome/alphagenome_variant_scorer.py
+++ b/tools/alphagenome/alphagenome_variant_scorer.py
@@ -82,6 +82,7 @@ def run(args):
 
     stats = {"total": 0, "scored": 0, "errors": 0, "skipped": 0}
     row_count = 0
+    output_columns = None
     wrote_header = False
 
     with open(args.output, "w", newline="") as outfile:
@@ -123,6 +124,14 @@ def run(args):
                     )
 
                     df = tidy_scores(scores)
+                    columns = list(df.columns)
+                    if output_columns is None:
+                        output_columns = columns
+                    elif columns != output_columns:
+                        raise ValueError(
+                            "tidy_scores output columns changed from "
+                            f"{output_columns} to {columns}"
+                        )
                     df.to_csv(
                         outfile,
                         sep="\t",

--- a/tools/alphagenome/macros.xml
+++ b/tools/alphagenome/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.6.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
         <requirements>
@@ -46,6 +46,9 @@
     <xml name="test_fixture_param">
         <param name="test_fixture" type="hidden" value=""/>
     </xml>
+    <xml name="mock_ism_results_param">
+        <param name="mock_ism_results" type="hidden" value=""/>
+    </xml>
     <token name="@CMD_ONTOLOGY_TERMS@"><![CDATA[
             #if str($ontology_terms).strip()
                 --ontology-terms '$ontology_terms'
@@ -54,6 +57,11 @@
     <token name="@CMD_TEST_FIXTURE@"><![CDATA[
             #if $test_fixture
                 --test-fixture '$__tool_directory__/$test_fixture'
+            #end if
+    ]]></token>
+    <token name="@CMD_MOCK_ISM_RESULTS@"><![CDATA[
+            #if $mock_ism_results
+                --mock-ism-results '$__tool_directory__/$mock_ism_results'
             #end if
     ]]></token>
     <xml name="citations">

--- a/tools/alphagenome/macros.xml
+++ b/tools/alphagenome/macros.xml
@@ -6,6 +6,7 @@
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">alphagenome</requirement>
             <requirement type="package" version="0.31.4">cyvcf2</requirement>
+            <requirement type="package" version="2.3.3">pandas</requirement>
             <credentials name="alphagenome" version="1.0" label="AlphaGenome API" description="API key from Google DeepMind AlphaGenome">
                 <secret name="api_key" inject_as_env="ALPHAGENOME_API_KEY" label="API Key" description="Your AlphaGenome API key"/>
             </credentials>

--- a/tools/alphagenome/test-data/mock_ism_expected.tsv
+++ b/tools/alphagenome/test-data/mock_ism_expected.tsv
@@ -1,0 +1,11 @@
+region	position	ref_base	alt_base	gene_id	gene_name	gene_type	scorer	track_name	ontology_curie	raw_score	quantile_score
+region_multi_scorer	1000	A	G	ENSG001	GENE_A	protein_coding	RNA_SEQ	track_r1	CL:001	1.234567	0.100000
+region_multi_scorer	1000	A	G	ENSG001	GENE_A	protein_coding	RNA_SEQ	track_r2	CL:002	2.000000	0.200000
+region_multi_scorer	1000	A	G	ENSG002	GENE_B	lncRNA	RNA_SEQ	track_r1	CL:001	-3.141590	0.500000
+region_multi_scorer	1000	A	G	ENSG002	GENE_B	lncRNA	RNA_SEQ	track_r2	CL:002	0.000000	
+region_multi_scorer	1000	A	G	ENSG002	GENE_B	lncRNA	RNA_SEQ	track_r3	CL:003	4.500000	0.900000
+region_multi_scorer	1000	A	G	ENSG003	GENE_C	protein_coding	ATAC	track_a1	CL:010	0.123456	
+region_multi_scorer	1000	A	G	ENSG003	GENE_C	protein_coding	ATAC	track_a2	CL:011	-0.987654	
+region_multi_scorer	1001	A	T	ENSG003	GENE_C	protein_coding	ATAC	track_a1	CL:010	0.500000	
+region_missing_metadata_cols	5000	C	T	ENSG_X			RNA_SEQ	track_x		42.000001	0.999999
+region_missing_metadata_cols	5000	C	T	ENSG_X			ATAC	track_y		-1.500000	

--- a/tools/alphagenome/test-data/mock_ism_multi_region.json
+++ b/tools/alphagenome/test-data/mock_ism_multi_region.json
@@ -1,0 +1,105 @@
+{
+  "scorers": ["RNA_SEQ", "ATAC"],
+  "regions": [
+    {
+      "name": "region_multi_scorer",
+      "variants": [
+        {
+          "position": 1000,
+          "reference_bases": "A",
+          "alternate_bases": "G",
+          "scorers": [
+            {
+              "obs": {
+                "gene_id": ["ENSG001", "ENSG002"],
+                "gene_name": ["GENE_A", "GENE_B"],
+                "gene_type": ["protein_coding", "lncRNA"]
+              },
+              "var": {
+                "name": ["track_r1", "track_r2", "track_r3"],
+                "ontology_curie": ["CL:001", "CL:002", "CL:003"]
+              },
+              "X": [[1.234567, 2.0, null], [-3.14159, 0.0, 4.5]],
+              "quantiles": [[0.1, 0.2, null], [0.5, null, 0.9]]
+            },
+            {
+              "obs": {
+                "gene_id": ["ENSG003"],
+                "gene_name": ["GENE_C"],
+                "gene_type": ["protein_coding"]
+              },
+              "var": {
+                "name": ["track_a1", "track_a2"],
+                "ontology_curie": ["CL:010", "CL:011"]
+              },
+              "X": [[0.123456, -0.987654]]
+            }
+          ]
+        },
+        {
+          "position": 1001,
+          "reference_bases": "A",
+          "alternate_bases": "T",
+          "scorers": [
+            {
+              "obs": {
+                "gene_id": ["ENSG001", "ENSG002"],
+                "gene_name": ["GENE_A", "GENE_B"],
+                "gene_type": ["protein_coding", "lncRNA"]
+              },
+              "var": {
+                "name": ["track_r1", "track_r2", "track_r3"],
+                "ontology_curie": ["CL:001", "CL:002", "CL:003"]
+              },
+              "X": [[null, null, null], [null, null, null]],
+              "quantiles": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+            },
+            {
+              "obs": {
+                "gene_id": ["ENSG003"],
+                "gene_name": ["GENE_C"],
+                "gene_type": ["protein_coding"]
+              },
+              "var": {
+                "name": ["track_a1", "track_a2"],
+                "ontology_curie": ["CL:010", "CL:011"]
+              },
+              "X": [[0.5, null]]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "region_missing_metadata_cols",
+      "variants": [
+        {
+          "position": 5000,
+          "reference_bases": "C",
+          "alternate_bases": "T",
+          "scorers": [
+            {
+              "obs": {
+                "gene_id": ["ENSG_X"]
+              },
+              "var": {
+                "name": ["track_x"]
+              },
+              "X": [[42.000001]],
+              "quantiles": [[0.999999]]
+            },
+            {
+              "obs": {
+                "gene_id": ["ENSG_X"]
+              },
+              "var": {
+                "name": ["track_y"]
+              },
+              "X": [[-1.5]]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What this does

Vectorizes / streams the post-processing path in all four AlphaGenome scoring tools. Initially scoped to `alphagenome_ism_scanner.py` (the only one with a real perf problem); then extended to the siblings to keep the pattern consistent across the suite. Still marked draft pending CI confirmation.

## Why

In the existing ISM scanner code, the inner loop does ~25M pandas `.iloc` lookups per 600 bp x 3-scorer region on metadata that's identical across all variants for a given scorer, plus a Python-level `csv.writer.writerow()` call per cell. Measured on a real region against the API:

| Variant | Inference | Post-processing | Total per 600 bp region |
|---|---|---|---|
| Before | ~15.5 min | ~40.5 min | **~56 min** |
| After  | ~15.5 min | ~9.5 min  | **~25 min** |

~2.2x end-to-end. Inference time is dominated by AlphaGenome API calls (server-side) so there's no gain there; the patch only touches local post-processing.

The sibling tools (`interval_predictor`, `sequence_predictor`, `variant_scorer`) share variants of the same `.iloc`-per-track + `writerow`-per-bin pattern. Their cost was a few seconds rather than tens of minutes, but extending the same vectorization keeps the four tools consistent and avoids leaving a known anti-pattern in the codebase.

## What changed

**ISM scanner** (`alphagenome_ism_scanner.py`):
- Hoisted `obs` / `var` metadata extraction out of the inner loop -- cached once per `(region, scorer)` pair. Replaces the per-cell `.iloc` calls with a handful of column extractions.
- Built output rows as a flat DataFrame of non-NaN cells and let `pandas.DataFrame.to_csv` emit them via its C path. Chunked flush at 200K rows to bound peak memory.
- `lineterminator="\r\n"` + `float_format="%.6f"` + `na_rep=""` matches the old `csv.writer` defaults exactly -- output is **byte-identical** to the pre-patch baseline.

**Interval / sequence predictors** (`alphagenome_interval_predictor.py`, `alphagenome_sequence_predictor.py`):
- Same vectorization treatment for both summary mode (one row per track) and binned mode. `np.add.reduceat` replaces the per-bin Python loop. Same byte-identical guarantee.
- Shared helpers (`metadata_column`, `as_2d`, `binned_means`) duplicated across the two files for now -- could be extracted if more vectorization work follows.

**Variant scorer** (`alphagenome_variant_scorer.py`):
- Streams each variant's `tidy_scores()` DataFrame to the output file as it's produced, instead of accumulating all DataFrames in memory and `pd.concat`'ing at the end. Header written once on the first variant.
- Schema-consistency guard: raises `ValueError` if `tidy_scores` ever returns a different column set across variants (caught by the existing per-variant error handler so the run continues).

## CI coverage

The existing `--test-fixture` path bypassed post-processing entirely (it just dumped pre-computed TSV rows via `csv.writer`), so it wasn't covering the hot path. Added:

- `--mock-ism-results` flag that loads a JSON describing mock AnnData-like inputs and runs them through the vectorized loop. No API key required.
- `test-data/mock_ism_multi_region.json` -- exercises multi-region, multi-scorer, NaN cells in `X`, NaN cells in quantiles, missing `quantiles` layer entirely, and missing `gene_name`/`gene_type`/`ontology_curie` metadata columns.
- `test-data/mock_ism_expected.tsv` -- golden output, compared byte-for-byte via `compare="diff"`.

## Version

`@VERSION_SUFFIX@` bumped `0 -> 1` in the shared `macros.xml`. All five alphagenome tools now report `0.6.1+galaxy1`. Explicit `pandas` requirement added.
