### PR TITLE
bedtools: remove lint skip file

### DIFF
--- a/tools/bedtools/.lint_skip
+++ b/tools/bedtools/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation


### PR DESCRIPTION
seems that it was forgotten to remove

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
