### PR TITLE
checkm2: fix linter errors

### DIFF
--- a/tools/checkm2/.lint_skip
+++ b/tools/checkm2/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/checkm2/checkm2.xml
+++ b/tools/checkm2/checkm2.xml
@@ -90,7 +90,7 @@
         <test expect_exit_code="1" expect_failure="true">
             <param name="input" value="test1.faa,test2.faa"/>
             <param name="model" value="--allmodels"/>
-            <param name="genes" value="--genes"/>
+            <param name="genes" value="true"/>
             <param name="ttable" value="13"/>
             <!-- <output name="quality">
                 <assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
