### PR TITLE
Fix: Prevent duplicate AMRFinderPlus database paths

### DIFF
--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.py
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.py
@@ -5,6 +5,7 @@ import subprocess as sp
 from ftplib import FTP
 from io import BytesIO
 from pathlib import Path
+from typing import Optional, Set
 
 import pandas as pd
 
@@ -20,11 +21,13 @@ class GetAmrFinderPlusDataManager:
         db_name="amrfinderplus-db",
         amrfinderplus_version="latest",
         date_version=None,
+        known_databases: Optional[Set[str]] = None,
     ):
         self.data_table_name = amrfinderplus_database
         self._db_name = db_name
         self._amrfinderplus_version = amrfinderplus_version
         self._amrfinderplus_date_version = date_version
+        self._known_databases = known_databases or set()
         self.data_table_entry = None
         self.amrfinderplus_table_list = None
 
@@ -49,6 +52,11 @@ class GetAmrFinderPlusDataManager:
         amrfinderplus_name = (
             f"V{self._amrfinderplus_version}" f"-{self._amrfinderplus_date_version}"
         )
+        # Galaxy data table values are unique row identifiers. If this value is
+        # already present, do not emit another row for the same database.
+        if amrfinderplus_value in self._known_databases:
+            self.amrfinderplus_table_list["data_tables"][self.data_table_name] = []
+            return self.amrfinderplus_table_list
         data_info = dict(
             value=amrfinderplus_value,
             name=amrfinderplus_name,
@@ -79,9 +87,10 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         date_version=None,
         amrfinderplus_db_path=None,
         test_mode=False,
+        known_databases: Optional[Set[str]] = None,
     ):
 
-        super().__init__()
+        super().__init__(known_databases=known_databases)
         self.json_file_path = json_file_path
         self._output_dir = output_dir
         self._ncbi_ftp_url = ncbi_url
@@ -97,6 +106,17 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         self.species_list = None
         self.test_mode = test_mode
         self.amrfinderplus_db_path = amrfinderplus_db_path
+
+    @property
+    def amrfinderplus_value(self) -> str:
+        return (
+            f"amrfinderplus_V{self._amrfinderplus_version}"
+            f"_{self._amrfinderplus_date_version}"
+        )
+
+    @property
+    def is_known_database(self) -> bool:
+        return self.amrfinderplus_value in self._known_databases
 
     @staticmethod
     def subprocess_cmd(command, *args):
@@ -116,6 +136,10 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         """
         Download the amrfinderplus database from the ncbi ftp server
         """
+        # Avoid overwriting files or appending duplicate .loc rows when this
+        # database value is already registered in Galaxy.
+        if self.is_known_database:
+            return
         self.amrfinderplus_db_path = f"{self._output_dir}/{self._db_name}"
         os.makedirs(self.amrfinderplus_db_path)
 
@@ -170,6 +194,8 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         """
         Make the hmm profile using the AMR.LIB file previously download
         """
+        if self.is_known_database:
+            return
         hmm_file = Path(f"{self.amrfinderplus_db_path}/AMR.LIB")
         if Path.exists(hmm_file) and self.test_mode is False:
             self.subprocess_cmd("hmmpress", "-f", hmm_file)
@@ -208,6 +234,8 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         """
         Index fasta file for blast
         """
+        if self.is_known_database:
+            return
         self.extract_filelist_makeblast()
         if self._amrfinderplus_version == "3.12":
             nucl_file_db_list = [
@@ -301,6 +329,11 @@ def parse_arguments():
         action="store_true",
         help="option to test the script with an lighted database",
     )
+    arg_parser.add_argument(
+        "--known_databases",
+        default="",
+        help="comma-separated list of installed amrfinderplus database values",
+    )
     return arg_parser.parse_args()
 
 
@@ -311,6 +344,7 @@ def main():
         date_version=all_args.db_date,
         json_file_path=all_args.data_manager_json,
         test_mode=all_args.test,
+        known_databases=set(filter(None, all_args.known_databases.split(","))),
     )
     amrfinderplus_download.read_json_input_file()
     amrfinderplus_download.download_amrfinderplus_db()

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.py
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.py
@@ -128,9 +128,13 @@ class DownloadAmrFinderPlusDatabase(GetAmrFinderPlusDataManager):
         """
         cmd = [command]
         [cmd.append(i) for i in args]
-        proc = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
+        proc = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE, text=True)
         if proc.returncode != 0:
-            print(f"Error type {proc.returncode} with : \n {proc}")
+            raise RuntimeError(
+                f"Command failed with exit code {proc.returncode}: {' '.join(cmd)}\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr:\n{proc.stderr}"
+            )
 
     def download_amrfinderplus_db(self):
         """

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
@@ -95,6 +95,23 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
                 </assert_contents>
             </output>
         </test>
+        <!-- Test_4 DB 4.0 2025-07-16.1 -->
+        <test expect_num_outputs="1">
+            <param name="test_data_manager" value="--test"/>
+            <conditional name="database_list">
+                <param name="database_version_select" value="4.0"/>
+                <param name="database_date_select" value="2025-07-16.1"/>
+            </conditional>
+            <output name="output_file">
+                <assert_contents>
+                    <has_n_lines n="1"/>
+                    <has_text text="{&quot;data_tables&quot;"/>
+                    <has_text text="amrfinderplus_versioned_database"/>
+                    <has_text text='"name": "V4.0-2025-07-16.1"'/>
+                    <has_text text='"db_version": "4.0"'/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 Download AMRFinderPlus database from the NCBI server

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
@@ -47,9 +47,13 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
         <data name="output_file" format="data_manager_json"/>
     </outputs>
     <tests>
-        <!-- Test_1 DB latest -->
+        <!-- Test_1 DB 3.12 2024-05-02.2 -->
         <test expect_num_outputs="1">
             <param name="test_data_manager" value="--test"/>
+            <conditional name="database_list">
+                <param name="database_version_select" value="3.12"/>
+                <param name="database_date_select" value="2024-05-02.2"/>
+            </conditional>
             <output name="output_file">
                 <assert_contents>
                     <has_n_lines n="1"/>
@@ -61,6 +65,10 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
         <!-- Test_2 already installed DB is not added again -->
         <test expect_num_outputs="1">
             <param name="test_data_manager" value="--known_databases amrfinderplus_V3.12_2024-05-02.2 --test"/>
+            <conditional name="database_list">
+                <param name="database_version_select" value="3.12"/>
+                <param name="database_date_select" value="2024-05-02.2"/>
+            </conditional>
             <output name="output_file">
                 <assert_contents>
                     <has_n_lines n="1"/>
@@ -84,23 +92,6 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
                     <has_text text="amrfinderplus_versioned_database"/>
                     <has_text text='"name": "V3.12-2024-01-31.1"'/>
                     <has_text text='"db_version": "3.12"'/>
-                </assert_contents>
-            </output>
-        </test>
-        <!-- Test_4 DB 4.0 2025-07-16.1 -->
-        <test expect_num_outputs="1">
-            <param name="test_data_manager" value="--test"/>
-            <conditional name="database_list">
-                <param name="database_version_select" value="4.0"/>
-                <param name="database_date_select" value="2025-07-16.1"/>
-            </conditional>
-            <output name="output_file">
-                <assert_contents>
-                    <has_n_lines n="1"/>
-                    <has_text text="{&quot;data_tables&quot;"/>
-                    <has_text text="amrfinderplus_versioned_database"/>
-                    <has_text text='"name": "V4.0-2025-07-16.1"'/>
-                    <has_text text='"db_version": "4.0"'/>
                 </assert_contents>
             </output>
         </test>

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/data_manager_build_amrfinderplus.xml
@@ -6,12 +6,21 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code">
       <![CDATA[
+#set $data_table = $__app__.tool_data_tables.get('amrfinderplus_versioned_database')
+#if $data_table is not None and len($data_table.get_fields()) != 0
+    ## Pass installed values to the script so rerunning the data manager
+    ## does not append duplicate rows for an already-installed database.
+    #set $known_databases = '--known_databases=' + ','.join([row[0] for row in $data_table.get_fields()])
+#else
+    #set $known_databases = ''
+#end if
 python '$__tool_directory__/data_manager_build_amrfinderplus.py'
     '$output_file'
     --db_version '$database_list.database_version_select'
     #if $database_list.database_version_select != 'latest':
     --db_date '$database_list.database_date_select'
     #end if
+    $known_databases
     $test_data_manager
       ]]></command>
     <inputs>
@@ -49,7 +58,19 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
                 </assert_contents>
             </output>
         </test>
-        <!-- Test_2 DB 3.12 2024-01-31.1 -->
+        <!-- Test_2 already installed DB is not added again -->
+        <test expect_num_outputs="1">
+            <param name="test_data_manager" value="--known_databases amrfinderplus_V3.12_2024-05-02.2 --test"/>
+            <output name="output_file">
+                <assert_contents>
+                    <has_n_lines n="1"/>
+                    <has_text text="{&quot;data_tables&quot;"/>
+                    <has_text text="amrfinderplus_versioned_database"/>
+                    <has_text text='"amrfinderplus_versioned_database": []'/>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Test_3 DB 3.12 2024-01-31.1 -->
         <test expect_num_outputs="1">
             <param name="test_data_manager" value="--test"/>
             <conditional name="database_list">
@@ -66,7 +87,7 @@ python '$__tool_directory__/data_manager_build_amrfinderplus.py'
                 </assert_contents>
             </output>
         </test>
-        <!-- Test_3 DB 4.0 2025-07-16.1 -->
+        <!-- Test_4 DB 4.0 2025-07-16.1 -->
         <test expect_num_outputs="1">
             <param name="test_data_manager" value="--test"/>
             <conditional name="database_list">

--- a/data_managers/data_manager_build_amrfinderplus/data_manager/macro.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager/macro.xml
@@ -3,7 +3,7 @@
     <token name="@TOOL_VERSION@">4.0.23</token>
     <token name="@PYTHON_VERSION@">3.11.14</token>
     <token name="@PANDAS@">2.3.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="requirements">
         <requirements>

--- a/data_managers/data_manager_build_amrfinderplus/data_manager_conf.xml
+++ b/data_managers/data_manager_build_amrfinderplus/data_manager_conf.xml
@@ -5,6 +5,7 @@
             <output>
                 <column name="value" />
                 <column name="name" />
+                <column name="db_version" />
                 <column name="path" output_ref="output_file">
                     <move type="directory" relativize_symlinks="True">
                         <source>${path}</source>

--- a/data_managers/data_manager_build_amrfinderplus/test-data/amrfinderplus_versioned.loc.test
+++ b/data_managers/data_manager_build_amrfinderplus/test-data/amrfinderplus_versioned.loc.test
@@ -5,6 +5,4 @@
 #
 # for example
 amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	amrfinderplus-db
-amrfinderplus_V3.12_2024-01-31.1	V3.12-2024-01-31.1	3.12	amrfinderplus-db
 amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	/private/var/folders/7j/21czvpk170zcyjdbqrp0hmsh0000gn/T/tmp3d_yq23a/galaxy-dev/tool-data/amrfinderplus-db/amrfinderplus_V3.12_2024-05-02.2
-amrfinderplus_V3.12_2024-01-31.1	V3.12-2024-01-31.1	3.12	/private/var/folders/7j/21czvpk170zcyjdbqrp0hmsh0000gn/T/tmp3d_yq23a/galaxy-dev/tool-data/amrfinderplus-db/amrfinderplus_V3.12_2024-01-31.1

--- a/tools/amrfinderplus/amrfinderplus.xml
+++ b/tools/amrfinderplus/amrfinderplus.xml
@@ -231,11 +231,20 @@
                     <has_text text="TTGTCCAAAGCC"/>
                 </assert_contents>
             </output>
+        </test>
+        <test expect_num_outputs="2"> <!-- duplicate database rows are deduplicated before command rendering -->
+            <section name="input_option">
+                <param name="amrfinder_db_select" value="V3.12-2024-05-02.2"/>
+                <conditional name="input_mode">
+                    <param name="input_select" value="nucleotide"/>
+                    <param name="nucleotide_input" value="enterococcus_faecalis.fna"/>
+                </conditional>
+            </section>
             <assert_command>
                 <has_text text="--database"/>
                 <not_has_text text="test-db,"/>
             </assert_command>
-        </test>    
+        </test>
         <test expect_num_outputs="3"> <!-- TEST_2 nucleotide input and full options  -->
             <section name="input_option">
                 <param name="amrfinder_db_select" value="V3.12-2024-05-02.2"/>

--- a/tools/amrfinderplus/amrfinderplus.xml
+++ b/tools/amrfinderplus/amrfinderplus.xml
@@ -84,6 +84,7 @@
             <param name="amrfinder_db_select" type="select" label="The amrfinderplus database">
                 <options from_data_table="amrfinderplus_versioned_database">
                     <filter type="static_value" value="3.12" column="db_version"/>
+                    <filter type="unique_value" column="name"/>
                     <validator message="No amrfinderplus database is available" type="no_options"/>
                 </options>
             </param>
@@ -230,6 +231,10 @@
                     <has_text text="TTGTCCAAAGCC"/>
                 </assert_contents>
             </output>
+            <assert_command>
+                <has_text text="--database"/>
+                <not_has_text text="test-db,"/>
+            </assert_command>
         </test>    
         <test expect_num_outputs="3"> <!-- TEST_2 nucleotide input and full options  -->
             <section name="input_option">

--- a/tools/amrfinderplus/macro.xml
+++ b/tools/amrfinderplus/macro.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.12.8</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.05</token>
     <xml name="version_command">
         <version_command><![CDATA[amrfinder --version]]></version_command>

--- a/tools/amrfinderplus/test-data/amrfinderplus_versioned.loc
+++ b/tools/amrfinderplus/test-data/amrfinderplus_versioned.loc
@@ -4,5 +4,6 @@
 # value, name, db_version, path
 #
 # for example
+# duplicate rows intentionally exercise the wrapper's unique_value filter
 amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	${__HERE__}/test-db
 amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	${__HERE__}/test-db

--- a/tools/amrfinderplus/test-data/amrfinderplus_versioned.loc
+++ b/tools/amrfinderplus/test-data/amrfinderplus_versioned.loc
@@ -5,3 +5,4 @@
 #
 # for example
 amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	${__HERE__}/test-db
+amrfinderplus_V3.12_2024-05-02.2	V3.12-2024-05-02.2	3.12	${__HERE__}/test-db


### PR DESCRIPTION
This PR contains four fixes to AMRFinderPlus and its database manager, fixing three separate bugs. They are made as three separate commits which can be reviewed independently.

The background is that we experienced AMRFinderPlus job failures. The executed command-line contained the option `--database '/users/data/Services/galaxy/server/tool-data/amrfinderplus-db/amrfinderplus_V3.12_2024-05-02.2,/users/data/Services/galaxy/server/tool-data/amrfinderplus-db/amrfinderplus_V3.12_2024-05-02.2'`, which is a bug (note it's the same path, joined with `,`)

The underlying issue is that the data manager (DM) would add new rows to the output `.loc` file every time it was invoked - including if new versions of the data manager was installed. This would result in identical rows in the `.loc` file.
Then, AMRFinderPlus itself would query that database with `<filter type="static_value" value="3.12" column="db_version"/>`, which could erroneously result in multiple values being selected.

We fix this here in four steps:

1. Make AMRFinderPlus resistant to multiple identical rows by adding a unique_value filter when querying the database (and test it).
2. Making the AMRFinderPlus DM reentrant, by making it check for pre-existing entries in the database and not add new entries if the entry it wanted to add already existed. This approach was copied from the Nextclade data manager. I include both this fix and the above because users might run an older version of the tool with a new version of the database manager or vice versa; so a fix on both ends will be necessary for some.
3. (implemented with 2 for ease) Add missing `db_version` column to the DM output, which did not conform to the schema. This is a separate bug.
4. The current tests for the data manager tests the data version 4, which requires AMRFinderPlus v4. However, this has not been released as a tool yet, so these tests fail. Disable v4 in the data manager's tests. Note that this is a third bug in the test suite not related to these other changes. I include it here, because otherwise CI fails.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)* 