### PR TITLE
raxmlng - tool version and version suffix exist now only in macros

### DIFF
--- a/tools/raxmlng/raxmlng.xml
+++ b/tools/raxmlng/raxmlng.xml
@@ -1,8 +1,6 @@
 <tool id="raxmlng" name="RAxML-NG" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="22.01">
     <description>Maximum Likelihood based inference of large phylogenetic trees</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.0.1</token>
-        <token name="@VERSION_SUFFIX@">2</token>
         <import>raxmlng_macros.xml</import>
     </macros>
     <xrefs>

--- a/tools/raxmlng/raxmlng_macros.xml
+++ b/tools/raxmlng/raxmlng_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@TOOL_VERSION@">2.0.1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <xml name="m_raxmlng_msa">   
         <param name="infile" argument="--msa" type="data" format="fasta,phylip" label="Input file with aligned sequences (FASTA/PHYLIP)"
                help="At least four aligned sequences are needed for RAxML-NG.">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Closes #7956 
