### PR TITLE
Linter fixes for add name

### DIFF
--- a/tools/add_input_name_as_column/.lint_skip
+++ b/tools/add_input_name_as_column/.lint_skip
@@ -1,2 +1,2 @@
+# there is no citation
 CitationsMissing
-TestsCaseValidation

--- a/tools/add_input_name_as_column/add_input_name_as_column.xml
+++ b/tools/add_input_name_as_column/add_input_name_as_column.xml
@@ -1,7 +1,7 @@
-<tool id="addName" name="Add input name as column" version="0.2.0" profile="17.09">
+<tool id="addName" name="Add input name as column" version="0.3.0" profile="25.0">
     <description>to an existing tabular file</description>
     <requirements>
-        <requirement type="package" version="3.7">python</requirement>
+        <requirement type="package" version="3.13.7">python</requirement>
     </requirements>
     <required_files>
         <include path="add_input_name_as_column.py"/>
@@ -38,13 +38,17 @@ $prepend
     <tests>
         <test>
             <param name="input" value="signature.tab" ftype="tabular" />
-            <param name="contains_header" value="yes" />
-            <param name="colname" value="sample" />
+            <conditional name="header">
+                <param name="contains_header" value="yes" />
+                <param name="colname" value="sample" />
+            </conditional>
             <output name="output" file="signature_with_header.tab" ftype="tabular"/>
         </test>
         <test>
             <param name="input" value="signature.tab" ftype="tabular" />
-            <param name="contains_header" value="no" />
+            <conditional name="header">
+                <param name="contains_header" value="no" />
+            </conditional>
             <param name="prepend" value="true" />
             <output name="output" file="signature_without_header.tab" ftype="tabular"/>
         </test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
