### PR TITLE
Pretext Map: add new ultra resolution mode

### DIFF
--- a/tools/pretext/pretext_map.xml
+++ b/tools/pretext/pretext_map.xml
@@ -2,7 +2,7 @@
     <description>converts SAM or BAM files into genome contact maps</description>
     <macros>
         <token name="@TOOL_VERSION@">0.2.4</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">25.0</token>
     </macros>
     <requirements>
@@ -32,11 +32,13 @@
             --filterExclude '$filter.filter_list'
         #end if 
         $highRes
+        $ultraRes
         -o output.pretext
     ]]></command>
     <inputs>
         <param name="input" type="data" format="sam,bam" label="Input dataset in SAM or BAM format"/>
         <param argument="--highRes" type="boolean" truevalue="--highRes" falsevalue="" label="High resolution mode" help="Use high resolution mode for better contact map resolution"/>
+        <param argument="--ultraRes" type="boolean" truevalue="--ultraRes" falsevalue="" label="Ultra resolution mode" help="Use ultra resolution mode for best contact map resolution"/>
         <conditional name="sorting">
             <param argument="--sortby" type="select" label="Sort by" help="Sort the genome by length or name of the scaffolds">
                 <option value="nosort">Don't sort</option>
@@ -91,7 +93,7 @@
         <data format="pretext" name="pretext_map_out" from_work_dir="output.pretext" label="${tool.name} on ${on_string}"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" ftype="bam" value="test.bam"/>
             <param name="highRes" value="true"/>
             <conditional name="sorting">
@@ -109,7 +111,7 @@
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" ftype="sam" value="test.sam"/>
             <param name="highRes" value="false"/>
             <conditional name="sorting">


### PR DESCRIPTION
This PR adds a new ultra_resolution parameter to Pretext Map output generation, as requested by @Delphine-L for the VGP.

A corresponding test was not included because the parameter requires at least 40 GB of RAM to run, as documented [here](https://github.com/sanger-tol/PretextMap/blob/1f9c50759a1617ecf494f0b805e2ba9fd26de71d/README.md?plain=1#L41). 

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
