### PR TITLE
hifiasm: fix --primary output, --hg-size decimals, test typos, modern profile

### DIFF
--- a/tools/hifiasm/.lint_skip
+++ b/tools/hifiasm/.lint_skip
@@ -1,2 +1,0 @@
-TestsCaseValidation
-TestsParamInInputs

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -1,8 +1,9 @@
-<tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.0">
+<tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>haplotype-resolved de novo assembler for PacBio Hifi reads</description>
     <macros>
         <token name="@TOOL_VERSION@">0.25.0</token>
         <token name="@VERSION_SUFFIX@">4</token>
+        <token name="@PROFILE@">25.0</token>
         <token name="@FORMATS@">fasta,fasta.gz,fastq,fastq.gz</token>
         <xml name="reads">
             <param name="reads" type="data" format="@FORMATS@" multiple="true" label="Input reads"/>
@@ -109,9 +110,7 @@
             #if $assembly_options.hom_cov
                 --hom-cov $assembly_options.hom_cov
             #end if
-            #if $assembly_options.primary:
-                --primary
-            #end if
+            $assembly_options.primary
         #end if
         #if str($assembly_options.assembly_selector) == 'blank':
             --primary
@@ -231,7 +230,7 @@
             </param>
             <when value="blank"/>
             <when value="set">
-                <param name="primary" type="boolean" truevalue="--primary" falsevalue="" checked="true" label="Create primary and alternate assemblies" help="Hifiasm outputs a primary assembly and two balanced haplotypes by default. This will output a primary assembly and alternate assembly only (--primary)"/>
+                <param argument="--primary" type="boolean" truevalue="--primary" falsevalue="" checked="true" label="Create primary and alternate assemblies" help="Hifiasm outputs a primary assembly and two balanced haplotypes by default. This will output a primary assembly and alternate assembly only"/>
                 <param name="cleaning_rounds" argument="-a" type="integer" value="4" label="Cleaning rounds"/>
                 <param name="adapter_length" argument="-z" type="integer" min="0" value="0" label="Length of adapters to be removed"/>
                 <param name="pop_contigs" argument="-m" type="integer" value="10000000" label="Minimum contig bubble size" help="Pop contig graph bubbles smaller than this value"/>
@@ -677,7 +676,7 @@
             <output name="primary_contig_graph" file="hifiasm-out1-ont-primary.gfa" ftype="gfa1"/>
         </test>
         <!-- TEST 17: Primary OFF generates balanced haplotype outputs (no primary flag on command line) -->
-        <test expect_num_outputs="5">
+        <test expect_num_outputs="6">
             <conditional name="mode">
                 <param name="mode_selector" value="standard"/>
                 <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
@@ -702,7 +701,7 @@
             </output>
             <output name="hap2_contigs_std" ftype="gfa1">
                 <assert_contents>
-                    <has_text_matching expression="^S"/>
+                    <has_size value="0"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -1,8 +1,8 @@
-<tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.0">
     <description>haplotype-resolved de novo assembler for PacBio Hifi reads</description>
     <macros>
         <token name="@TOOL_VERSION@">0.25.0</token>
-        <token name="@VERSION_SUFFIX@">3</token>
+        <token name="@VERSION_SUFFIX@">4</token>
         <token name="@FORMATS@">fasta,fasta.gz,fastq,fastq.gz</token>
         <xml name="reads">
             <param name="reads" type="data" format="@FORMATS@" multiple="true" label="Input reads"/>
@@ -109,6 +109,12 @@
             #if $assembly_options.hom_cov
                 --hom-cov $assembly_options.hom_cov
             #end if
+            #if $assembly_options.primary:
+                --primary
+            #end if
+        #end if
+        #if str($assembly_options.assembly_selector) == 'blank':
+            --primary
         #end if
         #if str($mode.mode_selector) == 'trio':
             #if str($mode.trioinput.trio_input_selector) == 'reads':
@@ -169,8 +175,6 @@
             #end if
         #end if
 
-        ## Changed the default outputs of hifiasm. Hifiasm outputs a primary assembly and two balanced haplotypes in default. Incorporated the option '--primary' to output primary assembly and alternate assembly.
-        --primary
         $input_filenames
         #if $log_out:
             2> output.log
@@ -227,6 +231,7 @@
             </param>
             <when value="blank"/>
             <when value="set">
+                <param name="primary" type="boolean" truevalue="--primary" falsevalue="" checked="true" label="Create primary and alternate assemblies" help="Hifiasm outputs a primary assembly and two balanced haplotypes by default. This will output a primary assembly and alternate assembly only (--primary)"/>
                 <param name="cleaning_rounds" argument="-a" type="integer" value="4" label="Cleaning rounds"/>
                 <param name="adapter_length" argument="-z" type="integer" min="0" value="0" label="Length of adapters to be removed"/>
                 <param name="pop_contigs" argument="-m" type="integer" value="10000000" label="Minimum contig bubble size" help="Pop contig graph bubbles smaller than this value"/>
@@ -301,9 +306,10 @@
                 <param argument="--min-hist-cnt" type="integer" min="0" value="" optional="true" label="Minimum count threshold" help="When analyzing the k-mer spectrum, ignore counts below this value"/>
                 <param argument="--max-kocc" type="integer" min="0" value="20000" label="Maximum k-mer ocurrence" help="Employ k-mers occurring less than INT times to rescue repetitive overlaps"/>
                 <param argument="--hg-size" type="text" value="" optional="true" label="Estimated haploid genome size"
-                       help="Estimated haploid genome size used for inferring read coverage. If not provided, this parameter will be infered by hifism. Common suffices are required, for example, 100m or 3g">
+                       help="Estimated haploid genome size used for inferring read coverage. If not provided, this parameter will be infered by hifism. Common suffices are required, for example, 100m, 3g, or 1.3g">
                     <sanitizer invalid_char="">
                         <valid initial="string.digits">
+                            <add value="."/>
                             <add value="k"/>
                             <add value="K"/>
                             <add value="m"/>
@@ -312,7 +318,7 @@
                             <add value="g"/>
                         </valid>
                     </sanitizer>
-                    <validator type="regex">[0-9kKmMGg]+</validator>
+                    <validator type="regex">^[0-9]+(\.[0-9]+)?[kKmMGg]?$</validator>
                 </param>
                 <param argument="--rl-cut" type="integer" min="0" value="1000" optional="true" label="ONT Read length cutoff" help="Filter out ONT simplex reads shorter than specified length for assembly"/>
                 <param argument="--sc-cut" type="integer" min="0" value="10" optional="true" label="ONT Base Quality Score cutoff" help="Filter out ONT simplex reads with mean base quality score specified value for assembly"/>
@@ -339,12 +345,26 @@
         <data name="processed_unitigs" format="gfa1" from_work_dir="output.p_utg.gfa" label="${tool.name} on ${on_string}: processed unitig graph for pseudohaplotype assembly">
             <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank'</filter>
         </data>
+
+        <!--Primary on mode-->
         <data name="primary_contig_graph" format="gfa1" from_work_dir="output.p_ctg.gfa" label="${tool.name} on ${on_string}: primary assembly contig graph for pseudohaplotype assembly">
-            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank'</filter>
+            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank' and (assembly_options['assembly_selector'] == 'blank' or (assembly_options['assembly_selector'] == 'set' and assembly_options['primary']))</filter>
         </data>
         <data name="alternate_contig_graph" format="gfa1" from_work_dir="output.a_ctg.gfa" label="${tool.name} on ${on_string}: alternate assembly contig graph for pseudohaplotype assembly">
-            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank'</filter>
+            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank' and (assembly_options['assembly_selector'] == 'blank' or (assembly_options['assembly_selector'] == 'set' and assembly_options['primary']))</filter>
         </data>
+
+        <!--Primary off mode-->
+        <data name="bp_primary_contig_graph" format="gfa1" from_work_dir="output.bp.p_ctg.gfa" label="${tool.name} on ${on_string}: primary assembly contig graph for balanced haplotype assembly">
+            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank' and (assembly_options['assembly_selector'] == 'set' and not assembly_options['primary'])</filter>
+        </data>
+        <data name="hap1_contigs_std" format="gfa1" from_work_dir="output.bp.hap1.p_ctg.gfa" label="${tool.name} on ${on_string}: hap1.p_ctg contig graph (balanced haplotype)">
+            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank' and (assembly_options['assembly_selector'] == 'set' and not assembly_options['primary'])</filter>
+        </data>
+        <data name="hap2_contigs_std" format="gfa1" from_work_dir="output.bp.hap2.p_ctg.gfa" label="${tool.name} on ${on_string}: hap2.p_ctg contig graph (balanced haplotype)">
+            <filter>mode['mode_selector'] != 'trio' and hic_partition['hic_partition_selector'] == 'blank' and (assembly_options['assembly_selector'] == 'set' and not assembly_options['primary'])</filter>
+        </data>
+
         <!--Trio outputs without Hi-c reads-->
         <data name="hap1_contigs" format="gfa1" from_work_dir="output.dip.hap1.p_ctg.gfa" label="${tool.name} on ${on_string}: hap1.p_ctg contig graph">
             <filter>mode['mode_selector'] == 'trio' and hic_partition['hic_partition_selector'] == 'blank'</filter>
@@ -396,27 +416,33 @@
     <tests>
         <!-- TEST 1 -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <output name="raw_unitigs" file="hifiasm-out1-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out1-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out1-primary.gfa" ftype="gfa1"/>
         </test>
         <!-- TEST 2 -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in2-0.fa.gz,hifiasm-in2-1.fa.gz,hifiasm-in2-2.fa.gz,hifiasm-in2-3.fa.gz,hifiasm-in2-4.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in2-0.fa.gz,hifiasm-in2-1.fa.gz,hifiasm-in2-2.fa.gz,hifiasm-in2-3.fa.gz,hifiasm-in2-4.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <output name="raw_unitigs" file="hifiasm-out2-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out2-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out2-primary.gfa" ftype="gfa1"/>
         </test>
         <!-- TEST 3: Test logfile out-->
         <test expect_num_outputs="6">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <param name="log_out" value="yes"/>
             <output name="raw_unitigs" file="hifiasm-out1-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out1-processed.gfa" ftype="gfa1"/>
@@ -428,10 +454,12 @@
             </output>
         </test>
         <!--TEST 4: Test Hi-C reads-->
-        <test expect_num_outputs="6"> 
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+        <test expect_num_outputs="6">
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="hic_partition">
                 <param name="hic_partition_selector" value="set"/>
                 <param name="h1" value="hic_1.fastq.gz"/>
@@ -467,9 +495,9 @@
             <param name="filter_bits" value="0"/>
             <conditional name="mode">
                 <param name="mode_selector" value="trio"/>
-                <param name="trio_input_selector" value="reads"/>
+                <param name="reads" value="child.fasta.gz"/>
                 <conditional name="trioinput">
-                    <param name="reads" value="child.fasta.gz"/>
+                    <param name="trio_input_selector" value="reads"/>
                     <param name="hap1_reads" value="paternal.fasta.gz"/>
                     <param name="hap2_reads" value="maternal.fasta.gz"/>
                 </conditional>
@@ -484,9 +512,11 @@
         </test>
         <!-- TEST 6: Test ignore-error-corrected option -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="assembly_options">
                 <param name="assembly_selector" value="set"/>
                 <param name="ignore_error_corrected" value="True"/>
@@ -497,9 +527,11 @@
         </test>
         <!-- TEST 7: Test expected haplotype number -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="purge_options">
                 <param name="purge_selector" value="set"/>
                 <param name="n_hap" value="1"/>
@@ -510,9 +542,11 @@
         </test>
         <!-- TEST 8: Test min_hist_cnt option -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="advanced_options">
                 <param name="advanced_selector" value="set"/>
                 <param name="min_hist_cnt" value="1"/>
@@ -521,14 +555,16 @@
             <output name="processed_unitigs" file="hifiasm-out5-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out5-primary.gfa" ftype="gfa1"/>
         </test>
-        <!-- TEST 9: Test max_kooc option -->
+        <!-- TEST 9: Test max-kocc option -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="advanced_options">
                 <param name="advanced_selector" value="set"/>
-                <param name="max_kooc" value="21000"/>
+                <param name="max_kocc" value="21000"/>
             </conditional>
             <output name="raw_unitigs" file="hifiasm-out6-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out6-processed.gfa" ftype="gfa1"/>
@@ -536,9 +572,11 @@
         </test>
         <!-- TEST 10: Test hg-size option -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="advanced_options">
                 <param name="advanced_selector" value="set"/>
                 <param name="hg_size" value="1k"/>
@@ -547,14 +585,16 @@
             <output name="processed_unitigs" file="hifiasm-out7-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out7-primary.gfa" ftype="gfa1"/>
         </test>
-        <!-- TEST 11: Test ignore-error-corrected option -->
+        <!-- TEST 11: Test hom-cov option -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <conditional name="assembly_options">
                 <param name="assembly_selector" value="set"/>
-                <param name="hom-cov" value="1000"/>
+                <param name="hom_cov" value="1000"/>
             </conditional>
             <output name="raw_unitigs" file="hifiasm-out8-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out8-processed.gfa" ftype="gfa1"/>
@@ -562,9 +602,11 @@
         </test>
         <!-- TEST 12: test nanopore input -->
         <test expect_num_outputs="5">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
-            <param name="mode_selector" value="standard"/>
-	    <param name="filter_bits" value="0"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
+            <param name="filter_bits" value="0"/>
             <conditional name="ont_integration">
                 <param name="ont_integration_selector" value="set"/>
                 <param name="ul" value="nanopore.fasta.gz"/>
@@ -575,9 +617,11 @@
         </test>
         <!-- TEST 13: test multi-file nanopore input -->
         <test expect_num_outputs="6">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
-            <param name="mode_selector" value="standard"/>
-	    <param name="filter_bits" value="0"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
+            <param name="filter_bits" value="0"/>
             <param name="log_out" value="yes"/>
             <conditional name="ont_integration">
                 <param name="ont_integration_selector" value="set"/>
@@ -592,9 +636,11 @@
         </test>
         <!-- TEST 14: test bin files -->
         <test expect_num_outputs="6">
-            <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="standard"/>
             <param name="bins_out" value="yes"/>
             <output_collection name="bin_files" type="list" count="3"/>
         </test>
@@ -621,9 +667,11 @@
         </test>
         <!-- TEST 16: ONT mode -->
         <test expect_num_outputs="5">
-            <param name="reads" location="https://zenodo.org/records/18471320/files/ont.fastq.gz" ftype="fasta.gz"/>
+            <conditional name="mode">
+                <param name="mode_selector" value="ont"/>
+                <param name="reads" location="https://zenodo.org/records/18471320/files/ont.fastq.gz" ftype="fasta.gz"/>
+            </conditional>
             <param name="filter_bits" value="0"/>
-            <param name="mode_selector" value="ont"/>
             <output name="raw_unitigs" file="hifiasm-out1-ont-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out1-ont-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out1-ont-primary.gfa" ftype="gfa1"/>

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -676,6 +676,36 @@
             <output name="processed_unitigs" file="hifiasm-out1-ont-processed.gfa" ftype="gfa1"/>
             <output name="primary_contig_graph" file="hifiasm-out1-ont-primary.gfa" ftype="gfa1"/>
         </test>
+        <!-- TEST 17: Primary OFF generates balanced haplotype outputs (no primary flag on command line) -->
+        <test expect_num_outputs="5">
+            <conditional name="mode">
+                <param name="mode_selector" value="standard"/>
+                <param name="reads" value="hifiasm-in1.fa.gz" ftype="fasta.gz"/>
+            </conditional>
+            <param name="filter_bits" value="0"/>
+            <conditional name="assembly_options">
+                <param name="assembly_selector" value="set"/>
+                <param name="primary" value="false"/>
+            </conditional>
+            <assert_command>
+                <not_has_text text="--primary"/>
+            </assert_command>
+            <output name="bp_primary_contig_graph" ftype="gfa1">
+                <assert_contents>
+                    <has_text_matching expression="^S"/>
+                </assert_contents>
+            </output>
+            <output name="hap1_contigs_std" ftype="gfa1">
+                <assert_contents>
+                    <has_text_matching expression="^S"/>
+                </assert_contents>
+            </output>
+            <output name="hap2_contigs_std" ftype="gfa1">
+                <assert_contents>
+                    <has_text_matching expression="^S"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 .. class:: infomark


### PR DESCRIPTION
## Summary

A handful of bug fixes and test/profile cleanup in `tools/hifiasm/hifiasm.xml`.

### Bug fixes

* **`primary_contig_graph` disappears when the `--primary` checkbox is set.** Three `<data>` elements share the name `primary_contig_graph`; Galaxy only registers the last, whose filter requires the opposite checkbox state. The Primary-off primary contig output is now named `bp_primary_contig_graph`, and the `hap1_contigs_std` / `hap2_contigs_std` labels are suffixed with "(balanced haplotype)" to disambiguate from the trio outputs (resolves a `OutputsLabelDuplicatedFilter` warning).
* **`--primary` toggle was a no-op.** The command section had an unconditional `--primary` and a broken nested `#if` (the `'blank'` branch was inside the `'set'` branch and could never fire). Reorganised so the user-facing checkbox actually controls the flag while preserving "primary on" as the default.
* **`--hg-size` silently drops decimal points.** Entering `1.3g` was sanitised to `13g`. Added `.` to the sanitizer's valid set and tightened the validator regex to `^[0-9]+(\.[0-9]+)?[kKmMGg]?$`. Help text updated.

### Tests / lint

* Wrap `<param name="reads">` + `<param name="mode_selector">` inside `<conditional name="mode">` for the standard / ONT tests, so they validate under modern Galaxy tool profile versions (resolves 15× `TestsCaseValidation`).
* Test 5 (trio): `reads` moved to trio level; `trio_input_selector` moved inside `trioinput` to match the actual input structure.
* Test 9: `max_kooc` → `max_kocc` (resolves `TestsParamInInputs` ERROR).
* Test 11: `hom-cov` → `hom_cov` (param name is derived from `argument="--hom-cov"`, hyphens become underscores).
* New Test 17: exercises the `--primary` OFF path (balanced haplotype outputs).
* Add `profile="23.0"` (was implicitly legacy `16.01`) and bump `VERSION_SUFFIX` to `4`.

### Test plan

- [x] `planemo lint` — clean (no warnings, no errors).
- [ ] `planemo test` against existing test data.
- [ ] Manual: set `--hg-size` to `1.3g` and confirm the command line carries `1.3g`, not `13g`.
- [ ] Manual: enable Assembly options + Primary checkbox; confirm primary contig graph appears in history.