### PR TITLE
Gtdbtk update and make it actually work

### DIFF
--- a/tools/gtdbtk/gtdbtk_classify_wf.xml
+++ b/tools/gtdbtk/gtdbtk_classify_wf.xml
@@ -12,10 +12,15 @@
 
 mkdir input_dir &&
 mkdir output_dir &&
+mkdir scratch_dir &&
+mkdir tmp_dir &&
 #for $i in $input:
     ## gtdbtk uses the file extension to determine the input format.
-    #set ext = "." + $i.ext
-    #set input_identifier = re.sub('[^\w\-.]', '_', str($i.element_identifier)) + $ext
+    #set ext = $i.ext
+    #if $ext.endswith(".gz")
+        #set ext = "gz"
+    #end if
+    #set input_identifier = re.sub('[^\w\-.]', '_', str($i.element_identifier)) + "." + $ext
     ln -s '${i}' input_dir/'${input_identifier}' &&
 #end for
 export GTDBTK_DATA_PATH=$gtdbtk_db.fields.path &&
@@ -23,13 +28,19 @@ gtdbtk classify_wf
 --genome_dir input_dir
 --extension '$ext'
 --out_dir output_dir
+--prefix gtdbtk
 --cpus "\${GALAXY_SLOTS:-4}"
+--tmpdir tmp_dir
+$advanced.place_species
 --min_perc_aa $advanced.min_perc_aa
+$advanced.genes
+--pplacer_cpus "\${GALAXY_SLOTS:-4}"
 $advanced.force
+--scratch_dir scratch_dir
+$advanced.write_single_copy_genes
+--keep_intermediates
 --min_af $advanced.min_af
-$full_tree
-## Required unless mash_db is available:
---skip_ani_screen
+$advanced.full_tree
 
 #if str($advanced.output_process_log) == 'yes':
     && cat output_dir/gtdbtk.warnings.log output_dir/gtdbtk.log > '$process_log'
@@ -44,16 +55,19 @@ $full_tree
             </options>
         </param>
         <section name="advanced" title="Advanced options">
+            <param argument="--place_species" type="boolean" truevalue="--place_species" falsevalue="" checked="false" label="Place species in pplacer trees even if they are classified with skani?"/>
             <param argument="--min_perc_aa" type="integer" min="0" max="100" value="10" label="Exclude genomes that do not have at least this percentage of AA in the MSA" help="Inclusive bound"/>
+            <param argument="--genes" type="boolean" truevalue="--genes" falsevalue="" checked="false" label="Input files contain predicted proteins as amino acids?" help="This skips gene calling, ANI screening, and ANI classification."/>
             <param argument="--force" type="boolean" truevalue="--force" falsevalue="" checked="false" label="Continue processing if an error occurs on a single genome?"/>
-            <param argument="--min_af" type="float" min="0" max="1" value="0.65" label="Minimum alignment fraction to consider closest genome"/>
+            <param argument="--write_single_copy_genes" type="boolean" truevalue="--write_single_copy_genes" falsevalue="" checked="false" label="Output unaligned single-copy marker genes?"/>
+            <param argument="--min_af" type="float" min="0" max="1" value="0.5" label="Minimum alignment fraction to assign genome to a species cluster"/>
             <param argument="--full_tree" type="boolean" truevalue="--full_tree" falsevalue="" checked="false" label="Use the full tree" help="Use the unsplit bacterial tree for the classify step; this is the original GTDB-Tk approach (version &lt; 2) and requires more than 320 GB of RAM to load the reference tree (default: False)"/>
             <param name="output_process_log" type="boolean" truevalue="yes" falsevalue="no" checked="false" label="Output process log file?"/>
         </section>
     </inputs>
     <outputs>
         <data name="process_log" format="txt" label="${tool.name} on ${on_string} (process log)">
-            <filter>advanced['output_process_log']</filter>
+            <filter>advanced['output_process_log'] == 'yes'</filter>
         </data>
         <collection name="output_align" type="list" format="fasta.gz" label="${tool.name} on ${on_string} (align)">
             <discover_datasets pattern="(?P&lt;designation&gt;.+)\.fasta.gz" ext="fasta.gz" directory="output_dir/align"/>
@@ -130,6 +144,22 @@ $full_tree
         <test expect_failure="true">
             <param name="input" value="genome_1.fna.gz" ftype="fasta.gz"/>
             <param name="gtdbtk_db" value="gtdbtk214"/>
+            <section name="advanced">
+                <param name="place_species" value="true"/>
+                <param name="genes" value="true"/>
+                <param name="force" value="true"/>
+                <param name="write_single_copy_genes" value="true"/>
+            </section>
+            <assert_command>
+                <has_text text="--prefix gtdbtk"/>
+                <has_text text="--place_species"/>
+                <has_text text="--genes"/>
+                <has_text text="--pplacer_cpus"/>
+                <has_text text="--force"/>
+                <has_text text="--write_single_copy_genes"/>
+                <has_text text="--keep_intermediates"/>
+                <has_text text="--skip_ani_screen" negate="true"/>
+            </assert_command>
             <assert_stderr>
                 <has_text text="Fatal error: Exit code 1"/>
             </assert_stderr>
@@ -162,4 +192,3 @@ Results can be impacted by a lack of marker genes or contamination.
     ]]></help>
     <expand macro="citations"/>
 </tool>
-

--- a/tools/gtdbtk/macros.xml
+++ b/tools/gtdbtk/macros.xml
@@ -1,7 +1,7 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.7.1</token>
+    <token name="@TOOL_VERSION@">2.7.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">22.05</token>
+    <token name="@PROFILE@">24.0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">gtdbtk</requirement>

--- a/tools/picrust2/.lint_skip
+++ b/tools/picrust2/.lint_skip
@@ -1,2 +1,0 @@
-TestsExpectNumOutputsFailing
-TestsCaseValidation

--- a/tools/picrust2/add_descriptions.xml
+++ b/tools/picrust2/add_descriptions.xml
@@ -6,7 +6,7 @@
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>add_descriptions.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 add_descriptions.py
     --input '$input'
     --output '$func_abun_table_description'
@@ -44,32 +44,32 @@ add_descriptions.py
         <data name="func_abun_table_description" format="tabular" from_work_dir="added_description.tsv"/>
     </outputs>
     <tests>
-    <test expect_num_outputs="1">
-        <param name="input" value="pred_metagenome_unstrat.tsv.gz"/>
-        <conditional name="map_file">
-            <param name="selector" value="default"/>
-            <param name="map_type" value="EC"/>
-        </conditional>
-        <output name="func_abun_table_description">
-            <assert_contents>
-                <has_text text="description"/>
-                <has_n_lines n="1000"/>
-            </assert_contents>
-        </output>
-    </test>
-    <test expect_num_outputs="1">
-        <param name="input" value="pred_metagenome_unstrat.tsv.gz"/>
-        <conditional name="map_file">
-            <param name="selector" value="custom"/>
-            <param name="custom_map_table" value="ec_unstrat_test.txt.gz"/>
-        </conditional>
-        <output name="func_abun_table_description">
-            <assert_contents>
-                <has_text text="description"/>
-                <has_n_lines n="1000"/>
-            </assert_contents>
-        </output>
-    </test>
+        <test expect_num_outputs="1">
+            <param name="input" value="pred_metagenome_unstrat.tsv.gz"/>
+            <conditional name="map_file">
+                <param name="selector" value="default"/>
+                <param name="map_type" value="EC"/>
+            </conditional>
+            <output name="func_abun_table_description">
+                <assert_contents>
+                    <has_text text="description"/>
+                    <has_n_lines n="1000"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="input" value="pred_metagenome_unstrat.tsv.gz"/>
+            <conditional name="map_file">
+                <param name="selector" value="custom"/>
+                <param name="custom_map_table" value="ec_unstrat_test.txt.gz"/>
+            </conditional>
+            <output name="func_abun_table_description">
+                <assert_contents>
+                    <has_text text="description"/>
+                    <has_n_lines n="1000"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 @HELP_HEADER@

--- a/tools/picrust2/add_descriptions.xml
+++ b/tools/picrust2/add_descriptions.xml
@@ -25,11 +25,10 @@ add_descriptions.py
             </param>
             <when value="default">
                 <param argument="--map_type" type="select" label="Mapping table to use">
-                    <option value="COG">Clusters of Orthologous Genes database (COG)</option>
                     <option value="EC">Enzyme Commission number database (EC number)</option>
+                    <option value="GO">Gene Ontology (GO)</option>
                     <option value="KO">KEGG Orthology database (KO)</option>
                     <option value="PFAM">Pfam database</option>
-                    <option value="TIGRFAM">TIGRFAM database</option>
                     <option value="METACYC">Metabolic Pathway database (MetaCyc)</option>
                 </param>
             </when>
@@ -45,7 +44,7 @@ add_descriptions.py
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name="input" value="pred_metagenome_unstrat.tsv.gz"/>
+            <param name="input" value="ec_unstrat_no_prefix.tsv"/>
             <conditional name="map_file">
                 <param name="selector" value="default"/>
                 <param name="map_type" value="EC"/>
@@ -53,7 +52,8 @@ add_descriptions.py
             <output name="func_abun_table_description">
                 <assert_contents>
                     <has_text text="description"/>
-                    <has_n_lines n="1000"/>
+                    <has_text text="Alcohol dehydrogenase"/>
+                    <has_n_lines n="4"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/picrust2/hsp.xml
+++ b/tools/picrust2/hsp.xml
@@ -9,7 +9,7 @@
     <command detect_errors="aggressive"><![CDATA[
 hsp.py
     --tree '$tree'
-    @HSP_DATABASE_PARAM@
+    @HSP_DATABASE_PARAMS@
     @HSP_PARAMS@
     --output '$prediction_output'
     $check
@@ -56,6 +56,12 @@ hsp.py
                     <has_n_lines n="38"/>
                 </assert_contents>
             </output>
+            <assert_command>
+                <has_text text="--database 'SC'"/>
+                <has_text text="--reference 'bac'"/>
+                <has_text text="--in_trait '16S'"/>
+                <has_text text="--edge_exponent 0.0"/>
+            </assert_command>
         </test>
         <test expect_num_outputs="1">
             <param name="tree" ftype="newick" value="out_tree.zip"/>

--- a/tools/picrust2/hsp.xml
+++ b/tools/picrust2/hsp.xml
@@ -21,7 +21,7 @@ hsp.py
     <inputs>
         <param argument="--tree" type="data" format="newick" label="Newick tree with study sequences placed amongst reference sequences" help="The full reference tree containing both study sequences (i.e. ASVs or OTUs) and reference sequences."/>
         <expand macro="hsp_database_params"/>
-        <expand macro="hsp_params" nsti_truevalue="--calculate_NSTI" nsti_checked="false" in_trait_arg="--in_trait" in_trait_multiple="false" in_trait_label_suff="">
+        <expand macro="hsp_params" in_trait_arg="--in_trait" in_trait_multiple="false" in_trait_label_suff="">
             <token name="add_default_traits">
                 <option value="16S">16S</option>
                 <option value="PHENO">PHENO</option>
@@ -32,6 +32,7 @@ hsp.py
             <!-- add the seed parameter here (for the emp_prob option) .. param absent in picrust2_pipeline -->
             <param argument="--seed" type="integer" value="100" label="Seed to make output reproducible" help="is necessary for the emp_prob method"/>
         </expand>
+        <param argument="--calculate_NSTI" type="boolean" truevalue="--calculate_NSTI" falsevalue="" checked="false" label="Calculate NSTI and add to output file" help="And add to output file"/>
         <param argument="--check" type="boolean" truevalue="--check" falsevalue="" checked="false" label="Check input trait table before HSP"/>
     </inputs>
     <outputs>
@@ -40,6 +41,8 @@ hsp.py
     <tests>
         <test expect_num_outputs="1">
             <param name="tree" ftype="newick" value="out_tree.zip"/>
+            <param name="database" value="oldIMG"/>
+            <param name="reference" value="bac"/>
             <conditional name="trait_input">
                 <param name="selector" value="default"/>
                 <param name="in_trait" value="16S"/>
@@ -57,7 +60,7 @@ hsp.py
                 </assert_contents>
             </output>
             <assert_command>
-                <has_text text="--database 'SC'"/>
+                <has_text text="--database 'oldIMG'"/>
                 <has_text text="--reference 'bac'"/>
                 <has_text text="--in_trait '16S'"/>
                 <has_text text="--edge_exponent 0.0"/>
@@ -84,6 +87,8 @@ hsp.py
         </test>
         <test expect_num_outputs="1">
             <param name="tree" ftype="newick" value="out_tree.zip"/>
+            <param name="database" value="oldIMG"/>
+            <param name="reference" value="bac"/>
             <conditional name="trait_input">
                 <param name="selector" value="default"/>
                 <param name="in_trait" value="16S"/>

--- a/tools/picrust2/hsp.xml
+++ b/tools/picrust2/hsp.xml
@@ -6,10 +6,10 @@
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>hsp.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
-@VAR_ACCESS_FOO@
+    <command detect_errors="aggressive"><![CDATA[
 hsp.py
     --tree '$tree'
+    @HSP_DATABASE_PARAM@
     @HSP_PARAMS@
     --output '$prediction_output'
     $check
@@ -20,6 +20,7 @@ hsp.py
     ]]></command>
     <inputs>
         <param argument="--tree" type="data" format="newick" label="Newick tree with study sequences placed amongst reference sequences" help="The full reference tree containing both study sequences (i.e. ASVs or OTUs) and reference sequences."/>
+        <expand macro="hsp_database_params"/>
         <expand macro="hsp_params" nsti_truevalue="--calculate_NSTI" nsti_checked="false" in_trait_arg="--in_trait" in_trait_multiple="false" in_trait_label_suff="">
             <token name="add_default_traits">
                 <option value="16S">16S</option>
@@ -37,63 +38,63 @@ hsp.py
         <data name="prediction_output" format="tabular"/>
     </outputs>
     <tests>
-    <test expect_num_outputs="1">
-        <param name="tree" ftype="newick" value="out_tree.zip"/>
-        <conditional name="trait_input">
-            <param name="selector" value="default"/>
-            <param name="in_trait" value="16S"/>
-        </conditional>
-        <conditional name="hsp_method__options">
-            <param name="hsp_method" value="mp"/>
-            <param name="edge_exponent" value="0.0"/>
-        </conditional>
-        <param name="calculate_NSTI" value="false"/>
-        <param name="check" value="false"/>
-        <output name="prediction_output" ftype="tabular">
-            <assert_contents>
-                <has_text text="sequence"/>
-                <has_n_lines n="38"/>
-            </assert_contents>
-        </output>
-    </test>
-    <test expect_num_outputs="1">
-        <param name="tree" ftype="newick" value="out_tree.zip"/>
-        <conditional name="trait_input">
-            <param name="selector" value="custom"/>
-            <param name="observed_trait_table" value="known_traits.tsv.gz"/>
-        </conditional>
-        <conditional name="hsp_method__options">
-            <param name="hsp_method" value="mp"/>
-            <param name="edge_exponent" value="0.0"/>
-        </conditional>
-        <param name="calculate_NSTI" value="false"/>
-        <param name="check" value="false"/>
-        <output name="prediction_output">
-            <assert_contents>
-                <has_text text="2040502012"/>
-                <has_n_lines n="20005"/>
-            </assert_contents>
-        </output>
-    </test>
-    <test expect_num_outputs="1">
-        <param name="tree" ftype="newick" value="out_tree.zip"/>
-        <conditional name="trait_input">
-            <param name="selector" value="default"/>
-            <param name="in_trait" value="16S"/>
-        </conditional>
-        <conditional name="hsp_method__options">
-            <param name="hsp_method" value="emp_prob"/>
-            <param name="seed" value="100"/>
-        </conditional>
-        <param name="calculate_NSTI" value="false"/>
-        <param name="check" value="false"/>
-        <output name="prediction_output">
-            <assert_contents>
-                <has_text text="sequence"/>
-                <has_n_lines n="38"/>
-            </assert_contents>
-        </output>
-    </test>
+        <test expect_num_outputs="1">
+            <param name="tree" ftype="newick" value="out_tree.zip"/>
+            <conditional name="trait_input">
+                <param name="selector" value="default"/>
+                <param name="in_trait" value="16S"/>
+            </conditional>
+            <conditional name="hsp_method_options">
+                <param name="hsp_method" value="mp"/>
+                <param name="edge_exponent" value="0.0"/>
+            </conditional>
+            <param name="calculate_NSTI" value="false"/>
+            <param name="check" value="false"/>
+            <output name="prediction_output" ftype="tabular">
+                <assert_contents>
+                    <has_text text="sequence"/>
+                    <has_n_lines n="38"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="tree" ftype="newick" value="out_tree.zip"/>
+            <conditional name="trait_input">
+                <param name="selector" value="custom"/>
+                <param name="observed_trait_table" value="known_traits.tsv.gz"/>
+            </conditional>
+            <conditional name="hsp_method_options">
+                <param name="hsp_method" value="mp"/>
+                <param name="edge_exponent" value="0.0"/>
+            </conditional>
+            <param name="calculate_NSTI" value="false"/>
+            <param name="check" value="false"/>
+            <output name="prediction_output">
+                <assert_contents>
+                    <has_text text="2040502012"/>
+                    <has_n_lines n="20005"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="tree" ftype="newick" value="out_tree.zip"/>
+            <conditional name="trait_input">
+                <param name="selector" value="default"/>
+                <param name="in_trait" value="16S"/>
+            </conditional>
+            <conditional name="hsp_method_options">
+                <param name="hsp_method" value="emp_prob"/>
+                <param name="seed" value="100"/>
+            </conditional>
+            <param name="calculate_NSTI" value="false"/>
+            <param name="check" value="false"/>
+            <output name="prediction_output">
+                <assert_contents>
+                    <has_text text="sequence"/>
+                    <has_n_lines n="38"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 @HELP_HEADER@

--- a/tools/picrust2/macros.xml
+++ b/tools/picrust2/macros.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0"?>
 <macros>
-    <token name="@TOOL_VERSION@">2.5.3</token>
+    <token name="@TOOL_VERSION@">2.6.3</token>
     <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">22.01</token>
+    <token name="@PROFILE@">25.0</token>
     <xml name="bio_tool">
         <xrefs>
             <xref type="bio.tools">picrust2</xref>
@@ -29,55 +28,69 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
             <citation type="doi">10.1038/s41587-020-0548-6</citation>
         </citations>
     </xml>
-
-
-
-    <token name="@VAR_ACCESS_FOO@"><![CDATA[
-    ## in picrust2_pipeline the parameters are within a section or a
-    ## conditional. in the separate sections they are not.
-    ## this function allows unified access
-    #def getVarCond($sec_cond, $var)
-        #if $varExists($var)
-            #return $getVar($var)
-        #else if $varExists($sec_cond + "." + $var)
-            #return $getVar($sec_cond + "." + $var)
-        #else
-            #return 
-        #end if
-    #end def
-    ]]></token>
-
     <!-- macros for place_seqs -->
-
     <token name="@PLACE_SEQS_PREPROCESSING@"><![CDATA[
         ## determine project dir which is something like /lib/python3.8/site-packages/picrust2/default_files/
         PROJECT_DIR=\$(python -c 'from picrust2 import default; print(default.project_dir)') &&
         REF_DIR_BASE=\$PROJECT_DIR"/default_files/" &&
-        #if $getVarCond("place_seqs_section", "ref_dir.selector") == "custom"
+        #if $ref_dir.selector == "custom"
             mkdir -p custom/ &&
-            ln -s '$getVarCond("place_seqs_section", "ref_dir.custom_fna")' custom/custom.fna &&
-            ln -s '$getVarCond("place_seqs_section", "ref_dir.custom_hmm")' custom/custom.hmm &&
-            #if $getVarCond("place_seqs_section", "placement_tool") == "epa-ng"
-                ln -s '$getVarCond("place_seqs_section", "ref_dir.custom_model")' custom/custom.model &&
-            #else if $getVarCond("place_seqs_section", "placement_tool")
-                ln -s '$getVarCond("place_seqs_section", "ref_dir.custom_model")' custom/custom.raxml_info &&
+            ln -s '$ref_dir.custom_fna' custom/custom.fna &&
+            ln -s '$ref_dir.custom_hmm' custom/custom.hmm &&
+            #if $placement_tool == "epa-ng"
+                ln -s '$ref_dir.custom_model' custom/custom.model &&
+            #else
+                ln -s '$ref_dir.custom_model' custom/custom.raxml_info &&
             #end if
-            ln -s '$getVarCond("place_seqs_section", "ref_dir.custom_tre")' custom/custom.tre &&
+            ln -s '$ref_dir.custom_tre' custom/custom.tre &&
+        #end if
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_PLACE_SEQS_PREPROCESSING@"><![CDATA[
+        #if $place_seqs_section.ref_dir1.selector == "custom"
+            mkdir -p custom_ref1/ &&
+            ln -s '$place_seqs_section.ref_dir1.custom_fna' custom_ref1/custom.fna &&
+            ln -s '$place_seqs_section.ref_dir1.custom_hmm' custom_ref1/custom.hmm &&
+            #if $place_seqs_section.placement_tool == "epa-ng"
+                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom.model &&
+            #else
+                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom.raxml_info &&
+            #end if
+            ln -s '$place_seqs_section.ref_dir1.custom_tre' custom_ref1/custom.tre &&
+        #end if
+        #if $place_seqs_section.ref_dir2.selector == "custom"
+            mkdir -p custom_ref2/ &&
+            ln -s '$place_seqs_section.ref_dir2.custom_fna' custom_ref2/custom.fna &&
+            ln -s '$place_seqs_section.ref_dir2.custom_hmm' custom_ref2/custom.hmm &&
+            #if $place_seqs_section.placement_tool == "epa-ng"
+                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom.model &&
+            #else
+                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom.raxml_info &&
+            #end if
+            ln -s '$place_seqs_section.ref_dir2.custom_tre' custom_ref2/custom.tre &&
         #end if
     ]]></token>
     <token name="@PLACE_SEQS_PARAMS@"><![CDATA[
-        --study_fasta '$getVarCond("place_seqs_section", "study_fasta")'
-        --placement_tool '$getVarCond("place_seqs_section", "placement_tool")'
-        ## set refdir (default is prokaryotic), even if the default will
-        ## be treated internally as `"\$REF_DIR_BASE"$ref_dir.selector`
-        ## picrust2 will complain about non-default reference files
-        ## specified with default pathway mapfile
-        #if $getVarCond("place_seqs_section", "ref_dir.selector") == "custom"
+        --study_fasta '$study_fasta'
+        --placement_tool '$placement_tool'
+        #if $ref_dir.selector == "custom"
             --ref_dir custom/
-        #else if $getVarCond("place_seqs_section", "ref_dir.selector") != "prokaryotic/pro_ref/"
-            --ref_dir "\$REF_DIR_BASE"$getVarCond("place_seqs_section", "ref_dir.selector")
+        #else if $ref_dir.selector in ["fungi/fungi_ITS/", "fungi/fungi_18S/"]
+            --ref_dir "\$REF_DIR_BASE"$ref_dir.selector
+        #else if $ref_dir.selector != "bac"
+            --ref_dir '$ref_dir.selector'
         #end if
-        --min_align $getVarCond("place_seqs_section", "min_align")
+        --min_align $min_align
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_PLACE_SEQS_PARAMS@"><![CDATA[
+        --study_fasta '$place_seqs_section.study_fasta'
+        --placement_tool '$place_seqs_section.placement_tool'
+        #if $place_seqs_section.ref_dir1.selector == "custom"
+            --ref_dir1 custom_ref1/
+        #end if
+        #if $place_seqs_section.ref_dir2.selector == "custom"
+            --ref_dir2 custom_ref2/
+        #end if
+        --min_align $place_seqs_section.min_align
     ]]></token>
     <xml name="place_seqs_params">
         <param argument="--study_fasta" type="data" format="fasta" label="Study sequences" help="Sequences of the representative OTUs and/or ASVs. Sequences need to be on the positive strand and the headerline should be only one field, i.e. no additional whitespace-delimited fields"/>
@@ -87,13 +100,17 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
         </param>
         <conditional name="ref_dir">
             <param name="selector" type="select" label="Reference data" help="Used for sequence placement">
-                <option value="prokaryotic/pro_ref/" selected="true">Prokaryotic 16S rRNA gene</option>
+                <option value="bac" selected="true">Bacterial 16S rRNA gene</option>
+                <option value="arc">Archaeal 16S rRNA gene</option>
+                <option value="oldIMG">Legacy IMG prokaryotic 16S rRNA gene</option>
                 <!-- TODO https://github.com/picrust/picrust2/issues/276 -->
                 <option value="fungi/fungi_ITS/">Fungal ITS (only for epa-ng)</option>
                 <option value="fungi/fungi_18S/">Fungal 18S (only for epa-ng)</option>
                 <option value="custom">Custom reference sequence files</option>
             </param>
-            <when value="prokaryotic/pro_ref/"/>
+            <when value="bac"/>
+            <when value="arc"/>
+            <when value="oldIMG"/>
             <when value="fungi/fungi_ITS/"/>
             <when value="fungi/fungi_18S/"/>
             <when value="custom">
@@ -105,53 +122,89 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
         </conditional>
         <param argument="--min_align" type="float" value="0.80" min="0.0" max="1.0" label="Minimum alignment length" help="Proportion of the total length of an input query sequence that must align with reference sequences. Sequences with lengths below this value will be excluded from the placement and all subsequent steps"/>
     </xml>
+    <xml name="picrust2_pipeline_place_seqs_params">
+        <param argument="--study_fasta" type="data" format="fasta" label="Study sequences" help="Sequences of the representative OTUs and/or ASVs. Sequences need to be on the positive strand and the headerline should be only one field, i.e. no additional whitespace-delimited fields"/>
+        <param argument="--placement_tool" type="select" label="Placement tool" help="Used for placing sequences into reference tree">
+            <option value="epa-ng" selected="true">EPA-ng -  Fast, parallel, highly accurate Maximum Likelihood Phylogenetic Placement, by the team behind RAxML(-ng)</option>
+            <option value="sepp">SEPP - SATe-enabled Phylogenetic Placement</option>
+        </param>
+        <conditional name="ref_dir1">
+            <param name="selector" type="select" label="Domain 1 reference data" help="Bacterial reference data are used by default">
+                <option value="default" selected="true">Default bacterial 16S rRNA gene reference</option>
+                <option value="custom">Custom reference sequence files</option>
+            </param>
+            <when value="default"/>
+            <when value="custom">
+                <param name="custom_fna" type="data" format="fasta" label="Multiple-sequence alignment of reference sequences"/>
+                <param name="custom_hmm" type="data" format="hmm2,hmm3" label="Hidden-markov model of the multiple-sequence alignment" help="The HMM of the alignment can be created using hmmbuild"/>
+                <param name="custom_tre" type="data" format="newick" label="Tree of the reference sequences"/>
+                <param name="custom_model" type="data" format="txt" label="Modelfile" help="For epa-ng: output by RaXmL specifying the best parameters for the tree, for sepp see examples in PICRUSt2 repository"/>
+            </when>
+        </conditional>
+        <conditional name="ref_dir2">
+            <param name="selector" type="select" label="Domain 2 reference data" help="Archaeal reference data are used by default">
+                <option value="default" selected="true">Default archaeal 16S rRNA gene reference</option>
+                <option value="custom">Custom reference sequence files</option>
+            </param>
+            <when value="default"/>
+            <when value="custom">
+                <param name="custom_fna" type="data" format="fasta" label="Multiple-sequence alignment of reference sequences"/>
+                <param name="custom_hmm" type="data" format="hmm2,hmm3" label="Hidden-markov model of the multiple-sequence alignment" help="The HMM of the alignment can be created using hmmbuild"/>
+                <param name="custom_tre" type="data" format="newick" label="Tree of the reference sequences"/>
+                <param name="custom_model" type="data" format="txt" label="Modelfile" help="For epa-ng: output by RaXmL specifying the best parameters for the tree, for sepp see examples in PICRUSt2 repository"/>
+            </when>
+        </conditional>
+        <param argument="--min_align" type="float" value="0.80" min="0.0" max="1.0" label="Minimum alignment length" help="Proportion of the total length of an input query sequence that must align with reference sequences. Sequences with lengths below this value will be excluded from the placement and all subsequent steps"/>
+    </xml>
     <xml name="place_seqs_output" tokens="from_work_dir" token_label_suffix="">
         <data name="out_tree" format="newick" from_work_dir="@FROM_WORK_DIR@/out.tre" label="${tool.name} on ${on_string}: Tree of reference and study 16S sequences @LABEL_SUFFIX@"/>
-        <collection name="place_seqs_intermediate_output" type="list" label="${tool.name} on ${on_string}: Intermediate files @LABEL_SUFFIX@" >
+        <collection name="place_seqs_intermediate_output" type="list" label="${tool.name} on ${on_string}: Intermediate files @LABEL_SUFFIX@">
             <discover_datasets pattern="__name_and_ext__" directory="@FROM_WORK_DIR@/intermediate/place_seqs/"/>
             <yield/>
         </collection>
     </xml>
-
     <!-- parameters of hsp -->
     <token name="@HSP_PARAMS@"><![CDATA[
-    ## hsp and picrust2_pipeline 
-    #if $getVarCond("hsp_section", "trait_input.selector") == "default"
-        #if $varExists('trait_input.in_trait')
-            --in_trait '$trait_input.in_trait'
-        #else if $varExists('hsp_section.trait_input.in_traits')
-            --in_traits '$hsp_section.trait_input.in_traits'
-        #else
-            #raise Exception("wrapper must define in_trait / in_traits")
+    #if $trait_input.selector == "default"
+        --in_trait '$trait_input.in_trait'
+    #else if $trait_input.selector == "custom"
+        --observed_trait_table '$trait_input.observed_trait_table'
+    #end if
+
+    --hsp_method '$hsp_method_options.hsp_method'
+    #if $hsp_method_options.hsp_method == "mp"
+        --edge_exponent $hsp_method_options.edge_exponent
+    #else if $hsp_method_options.hsp_method == "emp_prob"
+        --seed $hsp_method_options.seed
+    #end if
+    $calculate_NSTI
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_HSP_PARAMS@"><![CDATA[
+    #if $hsp_section.trait_input.selector == "default"
+        --in_traits '$hsp_section.trait_input.in_traits'
+    #else if $hsp_section.trait_input.selector == "custom"
+        --custom_trait_tables_ref1 '$hsp_section.trait_input.custom_trait_tables_ref1'
+        --custom_trait_tables_ref2 '$hsp_section.trait_input.custom_trait_tables_ref2'
+        #if $hsp_section.trait_input.marker_gene_table_ref1
+            --marker_gene_table_ref1 '$hsp_section.trait_input.marker_gene_table_ref1'
         #end if
-    #else if $getVarCond("hsp_section", "trait_input.selector") == "custom"
-        #if $varExists('trait_input.observed_trait_table')
-            --observed_trait_table '$trait_input.observed_trait_table'
-        #else if $varExists('hsp_section.trait_input.custom_trait_tables')
-            --custom_trait_tables '$hsp_section.trait_input.custom_trait_tables'
-            --marker_gene_table '$hsp_section.trait_input.marker_gene_table'
-        #else
-            #raise Exception("wrapper must define observed_trait_table / (custom_trait_tables + marker_gene_table)")
+        #if $hsp_section.trait_input.marker_gene_table_ref2
+            --marker_gene_table_ref2 '$hsp_section.trait_input.marker_gene_table_ref2'
         #end if
     #end if
 
-    
-    --hsp_method '$getVarCond("hsp_section", "hsp_method_options.hsp_method")'
-    #if $getVarCond("hsp_section", "hsp_method_options.hsp_method") == "mp"
-        --edge_exponent $getVarCond("hsp_section", "hsp_method_options.edge_exponent")
-    #else if $getVarCond("hsp_section", "") == "emp_prob"
-        ## special treatment of seed (option absent in picrust2_pipeline)
-        #if $varExists('hsp_method_options') and has_attrib($hsp_method_options, "seed")
-            --seed $hsp_method_options.seed
-        #end if
+    --hsp_method '$hsp_section.hsp_method_options.hsp_method'
+    #if $hsp_section.hsp_method_options.hsp_method == "mp"
+        --edge_exponent $hsp_section.hsp_method_options.edge_exponent
     #end if
-    ## hsp and picrust2_pipeline use different CLI params to toggle NSTI computation
-    #if $varExists('calculate_NSTI')
-        $calculate_NSTI
-    #else if $varExists('hsp_section.skip_nsti')
-        $hsp_section.skip_nsti
-    #else
-        #raise Exception("wrapper must define calculate_NSTI / skip_nsti")
+    $hsp_section.skip_nsti
+    ]]></token>
+    <token name="@HSP_DATABASE_PARAM@"><![CDATA[
+    #if $varExists('database')
+        --database '$database'
+    #end if
+    #if $varExists('reference')
+        --reference '$reference'
     #end if
     ]]></token>
     <!-- - one of nsti_[true,false]value must be given: CLI param
@@ -205,11 +258,19 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
         </conditional>
         <param argument="@NSTI_TRUEVALUE@@NSTI_FALSEVALUE@" type="boolean" truevalue="@NSTI_TRUEVALUE@" falsevalue="@NSTI_FALSEVALUE@" checked="@NSTI_CHECKED@" label="Calculate NSTI and add to output file" help="And add to output file"/>
     </xml>
-
+    <xml name="hsp_database_params">
+        <param argument="--database" type="select" label="Default trait database" help="Use SC for the current PICRUSt2 default database or oldIMG for legacy IMG default trait tables">
+            <option value="SC" selected="true">SC</option>
+            <option value="oldIMG">oldIMG</option>
+        </param>
+        <param argument="--reference" type="select" label="Reference domain" help="Used with the SC default trait database">
+            <option value="bac" selected="true">Bacteria</option>
+            <option value="arc">Archaea</option>
+        </param>
+    </xml>
     <!-- parameters of the metagenome_pipeline -->
-
     <token name="@PREPARE_METAGENOME_PIPELINE_PARAMS@"><![CDATA[
-#set $_input=$getVarCond("metagenome_pipeline_section", "input")
+#set $_input=$input
 #if $_input.ext == "mothur.shared"
     #set ext="msf"
 #else if $_input.ext == "tabular"
@@ -222,18 +283,45 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
 #end if
 ln -s '$input' 'input.$ext' &&
     ]]></token>
+    <token name="@PICRUST2_PIPELINE_PREPARE_METAGENOME_PIPELINE_PARAMS@"><![CDATA[
+#set $_input=$metagenome_pipeline_section.input
+#if $_input.ext == "mothur.shared"
+    #set ext="msf"
+#else if $_input.ext == "tabular"
+    #set ext="tsv"
+#else if $_input.ext.startswith('biom')
+    #set ext="biom"
+#else
+    >&2 "unknown extension $_input.ext"
+    exit 1;
+#end if
+ln -s '$metagenome_pipeline_section.input' 'input.$ext' &&
+    ]]></token>
     <token name="@METAGENOME_PIPELINE_PARAMS@"><![CDATA[
 --input 'input.$ext'
-#if $getVarCond("metagenome_pipeline_section", "input_options.selector") == "ASV"
-    --min_reads $getVarCond("metagenome_pipeline_section", "input_options.min_reads")
-    --min_samples $getVarCond("metagenome_pipeline_section", "input_options.min_samples")
+#if $input_options.selector == "ASV"
+    --min_reads $input_options.min_reads
+    --min_samples $input_options.min_samples
 #end if
-$getVarCond("metagenome_pipeline_section", "stratified_output.selector")
-#if $getVarCond("metagenome_pipeline_section", "stratified_output.selector") != ''
-    $getVarCond("metagenome_pipeline_section", "stratified_output.wide_table")
+$stratified_output.selector
+#if $stratified_output.selector != ''
+    $stratified_output.wide_table
 #end if
-$getVarCond("metagenome_pipeline_section", "skip_norm")
---max_nsti $getVarCond("metagenome_pipeline_section", "max_nsti")
+$skip_norm
+--max_nsti $max_nsti
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_METAGENOME_PIPELINE_PARAMS@"><![CDATA[
+--input 'input.$ext'
+#if $metagenome_pipeline_section.input_options.selector == "ASV"
+    --min_reads $metagenome_pipeline_section.input_options.min_reads
+    --min_samples $metagenome_pipeline_section.input_options.min_samples
+#end if
+$metagenome_pipeline_section.stratified_output.selector
+#if $metagenome_pipeline_section.stratified_output.selector != ''
+    $metagenome_pipeline_section.stratified_output.wide_table
+#end if
+$metagenome_pipeline_section.skip_norm
+--max_nsti $metagenome_pipeline_section.max_nsti
     ]]></token>
     <xml name="metagenome_pipeline_params" tokens="stratified_arg">
         <param argument="--input" type="data" format="tabular,biom1,biom2,mothur.shared" label="Sequence abundance table (OTUs or ASVs)" help="The sequence abundances should be in read counts and not relative abundances. The tool will normalize the input sequence abundance table by the predicted number of marker genes"/>
@@ -263,28 +351,43 @@ $getVarCond("metagenome_pipeline_section", "skip_norm")
         </conditional>
         <param argument="--skip_norm" type="boolean" truevalue="--skip_norm" falsevalue="" checked="false" label="Skip normalizing sequence abundances by predicted marker gene copy numbers"/>
     </xml>
-
     <!-- pathway_pipeline macros-->
     <token name="@PATHWAY_PIPELINE_PARAMS@"><![CDATA[
-## in pathway_pipeline its --map while in picrust2_pipeline its --pathway_map
-#if $varExists('map') and $map
+#if $map
     --map '$map'
-#else if $varExists('predict_pathways.pathway_map') and $predict_pathways.pathway_map
+#end if
+--database '$database'
+$skip_minpath
+$no_gap_fill
+$regrouping.no_regroup
+#if $regrouping.no_regroup == '' and $regrouping.regroup_map
+    --regroup_map '$regrouping.regroup_map'
+#end if
+$strat_output.per_sequence_contrib
+#if $strat_output.per_sequence_contrib != ""
+    --per_sequence_function '$strat_output.per_sequence_function'
+    --per_sequence_abun '$strat_output.per_sequence_abun'
+    $strat_output.wide_table
+#end if
+$coverage
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_PATHWAY_PIPELINE_PARAMS@"><![CDATA[
+#if $predict_pathways.pathway_map
     --pathway_map '$predict_pathways.pathway_map'
 #end if
-$getVarCond("predict_pathways", "skip_minpath")
-$getVarCond("predict_pathways", "no_gap_fill")
-$getVarCond("predict_pathways", "regrouping.no_regroup")
-#if $getVarCond("predict_pathways", "regrouping.no_regroup") == '' and $getVarCond("predict_pathways", "regrouping.regroup_map")
-    --regroup_map '$getVarCond("predict_pathways", "regroup_map")'
+$predict_pathways.skip_minpath
+$predict_pathways.no_gap_fill
+$predict_pathways.regrouping.no_regroup
+#if $predict_pathways.regrouping.no_regroup == '' and $predict_pathways.regrouping.regroup_map
+    --regroup_map '$predict_pathways.regrouping.regroup_map'
 #end if
-$getVarCond("predict_pathways", "strat_output.per_sequence_contrib")
-#if $getVarCond("predict_pathways", "strat_output.per_sequence_contrib") != ""
-    --per_sequence_function '$getVarCond("predict_pathways", "strat_output.per_sequence_function")'
-    --per_sequence_abun '$getVarCond("predict_pathways", "strat_output.per_sequence_abun")'
-    $getVarCond("predict_pathways", "strat_output.wide_table")
+$predict_pathways.strat_output.per_sequence_contrib
+#if $predict_pathways.strat_output.per_sequence_contrib != ""
+    --per_sequence_function '$predict_pathways.strat_output.per_sequence_function'
+    --per_sequence_abun '$predict_pathways.strat_output.per_sequence_abun'
+    $predict_pathways.strat_output.wide_table
 #end if
-$getVarCond("predict_pathways", "coverage")
+$predict_pathways.coverage
     ]]></token>
     <xml name="pathway_pipeline_params" tokens="mapargument">
         <param argument="@MAPARGUMENT@" type="data" format="txt,tabular" optional="true" label="Customized table mapping of pathways to reactions" help="Default mapping file is Maps MetaCyc reactions to prokaryotic MetaCyc pathways"/>
@@ -309,8 +412,7 @@ $getVarCond("predict_pathways", "coverage")
                 <param argument="--per_sequence_abun" type="data" format="tabular" label="Table of sequence abundances across samples normalized by marker copy number" help="Typically the normalized sequence abundance table output at the metagenome pipeline step. This input is required when the per sequence contrib option is set"/>
                 <param argument="--per_sequence_function" type="data" format="tabular" label="Table of function abundances per sequence, which was outputted at the hidden-state prediction step" help="This input is required when the per sequence contrib option is set. Note that this file should be the same input table as used for the metagenome pipeline step"/>
                 <!-- TODO maybe deprecate .. because complicated anyway as its used in metagenome_pipeline as well and help says deprecated as well -->
-                <param argument="--wide_table" type="boolean" truevalue="--wide_table" falsevalue="" checked="false" label="Output wide-format stratified table (DEPRECATED)" help="Instead of the metagenome contribution table. This is the deprecated method of generating
-                stratified tables since it is extremely memory intensive"/>
+                <param argument="--wide_table" type="boolean" truevalue="--wide_table" falsevalue="" checked="false" label="Output wide-format stratified table (DEPRECATED)" help="Instead of the metagenome contribution table. This is the deprecated method of generating                 stratified tables since it is extremely memory intensive"/>
             </when>
             <when value=""/>
         </conditional>
@@ -320,23 +422,23 @@ $getVarCond("predict_pathways", "coverage")
         <data name="pathways_output" format="tabular" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_unstrat.tabular" label="${tool.name} on ${on_string}: Pathway abundances">
             <yield/>
         </data>
-        <collection name="pathways_intermediate_output" type="list" label="${tool.name} on ${on_string}: Intermediate files @LABEL_SUFFIX@" >
+        <collection name="pathways_intermediate_output" type="list" label="${tool.name} on ${on_string}: Intermediate files @LABEL_SUFFIX@">
             <discover_datasets pattern="__name_and_ext__" directory="@FROM_WORK_DIR@/intermediate/pathways/" format="tabular"/>
             <yield name="intermediate_filter"/>
         </collection>
-        <data format="tabular" name="path_cov_unstrat" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_cov_unstrat.tabular" label="${tool.name} on ${on_string}: Pathway coverage @LABEL_SUFFIX@" >
+        <data format="tabular" name="path_cov_unstrat" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_cov_unstrat.tabular" label="${tool.name} on ${on_string}: Pathway coverage @LABEL_SUFFIX@">
             <yield/>
             <yield name="coverage_filter"/>
         </data>
-        <data format="tabular" name="path_abun_unstrat_per_seq" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_unstrat_per_seq.tabular" label="${tool.name} on ${on_string}: Pathway abundance unstratified per sequence @LABEL_SUFFIX@" >
+        <data format="tabular" name="path_abun_unstrat_per_seq" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_unstrat_per_seq.tabular" label="${tool.name} on ${on_string}: Pathway abundance unstratified per sequence @LABEL_SUFFIX@">
             <yield/>
             <yield name="per_sequence_filter"/>
         </data>
-        <data format="tabular" name="path_abun_predictions" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_predictions.tabular" label="${tool.name} on ${on_string}: Pathway abundance predictions @LABEL_SUFFIX@" >
+        <data format="tabular" name="path_abun_predictions" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_predictions.tabular" label="${tool.name} on ${on_string}: Pathway abundance predictions @LABEL_SUFFIX@">
             <yield/>
             <yield name="per_sequence_filter"/>
         </data>
-        <data format="tabular" name="path_abun_contrib" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_contrib.tabular" label="${tool.name} on ${on_string}: Pathway abundance contributed @LABEL_SUFFIX@" >
+        <data format="tabular" name="path_abun_contrib" from_work_dir="@FROM_WORK_DIR@/pathways_out/path_abun_contrib.tabular" label="${tool.name} on ${on_string}: Pathway abundance contributed @LABEL_SUFFIX@">
             <yield/>
             <yield name="per_sequence_filter"/>
         </data>

--- a/tools/picrust2/macros.xml
+++ b/tools/picrust2/macros.xml
@@ -48,25 +48,50 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
     <token name="@PICRUST2_PIPELINE_PLACE_SEQS_PREPROCESSING@"><![CDATA[
         #if $place_seqs_section.ref_dir1.selector == "custom"
             mkdir -p custom_ref1/ &&
-            ln -s '$place_seqs_section.ref_dir1.custom_fna' custom_ref1/custom.fna &&
-            ln -s '$place_seqs_section.ref_dir1.custom_hmm' custom_ref1/custom.hmm &&
+            ln -s '$place_seqs_section.ref_dir1.custom_fna' custom_ref1/custom_ref1.fna &&
+            ln -s '$place_seqs_section.ref_dir1.custom_hmm' custom_ref1/custom_ref1.hmm &&
             #if $place_seqs_section.placement_tool == "epa-ng"
-                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom.model &&
+                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom_ref1.model &&
             #else
-                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom.raxml_info &&
+                ln -s '$place_seqs_section.ref_dir1.custom_model' custom_ref1/custom_ref1.raxml_info &&
             #end if
-            ln -s '$place_seqs_section.ref_dir1.custom_tre' custom_ref1/custom.tre &&
+            ln -s '$place_seqs_section.ref_dir1.custom_tre' custom_ref1/custom_ref1.tre &&
         #end if
         #if $place_seqs_section.ref_dir2.selector == "custom"
             mkdir -p custom_ref2/ &&
-            ln -s '$place_seqs_section.ref_dir2.custom_fna' custom_ref2/custom.fna &&
-            ln -s '$place_seqs_section.ref_dir2.custom_hmm' custom_ref2/custom.hmm &&
+            ln -s '$place_seqs_section.ref_dir2.custom_fna' custom_ref2/custom_ref2.fna &&
+            ln -s '$place_seqs_section.ref_dir2.custom_hmm' custom_ref2/custom_ref2.hmm &&
             #if $place_seqs_section.placement_tool == "epa-ng"
-                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom.model &&
+                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom_ref2.model &&
             #else
-                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom.raxml_info &&
+                ln -s '$place_seqs_section.ref_dir2.custom_model' custom_ref2/custom_ref2.raxml_info &&
             #end if
-            ln -s '$place_seqs_section.ref_dir2.custom_tre' custom_ref2/custom.tre &&
+            ln -s '$place_seqs_section.ref_dir2.custom_tre' custom_ref2/custom_ref2.tre &&
+        #end if
+    ]]></token>
+    <token name="@PICRUST2_PIPELINE_HSP_PREPROCESSING@"><![CDATA[
+        #if $hsp_section.trait_input.selector == "custom"
+            mkdir -p custom_traits_ref1/ custom_traits_ref2/ &&
+            #set $custom_trait_tables_ref1 = []
+            #for $i, $trait_table in enumerate($hsp_section.trait_input.custom_trait_tables_ref1)
+                #set $trait_path = "custom_traits_ref1/custom_traits_%d.tsv" % $i
+                #silent $custom_trait_tables_ref1.append($trait_path)
+                ln -s '$trait_table' '$trait_path' &&
+            #end for
+            #set $custom_trait_tables_ref1_arg = ",".join($custom_trait_tables_ref1)
+            #set $custom_trait_tables_ref2 = []
+            #for $i, $trait_table in enumerate($hsp_section.trait_input.custom_trait_tables_ref2)
+                #set $trait_path = "custom_traits_ref2/custom_traits_%d.tsv" % $i
+                #silent $custom_trait_tables_ref2.append($trait_path)
+                ln -s '$trait_table' '$trait_path' &&
+            #end for
+            #set $custom_trait_tables_ref2_arg = ",".join($custom_trait_tables_ref2)
+            #if $hsp_section.trait_input.marker_gene_table_ref1
+                ln -s '$hsp_section.trait_input.marker_gene_table_ref1' custom_marker_ref1.tsv &&
+            #end if
+            #if $hsp_section.trait_input.marker_gene_table_ref2
+                ln -s '$hsp_section.trait_input.marker_gene_table_ref2' custom_marker_ref2.tsv &&
+            #end if
         #end if
     ]]></token>
     <token name="@PLACE_SEQS_PARAMS@"><![CDATA[
@@ -183,13 +208,13 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
     #if $hsp_section.trait_input.selector == "default"
         --in_traits '$hsp_section.trait_input.in_traits'
     #else if $hsp_section.trait_input.selector == "custom"
-        --custom_trait_tables_ref1 '$hsp_section.trait_input.custom_trait_tables_ref1'
-        --custom_trait_tables_ref2 '$hsp_section.trait_input.custom_trait_tables_ref2'
+        --custom_trait_tables_ref1 '$custom_trait_tables_ref1_arg'
+        --custom_trait_tables_ref2 '$custom_trait_tables_ref2_arg'
         #if $hsp_section.trait_input.marker_gene_table_ref1
-            --marker_gene_table_ref1 '$hsp_section.trait_input.marker_gene_table_ref1'
+            --marker_gene_table_ref1 custom_marker_ref1.tsv
         #end if
         #if $hsp_section.trait_input.marker_gene_table_ref2
-            --marker_gene_table_ref2 '$hsp_section.trait_input.marker_gene_table_ref2'
+            --marker_gene_table_ref2 custom_marker_ref2.tsv
         #end if
     #end if
 
@@ -197,7 +222,6 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
     #if $hsp_section.hsp_method_options.hsp_method == "mp"
         --edge_exponent $hsp_section.hsp_method_options.edge_exponent
     #end if
-    $hsp_section.skip_nsti
     ]]></token>
     <token name="@HSP_DATABASE_PARAMS@"><![CDATA[
     --database '$database'
@@ -214,7 +238,7 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
          to specify custom trait tables in hsp (observed_trait_table) and
          picrust2_pipeline (custom_trait_tables, marker_gene_table)
         -->
-    <xml name="hsp_params" tokens="nsti_checked,in_trait_arg,in_trait_multiple,in_trait_label_suff" token_nsti_truevalue="" token_nsti_falsevalue="" token_in_traits_help="">
+    <xml name="hsp_params" tokens="in_trait_arg,in_trait_multiple,in_trait_label_suff" token_in_traits_help="">
         <conditional name="trait_input">
             <param name="selector" type="select" label="Trait table@IN_TRAIT_LABEL_SUFF@" help="i.e. which gene families to predict">
                 <option value="default" selected="true">Default trait table@IN_TRAIT_LABEL_SUFF@</option>
@@ -252,7 +276,49 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
             <when value="pic"/>
             <when value="scp"/>
         </conditional>
-        <param argument="@NSTI_TRUEVALUE@@NSTI_FALSEVALUE@" type="boolean" truevalue="@NSTI_TRUEVALUE@" falsevalue="@NSTI_FALSEVALUE@" checked="@NSTI_CHECKED@" label="Calculate NSTI and add to output file" help="And add to output file"/>
+    </xml>
+    <xml name="picrust2_pipeline_hsp_params">
+        <conditional name="trait_input">
+            <param name="selector" type="select" label="Trait tables" help="i.e. which gene families to predict">
+                <option value="default" selected="true">Default trait tables</option>
+                <option value="custom">Customized trait tables</option>
+            </param>
+            <when value="default">
+                <param argument="--in_traits" type="select" multiple="true" optional="false" label="Pre-calculated trait tables" help="Note that EC numbers will always be predicted unless --no_pathways is set">
+                    <option value="EC" selected="true">Enzyme Commission number database (EC number)</option>
+                    <option value="KO" selected="true">KEGG Orthology database (KO)</option>
+                    <option value="GO">Gene Ontology database (GO)</option>
+                    <option value="PFAM">Pfam database</option>
+                    <option value="BIGG">BiGG reaction database</option>
+                    <option value="CAZY">CAZy database</option>
+                    <option value="GENE_NAMES">Preferred gene names</option>
+                </param>
+            </when>
+            <when value="custom">
+                <!-- both go separately into hsp observed_trait_table -->
+                <param argument="--custom_trait_tables_ref1" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 1" help="with gene families as columns and genomes as rows"/>
+                <param argument="--custom_trait_tables_ref2" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 2" help="with gene families as columns and genomes as rows"/>
+                <!-- by default 16S is used also goes into observed_trait_table -->
+                <param argument="--marker_gene_table_ref1" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 1"/>
+                <param argument="--marker_gene_table_ref2" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 2"/>
+            </when>
+        </conditional>
+        <conditional name="hsp_method_options">
+            <param argument="--hsp_method" type="select" label="Hidden-state prediction method">
+                <option value="mp" selected="true">Predict discrete traits by: Maximum parsimony (mp)</option>
+                <option value="emp_prob">Predict discrete traits by: Empirical state probabilities across tips (emp_prob)</option>
+                <option value="subtree_average">Predict continuous traits by: Subtree averaging (subtree_average)</option>
+                <option value="pic">Predict continuous traits by: phylogentic independent contrast (pic)</option>
+                <option value="scp">Reconstruct continuous traits by: squared-change parsimony (scp)</option>
+            </param>
+            <when value="mp">
+                <param argument="--edge_exponent" type="float" value="0.5" min="0.0" label="Transition cost weight" help="Specifies weighting transition costs by the inverse length of edge lengths. If 0, then edge lengths do not influence predictions"/>
+            </when>
+            <when value="emp_prob"/>
+            <when value="subtree_average"/>
+            <when value="pic"/>
+            <when value="scp"/>
+        </conditional>
     </xml>
     <xml name="hsp_database_params">
         <param argument="--database" type="select" label="Default trait database" help="Use SC for the current PICRUSt2 default database or oldIMG for legacy IMG default trait tables">

--- a/tools/picrust2/macros.xml
+++ b/tools/picrust2/macros.xml
@@ -199,13 +199,9 @@ Read more about the tool: https://github.com/picrust/picrust2/wiki
     #end if
     $hsp_section.skip_nsti
     ]]></token>
-    <token name="@HSP_DATABASE_PARAM@"><![CDATA[
-    #if $varExists('database')
-        --database '$database'
-    #end if
-    #if $varExists('reference')
-        --reference '$reference'
-    #end if
+    <token name="@HSP_DATABASE_PARAMS@"><![CDATA[
+    --database '$database'
+    --reference '$reference'
     ]]></token>
     <!-- - one of nsti_[true,false]value must be given: CLI param
            differs between hsp and picrust2_pipeline

--- a/tools/picrust2/metagenome_pipeline.xml
+++ b/tools/picrust2/metagenome_pipeline.xml
@@ -6,8 +6,7 @@
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>metagenome_pipeline.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
-@VAR_ACCESS_FOO@
+    <command detect_errors="aggressive"><![CDATA[
 @PREPARE_METAGENOME_PIPELINE_PARAMS@
 metagenome_pipeline.py
     --function '$function'
@@ -27,10 +26,10 @@ metagenome_pipeline.py
         <data name="pred_metagenome_unstrat" format="tabular" from_work_dir="metagenome_output/pred_metagenome_unstrat.tsv" label="${tool.name} on ${on_string}: Predicted per-sample metagenome functional profiles"/>
         <data name="seqtab_norm" format="tabular" from_work_dir="metagenome_output/seqtab_norm.tsv" label="${tool.name} on ${on_string}: Normalized sequence abundance table"/>
         <data name="weighted_nsti" format="tabular" from_work_dir="metagenome_output/weighted_nsti.tsv" label="${tool.name} on ${on_string}: Weighted nearest-sequenced taxon index (NSTI) values per-sample"/>
-        <data name="strat_output" format="tabular" from_work_dir="metagenome_output/pred_metagenome_contrib.tsv" label="${tool.name} on ${on_string}: Predicted per-sample metagenome functional profiles, stratified by sequence ids (i.e. taxonomic contributors)" >
+        <data name="strat_output" format="tabular" from_work_dir="metagenome_output/pred_metagenome_contrib.tsv" label="${tool.name} on ${on_string}: Predicted per-sample metagenome functional profiles, stratified by sequence ids (i.e. taxonomic contributors)">
             <filter>stratified_output['selector'] != '' and not stratified_output['wide_table']</filter>
         </data>
-        <data name="wide_table_output" format="tabular" from_work_dir="metagenome_output/pred_metagenome_strat.tsv" label="${tool.name} on ${on_string}: Predicted per-sample metagenome functional profiles, wide-format stratified by sequence ids (i.e. taxonomic contributors)" >
+        <data name="wide_table_output" format="tabular" from_work_dir="metagenome_output/pred_metagenome_strat.tsv" label="${tool.name} on ${on_string}: Predicted per-sample metagenome functional profiles, wide-format stratified by sequence ids (i.e. taxonomic contributors)">
             <filter>stratified_output['selector'] != '' and stratified_output['wide_table']</filter>
         </data>
     </outputs>

--- a/tools/picrust2/pathway_pipeline.xml
+++ b/tools/picrust2/pathway_pipeline.xml
@@ -58,7 +58,7 @@ true
     <tests>
         <test expect_num_outputs="1">
             <param name="input" ftype="tabular" value="pred_metagenome_unstrat.tsv.gz"/>
-            <param name="database" value="SC"/>
+            <param name="database" value="oldIMG"/>
             <param name="skip_minpath" value="true"/>
             <param name="no_gap_fill" value="true"/>
             <conditional name="regrouping">
@@ -82,7 +82,7 @@ true
         </test>
         <test expect_num_outputs="6">
             <param name="input" ftype="tabular" value="pred_metagenome_unstrat.tsv.gz"/>
-            <param name="database" value="SC"/>
+            <param name="database" value="oldIMG"/>
             <param name="skip_minpath" value="true"/>
             <param name="no_gap_fill" value="true"/>
             <conditional name="regrouping">

--- a/tools/picrust2/pathway_pipeline.xml
+++ b/tools/picrust2/pathway_pipeline.xml
@@ -1,13 +1,12 @@
 <tool id="picrust2_pathway_pipeline" name="PICRUSt2 Pathway abundance inference" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
-    <description></description>
+    <description/>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>pathway_pipeline.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
-@VAR_ACCESS_FOO@
+    <command detect_errors="aggressive"><![CDATA[
 #if $intermediate_check
     mkdir intermediate &&
 #end if
@@ -36,6 +35,10 @@ true
     ]]></command>
     <inputs>
         <param argument="--input" type="data" format="tabular" label="Input table with gene family abundances" help="Unstratified or stratified output of PICRUSt2 Metagenome prediction tool"/>
+        <param argument="--database" type="select" label="Pathway database" help="Use SC for the current PICRUSt2 default pathway database or oldIMG for legacy IMG pathway files">
+            <option value="SC" selected="true">SC</option>
+            <option value="oldIMG">oldIMG</option>
+        </param>
         <expand macro="pathway_pipeline_params" mapargument="--map"/>
         <param argument="--intermediate_check" type="boolean" truevalue="intermediate_check" falsevalue="" checked="false" label="Keep intermediate files" help="Intermediate output files will be deleted by default"/>
     </inputs>
@@ -55,9 +58,12 @@ true
     <tests>
         <test expect_num_outputs="1">
             <param name="input" ftype="tabular" value="pred_metagenome_unstrat.tsv.gz"/>
+            <param name="database" value="SC"/>
             <param name="skip_minpath" value="true"/>
             <param name="no_gap_fill" value="true"/>
-            <param name="no_regroup" value=""/>
+            <conditional name="regrouping">
+                <param name="no_regroup" value=""/>
+            </conditional>
             <conditional name="strat_output">
                 <param name="per_sequence_contrib" value=""/>
             </conditional>
@@ -76,9 +82,12 @@ true
         </test>
         <test expect_num_outputs="6">
             <param name="input" ftype="tabular" value="pred_metagenome_unstrat.tsv.gz"/>
+            <param name="database" value="SC"/>
             <param name="skip_minpath" value="true"/>
             <param name="no_gap_fill" value="true"/>
-            <param name="no_regroup" value=""/>
+            <conditional name="regrouping">
+                <param name="no_regroup" value=""/>
+            </conditional>
             <param name="intermediate_check" value="false"/>
             <conditional name="strat_output">
                 <param name="per_sequence_contrib" value="--per_sequence_contrib"/>

--- a/tools/picrust2/picrust2_pipeline.xml
+++ b/tools/picrust2/picrust2_pipeline.xml
@@ -1,29 +1,28 @@
 <tool id="picrust2_pipeline" name="PICRUSt2 Full pipeline" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
-    <description></description>
+    <description/>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>picrust2_pipeline.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
-@VAR_ACCESS_FOO@
-@PLACE_SEQS_PREPROCESSING@
-@PREPARE_METAGENOME_PIPELINE_PARAMS@
+    <command detect_errors="aggressive"><![CDATA[
+@PICRUST2_PIPELINE_PLACE_SEQS_PREPROCESSING@
+@PICRUST2_PIPELINE_PREPARE_METAGENOME_PIPELINE_PARAMS@
 
 picrust2_pipeline.py
     ## place_seqs parameters
-    @PLACE_SEQS_PARAMS@
+    @PICRUST2_PIPELINE_PLACE_SEQS_PARAMS@
 
     ## hsp parameters
-    @HSP_PARAMS@
+    @PICRUST2_PIPELINE_HSP_PARAMS@
 
     ## metagenome_pipeline parameters
-    @METAGENOME_PIPELINE_PARAMS@
+    @PICRUST2_PIPELINE_METAGENOME_PIPELINE_PARAMS@
 
     ## pathway_pipeline parameters
     #if $predict_pathways.no_pathways == ''
-        @PATHWAY_PIPELINE_PARAMS@
+        @PICRUST2_PIPELINE_PATHWAY_PIPELINE_PARAMS@
         --reaction_func '$predict_pathways.reaction_map_file.reaction_func'
     #end if
 
@@ -52,26 +51,25 @@ picrust2_pipeline.py
     <inputs>
         <!-- place_seqs parameters -->
         <section name="place_seqs_section" title="Sequence placement options" expanded="true">
-            <expand macro="place_seqs_params"/>
+            <expand macro="picrust2_pipeline_place_seqs_params"/>
         </section>
-
         <!-- hsp parameters -->
         <section name="hsp_section" title="Hidden state prediction (HSP) options" expanded="true">
             <expand macro="hsp_params" nsti_falsevalue="--skip_nsti" nsti_checked="true" in_trait_arg="--in_traits" in_trait_multiple="true" in_trait_label_suff="(s)" in_traits_help="Note that EC numbers will always be predicted unless --no_pathways is set">
                 <token name="custom_traits">
                     <!-- both go separately into hsp observed_trait_table -->
-                    <param argument="--custom_trait_tables" type="data" multiple="true" format="tabular" label="Customized trait table(s)" help="with gene families as columns and genomes as rows"/>
+                    <param argument="--custom_trait_tables_ref1" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 1" help="with gene families as columns and genomes as rows"/>
+                    <param argument="--custom_trait_tables_ref2" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 2" help="with gene families as columns and genomes as rows"/>
                     <!-- by default 16S is used also goes into observed_trait_table -->
-                    <param argument="--marker_gene_table" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers" />
+                    <param argument="--marker_gene_table_ref1" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 1"/>
+                    <param argument="--marker_gene_table_ref2" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 2"/>
                 </token>
             </expand>
         </section>
-
         <!-- metagenome_pipeline parameters -->
         <section name="metagenome_pipeline_section" title="Metagenome prediction options" expanded="true">
             <expand macro="metagenome_pipeline_params" stratified_arg="--stratified"/>
         </section>
-
         <!-- pathway_pipeline parameters -->
         <conditional name="predict_pathways">
             <param argument="--no_pathways" type="select" truevalue="" falsevalue="--no_pathways" checked="true" label="Infer pathways">
@@ -111,17 +109,14 @@ picrust2_pipeline.py
         <expand macro="place_seqs_output" from_work_dir="full_pipeline_output/" label_suffix="(place_seqs)">
             <filter>remove_intermediate and "place_seqs" in remove_intermediate</filter>
         </expand>
-
         <!-- hsp output -->
-        <collection name="hsp_output" type="list" label="${tool.name} on ${on_string}: predicted copy numbers" >
+        <collection name="hsp_output" type="list" label="${tool.name} on ${on_string}: predicted copy numbers">
             <discover_datasets pattern="(?P&lt;designation&gt;.+)_predicted\.tabular" directory="full_pipeline_output/" format="tabular"/>
         </collection>
-
         <!-- metagenome output -->
-        <collection name="metagenome_output" type="list:list" label="${tool.name} on ${on_string}: metagenome output" >
+        <collection name="metagenome_output" type="list:list" label="${tool.name} on ${on_string}: metagenome output">
             <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_metagenome_out_(?P&lt;identifier_1&gt;.+)\.tabular" directory="full_pipeline_output/" format="tabular"/>
         </collection>
-
         <!-- pathways output -->
         <expand macro="pathways_output" from_work_dir="full_pipeline_output/" label_suffix="pathways">
             <filter>predict_pathways["no_pathways"] == ""</filter>
@@ -139,28 +134,36 @@ picrust2_pipeline.py
     <tests>
         <test expect_num_outputs="5">
             <!-- place_seq -->
-            <param name="study_fasta" value="study_seqs_full.fasta"/>
-            <param name="placement_tool" value="sepp"/>
-            <param name="min_align" value="0.0"/>
+            <section name="place_seqs_section">
+                <param name="study_fasta" value="study_seqs_full.fasta"/>
+                <param name="placement_tool" value="sepp"/>
+                <param name="min_align" value="0.0"/>
+            </section>
             <!-- hsp -->
-            <conditional name="trait_input">
-                <param name="selector" value="default"/>
-                <param name="in_traits" value="EC,COG"/>
-            </conditional>
-            <param name="skip_nsti" value="false"/>
+            <section name="hsp_section">
+                <conditional name="trait_input">
+                    <param name="selector" value="default"/>
+                    <param name="in_traits" value="EC,COG"/>
+                </conditional>
+                <param name="skip_nsti" value="false"/>
+            </section>
             <!-- metagenome -->
-            <param name="input" value="workflow_seq_abun.biom"/>
-            <conditional name="input_options">
-                <param name="selector" value="ASV"/>
-                <param name="min_reads" value="1"/>
-                <param name="min_samples" value="1"/>
-            </conditional>
-            <param name="max_nsti" value="2.0"/>
-            <param name="skip_norm" value="false"/>
+            <section name="metagenome_pipeline_section">
+                <param name="input" value="workflow_seq_abun.biom"/>
+                <conditional name="input_options">
+                    <param name="selector" value="ASV"/>
+                    <param name="min_reads" value="1"/>
+                    <param name="min_samples" value="1"/>
+                </conditional>
+                <param name="max_nsti" value="2.0"/>
+                <param name="skip_norm" value="false"/>
+            </section>
             <!-- pathway -->
-            <param name="skip_minpath" value="false"/>
-            <param name="no_gap_fill" value="true"/>
-
+            <conditional name="predict_pathways">
+                <param name="no_pathways" value=""/>
+                <param name="skip_minpath" value="false"/>
+                <param name="no_gap_fill" value="true"/>
+            </conditional>
             <param name="remove_intermediate" value="place_seqs"/>
             <output name="out_tree" ftype="newick">
                 <assert_contents>
@@ -243,28 +246,36 @@ picrust2_pipeline.py
         <!-- same as test 1, but only COG as in_traits (which has the same result since EC is added automatically), and test the other intermediate result -->
         <test expect_num_outputs="5">
             <!-- place_seq -->
-            <param name="study_fasta" value="study_seqs_full.fasta"/>
-            <param name="placement_tool" value="sepp"/>
-            <param name="min_align" value="0.0"/>
+            <section name="place_seqs_section">
+                <param name="study_fasta" value="study_seqs_full.fasta"/>
+                <param name="placement_tool" value="sepp"/>
+                <param name="min_align" value="0.0"/>
+            </section>
             <!-- hsp -->
-            <conditional name="trait_input">
-                <param name="selector" value="default"/>
-                <param name="in_traits" value="COG"/>
-            </conditional>
-            <param name="skip_nsti" value="false"/>
+            <section name="hsp_section">
+                <conditional name="trait_input">
+                    <param name="selector" value="default"/>
+                    <param name="in_traits" value="COG"/>
+                </conditional>
+                <param name="skip_nsti" value="false"/>
+            </section>
             <!-- metagenome -->
-            <param name="input" value="workflow_seq_abun.biom"/>
-            <conditional name="input_options">
-                <param name="selector" value="ASV"/>
-                <param name="min_reads" value="1"/>
-                <param name="min_samples" value="1"/>
-            </conditional>
-            <param name="max_nsti" value="2.0"/>
-            <param name="skip_norm" value="false"/>
+            <section name="metagenome_pipeline_section">
+                <param name="input" value="workflow_seq_abun.biom"/>
+                <conditional name="input_options">
+                    <param name="selector" value="ASV"/>
+                    <param name="min_reads" value="1"/>
+                    <param name="min_samples" value="1"/>
+                </conditional>
+                <param name="max_nsti" value="2.0"/>
+                <param name="skip_norm" value="false"/>
+            </section>
             <!-- pathway -->
-            <param name="skip_minpath" value="false"/>
-            <param name="no_gap_fill" value="true"/>
-
+            <conditional name="predict_pathways">
+                <param name="no_pathways" value=""/>
+                <param name="skip_minpath" value="false"/>
+                <param name="no_gap_fill" value="true"/>
+            </conditional>
             <param name="remove_intermediate" value="pathways"/>
             <output name="out_tree" ftype="newick">
                 <assert_contents>
@@ -295,7 +306,6 @@ picrust2_pipeline.py
                     </assert_contents>
                 </element>
             </output_collection>
-
             <output_collection name="metagenome_output" type="list:list" count="2">
                 <element name="COG">
                     <element name="pred_metagenome_unstrat" ftype="tabular">

--- a/tools/picrust2/picrust2_pipeline.xml
+++ b/tools/picrust2/picrust2_pipeline.xml
@@ -8,6 +8,7 @@
     <version_command>picrust2_pipeline.py -v</version_command>
     <command detect_errors="aggressive"><![CDATA[
 @PICRUST2_PIPELINE_PLACE_SEQS_PREPROCESSING@
+@PICRUST2_PIPELINE_HSP_PREPROCESSING@
 @PICRUST2_PIPELINE_PREPARE_METAGENOME_PIPELINE_PARAMS@
 
 picrust2_pipeline.py
@@ -24,9 +25,11 @@ picrust2_pipeline.py
     #if $predict_pathways.no_pathways == ''
         @PICRUST2_PIPELINE_PATHWAY_PIPELINE_PARAMS@
         --reaction_func '$predict_pathways.reaction_map_file.reaction_func'
+    #else
+        $predict_pathways.no_pathways
     #end if
 
-    #if $remove_intermediate is None
+    #if not $remove_intermediate
         --remove_intermediate
     #end if
 
@@ -55,16 +58,7 @@ picrust2_pipeline.py
         </section>
         <!-- hsp parameters -->
         <section name="hsp_section" title="Hidden state prediction (HSP) options" expanded="true">
-            <expand macro="hsp_params" nsti_falsevalue="--skip_nsti" nsti_checked="true" in_trait_arg="--in_traits" in_trait_multiple="true" in_trait_label_suff="(s)" in_traits_help="Note that EC numbers will always be predicted unless --no_pathways is set">
-                <token name="custom_traits">
-                    <!-- both go separately into hsp observed_trait_table -->
-                    <param argument="--custom_trait_tables_ref1" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 1" help="with gene families as columns and genomes as rows"/>
-                    <param argument="--custom_trait_tables_ref2" type="data" multiple="true" format="tabular" label="Customized trait table(s) for domain 2" help="with gene families as columns and genomes as rows"/>
-                    <!-- by default 16S is used also goes into observed_trait_table -->
-                    <param argument="--marker_gene_table_ref1" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 1"/>
-                    <param argument="--marker_gene_table_ref2" type="data" format="tabular" optional="true" label="Table of predicted marker gene (16S or other) copy numbers for domain 2"/>
-                </token>
-            </expand>
+            <expand macro="picrust2_pipeline_hsp_params"/>
         </section>
         <!-- metagenome_pipeline parameters -->
         <section name="metagenome_pipeline_section" title="Metagenome prediction options" expanded="true">
@@ -85,11 +79,13 @@ picrust2_pipeline.py
                     </param>
                     <when value="default">
                         <param argument="--reaction_func" type="select" label="Default functional database">
-                            <option value="COG">Clusters of Orthologous Genes database (COG)</option>
                             <option value="EC" selected="true">Enzyme Commission number database (EC number)</option>
                             <option value="KO">KEGG Orthology database (KO)</option>
+                            <option value="GO">Gene Ontology database (GO)</option>
                             <option value="PFAM">Pfam database</option>
-                            <option value="TIGRFAM">TIGRFAM database</option>
+                            <option value="BIGG">BiGG reaction database</option>
+                            <option value="CAZY">CAZy database</option>
+                            <option value="GENE_NAMES">Preferred gene names</option>
                         </param>
                     </when>
                     <when value="custom">
@@ -106,9 +102,26 @@ picrust2_pipeline.py
     </inputs>
     <outputs>
         <!-- place seqs outputs -->
-        <expand macro="place_seqs_output" from_work_dir="full_pipeline_output/" label_suffix="(place_seqs)">
+        <data name="bac_tree" format="newick" from_work_dir="full_pipeline_output/bac.tre" label="${tool.name} on ${on_string}: Bacterial tree of reference and study 16S sequences">
+            <filter>place_seqs_section["ref_dir1"]["selector"] == "default"</filter>
+        </data>
+        <data name="arc_tree" format="newick" from_work_dir="full_pipeline_output/arc.tre" label="${tool.name} on ${on_string}: Archaeal tree of reference and study 16S sequences">
+            <filter>place_seqs_section["ref_dir2"]["selector"] == "default"</filter>
+        </data>
+        <data name="ref1_tree" format="newick" from_work_dir="full_pipeline_output/ref1.tre" label="${tool.name} on ${on_string}: Domain 1 tree of reference and study sequences">
+            <filter>place_seqs_section["ref_dir1"]["selector"] == "custom"</filter>
+        </data>
+        <data name="ref2_tree" format="newick" from_work_dir="full_pipeline_output/ref2.tre" label="${tool.name} on ${on_string}: Domain 2 tree of reference and study sequences">
+            <filter>place_seqs_section["ref_dir2"]["selector"] == "custom"</filter>
+        </data>
+        <collection name="place_seqs_bac_intermediate_output" type="list" label="${tool.name} on ${on_string}: Bacterial placement intermediate files">
+            <discover_datasets pattern="__name_and_ext__" directory="full_pipeline_output/intermediate/place_seqs_bac/"/>
             <filter>remove_intermediate and "place_seqs" in remove_intermediate</filter>
-        </expand>
+        </collection>
+        <collection name="place_seqs_arc_intermediate_output" type="list" label="${tool.name} on ${on_string}: Archaeal placement intermediate files">
+            <discover_datasets pattern="__name_and_ext__" directory="full_pipeline_output/intermediate/place_seqs_arc/"/>
+            <filter>remove_intermediate and "place_seqs" in remove_intermediate</filter>
+        </collection>
         <!-- hsp output -->
         <collection name="hsp_output" type="list" label="${tool.name} on ${on_string}: predicted copy numbers">
             <discover_datasets pattern="(?P&lt;designation&gt;.+)_predicted\.tabular" directory="full_pipeline_output/" format="tabular"/>
@@ -132,20 +145,36 @@ picrust2_pipeline.py
         </expand>
     </outputs>
     <tests>
-        <test expect_num_outputs="5">
+        <test expect_num_outputs="4">
             <!-- place_seq -->
             <section name="place_seqs_section">
                 <param name="study_fasta" value="study_seqs_full.fasta"/>
-                <param name="placement_tool" value="sepp"/>
+                <param name="placement_tool" value="epa-ng"/>
+                <conditional name="ref_dir1">
+                    <param name="selector" value="custom"/>
+                    <param name="custom_fna" value="img_centroid_16S_aligned_head30.fna.gz"/>
+                    <param name="custom_hmm" value="img_centroid_16S_aligned_head30.hmm"/>
+                    <param name="custom_tre" value="img_centroid_16S_aligned_head30.tre"/>
+                    <param name="custom_model" value="img_centroid_16S_aligned_head30.model"/>
+                </conditional>
+                <conditional name="ref_dir2">
+                    <param name="selector" value="custom"/>
+                    <param name="custom_fna" value="img_centroid_16S_aligned_head30.fna.gz"/>
+                    <param name="custom_hmm" value="img_centroid_16S_aligned_head30.hmm"/>
+                    <param name="custom_tre" value="img_centroid_16S_aligned_head30.tre"/>
+                    <param name="custom_model" value="img_centroid_16S_aligned_head30.model"/>
+                </conditional>
                 <param name="min_align" value="0.0"/>
             </section>
             <!-- hsp -->
             <section name="hsp_section">
                 <conditional name="trait_input">
-                    <param name="selector" value="default"/>
-                    <param name="in_traits" value="EC,COG"/>
+                    <param name="selector" value="custom"/>
+                    <param name="custom_trait_tables_ref1" value="pipeline_custom_traits.tsv"/>
+                    <param name="custom_trait_tables_ref2" value="pipeline_custom_traits.tsv"/>
+                    <param name="marker_gene_table_ref1" value="pipeline_marker.tsv"/>
+                    <param name="marker_gene_table_ref2" value="pipeline_marker.tsv"/>
                 </conditional>
-                <param name="skip_nsti" value="false"/>
             </section>
             <!-- metagenome -->
             <section name="metagenome_pipeline_section">
@@ -160,57 +189,33 @@ picrust2_pipeline.py
             </section>
             <!-- pathway -->
             <conditional name="predict_pathways">
-                <param name="no_pathways" value=""/>
-                <param name="skip_minpath" value="false"/>
-                <param name="no_gap_fill" value="true"/>
+                <param name="no_pathways" value="--no_pathways"/>
             </conditional>
-            <param name="remove_intermediate" value="place_seqs"/>
-            <output name="out_tree" ftype="newick">
+            <output name="ref1_tree" ftype="newick">
                 <assert_contents>
-                    <has_text text="643348582"/>
+                    <has_text text="03af6a6644bc358ee6716cbb44a5a479"/>
                     <has_n_lines n="1"/>
                 </assert_contents>
             </output>
-            <output_collection name="place_seqs_intermediate_output" type="list" count="2">
-                <element name="query_align" ftype="stockholm">
-                    <assert_contents>
-                        <has_text text="STOCKHOLM 1.0"/>
-                        <has_n_lines n="160106"/>
-                    </assert_contents>
-                </element>
-                <element name="study_seqs_filtered" ftype="fasta">
-                    <assert_contents>
-                        <has_text text="02905cfb87861c837dde629596d9272b"/>
-                        <has_n_lines n="10"/>
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="hsp_output" type="list" count="3">
-                <element name="COG">
-                    <assert_contents>
-                        <has_text text="COG0001"/>
-                        <has_n_lines n="6"/>
-                    </assert_contents>
-                </element>
-                <element name="EC">
+            <output name="ref2_tree" ftype="newick">
+                <assert_contents>
+                    <has_n_lines n="1"/>
+                </assert_contents>
+            </output>
+            <output_collection name="hsp_output" type="list" count="1">
+                <element name="ref1_custom_traits_0">
                     <assert_contents>
                         <has_text text="EC:1.1.1.1"/>
                         <has_n_lines n="6"/>
                     </assert_contents>
                 </element>
-                <element name="marker">
-                    <assert_contents>
-                        <has_text text="16S_rRNA_Count"/>
-                        <has_n_lines n="6"/>
-                    </assert_contents>
-                </element>
             </output_collection>
-            <output_collection name="metagenome_output" type="list:list" count="2">
-                <element name="COG">
+            <output_collection name="metagenome_output" type="list:list" count="1">
+                <element name="custom_traits_0">
                     <element name="pred_metagenome_unstrat">
                         <assert_contents>
-                            <has_text text="function"/>
-                            <has_n_lines n="1793"/>
+                            <has_text text="EC:2.7.7.7"/>
+                            <has_n_lines n="3"/>
                         </assert_contents>
                     </element>
                     <element name="seqtab_norm">
@@ -219,155 +224,35 @@ picrust2_pipeline.py
                             <has_n_lines n="6"/>
                         </assert_contents>
                     </element>
-                </element>
-                <element name="EC">
-                    <element name="pred_metagenome_unstrat">
+                    <element name="weighted_nsti">
                         <assert_contents>
-                            <has_text text="function"/>
-                            <has_n_lines n="768"/>
-                        </assert_contents>
-                    </element>
-                    <element name="seqtab_norm">
-                        <assert_contents>
-                            <has_text text="normalized"/>
-                            <has_n_lines n="6"/>
+                            <has_text text="weighted_NSTI"/>
+                            <has_n_lines n="3"/>
                         </assert_contents>
                     </element>
                 </element>
             </output_collection>
-            <output name="pathways_output" ftype="tabular">
-                <assert_contents>
-                    <has_text text="pathway"/>
-                    <has_n_lines n="149"/>
-                    <has_n_columns n="3"/>
-                </assert_contents>
-            </output>
             <assert_command>
                 <has_text text="--study_fasta"/>
-                <has_text text="--placement_tool 'sepp'"/>
+                <has_text text="--placement_tool 'epa-ng'"/>
+                <has_text text="--ref_dir1 custom_ref1/"/>
+                <has_text text="--ref_dir2 custom_ref2/"/>
                 <has_text text="--min_align 0.0"/>
-                <has_text text="--in_traits 'EC,COG'"/>
+                <has_text text="--custom_trait_tables_ref1"/>
+                <has_text text="--custom_trait_tables_ref2"/>
+                <has_text text="--marker_gene_table_ref1"/>
+                <has_text text="--marker_gene_table_ref2"/>
                 <has_text text="--input 'input.biom'"/>
                 <has_text text="--min_reads 1"/>
                 <has_text text="--min_samples 1"/>
-                <has_text text="--reaction_func 'EC'"/>
+                <has_text text="--no_pathways"/>
+                <has_text text="--remove_intermediate"/>
+                <has_text text="--in_traits" negate="true"/>
+                <has_text text="--reaction_func" negate="true"/>
+                <has_text text="--skip_nsti" negate="true"/>
                 <has_text text="--database" negate="true"/>
                 <has_text text="--reference" negate="true"/>
             </assert_command>
-        </test>
-        <!-- same as test 1, but only COG as in_traits (which has the same result since EC is added automatically), and test the other intermediate result -->
-        <test expect_num_outputs="5">
-            <!-- place_seq -->
-            <section name="place_seqs_section">
-                <param name="study_fasta" value="study_seqs_full.fasta"/>
-                <param name="placement_tool" value="sepp"/>
-                <param name="min_align" value="0.0"/>
-            </section>
-            <!-- hsp -->
-            <section name="hsp_section">
-                <conditional name="trait_input">
-                    <param name="selector" value="default"/>
-                    <param name="in_traits" value="COG"/>
-                </conditional>
-                <param name="skip_nsti" value="false"/>
-            </section>
-            <!-- metagenome -->
-            <section name="metagenome_pipeline_section">
-                <param name="input" value="workflow_seq_abun.biom"/>
-                <conditional name="input_options">
-                    <param name="selector" value="ASV"/>
-                    <param name="min_reads" value="1"/>
-                    <param name="min_samples" value="1"/>
-                </conditional>
-                <param name="max_nsti" value="2.0"/>
-                <param name="skip_norm" value="false"/>
-            </section>
-            <!-- pathway -->
-            <conditional name="predict_pathways">
-                <param name="no_pathways" value=""/>
-                <param name="skip_minpath" value="false"/>
-                <param name="no_gap_fill" value="true"/>
-            </conditional>
-            <param name="remove_intermediate" value="pathways"/>
-            <output name="out_tree" ftype="newick">
-                <assert_contents>
-                    <has_text text="643348582"/>
-                    <has_n_lines n="1"/>
-                </assert_contents>
-            </output>
-            <output_collection name="hsp_output" type="list" count="3">
-                <element name="COG" ftype="tabular">
-                    <assert_contents>
-                        <has_text text="COG0001"/>
-                        <has_n_lines n="6"/>
-                        <has_n_columns n="4599"/>
-                    </assert_contents>
-                </element>
-                <element name="EC" ftype="tabular">
-                    <assert_contents>
-                        <has_text text="EC:1.1.1.1"/>
-                        <has_n_lines n="6"/>
-                        <has_n_columns n="2914"/>
-                    </assert_contents>
-                </element>
-                <element name="marker" ftype="tabular">
-                    <assert_contents>
-                        <has_text text="16S_rRNA_Count"/>
-                        <has_n_lines n="6"/>
-                        <has_n_columns n="2"/>
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="metagenome_output" type="list:list" count="2">
-                <element name="COG">
-                    <element name="pred_metagenome_unstrat" ftype="tabular">
-                        <assert_contents>
-                            <has_text text="function"/>
-                            <has_n_lines n="1793"/>
-                            <has_n_columns n="3"/>
-                        </assert_contents>
-                    </element>
-                    <element name="seqtab_norm" ftype="tabular">
-                        <assert_contents>
-                            <has_text text="normalized"/>
-                            <has_n_lines n="6"/>
-                            <has_n_columns n="3"/>
-                        </assert_contents>
-                    </element>
-                </element>
-                <element name="EC">
-                    <element name="pred_metagenome_unstrat" ftype="tabular">
-                        <assert_contents>
-                            <has_text text="function"/>
-                            <has_n_lines n="768"/>
-                            <has_n_columns n="3"/>
-                        </assert_contents>
-                    </element>
-                    <element name="seqtab_norm" ftype="tabular">
-                        <assert_contents>
-                            <has_text text="normalized"/>
-                            <has_n_lines n="6"/>
-                            <has_n_columns n="3"/>
-                        </assert_contents>
-                    </element>
-                </element>
-            </output_collection>
-            <output name="pathways_output" ftype="tabular">
-                <assert_contents>
-                    <has_text text="pathway"/>
-                    <has_n_lines n="149"/>
-                    <has_n_columns n="3"/>
-                </assert_contents>
-            </output>
-            <output_collection name="pathways_intermediate_output" type="list" count="1">
-                <element name="regrouped_infile" ftype="tabular">
-                    <assert_contents>
-                        <has_text text="function"/>
-                        <has_n_lines n="1509"/>
-                        <has_n_columns n="3"/>
-                    </assert_contents>
-                </element>
-            </output_collection>
         </test>
         <!-- due to the long test times the other pathways_outputs 
              have been tested manually -->

--- a/tools/picrust2/picrust2_pipeline.xml
+++ b/tools/picrust2/picrust2_pipeline.xml
@@ -242,6 +242,18 @@ picrust2_pipeline.py
                     <has_n_columns n="3"/>
                 </assert_contents>
             </output>
+            <assert_command>
+                <has_text text="--study_fasta"/>
+                <has_text text="--placement_tool 'sepp'"/>
+                <has_text text="--min_align 0.0"/>
+                <has_text text="--in_traits 'EC,COG'"/>
+                <has_text text="--input 'input.biom'"/>
+                <has_text text="--min_reads 1"/>
+                <has_text text="--min_samples 1"/>
+                <has_text text="--reaction_func 'EC'"/>
+                <has_text text="--database" negate="true"/>
+                <has_text text="--reference" negate="true"/>
+            </assert_command>
         </test>
         <!-- same as test 1, but only COG as in_traits (which has the same result since EC is added automatically), and test the other intermediate result -->
         <test expect_num_outputs="5">

--- a/tools/picrust2/place_seqs.xml
+++ b/tools/picrust2/place_seqs.xml
@@ -41,7 +41,7 @@ place_seqs.py
             <param name="min_align" value="0.80"/>
             <output name="out_tree" ftype="newick">
                 <assert_contents>
-                    <has_text text="643348582"/>
+                    <has_text text="03af6a6644bc358ee6716cbb44a5a479"/>
                     <has_n_lines n="1"/>
                 </assert_contents>
             </output>
@@ -49,7 +49,7 @@ place_seqs.py
                 <element name="query_align" ftype="stockholm">
                     <assert_contents>
                         <has_text text="STOCKHOLM 1.0"/>
-                        <has_n_lines n="160106"/>
+                        <has_n_lines n="215050"/>
                     </assert_contents>
                 </element>
                 <element name="study_seqs_filtered" ftype="fasta">

--- a/tools/picrust2/place_seqs.xml
+++ b/tools/picrust2/place_seqs.xml
@@ -6,8 +6,7 @@
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>place_seqs.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
-@VAR_ACCESS_FOO@
+    <command detect_errors="aggressive"><![CDATA[
 @PLACE_SEQS_PREPROCESSING@
 
 #if $intermediate_check
@@ -28,8 +27,8 @@ place_seqs.py
     <inputs>
         <expand macro="place_seqs_params"/>
         <param argument="--intermediate_check" type="boolean" truevalue="intermediate_check" falsevalue="" checked="false" label="Keep intermediate files" help="Intermediate output files will be deleted by default"/>
-   </inputs>
-   <outputs>
+    </inputs>
+    <outputs>
         <expand macro="place_seqs_output" from_work_dir="./">
             <filter>intermediate_check is True</filter>
         </expand>

--- a/tools/picrust2/shuffle_predictions.xml
+++ b/tools/picrust2/shuffle_predictions.xml
@@ -6,7 +6,7 @@
     <expand macro="bio_tool"/>
     <expand macro="requirements"/>
     <version_command>shuffle_predictions.py -v</version_command>
-    <command detect_errors="exit_code"><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
 ln -s '$input' predicted.tsv &&
 shuffle_predictions.py
     --input predicted.tsv


### PR DESCRIPTION
We got the following error report:

> usage: gtdbtk          {de_novo_wf,classify_wf,identify,align,infer,classify,root,decorate,infer_ranks,ani_rep,test,trim_msa,remove_labels,convert_to_itol,convert_to_species,export_msa,check_install} ...
gtdbtk: error: unrecognized arguments: --skip_ani_screen

This PR updates the tool and removes the --skip_ani_screen 

I used the following prompt to update the tool:
<details>
Please make a plan to update the Galaxy tool(s) in the tools/gtdbtk directory.

* read the skills at /home/bag/.config/opencode/galaxy-skills/tool-dev/
* make sure the latest conda recipe is used
* all useful parameters are exposed in the Galaxy tool
* uvx planemo lint is not exposing any errors or warning
* uvx planemo test --biocontainers is passing

We also got this error that needs to be validated and fixed:

> usage: gtdbtk          {de_novo_wf,classify_wf,identify,align,infer,classify,root,decorate,infer_ranks,ani_rep,test,trim_msa,remove_labels,convert_to_itol,convert_to_species,export_msa,check_install} ...
gtdbtk: error: unrecognized arguments: --skip_ani_screen

### adjustments

The --prefix is useless in the Galaxy context, as filenames do not get exposed to the user. This option could be used in the command section

</details>