### PR TITLE
Adjust fields in ncbi-datasets to match current NCBI terms

### DIFF
--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">18.25.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">18.26.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">25.0</token>
     <token name="@LICENSE@">MIT</token>
     <token name="@PROFILE_AND_LICENSE@">profile="@PROFILE@" license="@LICENSE@"</token>

--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">18.25.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">25.0</token>
     <token name="@LICENSE@">MIT</token>
     <token name="@PROFILE_AND_LICENSE@">profile="@PROFILE@" license="@LICENSE@"</token>
@@ -156,7 +156,7 @@
             <option value="annotinfo-busco-missing">Annotation BUSCO Missing</option>
             <option value="annotinfo-busco-singlecopy">Annotation BUSCO Single Copy</option>
             <option value="annotinfo-busco-totalcount">Annotation BUSCO Total Count</option>
-            <option value="annotinfo-busco-ver">Annotation BUSCO Version</option>
+            <option value="annotinfo-busco-version">Annotation BUSCO Version</option>
             <option value="annotinfo-featcount-gene-non-coding">Annotation Count Gene Non-coding</option>
             <option value="annotinfo-featcount-gene-other">Annotation Count Gene Other</option>
             <option value="annotinfo-featcount-gene-protein-coding">Annotation Count Gene Protein-coding</option>
@@ -236,8 +236,8 @@
             <option value="assminfo-description">Assembly Description</option>
             <option value="assminfo-grouping-method">Assembly Grouping Method</option>
             <option value="assminfo-level">Assembly Level</option>
-            <option value="assminfo-linked-assmaccession">Assembly Linked Assembly Accession</option>
-            <option value="assminfo-linked-assmtype">Assembly Linked Assembly Type</option>
+            <option value="assminfo-linked-assm-accession">Assembly Linked Assembly Accession</option>
+            <option value="assminfo-linked-assm-type">Assembly Linked Assembly Type</option>
             <option value="assminfo-long-name">Assembly LongName</option>
             <option value="assminfo-name">Assembly Name</option>
             <option value="assminfo-notes">Assembly Notes</option>


### PR DESCRIPTION
Per https://www.ncbi.nlm.nih.gov/datasets/docs/v2/command-line-tools/using-dataformat/genome-data-reports/

Reported at https://help.galaxyproject.org/t/wrapper-for-datasets-download-genome-force/17711/4

Confirmed at https://usegalaxy.eu/u/jenj/h/error-ncbi-datasets-genomes

Resolves error:
> Error: field(s) [annotinfo-busco-ver], [assminfo-linked-assmaccession], [assminfo-linked-assmtype] not recognized.

Renames:
- `annotinfo-busco-ver` -> `annotinfo-busco-version`
- `assminfo-linked-assmaccession` -> `assminfo-linked-assm-accession`
- `assminfo-linked-assmtype` -> `assminfo-linked-assm-type`

Wrapper revision bumped (`@VERSION_SUFFIX@` `0` -> `1`).

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

