### PR TITLE
arriba - rm .lint_skip and fix warnings

### DIFF
--- a/tools/arriba/.lint_skip
+++ b/tools/arriba/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/arriba/arriba.xml
+++ b/tools/arriba/arriba.xml
@@ -460,7 +460,6 @@
             <param name="protein_domains" ftype="gff3" value="protein_domains.gff3"/>
             <conditional name="visualization">
                 <param name="do_viz" value="no"/>
-                <param name="cytobands" ftype="tabular" value="cytobands.tsv"/>
             </conditional>
             <output name="fusions_tsv">
                 <assert_contents>

--- a/tools/arriba/arriba_draw_fusions.xml
+++ b/tools/arriba/arriba_draw_fusions.xml
@@ -69,9 +69,9 @@
             <param name="protein_domains" ftype="gff3" value="protein_domains.gff3"/>
             <section name="visualization">
                 <param name="cytobands" ftype="tabular" value="cytobands.tsv"/>
-            </section>
-            <section name="options">
-                <param name="sampleName" value="My Test"/>
+                <section name="options">
+                    <param name="sampleName" value="My Test"/>
+                </section>
             </section>
             <output name="fusions_pdf">
                 <assert_contents>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
