### PR TITLE
linter fixes to pureclip

### DIFF
--- a/tools/pureclip/.lint_skip
+++ b/tools/pureclip/.lint_skip
@@ -1,2 +1,0 @@
-TestsExpectNumOutputs
-TestsCaseValidation

--- a/tools/pureclip/pureclip.xml
+++ b/tools/pureclip/pureclip.xml
@@ -243,50 +243,66 @@ pureclip
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="3">
             <param name="target_bam_file" value="aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
             <param name="genome_fasta_file" value="hsa_chrM.fa" ftype="fasta"/>
-            <param name="crosslink_bed_stats" value="True"/>
+            <section name="output_options">
+                <param name="crosslink_bed_stats" value="True"/>
+            </section>
             <output name="crosslink_bed_outfile" file="chrM:4000-8300.crosslink_sites.bed"/>
             <output name="binding_region_bed_outfile" file="chrM:4000-8300.binding_regions.bed"/>
             <output name="crosslink_bed_stats" file="chrM:4000-8300.crosslink_sites.bed.stats"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="target_bam_file" value="aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
             <param name="genome_fasta_file" value="hsa_chrM.fa" ftype="fasta"/>
             <param name="control_bam_file" value="input.aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
-            <param name="crosslink_bed_stats" value="True"/>
+            <section name="output_options">
+                <param name="crosslink_bed_stats" value="True"/>
+            </section>
             <output name="crosslink_bed_outfile" file="chrM:4000-8300.crosslink_sites.cov_input_signal.bed"/>
             <output name="binding_region_bed_outfile" file="chrM:4000-8300.binding_regions.cov_input_signal.bed"/>
             <output name="crosslink_bed_stats" file="chrM:4000-8300.crosslink_sites.cov_input_signal.bed.stats"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="target_bam_file" value="aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
             <param name="genome_fasta_file" value="hsa_chrM.fa" ftype="fasta"/>
-            <param name="motif_data_selector" value="supply_CL_motifs"/>
-            <param name="cl_motif_bed_file" value="fimo_clmotif_occurences.chrM:4000-8300.bed" ftype="bed"/>
-            <param name="max_motif_id" value="4"/>
-            <param name="crosslink_bed_stats" value="True"/>
+            <conditional name="motif_data">
+                <param name="motif_data_selector" value="supply_CL_motifs"/>
+                <param name="cl_motif_bed_file" value="fimo_clmotif_occurences.chrM:4000-8300.bed" ftype="bed"/>
+                <param name="max_motif_id" value="4"/>
+            </conditional>
+            <section name="output_options">
+                <param name="crosslink_bed_stats" value="True"/>
+            </section>
             <output name="crosslink_bed_outfile" file="chrM:4000-8300.crosslink_sites.cov_CLmotifs.bed" compare="re_match"/>
             <output name="binding_region_bed_outfile" file="chrM:4000-8300.binding_regions.cov_CLmotifs.bed" compare="re_match"/>
             <output name="crosslink_bed_stats" file="chrM:4000-8300.crosslink_sites.cov_CLmotifs.bed.stats" compare="re_match"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="target_bam_file" value="aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
             <param name="genome_fasta_file" value="hsa_chrM.fa" ftype="fasta"/>
             <param name="control_bam_file" value="input.aligned.prepro.R2.chrM:4000-8300.bam" ftype="bam"/>
-            <param name="bc_data_selector" value="manual_setting"/>
-            <param name="bandwidthn" value="50"/>
-            <param name="b1p" value="0.01"/>
-            <param name="b2p" value="0.15"/>
-            <param name="antp_option_selector" value="manual_select"/>
-            <param name="ntp" value="10"/>
-            <param name="ntp2" value="0"/>
-            <param name="advanced_params_selector" value="ap_specify"/>
-            <param name="fk" value="True"/>
-            <param name="mkn" value="0.9"/>
-            <param name="mtc" value="200"/>
-            <param name="crosslink_bed_stats" value="True"/>
+            <conditional name="bc_data">
+                <param name="bc_data_selector" value="manual_setting"/>
+                <param name="bandwidthn" value="50"/>
+                <param name="b1p" value="0.01"/>
+                <param name="b2p" value="0.15"/>
+                <conditional name="antp_option">
+                    <param name="antp_option_selector" value="manual_select"/>
+                    <param name="ntp" value="10"/>
+                    <param name="ntp2" value="0"/>
+                </conditional>
+            </conditional>
+            <conditional name="advanced_params">
+                <param name="advanced_params_selector" value="ap_specify"/>
+                <param name="fk" value="True"/>
+                <param name="mkn" value="0.9"/>
+                <param name="mtc" value="200"/>
+            </conditional>
+            <section name="output_options">
+                <param name="crosslink_bed_stats" value="True"/>
+            </section>
             <output name="crosslink_bed_outfile" file="chrM:4000-8300.crosslink_sites.test4.bed"/>
             <output name="binding_region_bed_outfile" file="chrM:4000-8300.binding_regions.test4.bed"/>
             <output name="crosslink_bed_stats" file="chrM:4000-8300.crosslink_sites.test4.bed.stats"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
