### PR TITLE
linter fixes for bigwig_outlier_bed

### DIFF
--- a/tools/bigwig_outlier_bed/.lint_skip
+++ b/tools/bigwig_outlier_bed/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/bigwig_outlier_bed/bigwig_outlier_bed.xml
+++ b/tools/bigwig_outlier_bed/bigwig_outlier_bed.xml
@@ -133,7 +133,7 @@
       <param name="bigwig" value="bigwig_sample"/>
       <param name="minwin" value="10"/>
       <param name="qhi" value="0.69"/>
-      <param name="qlo" value=""/>
+      <param name="qlo" value_json="null"/>
       <param name="tableout" value="create"/>
     </test>
     <test expect_num_outputs="3">


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
