### PR TITLE
Add DESeq2 lfcShrink methods

### DIFF
--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -517,14 +517,13 @@ get_contrast_coefficient_name <- function(dds, contrast_factor, lvl, ref) {
 }
 
 get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, independent_filtering, lfc_shrinkage_type, parallel) {
-    res <- results(
-        dds,
-        contrast = c(contrast_factor, lvl, ref),
-        cooksCutoff = cooks_cutoff,
-        independentFiltering = independent_filtering
-    )
-
     if (lfc_shrinkage_type == "none") {
+        res <- results(
+            dds,
+            contrast = c(contrast_factor, lvl, ref),
+            cooksCutoff = cooks_cutoff,
+            independentFiltering = independent_filtering
+        )
         return(list(results = res, unshrunken_results = NULL))
     }
 
@@ -536,6 +535,12 @@ get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, i
     }
 
     coefficient_name <- get_contrast_coefficient_name(dds, contrast_factor, lvl, ref)
+    res <- results(
+        dds,
+        name = coefficient_name,
+        cooksCutoff = cooks_cutoff,
+        independentFiltering = independent_filtering
+    )
     if (verbose) {
         cat(paste0("Applying DESeq2 lfcShrink type '", lfc_shrinkage_type, "' using coefficient '", coefficient_name, "'\n"))
     }
@@ -546,10 +551,21 @@ get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, i
         type = lfc_shrinkage_type,
         parallel = parallel
     )
-    output_res <- res
-    output_res$log2FoldChange <- shrunk_res$log2FoldChange
-    output_res$lfcSE <- shrunk_res$lfcSE
+    output_res <- shrunk_res
+    if (!("pvalue" %in% names(output_res)) && "pvalue" %in% names(res)) {
+        output_res$pvalue <- res$pvalue
+    }
+    if (!("padj" %in% names(output_res)) && "padj" %in% names(res)) {
+        output_res$padj <- res$padj
+    }
     list(results = output_res, unshrunken_results = res)
+}
+
+get_result_output_columns <- function(lfc_shrinkage_type) {
+    if (lfc_shrinkage_type == "none") {
+        return(c("geneID", "baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj"))
+    }
+    c("geneID", "baseMean", "log2FoldChange", "lfcSE", "pvalue", "padj")
 }
 
 if (verbose) {
@@ -797,11 +813,12 @@ if (is.null(opt$many_contrasts)) {
     res_sorted <- res[order(res$padj), ]
     out_df <- as.data.frame(res_sorted)
     out_df$geneID <- rownames(out_df) # nolint
-    out_df <- out_df[, c("geneID", "baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj")]
+    out_df <- out_df[, get_result_output_columns(opt$lfc_shrinkage_type)]
     filename <- opt$outfile
     write.table(out_df, file = filename, sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE)
+    threshold_res <- if (!is.null(unshrunken_res)) unshrunken_res else res
     if (independent_filtering) {
-        threshold <- unname(attr(res, "filterThreshold"))
+        threshold <- unname(attr(threshold_res, "filterThreshold"))
     } else {
         threshold <- 0
     }
@@ -832,11 +849,12 @@ if (is.null(opt$many_contrasts)) {
             res_sorted <- res[order(res$padj), ]
             out_df <- as.data.frame(res_sorted)
             out_df$geneID <- rownames(out_df) # nolint
-            out_df <- out_df[, c("geneID", "baseMean", "log2FoldChange", "lfcSE", "stat", "pvalue", "padj")]
+            out_df <- out_df[, get_result_output_columns(opt$lfc_shrinkage_type)]
             filename <- paste0(primary_factor, "_", lvl, "_vs_", ref)
             write.table(out_df, file = filename, sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE)
+            threshold_res <- if (!is.null(unshrunken_res)) unshrunken_res else res
             if (independent_filtering) {
-                threshold <- unname(attr(res, "filterThreshold"))
+                threshold <- unname(attr(threshold_res, "filterThreshold"))
             } else {
                 threshold <- 0
             }

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -67,6 +67,7 @@ spec <- matrix(c(
     "outlier_filter_off", "b", 0, "logical",
     "auto_mean_filter_off", "c", 0, "logical",
     "use_beta_priors", "d", 0, "logical",
+    "lfc_shrinkage_type", "L", 1, "character",
     "alpha_ma", "A", 1, "numeric",
     "prefilter", "P", 0, "logical",
     "prefilter_value", "V", 1, "numeric",
@@ -96,6 +97,14 @@ if (is.null(opt$outfile)) {
 }
 if (is.null(opt$factors) && is.null(opt$sample_sheet_mode)) {
     cat("'factors' is required when not using sample_sheet_mode\n")
+    q(status = 1)
+}
+if (is.null(opt$lfc_shrinkage_type)) {
+    opt$lfc_shrinkage_type <- "none"
+}
+valid_lfc_shrinkage_types <- c("none", "normal", "apeglm", "ashr")
+if (!(opt$lfc_shrinkage_type %in% valid_lfc_shrinkage_types)) {
+    cat(paste0("'lfc_shrinkage_type' must be one of: ", paste(valid_lfc_shrinkage_types, collapse = ", "), "\n"))
     q(status = 1)
 }
 
@@ -466,6 +475,66 @@ generate_specific_plots <- function(res, threshold, title_suffix) {
     plotMA(res, main = paste("MA-plot for", title_suffix), ylim = range(res$log2FoldChange, na.rm = TRUE), alpha = opt$alpha_ma)
 }
 
+get_contrast_coefficient_name <- function(dds, contrast_factor, lvl, ref) {
+    coefficient_name <- paste0(contrast_factor, "_", lvl, "_vs_", ref)
+    sanitized_coefficient_name <- paste0(
+        make.names(contrast_factor), "_",
+        make.names(lvl), "_vs_",
+        make.names(ref)
+    )
+    available_names <- resultsNames(dds)
+    coefficient_candidates <- unique(c(coefficient_name, sanitized_coefficient_name))
+    matching_names <- coefficient_candidates[coefficient_candidates %in% available_names]
+    if (length(matching_names) > 0) {
+        return(matching_names[1])
+    }
+
+    stop(
+        paste0(
+            "Could not find coefficient for '", contrast_factor, ": ", lvl, " vs ", ref, "' for lfcShrink. ",
+            "Checked: ", paste(coefficient_candidates, collapse = ", "), ". ",
+            "Available coefficients are: ", paste(available_names, collapse = ", "), ". ",
+            "lfcShrink requires a model coefficient; for non-reference pairwise contrasts, ",
+            "rerun with the requested reference level or disable lfcShrink."
+        )
+    )
+}
+
+get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, independent_filtering, lfc_shrinkage_type, parallel) {
+    res <- results(
+        dds,
+        contrast = c(contrast_factor, lvl, ref),
+        cooksCutoff = cooks_cutoff,
+        independentFiltering = independent_filtering
+    )
+
+    if (lfc_shrinkage_type == "none") {
+        return(res)
+    }
+
+    if (lfc_shrinkage_type == "apeglm" && !requireNamespace("apeglm", quietly = TRUE)) {
+        stop("lfcShrink type 'apeglm' requires the apeglm package.")
+    }
+    if (lfc_shrinkage_type == "ashr" && !requireNamespace("ashr", quietly = TRUE)) {
+        stop("lfcShrink type 'ashr' requires the ashr package.")
+    }
+
+    coefficient_name <- get_contrast_coefficient_name(dds, contrast_factor, lvl, ref)
+    if (verbose) {
+        cat(paste0("Applying DESeq2 lfcShrink type '", lfc_shrinkage_type, "' using coefficient '", coefficient_name, "'\n"))
+    }
+    shrunk_res <- lfcShrink(
+        dds,
+        coef = coefficient_name,
+        res = res,
+        type = lfc_shrinkage_type,
+        parallel = parallel
+    )
+    res$log2FoldChange <- shrunk_res$log2FoldChange
+    res$lfcSE <- shrunk_res$lfcSE
+    res
+}
+
 if (verbose) {
     cat(paste("primary factor:", primary_factor, "\n"))
     if (length(factors) > 1) {
@@ -604,6 +673,15 @@ if (is.null(opt$use_beta_priors)) {
 }
 sprintf("use_beta_prior is set to %s", beta_prior)
 
+if (beta_prior && opt$lfc_shrinkage_type != "none") {
+    cat("Error: DESeq2 lfcShrink cannot be combined with beta prior shrinkage. Turn off beta priors or set lfcShrink to none.\n")
+    q(status = 1)
+}
+if (!is.null(opt$many_contrasts) && opt$lfc_shrinkage_type != "none") {
+    cat("Error: lfcShrink is only supported for a single selected contrast. Disable many_contrasts or set lfcShrink to none.\n")
+    q(status = 1)
+}
+
 
 # dispersion fit type
 if (is.null(opt$fit_type)) {
@@ -682,11 +760,15 @@ if (is.null(opt$many_contrasts)) {
         contrast_factor <- primary_factor
     }
 
-    res <- results(
+    res <- get_contrast_results(
         dds,
-        contrast = c(contrast_factor, lvl, ref),
-        cooksCutoff = cooks_cutoff,
-        independentFiltering = independent_filtering
+        contrast_factor = contrast_factor,
+        lvl = lvl,
+        ref = ref,
+        cooks_cutoff = cooks_cutoff,
+        independent_filtering = independent_filtering,
+        lfc_shrinkage_type = opt$lfc_shrinkage_type,
+        parallel = parallel
     )
     if (verbose) {
         cat("summary of results\n")
@@ -716,11 +798,15 @@ if (is.null(opt$many_contrasts)) {
         ref <- all_levels[i]
         contrast_levels <- all_levels[(i + 1):n]
         for (lvl in contrast_levels) {
-            res <- results(
+            res <- get_contrast_results(
                 dds,
-                contrast = c(primary_factor, lvl, ref),
-                cooksCutoff = cooks_cutoff,
-                independentFiltering = independent_filtering
+                contrast_factor = primary_factor,
+                lvl = lvl,
+                ref = ref,
+                cooks_cutoff = cooks_cutoff,
+                independent_filtering = independent_filtering,
+                lfc_shrinkage_type = opt$lfc_shrinkage_type,
+                parallel = parallel
             )
             res_sorted <- res[order(res$padj), ]
             out_df <- as.data.frame(res_sorted)

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -444,9 +444,10 @@ generate_generic_plots <- function(dds, factors) {
 # these are plots which can be made for each comparison, e.g.
 # once for C vs A and once for B vs A
 generate_specific_plots <- function(res, threshold, title_suffix, unshrunken_res = NULL, lfc_shrinkage_type = "none") {
-    use <- res$baseMean > threshold
+    histogram_res <- if (!is.null(unshrunken_res)) unshrunken_res else res
+    use <- histogram_res$baseMean > threshold
     if (sum(!use) == 0) {
-        h <- hist(res$pvalue, breaks = 0:50 / 50, plot = FALSE)
+        h <- hist(histogram_res$pvalue, breaks = 0:50 / 50, plot = FALSE)
         barplot(
             height = h$counts,
             col = "powderblue",
@@ -457,8 +458,8 @@ generate_specific_plots <- function(res, threshold, title_suffix, unshrunken_res
         )
         text(x = c(0, length(h$counts)), y = 0, label = paste(c(0, 1)), adj = c(0.5, 1.7), xpd = NA)
     } else {
-        h1 <- hist(res$pvalue[!use], breaks = 0:50 / 50, plot = FALSE)
-        h2 <- hist(res$pvalue[use], breaks = 0:50 / 50, plot = FALSE)
+        h1 <- hist(histogram_res$pvalue[!use], breaks = 0:50 / 50, plot = FALSE)
+        h2 <- hist(histogram_res$pvalue[use], breaks = 0:50 / 50, plot = FALSE)
         colori <- c("filtered (low count)" = "khaki", "not filtered" = "powderblue")
         barplot(
             height = rbind(h1$counts, h2$counts),

--- a/tools/deseq2/deseq2.R
+++ b/tools/deseq2/deseq2.R
@@ -443,7 +443,7 @@ generate_generic_plots <- function(dds, factors) {
 
 # these are plots which can be made for each comparison, e.g.
 # once for C vs A and once for B vs A
-generate_specific_plots <- function(res, threshold, title_suffix) {
+generate_specific_plots <- function(res, threshold, title_suffix, unshrunken_res = NULL, lfc_shrinkage_type = "none") {
     use <- res$baseMean > threshold
     if (sum(!use) == 0) {
         h <- hist(res$pvalue, breaks = 0:50 / 50, plot = FALSE)
@@ -472,7 +472,23 @@ generate_specific_plots <- function(res, threshold, title_suffix) {
         text(x = c(0, length(h1$counts)), y = 0, label = paste(c(0, 1)), adj = c(0.5, 1.7), xpd = NA)
         legend("topright", fill = rev(colori), legend = rev(names(colori)), bg = "white")
     }
-    plotMA(res, main = paste("MA-plot for", title_suffix), ylim = range(res$log2FoldChange, na.rm = TRUE), alpha = opt$alpha_ma)
+    if (!is.null(unshrunken_res)) {
+        ma_ylim <- range(c(unshrunken_res$log2FoldChange, res$log2FoldChange), na.rm = TRUE)
+        plotMA(
+            unshrunken_res,
+            main = paste("MA-plot for", title_suffix, "(without LFC shrinkage)"),
+            ylim = ma_ylim,
+            alpha = opt$alpha_ma
+        )
+        plotMA(
+            res,
+            main = paste("MA-plot for", title_suffix, paste0("(LFC shrinkage: ", lfc_shrinkage_type, ")")),
+            ylim = ma_ylim,
+            alpha = opt$alpha_ma
+        )
+    } else {
+        plotMA(res, main = paste("MA-plot for", title_suffix), ylim = range(res$log2FoldChange, na.rm = TRUE), alpha = opt$alpha_ma)
+    }
 }
 
 get_contrast_coefficient_name <- function(dds, contrast_factor, lvl, ref) {
@@ -509,7 +525,7 @@ get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, i
     )
 
     if (lfc_shrinkage_type == "none") {
-        return(res)
+        return(list(results = res, unshrunken_results = NULL))
     }
 
     if (lfc_shrinkage_type == "apeglm" && !requireNamespace("apeglm", quietly = TRUE)) {
@@ -530,9 +546,10 @@ get_contrast_results <- function(dds, contrast_factor, lvl, ref, cooks_cutoff, i
         type = lfc_shrinkage_type,
         parallel = parallel
     )
-    res$log2FoldChange <- shrunk_res$log2FoldChange
-    res$lfcSE <- shrunk_res$lfcSE
-    res
+    output_res <- res
+    output_res$log2FoldChange <- shrunk_res$log2FoldChange
+    output_res$lfcSE <- shrunk_res$lfcSE
+    list(results = output_res, unshrunken_results = res)
 }
 
 if (verbose) {
@@ -760,7 +777,7 @@ if (is.null(opt$many_contrasts)) {
         contrast_factor <- primary_factor
     }
 
-    res <- get_contrast_results(
+    contrast_results <- get_contrast_results(
         dds,
         contrast_factor = contrast_factor,
         lvl = lvl,
@@ -770,6 +787,8 @@ if (is.null(opt$many_contrasts)) {
         lfc_shrinkage_type = opt$lfc_shrinkage_type,
         parallel = parallel
     )
+    res <- contrast_results$results
+    unshrunken_res <- contrast_results$unshrunken_results
     if (verbose) {
         cat("summary of results\n")
         cat(paste0(contrast_factor, ": ", lvl, " vs ", ref, "\n"))
@@ -788,7 +807,7 @@ if (is.null(opt$many_contrasts)) {
     }
     title_suffix <- paste0(primary_factor, ": ", lvl, " vs ", ref)
     if (!is.null(opt$plots)) {
-        generate_specific_plots(res, threshold, title_suffix)
+        generate_specific_plots(res, threshold, title_suffix, unshrunken_res, opt$lfc_shrinkage_type)
     }
 } else {
     # rotate through the possible contrasts of the primary factor
@@ -798,7 +817,7 @@ if (is.null(opt$many_contrasts)) {
         ref <- all_levels[i]
         contrast_levels <- all_levels[(i + 1):n]
         for (lvl in contrast_levels) {
-            res <- get_contrast_results(
+            contrast_results <- get_contrast_results(
                 dds,
                 contrast_factor = primary_factor,
                 lvl = lvl,
@@ -808,6 +827,8 @@ if (is.null(opt$many_contrasts)) {
                 lfc_shrinkage_type = opt$lfc_shrinkage_type,
                 parallel = parallel
             )
+            res <- contrast_results$results
+            unshrunken_res <- contrast_results$unshrunken_results
             res_sorted <- res[order(res$padj), ]
             out_df <- as.data.frame(res_sorted)
             out_df$geneID <- rownames(out_df) # nolint
@@ -821,7 +842,7 @@ if (is.null(opt$many_contrasts)) {
             }
             title_suffix <- paste0(primary_factor, ": ", lvl, " vs ", ref)
             if (!is.null(opt$plots)) {
-                generate_specific_plots(res, threshold, title_suffix)
+                generate_specific_plots(res, threshold, title_suffix, unshrunken_res, opt$lfc_shrinkage_type)
             }
         }
     }

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -308,7 +308,20 @@ Rscript '${__tool_directory__}/deseq2.R'
         <data name="deseq_out" format="tabular" label="DESeq2 result file on ${on_string}">
             <filter>'many_contrasts' not in output_options['output_selector']</filter>
             <actions>
-                <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),StdErr,Wald-Stats,P-value,P-adj"/>
+                <conditional name="advanced_options.lfc_shrinkage_type">
+                    <when value="none">
+                        <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),StdErr,Wald-Stats,P-value,P-adj"/>
+                    </when>
+                    <when value="normal">
+                        <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
+                    </when>
+                    <when value="apeglm">
+                        <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
+                    </when>
+                    <when value="ashr">
+                        <action name="column_names" type="metadata" default="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
+                    </when>
+                </conditional>
             </actions>
         </data>
         <collection name="split_output" type="list" label="DESeq2 result files on ${on_string}">
@@ -939,14 +952,49 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="output_selector" value="pdf,normCounts"/>
             </section>
             <output name="deseq_out">
+                <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
                 <assert_contents>
-                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.5.*\t0\.11.*"/>
+                    <has_line_matching expression="^FBgn0003360\t1933\.9504[^\t]*\t-2\.5[^\t]*\t0\.11[^\t]*\t[^\t]+e-104\t[^\t]+e-101$"/>
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
             <output name="plots" ftype="pdf">
                 <assert_contents>
                     <has_size min="1"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!--Test sample_sheet_contrasts mode with DESeq2 apeglm lfcShrink and non-simple factor levels -->
+        <test expect_num_outputs="2">
+            <param name="select_data|how" value="sample_sheet_contrasts"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="GSM461179_treat_single.counts" value="GSM461179_treat_single.counts"/>
+                    <element name="GSM461180_treat_paired.counts" value="GSM461180_treat_paired.counts"/>
+                    <element name="GSM461181_treat_paired.counts" value="GSM461181_treat_paired.counts"/>
+                    <element name="GSM461176_untreat_single.counts" value="GSM461176_untreat_single.counts"/>
+                    <element name="GSM461177_untreat_paired.counts" value="GSM461177_untreat_paired.counts"/>
+                    <element name="GSM461178_untreat_paired.counts" value="GSM461178_untreat_paired.counts"/>
+                    <element name="GSM461182_untreat_single.counts" value="GSM461182_untreat_single.counts"/>
+                </collection>
+            </param>
+            <param name="select_data|sample_sheet" value="sample_sheet_spaced_levels.tab"/>
+            <param name="select_data|design_formula_mode|mode" value="automatic"/>
+            <param name="select_data|design_formula_mode|factor" value="2"/>
+            <param name="select_data|design_formula_mode|reference_level" value="Untreated group"/>
+            <param name="select_data|design_formula_mode|target_level" value="Treated group"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="0"/>
+                <param name="lfc_shrinkage_type" value="apeglm"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="deseq_out">
+                <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
+                <assert_contents>
+                    <has_line_matching expression="^FBgn0003360\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+$"/>
+                    <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
         </test>
@@ -977,8 +1025,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="output_selector" value="normCounts"/>
             </section>
             <output name="deseq_out">
+                <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
                 <assert_contents>
-                    <has_text text="FBgn0003360"/>
+                    <has_line_matching expression="^FBgn0003360\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+$"/>
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
@@ -1010,8 +1059,9 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="output_selector" value="normCounts"/>
             </section>
             <output name="deseq_out">
+                <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
                 <assert_contents>
-                    <has_text text="FBgn0003360"/>
+                    <has_line_matching expression="^FBgn0003360\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+$"/>
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
@@ -1231,8 +1281,10 @@ When ``Log2 fold-change shrinkage after DESeq2`` is set to ``normal``,
 ``apeglm``, or ``ashr``, the log2 fold-change and standard-error columns are
 reported from DESeq2 ``lfcShrink`` for the selected single contrast. This option
 cannot be combined with the older beta-prior shrinkage option or with the
-all-pairwise-contrasts output. When plots are generated, the PDF includes both
-the regular MA plot without LFC shrinkage and the MA plot with the selected LFC
+all-pairwise-contrasts output. Shrunken result tables use ``lfcSE`` as column 4
+and omit the Wald statistic column because it is not part of the DESeq2
+``lfcShrink`` result. When plots are generated, the PDF includes both the
+regular MA plot without LFC shrinkage and the MA plot with the selected LFC
 shrinkage method.
 
 By selecting ``Output sample size factors`` in the "Output options"

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -965,7 +965,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             </output>
         </test>
         <!--Test sample_sheet_contrasts mode with DESeq2 apeglm lfcShrink and non-simple factor levels -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="select_data|how" value="sample_sheet_contrasts"/>
             <param name="select_data|countsFile">
                 <collection type="list">
@@ -988,7 +988,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="lfc_shrinkage_type" value="apeglm"/>
             </section>
             <section name="output_options">
-                <param name="output_selector" value="normCounts"/>
+                <param name="output_selector" value="pdf,normCounts"/>
             </section>
             <output name="deseq_out">
                 <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
@@ -997,9 +997,14 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
+            <output name="plots" ftype="pdf">
+                <assert_contents>
+                    <has_size min="1"/>
+                </assert_contents>
+            </output>
         </test>
         <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink apeglm -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="select_data|how" value="sample_sheet_contrasts"/>
             <param name="select_data|countsFile">
                 <collection type="list">
@@ -1022,7 +1027,7 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="lfc_shrinkage_type" value="apeglm"/>
             </section>
             <section name="output_options">
-                <param name="output_selector" value="normCounts"/>
+                <param name="output_selector" value="pdf,normCounts"/>
             </section>
             <output name="deseq_out">
                 <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
@@ -1031,9 +1036,14 @@ Rscript '${__tool_directory__}/deseq2.R'
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>
+            <output name="plots" ftype="pdf">
+                <assert_contents>
+                    <has_size min="1"/>
+                </assert_contents>
+            </output>
         </test>
         <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink ashr -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="select_data|how" value="sample_sheet_contrasts"/>
             <param name="select_data|countsFile">
                 <collection type="list">
@@ -1056,13 +1066,18 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="lfc_shrinkage_type" value="ashr"/>
             </section>
             <section name="output_options">
-                <param name="output_selector" value="normCounts"/>
+                <param name="output_selector" value="pdf,normCounts"/>
             </section>
             <output name="deseq_out">
                 <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
                 <assert_contents>
                     <has_line_matching expression="^FBgn0003360\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+\t[^\t]+$"/>
                     <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+            <output name="plots" ftype="pdf">
+                <assert_contents>
+                    <has_size min="1"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -954,7 +954,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             <output name="deseq_out">
                 <metadata name="column_names" value="GeneID,Base mean,log2(FC),lfcSE,P-value,P-adj"/>
                 <assert_contents>
-                    <has_line_matching expression="^FBgn0003360\t1933\.9504[^\t]*\t-2\.5[^\t]*\t0\.11[^\t]*\t[^\t]+e-104\t[^\t]+e-101$"/>
+                    <has_line_matching expression="^FBgn0003360\t1933\.9504[^\t]*\t-2\.5[^\t]*\t0\.11[^\t]*\t[0-9.]+e-[0-9]+\t[0-9.]+e-[0-9]+$"/>
                     <has_n_lines n="3999"/>
                 </assert_contents>
             </output>

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -133,6 +133,7 @@ Rscript '${__tool_directory__}/deseq2.R'
     $advanced_options.outlier_filter_off
     $advanced_options.auto_mean_filter_off
     $advanced_options.use_beta_priors
+    --lfc_shrinkage_type '$advanced_options.lfc_shrinkage_type'
 
     #if 'many_contrasts' in $output_options.output_selector
         -m
@@ -284,6 +285,12 @@ Rscript '${__tool_directory__}/deseq2.R'
             <param name="use_beta_priors" type="boolean" truevalue="-d" falsevalue="" checked="false"
                 label="Use beta priors"
                 help="Whether or not to put a zero-mean normal prior on the non-intercept coefficients"/>
+            <param name="lfc_shrinkage_type" type="select" label="Log2 fold-change shrinkage after DESeq2">
+                <option value="none" selected="true">Do not apply lfcShrink</option>
+                <option value="normal">DESeq2 lfcShrink: normal</option>
+                <option value="apeglm">DESeq2 lfcShrink: apeglm</option>
+                <option value="ashr">DESeq2 lfcShrink: ashr</option>
+            </param>
         </section>
         <section name="output_options" title="Output options">
             <param name="output_selector" type="select" multiple="True" optional="true" display="checkboxes" label="Output selector">
@@ -905,6 +912,105 @@ Rscript '${__tool_directory__}/deseq2.R'
                 </assert_contents>
             </output>
         </test>
+        <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink and non-simple factor levels -->
+        <test expect_num_outputs="2">
+            <param name="select_data|how" value="sample_sheet_contrasts"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="GSM461179_treat_single.counts" value="GSM461179_treat_single.counts"/>
+                    <element name="GSM461180_treat_paired.counts" value="GSM461180_treat_paired.counts"/>
+                    <element name="GSM461181_treat_paired.counts" value="GSM461181_treat_paired.counts"/>
+                    <element name="GSM461176_untreat_single.counts" value="GSM461176_untreat_single.counts"/>
+                    <element name="GSM461177_untreat_paired.counts" value="GSM461177_untreat_paired.counts"/>
+                    <element name="GSM461178_untreat_paired.counts" value="GSM461178_untreat_paired.counts"/>
+                    <element name="GSM461182_untreat_single.counts" value="GSM461182_untreat_single.counts"/>
+                </collection>
+            </param>
+            <param name="select_data|sample_sheet" value="sample_sheet_spaced_levels.tab"/>
+            <param name="select_data|design_formula_mode|mode" value="automatic"/>
+            <param name="select_data|design_formula_mode|factor" value="2"/>
+            <param name="select_data|design_formula_mode|reference_level" value="Untreated group"/>
+            <param name="select_data|design_formula_mode|target_level" value="Treated group"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="0"/>
+                <param name="lfc_shrinkage_type" value="normal"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="deseq_out">
+                <assert_contents>
+                    <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.5.*\t0\.11.*"/>
+                    <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink apeglm -->
+        <test expect_num_outputs="2">
+            <param name="select_data|how" value="sample_sheet_contrasts"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="GSM461179_treat_single.counts" value="GSM461179_treat_single.counts"/>
+                    <element name="GSM461180_treat_paired.counts" value="GSM461180_treat_paired.counts"/>
+                    <element name="GSM461181_treat_paired.counts" value="GSM461181_treat_paired.counts"/>
+                    <element name="GSM461176_untreat_single.counts" value="GSM461176_untreat_single.counts"/>
+                    <element name="GSM461177_untreat_paired.counts" value="GSM461177_untreat_paired.counts"/>
+                    <element name="GSM461178_untreat_paired.counts" value="GSM461178_untreat_paired.counts"/>
+                    <element name="GSM461182_untreat_single.counts" value="GSM461182_untreat_single.counts"/>
+                </collection>
+            </param>
+            <param name="select_data|sample_sheet" value="sample_sheet.tab"/>
+            <param name="select_data|design_formula_mode|mode" value="automatic"/>
+            <param name="select_data|design_formula_mode|factor" value="2"/>
+            <param name="select_data|design_formula_mode|reference_level" value="Untreated"/>
+            <param name="select_data|design_formula_mode|target_level" value="Treated"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="0"/>
+                <param name="lfc_shrinkage_type" value="apeglm"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="deseq_out">
+                <assert_contents>
+                    <has_text text="FBgn0003360"/>
+                    <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+        </test>
+        <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink ashr -->
+        <test expect_num_outputs="2">
+            <param name="select_data|how" value="sample_sheet_contrasts"/>
+            <param name="select_data|countsFile">
+                <collection type="list">
+                    <element name="GSM461179_treat_single.counts" value="GSM461179_treat_single.counts"/>
+                    <element name="GSM461180_treat_paired.counts" value="GSM461180_treat_paired.counts"/>
+                    <element name="GSM461181_treat_paired.counts" value="GSM461181_treat_paired.counts"/>
+                    <element name="GSM461176_untreat_single.counts" value="GSM461176_untreat_single.counts"/>
+                    <element name="GSM461177_untreat_paired.counts" value="GSM461177_untreat_paired.counts"/>
+                    <element name="GSM461178_untreat_paired.counts" value="GSM461178_untreat_paired.counts"/>
+                    <element name="GSM461182_untreat_single.counts" value="GSM461182_untreat_single.counts"/>
+                </collection>
+            </param>
+            <param name="select_data|sample_sheet" value="sample_sheet.tab"/>
+            <param name="select_data|design_formula_mode|mode" value="automatic"/>
+            <param name="select_data|design_formula_mode|factor" value="2"/>
+            <param name="select_data|design_formula_mode|reference_level" value="Untreated"/>
+            <param name="select_data|design_formula_mode|target_level" value="Treated"/>
+            <section name="advanced_options">
+                <param name="use_beta_priors" value="0"/>
+                <param name="lfc_shrinkage_type" value="ashr"/>
+            </section>
+            <section name="output_options">
+                <param name="output_selector" value="normCounts"/>
+            </section>
+            <output name="deseq_out">
+                <assert_contents>
+                    <has_text text="FBgn0003360"/>
+                    <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+        </test>
         <!--Test sample_sheet_contrasts with custom design formula -->
         <test expect_num_outputs="2">
             <param name="select_data|how" value="sample_sheet_contrasts"/>
@@ -1115,6 +1221,12 @@ Column Description
      7 p value adjusted for multiple testing with the Benjamini-Hochberg procedure
        which controls false discovery rate (FDR)
 ====== ==========================================================
+
+When ``Log2 fold-change shrinkage after DESeq2`` is set to ``normal``,
+``apeglm``, or ``ashr``, the log2 fold-change and standard-error columns are
+reported from DESeq2 ``lfcShrink`` for the selected single contrast. This option
+cannot be combined with the older beta-prior shrinkage option or with the
+all-pairwise-contrasts output.
 
 By selecting ``Output sample size factors`` in the "Output options"
 selection box, the size factors used to normalize the samples can also

--- a/tools/deseq2/deseq2.xml
+++ b/tools/deseq2/deseq2.xml
@@ -913,7 +913,7 @@ Rscript '${__tool_directory__}/deseq2.R'
             </output>
         </test>
         <!--Test sample_sheet_contrasts mode with DESeq2 lfcShrink and non-simple factor levels -->
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="select_data|how" value="sample_sheet_contrasts"/>
             <param name="select_data|countsFile">
                 <collection type="list">
@@ -936,12 +936,17 @@ Rscript '${__tool_directory__}/deseq2.R'
                 <param name="lfc_shrinkage_type" value="normal"/>
             </section>
             <section name="output_options">
-                <param name="output_selector" value="normCounts"/>
+                <param name="output_selector" value="pdf,normCounts"/>
             </section>
             <output name="deseq_out">
                 <assert_contents>
                     <has_text_matching expression="FBgn0003360\t1933\.9504.*\t-2\.5.*\t0\.11.*"/>
                     <has_n_lines n="3999"/>
+                </assert_contents>
+            </output>
+            <output name="plots" ftype="pdf">
+                <assert_contents>
+                    <has_size min="1"/>
                 </assert_contents>
             </output>
         </test>
@@ -1226,7 +1231,9 @@ When ``Log2 fold-change shrinkage after DESeq2`` is set to ``normal``,
 ``apeglm``, or ``ashr``, the log2 fold-change and standard-error columns are
 reported from DESeq2 ``lfcShrink`` for the selected single contrast. This option
 cannot be combined with the older beta-prior shrinkage option or with the
-all-pairwise-contrasts output.
+all-pairwise-contrasts output. When plots are generated, the PDF includes both
+the regular MA plot without LFC shrinkage and the MA plot with the selected LFC
+shrinkage method.
 
 By selecting ``Output sample size factors`` in the "Output options"
 selection box, the size factors used to normalize the samples can also

--- a/tools/deseq2/macros.xml
+++ b/tools/deseq2/macros.xml
@@ -25,10 +25,12 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@DESEQ2_VERSION@">bioconductor-deseq2</requirement>
+            <requirement type="package" version="@APEGLM_VERSION@">bioconductor-apeglm</requirement>
             <!-- Optional dependency of tximport, needed to import kallisto results https://github.com/galaxyproject/usegalaxy-playbook/issues/161 -->
             <requirement type="package" version="2.44.0">bioconductor-rhdf5</requirement>
             <requirement type="package" version="1.28.0">bioconductor-tximport</requirement>
             <requirement type="package" version="1.52.1">bioconductor-genomicfeatures</requirement>
+            <requirement type="package" version="@ASHR_VERSION@">r-ashr</requirement>
             <requirement type="package" version="1.20.3">r-getopt</requirement>
             <requirement type="package" version="0.9.3">r-ggrepel</requirement>
             <requirement type="package" version="3.1.3">r-gplots</requirement>
@@ -39,7 +41,9 @@
     </xml>
     <token name="@TOOL_VERSION@">2.11.40.8</token>
     <token name="@DESEQ2_VERSION@">1.40.2</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@APEGLM_VERSION@">1.22.1</token>
+    <token name="@ASHR_VERSION@">2.2_63</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="edam_ontology">
         <edam_topics>
@@ -52,6 +56,8 @@
     <xml name="citations">
         <citations>
             <citation type="doi">10.1186/s13059-014-0550-8</citation>
+            <citation type="doi">10.1093/bioinformatics/bty895</citation>
+            <citation type="doi">10.1093/biostatistics/kxw041</citation>
         </citations>
     </xml>
     <xml name="xrefs">

--- a/tools/deseq2/test-data/sample_sheet_spaced_levels.tab
+++ b/tools/deseq2/test-data/sample_sheet_spaced_levels.tab
@@ -1,0 +1,8 @@
+sample	treatment	sequencing
+GSM461179_treat_single.counts	Treated group	single
+GSM461180_treat_paired.counts	Treated group	paired
+GSM461181_treat_paired.counts	Treated group	paired
+GSM461176_untreat_single.counts	Untreated group	single
+GSM461177_untreat_paired.counts	Untreated group	paired
+GSM461178_untreat_paired.counts	Untreated group	paired
+GSM461182_untreat_single.counts	Untreated group	single


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.


## Summary
- Add DESeq2 `lfcShrink()` method selection for `normal`, `apeglm`, and `ashr`
- Resolve sanitized DESeq2 coefficient names for shrinkage contrasts
- Add dependencies, citations, and tests for shrinkage methods
