### PR TITLE
Fix tools/drhip

### DIFF
--- a/tools/drhip/drhip.xml
+++ b/tools/drhip/drhip.xml
@@ -62,36 +62,20 @@
             --tabular
     ]]></command>
     <inputs>
-        <param name="busted_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="BUSTED results" 
-               help="HyPhy BUSTED JSON result(s). Element identifier is used as gene name."/>
-        <param name="fel_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="FEL results" 
-               help="HyPhy FEL JSON result(s). Element identifier is used as gene name."/>
-        <param name="meme_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="MEME results" 
-               help="HyPhy MEME JSON result(s). Element identifier is used as gene name."/>
-        <param name="prime_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="PRIME results" 
-               help="HyPhy PRIME JSON result(s). Element identifier is used as gene name."/>
-        <param name="relax_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="RELAX results" 
-               help="HyPhy RELAX JSON result(s). Required for comparison group analyses. Element identifier is used as gene name."/>
-        <param name="contrastfel_files" type="data" format="hyphy_results.json" multiple="true" optional="true" 
-               label="Contrast-FEL results" 
-               help="HyPhy Contrast-FEL result(s). Required for comparison group analyses. Element identifier is used as gene name."/>
+        <param name="busted_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="BUSTED results" help="HyPhy BUSTED JSON result(s). Element identifier is used as gene name."/>
+        <param name="fel_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="FEL results" help="HyPhy FEL JSON result(s). Element identifier is used as gene name."/>
+        <param name="meme_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="MEME results" help="HyPhy MEME JSON result(s). Element identifier is used as gene name."/>
+        <param name="prime_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="PRIME results" help="HyPhy PRIME JSON result(s). Element identifier is used as gene name."/>
+        <param name="relax_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="RELAX results" help="HyPhy RELAX JSON result(s). Required for comparison group analyses. Element identifier is used as gene name."/>
+        <param name="contrastfel_files" type="data" format="hyphy_results.json" multiple="true" optional="true" label="Contrast-FEL results" help="HyPhy Contrast-FEL result(s). Required for comparison group analyses. Element identifier is used as gene name."/>
     </inputs>
     <outputs>
-        <data name="combined_summary" format="tabular" from_work_dir="output_dir/combined_summary.tab" 
-              label="${tool.name} on ${on_string}: Combined Summary"/>
-        <data name="combined_sites" format="tabular" from_work_dir="output_dir/combined_sites.tab" 
-              label="${tool.name} on ${on_string}: Combined Sites"/>
-        <data name="combined_comparison_summary" format="tabular" from_work_dir="output_dir/combined_comparison_summary.tab" 
-              label="${tool.name} on ${on_string}: Combined Comparison Summary">
+        <data name="combined_summary" format="tabular" from_work_dir="output_dir/combined_summary.tab" label="${tool.name} on ${on_string}: Combined Summary"/>
+        <data name="combined_sites" format="tabular" from_work_dir="output_dir/combined_sites.tab" label="${tool.name} on ${on_string}: Combined Sites"/>
+        <data name="combined_comparison_summary" format="tabular" from_work_dir="output_dir/combined_comparison_summary.tab" label="${tool.name} on ${on_string}: Combined Comparison Summary">
             <filter>relax_files or contrastfel_files</filter>
         </data>
-        <data name="combined_comparison_site" format="tabular" from_work_dir="output_dir/combined_comparison_site.tab" 
-              label="${tool.name} on ${on_string}: Combined Comparison Site">
+        <data name="combined_comparison_site" format="tabular" from_work_dir="output_dir/combined_comparison_site.tab" label="${tool.name} on ${on_string}: Combined Comparison Site">
             <filter>relax_files or contrastfel_files</filter>
         </data>
     </outputs>
@@ -103,24 +87,24 @@
             <param name="prime_files" value="PRIME/gene1.json" ftype="hyphy_results.json"/>
             <output name="combined_summary" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="BUSTED" />
-                    <has_text text="gene1.json" />
-                    <has_text text="pval" />
-                    <has_text text="omega" />
-                    <has_n_lines n="2" />
+                    <has_text text="gene"/>
+                    <has_text text="BUSTED"/>
+                    <has_text text="gene1.json"/>
+                    <has_text text="pval"/>
+                    <has_text text="omega"/>
+                    <has_n_lines n="2"/>
                     <has_n_columns n="9"/>
                 </assert_contents>
             </output>
             <output name="combined_sites" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="site" />
-                    <has_text text="gene1.json" />
-                    <has_text text="fel_selection" />
-                    <has_text text="meme_marker" />
-                    <has_text text="prime_marker" />
-                    <has_n_lines n="101" />
+                    <has_text text="gene"/>
+                    <has_text text="site"/>
+                    <has_text text="gene1.json"/>
+                    <has_text text="fel_selection"/>
+                    <has_text text="meme_qval"/>
+                    <has_text text="prime_marker"/>
+                    <has_n_lines n="101"/>
                     <has_n_columns n="8"/>
                 </assert_contents>
             </output>
@@ -134,50 +118,50 @@
             <param name="contrastfel_files" value="CONTRASTFEL/gene2.json" ftype="hyphy_results.json"/>
             <output name="combined_summary" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="BUSTED" />
-                    <has_text text="RELAX" />
-                    <has_text text="gene2.json" />
-                    <has_text text="pval" />
-                    <has_text text="omega" />
-                    <has_n_lines n="2" />
+                    <has_text text="gene"/>
+                    <has_text text="BUSTED"/>
+                    <has_text text="RELAX"/>
+                    <has_text text="gene2.json"/>
+                    <has_text text="pval"/>
+                    <has_text text="omega"/>
+                    <has_n_lines n="2"/>
                     <has_n_columns n="12"/>
                 </assert_contents>
             </output>
             <output name="combined_sites" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="site" />
-                    <has_text text="gene2.json" />
-                    <has_text text="fel_selection" />
-                    <has_text text="meme_marker" />
-                    <has_text text="prime_marker" />
-                    <has_n_lines n="101" />
+                    <has_text text="gene"/>
+                    <has_text text="site"/>
+                    <has_text text="gene2.json"/>
+                    <has_text text="fel_selection"/>
+                    <has_text text="meme_qval"/>
+                    <has_text text="prime_marker"/>
+                    <has_n_lines n="101"/>
                     <has_n_columns n="8"/>
                 </assert_contents>
             </output>
             <output name="combined_comparison_summary" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="comparison_group" />
-                    <has_text text="gene2.json" />
-                    <has_text text="Foreground" />
-                    <has_text text="Reference" />
-                    <has_text text="background" />
-                    <has_n_lines n="4" />
+                    <has_text text="gene"/>
+                    <has_text text="comparison_group"/>
+                    <has_text text="gene2.json"/>
+                    <has_text text="Foreground"/>
+                    <has_text text="Reference"/>
+                    <has_text text="background"/>
+                    <has_n_lines n="4"/>
                     <has_n_columns n="6"/>
                 </assert_contents>
             </output>
             <output name="combined_comparison_site" ftype="tabular">
                 <assert_contents>
-                    <has_text text="gene" />
-                    <has_text text="site" />
-                    <has_text text="comparison_group" />
-                    <has_text text="gene2.json" />
-                    <has_text text="cfel_beta" />
-                    <has_text text="Foreground" />
-                    <has_text text="Reference" />
-                    <has_n_lines n="301" />
+                    <has_text text="gene"/>
+                    <has_text text="site"/>
+                    <has_text text="comparison_group"/>
+                    <has_text text="gene2.json"/>
+                    <has_text text="cfel_beta"/>
+                    <has_text text="Foreground"/>
+                    <has_text text="Reference"/>
+                    <has_n_lines n="301"/>
                     <has_n_columns n="8"/>
                 </assert_contents>
             </output>

--- a/tools/drhip/drhip.xml
+++ b/tools/drhip/drhip.xml
@@ -105,7 +105,7 @@
                     <has_text text="meme_qval"/>
                     <has_text text="prime_marker"/>
                     <has_n_lines n="101"/>
-                    <has_n_columns n="8"/>
+                    <has_n_columns n="14"/>
                 </assert_contents>
             </output>
         </test>
@@ -137,7 +137,7 @@
                     <has_text text="meme_qval"/>
                     <has_text text="prime_marker"/>
                     <has_n_lines n="101"/>
-                    <has_n_columns n="8"/>
+                    <has_n_columns n="14"/>
                 </assert_contents>
             </output>
             <output name="combined_comparison_summary" ftype="tabular">

--- a/tools/drhip/drhip.xml
+++ b/tools/drhip/drhip.xml
@@ -1,7 +1,7 @@
 <tool id="drhip" name="DRHIP" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Data Reduction for HyPhy with Inference Processing</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.1.4</token>
+        <token name="@TOOL_VERSION@">0.1.5</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <token name="@PROFILE@">25.0</token>
     </macros>


### PR DESCRIPTION
Fixes: https://github.com/galaxyproject/tools-iuc/pull/8016

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
