### PR TITLE
Abricate: Fix Linter errors

### DIFF
--- a/tools/abricate/.lint_skip
+++ b/tools/abricate/.lint_skip
@@ -1,2 +1,0 @@
-InputsMissing
-TestsCaseValidation

--- a/tools/abricate/abricate.xml
+++ b/tools/abricate/abricate.xml
@@ -51,17 +51,17 @@
     </outputs>
     <tests>
         <!-- Basic test 0 - will produce no results. -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="Acetobacter.fna" ftype="fasta"/>
             <output name="report" ftype="tabular" file="output_noresults.txt"/>
         </test>
         <!-- Basic test 1 - will produce results. -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna" ftype="fasta"/>
             <output name="report" ftype="tabular" file="output_mrsa.txt"/>
         </test>
         <!-- Advanced test 2 - No header. -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna.gz" ftype="fasta.gz"/>
             <section name="adv">
                 <param name="db" value="card"/>
@@ -70,7 +70,7 @@
             <output name="report" ftype="tabular" file="output_noheader.txt"/>
         </test>
         <!-- Advanced test 3 - Changed DB to card -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna.bz2" ftype="fasta.bz2"/>
             <section name="adv">
                 <param name="db" value="card"/>
@@ -78,7 +78,7 @@
             <output name="report" ftype="tabular" file="output_db-card.txt"/>
         </test>
         <!-- Advanced test 4 - Changed DB to megares -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna" ftype="fasta"/>
             <section name="adv">
                 <param name="db" value="megares"/>
@@ -86,7 +86,7 @@
             <output name="report" ftype="tabular" file="output_db-megares.txt"/>
         </test>
         <!-- Advanced test 5 - Min DNA ID 100 -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna" ftype="fasta"/>
             <section name="adv">
                 <param name="min_dna_id" value="100"/>
@@ -94,7 +94,7 @@
             <output name="report" ftype="tabular" file="output_minid100.txt"/>
         </test>
         <!-- Advanced test 6 - Min Coverage 100 -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="MRSA0252.fna" ftype="fasta"/>
             <section name="adv">
                 <param name="min_cov" value="100"/>
@@ -102,12 +102,12 @@
             <output name="report" ftype="tabular" file="output_mincov100.txt"/>
         </test>
         <!-- Filetype test 7 - input a gbk -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="test.gbk" ftype="genbank"/>
             <output name="report" ftype="tabular" file="output_gbk.txt"/>
         </test>
         <!-- Filetype test 8 - input a gbk.gz -->
-        <test>
+        <test expect_num_outputs="1">
             <param name="file_input" value="test.gbk.gz" ftype="genbank.gz"/>
             <output name="report" ftype="tabular" file="output_gbk.txt"/>
         </test>

--- a/tools/abricate/abricate_list.xml
+++ b/tools/abricate/abricate_list.xml
@@ -13,12 +13,13 @@
         abricate --list > '$report'
     ]]></command>
     <inputs>
+        <param name="hidden" type="hidden" value="Lists available abricate databases. No configuration required."/>
     </inputs>
     <outputs>
         <data name="report" format="txt" label="${tool.name} - list of databases"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <output name="report" ftype="txt" file="output_list.txt" compare="diff" sort="true"/>
         </test>
     </tests>

--- a/tools/abricate/abricate_summary.xml
+++ b/tools/abricate/abricate_summary.xml
@@ -27,7 +27,7 @@
         <data name="summary" format="tabular"/>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="abricate_reports" value="output_db-card.txt,output_db-megares.txt"/>
             <output name="summary" ftype="tabular" file="output_summary.txt"/>
         </test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
