### PR TITLE
Lint fix: Add input name as column

### DIFF
--- a/tools/add_input_name_as_column/.lint_skip
+++ b/tools/add_input_name_as_column/.lint_skip
@@ -1,2 +1,0 @@
-# there is no citation
-CitationsMissing

--- a/tools/add_input_name_as_column/add_input_name_as_column.xml
+++ b/tools/add_input_name_as_column/add_input_name_as_column.xml
@@ -66,4 +66,13 @@ By default the column is appended.
 **TIP:** If your data is not TAB delimited, use *Text Manipulation->Convert*
 
     ]]></help>
+    <citations>
+        <citation type="bibtex">
+@misc{iuc_add_input_name_as_column,
+  author = {Galaxy IUC},
+  title = {Add input name as column},
+  url = {https://github.com/galaxyproject/tools-iuc/tree/main/tools/add_input_name_as_column},
+}
+        </citation>
+    </citations>
 </tool>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
