### PR TITLE
plink: linter and othe fixes

### DIFF
--- a/tools/plink/.lint_skip
+++ b/tools/plink/.lint_skip
@@ -1,2 +1,1 @@
 ToolVersionPEP404
-TestsCaseValidation

--- a/tools/plink/plink.xml
+++ b/tools/plink/plink.xml
@@ -1,8 +1,9 @@
-<tool id='plink' name='plink' version='@TOOL_VERSION@+galaxy@VERSION_SUFFIX@'>
+<tool id='plink' name='plink' version='@TOOL_VERSION@+galaxy@VERSION_SUFFIX@' profile="@PROFILE@">
     <description>genome association analysis toolset</description>
     <macros>
         <token name='@TOOL_VERSION@'>1.90b6.21</token>
-        <token name='@VERSION_SUFFIX@'>1</token>
+        <token name='@VERSION_SUFFIX@'>2</token>
+        <token name='@PROFILE@'>25.0</token>
         <xml name='template_sanitizer'>
             <sanitizer>
                 <valid initial='default'>
@@ -387,7 +388,7 @@
 ##        --rerun $functions.logfile
 ##      
     #end if
-    --memory \${GALAXY_MEMORY_MB:-8192}
+    --memory "\${GALAXY_MEMORY_MB:-8192}"
     --make-bed
     --out plink_output/plink_output
 
@@ -1155,7 +1156,7 @@
                     <param name='filter' value='Yes'/>
                     <param name='sex_select' value='--filter-cases'/>
                     <param name='no_sex_select' value='--allow-no-sex'/>
-                    <param name='nonfounders' value='--nonfounders'/>
+                    <param name='nonfounders' value='true'/>
                 </conditional>
             </conditional>
             <output name="plink_out">
@@ -1187,7 +1188,7 @@
                         <composite_data value="plink_2.fam"/>
                     </param>
                 </conditional>
-                <param name='recode' value='--recode'/>
+                <param name='recode' value='true'/>
                 <param name='template' value='@asd#123'/>
                 <param name='length' value='23'/>
                 <conditional name='update_cols'>
@@ -1237,10 +1238,10 @@
             </section>
             <conditional name='functions'>
                 <param name='func' value='stats'/>
-                <param name='freq' value='--freq'/>
-                <param name='hardy' value='--hardy'/>
-                <param name='missing' value='--missing'/>
-                <param name='het' value='--het'/>
+                <param name='freq' value='true'/>
+                <param name='hardy' value='true'/>
+                <param name='missing' value='true'/>
+                <param name='het' value='true'/>
                 <conditional name='sex'>
                     <param name='sex_stats' value='--check-sex'/>
                     <conditional name='mode'>
@@ -1362,12 +1363,12 @@
                     <conditional name='perm'>
                         <param name='perm' value='perm'/>
                     </conditional>
-                    <param name='genedrop' value='genedrop'/>
-                    <param name='perm_count' value='perm-count'/>
+                    <param name='genedrop' value='true'/>
+                    <param name='perm_count' value='true'/>
                     <param name='dominance' value='dominant'/>
-                    <param name='hide_covar' value='hide-covar'/>
-                    <param name='beta' value='beta'/>
-                    <param name='intercept' value='intercept'/>
+                    <param name='hide_covar' value='true'/>
+                    <param name='beta' value='true'/>
+                    <param name='intercept' value='true'/>
                 </conditional>
                 <param name='lambda' value='1.0'/>
             </conditional>

--- a/tools/plink/plink.xml
+++ b/tools/plink/plink.xml
@@ -364,7 +364,9 @@
             $functions.logistic.beta
             $functions.logistic.intercept
         #end if
-        --lambda $functions.lambda
+        #if $functions.lambda
+            --lambda $functions.lambda
+        #end if
     #elif $functions.func == 'ibd':
         #if $functions.genome.output_genome:
             --genome
@@ -1386,9 +1388,9 @@
                 <element name='plink_output.assoc.fisher.adjusted' value='out.assoc.fisher.adjusted' compare='sim_size' />
             </output_collection>
             <output_collection name='log_outfiles' type='list' count='3'>
-                <element name='plink_output.assoc.logistic' value='out.assoc.logistic'/>
                 <element name='plink_output.assoc.logistic.adjusted' value='out.assoc.logistic.adjusted'/>
                 <element name='plink_output.assoc.logistic.perm' value='out.assoc.logistic.perm' compare='sim_size'/>
+                <element name='plink_output.assoc.logistic' value='out.assoc.logistic'/>
             </output_collection>
         </test>
 

--- a/tools/plink/plink.xml
+++ b/tools/plink/plink.xml
@@ -24,6 +24,8 @@
                     <add value='X' />
                     <add value='Y' />
                     <add value=' ' />
+                    <add value='-' />
+                    <add value=',' />
                 </valid>
             </sanitizer>
         </xml>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/tools-iuc/issues/5331 and https://github.com/galaxyproject/tools-iuc/issues/5332

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
