### PR TITLE
quicktree: linter fixes

### DIFF
--- a/tools/quicktree/.lint_skip
+++ b/tools/quicktree/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/quicktree/quicktree.xml
+++ b/tools/quicktree/quicktree.xml
@@ -1,4 +1,4 @@
-<tool id="quicktree" name="Quicktree" version="@TOOL_VERSION@" profile="@PROFILE@">
+<tool id="quicktree" name="Quicktree" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description></description>
     <macros>
         <token name="@TOOL_VERSION@">2.5</token>

--- a/tools/quicktree/quicktree.xml
+++ b/tools/quicktree/quicktree.xml
@@ -1,8 +1,9 @@
-<tool id="quicktree" name="Quicktree" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
+<tool id="quicktree" name="Quicktree" version="@TOOL_VERSION@" profile="@PROFILE@">
     <description></description>
     <macros>
         <token name="@TOOL_VERSION@">2.5</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@PROFILE@">25.0</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">quicktree</xref>
@@ -73,46 +74,62 @@ input.quicktree
     </outputs>
     <tests>
         <test expect_num_outputs="1"><!-- test 1: with fasta input (with reformat) -->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.009.AA.fasta" ftype="fasta"/>
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.009.AA.fasta" ftype="fasta"/>
+            </conditional>
             <output name="output_file" file="example.009.AA.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 2: with stockholm input (no reformat)-->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.009.AA.stockholm" ftype="stockholm"/>
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.009.AA.stockholm" ftype="stockholm"/>
+            </conditional>
             <output name="output_file" file="example.009.AA.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 3: with clustalw input -->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.011.AA.clw" ftype="txt"/>
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.011.AA.clw" ftype="txt"/>
+            </conditional>
             <output name="output_file" file="example.011.AA.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 4: with phylip distance matrix input (lower triangle distance matrix) -->
-            <param name="format" value="dist"/>
-            <param name="input_file" value="example.001.AA.dist.lt.phy" ftype="mothur.dist"/>
+            <conditional name="input_type">
+                <param name="format" value="dist"/>
+                <param name="input_file" value="example.001.AA.dist.lt.phy" ftype="mothur.dist"/>
+            </conditional>
             <output name="output_file" file="example.001.AA.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 5: with phylip distance matrix input (square distance matrix) -->
-            <param name="format" value="dist"/>
-            <param name="input_file" value="example_dist_square_phylip.dist" ftype="mothur.dist"/>
+            <conditional name="input_type">
+                <param name="format" value="dist"/>
+                <param name="input_file" value="example_dist_square_phylip.dist" ftype="mothur.dist"/>
+            </conditional>
             <output name="output_file" file="example_dist_square_phylip.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 6: with phylip alignment input -->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.011.AA.phy" ftype="phylip"/>
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.011.AA.phy" ftype="phylip"/>
+            </conditional>
             <output name="output_file" file="example.011.AA.align.newick" ftype="newick"/>
         </test>
         <test expect_num_outputs="1"><!-- test 7: with distance matrix output -->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.009.AA.fasta" ftype="fasta"/>
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.009.AA.fasta" ftype="fasta"/>
+            </conditional>
             <param name="output_type" value="dist_out"/>
             <output name="output_file" file="example.009.AA.dist" ftype="mothur.dist"/>
         </test>
-         <test expect_num_outputs="1"><!-- test 8: test with all parameters set -->
-            <param name="format" value="align"/>
-            <param name="input_file" value="example.011.AA.phy" ftype="phylip"/>
-            <param name="upgma" value="-upgma"/>
-            <param name="kimura" value="-kimura"/>
+        <test expect_num_outputs="1"><!-- test 8: test with all parameters set -->
+            <conditional name="input_type">
+                <param name="format" value="align"/>
+                <param name="input_file" value="example.011.AA.phy" ftype="phylip"/>
+            </conditional>
+            <param name="upgma" value="true"/>
+            <param name="kimura" value="true"/>
             <param name="boot" value="100"/>
             <output name="output_file" file="example.011.AA.align.params.newick" ftype="newick"/>
         </test>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
