### PR TITLE
Add GH Action to auto-label pull requests as 'ready-for-review'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@ There are two labels that allow to ignore specific (false positive) tool linter 
 
 * `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
 * `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
+
+To request a review once your PR is ready, comment "please review" on the PR. This will
+automatically apply the `ready-for-review` label if the PR is not a draft, all review
+threads are resolved, and all CI checks have passed.

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Check PR Status and Apply Label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Check PR Status and Apply Label
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -10,9 +10,6 @@ jobs:
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, 'please review')
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      checks: read
 
     steps:
       - name: Check PR Status and Apply Label

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -93,6 +93,18 @@ jobs:
               r.name !== context.workflow
             );
 
+            // No check runs yet → not ready
+            if (relevant.length === 0) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: `⏳ No CI checks have reported for this PR yet. Please wait for CI to run and then try again.`
+              });
+              console.log("No check runs found. Skipping.");
+              return;
+            }
+
             // Any check still running → not ready
             const hasIncomplete = relevant.some(r => r.status !== 'completed');
             if (hasIncomplete) {

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -1,0 +1,99 @@
+name: Auto-Label Ready for Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-and-label:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, 'please review')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+
+    steps:
+      - name: Check PR Status and Apply Label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.issue.number;
+
+            // 1. Fetch PR details
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+
+            if (pr.draft) {
+              console.log("PR is a draft. Skipping.");
+              return;
+            }
+
+            // 2. Check for unresolved review threads
+            const query = `
+              query($owner: String!, $repo: String!, $pull_number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pull_number) {
+                    reviewThreads(first: 100) {
+                      nodes { isResolved }
+                    }
+                  }
+                }
+              }
+            `;
+            const graphqlResult = await github.graphql(query, { owner, repo, pull_number });
+            const threads = graphqlResult.repository.pullRequest.reviewThreads.nodes;
+            if (threads.some(t => !t.isResolved)) {
+              console.log("Unresolved review comments exist. Skipping.");
+              return;
+            }
+
+            // 3. Check CI - exclude this workflow's own run
+            const { data: checkRunsData } = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: pr.head.sha,
+              per_page: 100,
+            });
+
+            const relevant = checkRunsData.check_runs.filter(r =>
+              r.name !== context.workflow
+            );
+
+            // Any check still running → not ready
+            const hasIncomplete = relevant.some(r => r.status !== 'completed');
+            if (hasIncomplete) {
+              console.log("Some CI checks are still running. Skipping.");
+              return;
+            }
+
+            // Any check failed → report and stop
+            const failing = relevant.filter(r =>
+              r.conclusion !== 'success' &&
+              r.conclusion !== 'skipped' &&
+              r.conclusion !== 'neutral'
+            );
+            if (failing.length > 0) {
+              const lines = failing
+                .map(r => `- **${r.name}**: ${r.conclusion} → [view](${r.html_url})`)
+                .join('\n');
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: `❌ Please check the CI errors before requesting a review:\n\n${lines}`
+              });
+              return;
+            }
+
+            // 4. All good - add the label
+            console.log("All checks passed. Adding 'ready-for-review' label.");
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pull_number,
+              labels: ['ready-for-review']
+            });

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -40,19 +40,33 @@ jobs:
 
             // 2. Check for unresolved review threads
             const query = `
-              query($owner: String!, $repo: String!, $pull_number: Int!) {
+              query($owner: String!, $repo: String!, $pull_number: Int!, $cursor: String) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $pull_number) {
-                    reviewThreads(first: 100) {
+                    reviewThreads(first: 100, after: $cursor) {
                       nodes { isResolved }
+                      pageInfo { hasNextPage endCursor }
                     }
                   }
                 }
               }
             `;
-            const graphqlResult = await github.graphql(query, { owner, repo, pull_number });
-            const threads = graphqlResult.repository.pullRequest.reviewThreads.nodes;
-            if (threads.some(t => !t.isResolved)) {
+
+            let cursor = null;
+            let hasUnresolved = false;
+            let hasNextPage = false;
+            do {
+              const result = await github.graphql(query, { owner, repo, pull_number, cursor });
+              const { nodes, pageInfo } = result.repository.pullRequest.reviewThreads;
+              if (nodes.some(t => !t.isResolved)) {
+                hasUnresolved = true;
+                break;
+              }
+              cursor = pageInfo.endCursor;
+              hasNextPage = pageInfo.hasNextPage;
+            } while (hasNextPage);
+
+            if (hasUnresolved) {
               await github.rest.issues.createComment({
                 owner,
                 repo,

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -28,6 +28,12 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
 
             if (pr.draft) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: `⏸️ This PR is still a draft. Please mark it as ready for review before requesting a review.`
+              });
               console.log("PR is a draft. Skipping.");
               return;
             }
@@ -47,6 +53,12 @@ jobs:
             const graphqlResult = await github.graphql(query, { owner, repo, pull_number });
             const threads = graphqlResult.repository.pullRequest.reviewThreads.nodes;
             if (threads.some(t => !t.isResolved)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: `💬 There are unresolved review comments on this PR. Please resolve them before requesting a review.`
+              });
               console.log("Unresolved review comments exist. Skipping.");
               return;
             }
@@ -66,6 +78,12 @@ jobs:
             // Any check still running → not ready
             const hasIncomplete = relevant.some(r => r.status !== 'completed');
             if (hasIncomplete) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body: `⏳ Some CI checks are still running. Please wait for them to complete before requesting a review.`
+              });
               console.log("Some CI checks are still running. Skipping.");
               return;
             }
@@ -84,7 +102,7 @@ jobs:
                 owner,
                 repo,
                 issue_number: pull_number,
-                body: `❌ Please check the CI errors before requesting a review:\n\n${lines}`
+                body: `❌ Please check the CI errors before requesting a review.\n\nFailing checks:\n\n${lines}\n\n[View full CI summary](https://github.com/${owner}/${repo}/pull/${pull_number}/checks)`
               });
               return;
             }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
