### PR TITLE
linter fixes to krakentools

### DIFF
--- a/tools/krakentools/.lint_skip
+++ b/tools/krakentools/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/krakentools/alpha_diversity.xml
+++ b/tools/krakentools/alpha_diversity.xml
@@ -23,7 +23,7 @@ alpha_diversity.py
         </param>
     </inputs>
     <outputs>
-        <data name="output" format="txt" />
+        <data name="output" format="txt"/>
     </outputs>
     <tests>
         <test>
@@ -60,7 +60,7 @@ alpha_diversity.py
                 <assert_contents>
                     <has_text text="Simpson's Reciprocal Index: 51.458663200798206"/>
                 </assert_contents>
-            </output>              
+            </output>
         </test>
         <test>
             <param name="filename" value="bracken_abundance.tabular"/>

--- a/tools/krakentools/beta_diversity.xml
+++ b/tools/krakentools/beta_diversity.xml
@@ -11,15 +11,15 @@
 #set input_names=[]
 
 #for $input in $inputs
-        #set identifier = re.sub('[^\s\w\-.]', '_', str($input.element_identifier))
-	#silent $input_names.append($identifier)
-	ln -s '$input' '${identifier}' &&
+    #set identifier = re.sub('[^\s\w\-.]', '_', str($input.element_identifier))
+    #silent $input_names.append($identifier)
+    ln -s '$input' '${identifier}' &&
 #end for
 
 beta_diversity.py 
     --inputs
     #for $input_name in $input_names
-	'${input_name}' 
+    '${input_name}' 
     #end for
     --type '$sample.type'
     #if $sample.type == 'kreport'
@@ -49,15 +49,16 @@ beta_diversity.py
                 <expand macro="param_level"/>
             </when>
         </conditional>
-
     </inputs>
     <outputs>
-        <data name="output" format="tabular" />
+        <data name="output" format="tabular"/>
     </outputs>
     <tests>
         <test>
             <param name="inputs" value="beta_bracken_1.tabular,beta_bracken_2.tabular,beta_bracken_3.tabular"/>
-            <param name="type" value="bracken"/>
+            <conditional name="sample">
+                <param name="type" value="bracken"/>
+            </conditional>
             <output name="output" ftype="tabular">
                 <assert_contents>
                     <has_text_matching expression="#[012]&#9;beta_[a-z]+_[123].tabular \([0-9]+ reads\)" n="3"/>
@@ -69,7 +70,9 @@ beta_diversity.py
         </test>
         <test>
             <param name="inputs" value="beta_kreport_1.tabular,beta_kreport_2.tabular,beta_kreport_3.tabular"/>
-            <param name="type" value="kreport"/>
+            <conditional name="sample">
+                <param name="type" value="kreport"/>
+            </conditional>
             <output name="output" ftype="tabular">
                 <assert_contents>
                     <has_text text="beta_kreport_1.tabular"/>
@@ -82,8 +85,12 @@ beta_diversity.py
         </test>
         <test>
             <param name="inputs" value="beta_krona_1.tabular,beta_krona_2.tabular"/>
-            <param name="type" value="krona"/>
-            <param name="level" value="G"/>
+            <conditional name="sample">
+                <param name="type" value="krona"/>
+            </conditional>
+            <conditional name="sample">
+                <param name="level" value="G"/>
+            </conditional>
             <output name="output" ftype="tabular">
                 <assert_contents>
                     <has_text_matching expression="#[01]&#9;beta_[a-z]+_[12].tabular \([0-9]+ reads\)" n="2"/>

--- a/tools/krakentools/combine_kreports.xml
+++ b/tools/krakentools/combine_kreports.xml
@@ -13,7 +13,7 @@
     #end for
 #end if
 
-combine_kreports.py 	
+combine_kreports.py
     --reports
     #if $display_headers:
         #for $report in $reports
@@ -29,37 +29,37 @@ combine_kreports.py
     $only_combined
     ]]></command>
     <inputs>
-        <param argument="--reports" type="data" multiple="true" format="tabular" label="Kraken report file(s)" />
+        <param argument="--reports" type="data" multiple="true" format="tabular" label="Kraken report file(s)"/>
         <param name="display_headers" type="boolean" checked="true" truevalue="--display-headers" falsevalue="--no-headers" label="display headers in output"/>
         <param name="only_combined" type="boolean" checked="false" truevalue="--only-combined" falsevalue="" label="display only combined read counts and percentages"/>
     </inputs>
     <outputs>
-        <data name="output" format="tabular" />
+        <data name="output" format="tabular"/>
     </outputs>
     <tests>
         <test>
             <param name="reports" value="beta_kreport_1.tabular,beta_kreport_3.tabular"/>
-            <param name="display_headers" value="--no-headers"/>
+            <param name="display_headers" value="false"/>
             <output name="output" file="combined_kreport.tabular"/>
         </test>
         <test>
             <param name="reports" value="beta_kreport_1.tabular,beta_kreport_3.tabular"/>
-            <param name="display_headers" value="--no-headers"/>
-            <param name="only_combined" value="--only-combined"/>
+            <param name="display_headers" value="false"/>
+            <param name="only_combined" value="true"/>
             <output name="output" file="only_combined_count.tabular"/>
-    	</test>
+        </test>
         <test>
             <param name="reports" value="beta_kreport_1.tabular,beta_kreport_3.tabular"/>
-            <param name="display_headers" value="--display-headers"/>
-            <param name="only_combined" value="--only-combined"/>
-	    <output name="output">
-		 <assert_contents>
-		      <has_text text="#Number of Samples:"/>
-		      <has_text text="#S1"/>
-		      <has_text text="#S2"/>
-		      <has_text text="#perc"/>
-		 </assert_contents>
-	    </output>
+            <param name="display_headers" value="true"/>
+            <param name="only_combined" value="true"/>
+            <output name="output">
+                <assert_contents>
+                    <has_text text="#Number of Samples:"/>
+                    <has_text text="#S1"/>
+                    <has_text text="#S2"/>
+                    <has_text text="#perc"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/krakentools/extract_kraken_reads.xml
+++ b/tools/krakentools/extract_kraken_reads.xml
@@ -8,7 +8,7 @@
     <expand macro="requirements">
         <requirement type="package" version="1.14">gzip</requirement>
     </expand>
-    <command detect_errors="exit_code">
+    <command detect_errors="aggressive">
         <![CDATA[
 
         ##set input
@@ -101,26 +101,26 @@
                 </option>
             </param>
             <when value="single">
-                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A file" help="FASTQ or FASTQ input reads (may be gzipped)" />
+                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A file" help="FASTQ or FASTQ input reads (may be gzipped)"/>
             </when>
             <when value="paired">
-                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A forward file" help="FASTQ or FASTQ input reads (may be gzipped)" />
-                <param name="input_2" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A reverse file" help="FASTQ or FASTQ input reads (for paired reads, may be gzipped)" />
+                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A forward file" help="FASTQ or FASTQ input reads (may be gzipped)"/>
+                <param name="input_2" format="fastq,fasta,fastq.gz,fasta.gz" type="data" label="FASTQ/A reverse file" help="FASTQ or FASTQ input reads (for paired reads, may be gzipped)"/>
             </when>
             <when value="paired_collection">
-                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data_collection" collection_type="paired" label="Paired Collection" help="FASTQ or FASTA read pair collection (may be gzipped)" />
+                <param name="input_1" format="fastq,fasta,fastq.gz,fasta.gz" type="data_collection" collection_type="paired" label="Paired Collection" help="FASTQ or FASTA read pair collection (may be gzipped)"/>
             </when>
         </conditional>
-        <param name="results" argument="-k" format="tabular" type="data" label="Results" help="Results (classification) file from Kraken/KrakenUniq/Kraken2" />
-        <param argument="--report" format="tabular" type="data" label="Report" optional="true" help="Report file from Kraken/KrakenUniq/Kraken2" />
-        <param  argument="--taxid" type="text" value="" label="Taxonomic ID(s) to match" help="Space-delimited list of taxonomic IDs for which to extract matching reads">
+        <param name="results" argument="-k" format="tabular" type="data" label="Results" help="Results (classification) file from Kraken/KrakenUniq/Kraken2"/>
+        <param argument="--report" format="tabular" type="data" label="Report" optional="true" help="Report file from Kraken/KrakenUniq/Kraken2"/>
+        <param argument="--taxid" type="text" value="" label="Taxonomic ID(s) to match" help="Space-delimited list of taxonomic IDs for which to extract matching reads">
             <validator type="regex" message="Enter a space-separated list of numeric tax IDs">^\d+[\d ]*$</validator>
         </param>
-        <param argument="--max" type="integer" value="100000000" min="1" label="Maximum reads to save" help="Maximum number of reads to save for each ID" />
-        <param argument="--exclude" type="boolean" value="False" truevalue="--exclude" falsevalue="" label="Invert output" help="Instead of finding reads that match given taxonomic IDs, find all reads that DO NOT match given IDs" />
-        <param argument="--fastq_output" type="boolean" value="False" truevalue="--fastq-output" falsevalue="" label="Output as FASTQ" help="Write output as FASTQ instead of the default FASTA" />
-        <param argument="--include_parents" type="boolean" value="False" truevalue="--include-parents" falsevalue="" label="Include parents" help="Include reads classified at parent levels of the specified tax IDs" />
-        <param argument="--include_children" type="boolean" value="False" truevalue="--include-children" falsevalue="" label="Include children" help="Include reads classified more specifically than the specified tax IDs" />
+        <param argument="--max" type="integer" value="100000000" min="1" label="Maximum reads to save" help="Maximum number of reads to save for each ID"/>
+        <param argument="--exclude" type="boolean" value="False" truevalue="--exclude" falsevalue="" label="Invert output" help="Instead of finding reads that match given taxonomic IDs, find all reads that DO NOT match given IDs"/>
+        <param argument="--fastq_output" type="boolean" value="False" truevalue="--fastq-output" falsevalue="" label="Output as FASTQ" help="Write output as FASTQ instead of the default FASTA"/>
+        <param argument="--include_parents" type="boolean" value="False" truevalue="--include-parents" falsevalue="" label="Include parents" help="Include reads classified at parent levels of the specified tax IDs"/>
+        <param argument="--include_children" type="boolean" value="False" truevalue="--include-children" falsevalue="" label="Include children" help="Include reads classified more specifically than the specified tax IDs"/>
     </inputs>
     <outputs>
         <data name="output_1" format="fasta.gz" from_work_dir="output_1.gz" metadata_source="input_1" label="${tool.name} on ${on_string}: forward reads">
@@ -128,7 +128,7 @@
                 (library['type'] == 'single' or library['type'] == 'paired')
             </filter>
             <change_format>
-                <when input="fastq_output" value="--fastq-output" format="fastq.gz" />
+                <when input="fastq_output" value="--fastq-output" format="fastq.gz"/>
             </change_format>
         </data>
         <data name="output_2" format="fasta.gz" from_work_dir="output_2.gz" metadata_source="input_2" label="${tool.name} on ${on_string}: reverse reads">
@@ -136,132 +136,156 @@
                 (library['type'] == 'paired')
             </filter>
             <change_format>
-                <when input="fastq_output" value="--fastq-output" format="fastq.gz" />
+                <when input="fastq_output" value="--fastq-output" format="fastq.gz"/>
             </change_format>
         </data>
         <collection type="paired" name="output_collection" label="${tool.name} on ${on_string}: collection">
             <filter>(library['type'] == 'paired_collection')</filter>
-            <data name="forward" format="fasta.gz" metadata_source="input_1" from_work_dir="output_1.gz" >
-            <change_format>
-                <when input="fastq_output" value="--fastq-output" format="fastq.gz" />
-            </change_format>
+            <data name="forward" format="fasta.gz" metadata_source="input_1" from_work_dir="output_1.gz">
+                <change_format>
+                    <when input="fastq_output" value="--fastq-output" format="fastq.gz"/>
+                </change_format>
             </data>
-            <data name="reverse" format="fasta.gz" metadata_source="input_2" from_work_dir="output_2.gz" >
-            <change_format>
-                <when input="fastq_output" value="--fastq-output" format="fastq.gz" />
-            </change_format>
+            <data name="reverse" format="fasta.gz" metadata_source="input_2" from_work_dir="output_2.gz">
+                <change_format>
+                    <when input="fastq_output" value="--fastq-output" format="fastq.gz"/>
+                </change_format>
             </data>
         </collection>
     </outputs>
     <tests>
         <!-- test Kraken2 input, single input, unzipped -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq" ftype="fastq" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"  />
-        </test>        
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq" ftype="fastq"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
+        </test>
         <!-- test Kraken2 input, single input, zipped -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"  />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test paired input -->
         <test expect_num_outputs="2">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="input_2" value="extract_kraken_reads/R2.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="paired" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz" />
-            <output name="output_2" file="extract_kraken_reads/out2.k2.11176.fa" decompress="true" ftype="fasta.gz" />
+            <param name="library|input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+            <conditional name="library">
+                <param name="input_2" value="extract_kraken_reads/R2.fq.gz" ftype="fastq.gz"/>
+            </conditional>
+            <param name="library|type" value="paired"/>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
+            <output name="output_2" file="extract_kraken_reads/out2.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test paired collection input -->
         <test expect_num_outputs="3">
-            <param name="input_1">
-                <collection type="paired">
-                    <element name="forward" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-                    <element name="reverse" value="extract_kraken_reads/R2.fq.gz" ftype="fastq.gz" />
-                </collection>
-            </param>
-            <param name="library|type" value="paired_collection" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
+            <conditional name="library">
+                <param name="input_1">
+                    <collection type="paired">
+                        <element name="forward" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                        <element name="reverse" value="extract_kraken_reads/R2.fq.gz" ftype="fastq.gz"/>
+                    </collection>
+                </param>
+            </conditional>
+            <conditional name="library">
+                <param name="type" value="paired_collection"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
             <output_collection name="output_collection" type="paired">
-                <element name="forward" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz" />
-                <element name="reverse" file="extract_kraken_reads/out2.k2.11176.fa" decompress="true" ftype="fasta.gz" />
+                <element name="forward" file="extract_kraken_reads/out1.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
+                <element name="reverse" file="extract_kraken_reads/out2.k2.11176.fa" decompress="true" ftype="fasta.gz"/>
             </output_collection>
         </test>
         <!-- test Kraken1 input, include children -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken1.results" ftype="tabular" />
-            <param name="report" value="extract_kraken_reads/kraken1.report" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <param name="include_children" value="True" />
-            <output name="output_1" file="extract_kraken_reads/out1.k1.11176.children.fa" decompress="true" ftype="fasta.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken1.results" ftype="tabular"/>
+            <param name="report" value="extract_kraken_reads/kraken1.report" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <param name="include_children" value="True"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k1.11176.children.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test exclude -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken1.results" ftype="tabular" />
-            <param name="report" value="extract_kraken_reads/kraken1.report" ftype="tabular" />
-            <param name="taxid" value="10386" />
-            <param name="include_children" value="True" />
-            <param name="exclude" value="True" />
-            <output name="output_1" file="extract_kraken_reads/out1.k1.e10386.children.fa" decompress="true" ftype="fasta.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken1.results" ftype="tabular"/>
+            <param name="report" value="extract_kraken_reads/kraken1.report" ftype="tabular"/>
+            <param name="taxid" value="10386"/>
+            <param name="include_children" value="True"/>
+            <param name="exclude" value="True"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k1.e10386.children.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test max -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <param name="max" value="2" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.max2.fa" decompress="true" ftype="fasta.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <param name="max" value="2"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.max2.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test include parents -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <param name="include_parents" value="True" />
-            <param name="report" value="extract_kraken_reads/kraken2.report" ftype="tabular" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.parents.fa" decompress="true" ftype="fasta.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <param name="include_parents" value="True"/>
+            <param name="report" value="extract_kraken_reads/kraken2.report" ftype="tabular"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.parents.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test multiple tax IDs -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="10386 11176" />
-            <param name="exclude" value="True" />
-            <param name="include_parents" value="True" />
-            <param name="report" value="extract_kraken_reads/kraken2.report" ftype="tabular" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.exclude_both.fa" decompress="true" ftype="fasta.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="10386 11176"/>
+            <param name="exclude" value="True"/>
+            <param name="include_parents" value="True"/>
+            <param name="report" value="extract_kraken_reads/kraken2.report" ftype="tabular"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.exclude_both.fa" decompress="true" ftype="fasta.gz"/>
         </test>
         <!-- test multiple tax IDs -->
         <test expect_failure="true">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="10386 f5" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="10386 f5"/>
         </test>
         <!-- test FASTQ output -->
         <test expect_num_outputs="1">
-            <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz" />
-            <param name="library|type" value="single" />
-            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular" />
-            <param name="taxid" value="11176" />
-            <param name="fastq_output" value="true" />
-            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fq" decompress="true" ftype="fastq.gz" />
+            <conditional name="library">
+                <param name="input_1" value="extract_kraken_reads/R1.fq.gz" ftype="fastq.gz"/>
+                <param name="type" value="single"/>
+            </conditional>
+            <param name="results" value="extract_kraken_reads/kraken2.results" ftype="tabular"/>
+            <param name="taxid" value="11176"/>
+            <param name="fastq_output" value="true"/>
+            <output name="output_1" file="extract_kraken_reads/out1.k2.11176.fq" decompress="true" ftype="fastq.gz"/>
         </test>
     </tests>
     <help>
@@ -276,9 +300,9 @@ must provide (at minimum) the original sequence file(s), at least one taxonomy
 ID, and the Kraken output file.
         ]]>
     </help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
     <creator>
-        <person givenName="Jeremy" familyName="Volkening" url="https://github.com/jvolkening" />
-        <person givenName="Paul" familyName="Zierep" email="zierep@informatik.uni-freiburg.de" />
+        <person givenName="Jeremy" familyName="Volkening" url="https://github.com/jvolkening"/>
+        <person givenName="Paul" familyName="Zierep" email="zierep@informatik.uni-freiburg.de"/>
     </creator>
 </tool>

--- a/tools/krakentools/kreport2krona.xml
+++ b/tools/krakentools/kreport2krona.xml
@@ -13,11 +13,11 @@ kreport2krona.py
     $intermediate_ranks
     ]]></command>
     <inputs>
-        <param argument="--report" type="data" format="tabular" label="Kraken report file" />
+        <param argument="--report" type="data" format="tabular" label="Kraken report file"/>
         <param argument="--intermediate-ranks" type="boolean" checked="false" truevalue="--intermediate-ranks" falsevalue="" label="Include intermediate (i.e. non-standard) ranks"/>
     </inputs>
     <outputs>
-        <data name="output" format="tabular" />
+        <data name="output" format="tabular"/>
     </outputs>
     <tests>
         <test>
@@ -26,7 +26,7 @@ kreport2krona.py
         </test>
         <test>
             <param name="report" value="sample.tabular"/>
-            <param name="intermediate_ranks" value="--intermediate-ranks"/>
+            <param name="intermediate_ranks" value="true"/>
             <output name="output" file="output_intermediate.tabular"/>
         </test>
     </tests>

--- a/tools/krakentools/kreport2mpa.xml
+++ b/tools/krakentools/kreport2mpa.xml
@@ -14,12 +14,12 @@ kreport2mpa.py
     $percentages
     ]]></command>
     <inputs>
-        <param argument="--report" type="data" format="tabular" label="Kraken report file" />
-        <param argument="--intermediate-ranks" type="boolean" checked="false" truevalue="--intermediate-ranks" falsevalue="" label="Include intermediate ranks" help="Include non-standard levels. Default only outputs standard levels [D,P,C,O,F,G,S]." />
+        <param argument="--report" type="data" format="tabular" label="Kraken report file"/>
+        <param argument="--intermediate-ranks" type="boolean" checked="false" truevalue="--intermediate-ranks" falsevalue="" label="Include intermediate ranks" help="Include non-standard levels. Default only outputs standard levels [D,P,C,O,F,G,S]."/>
         <param argument="--percentages" type="boolean" checked="false" truevalue="--percentages" falsevalue="" label="Use percentage of total reads for output." help="Outputs percentages of reads instead of total reads."/>
     </inputs>
     <outputs>
-        <data name="output" format="tabular" />
+        <data name="output" format="tabular"/>
     </outputs>
     <tests>
         <test>
@@ -28,12 +28,12 @@ kreport2mpa.py
         </test>
         <test>
             <param name="report" value="sample.tabular"/>
-            <param name="intermediate_ranks" value="--intermediate-ranks"/>
+            <param name="intermediate_ranks" value="true"/>
             <output name="output" file="mpa_output_intermediate.tabular"/>
         </test>
         <test>
             <param name="report" value="sample.tabular"/>
-            <param name="percentages" value="--percentages"/>
+            <param name="percentages" value="true"/>
             <output name="output" file="mpa_output_percentages.tabular"/>
         </test>
     </tests>
@@ -56,37 +56,37 @@ A MetaPhlAn-style TEXT file
 
 :: 
 
-    k__Eukaryota	756
-    k__Eukaryota|k__Metazoa	402
-    k__Eukaryota|k__Metazoa|p__Chordata	402
-    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia	402
+    k__Eukaryota    756
+    k__Eukaryota|k__Metazoa    402
+    k__Eukaryota|k__Metazoa|p__Chordata    402
+    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia    402
 
 
 ``--intermediate-ranks``
 
 ::
 
-    x__cellular_organisms	836
-    x__cellular_organisms|k__Eukaryota	756
-    x__cellular_organisms|k__Eukaryota|x__Opisthokonta	747
-    x__cellular_organisms|k__Eukaryota|x__Opisthokonta|k__Metazoa	402
-    x__cellular_organisms|k__Eukaryota|x__Opisthokonta|k__Metazoa|x__Eumetazoa	402
+    x__cellular_organisms    836
+    x__cellular_organisms|k__Eukaryota    756
+    x__cellular_organisms|k__Eukaryota|x__Opisthokonta    747
+    x__cellular_organisms|k__Eukaryota|x__Opisthokonta|k__Metazoa    402
+    x__cellular_organisms|k__Eukaryota|x__Opisthokonta|k__Metazoa|x__Eumetazoa    402
 
 ``--percentages``
 
 ::
 
-    k__Eukaryota	56.0
-    k__Eukaryota|k__Metazoa	29.78
-    k__Eukaryota|k__Metazoa|p__Chordata	29.78
-    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia	29.78
-    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates	29.78
-    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates|f__Hominidae	29.78
-    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates|f__Hominidae|g__Homo	29.78
+    k__Eukaryota    56.0
+    k__Eukaryota|k__Metazoa    29.78
+    k__Eukaryota|k__Metazoa|p__Chordata    29.78
+    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia    29.78
+    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates    29.78
+    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates|f__Hominidae    29.78
+    k__Eukaryota|k__Metazoa|p__Chordata|c__Mammalia|o__Primates|f__Hominidae|g__Homo    29.78
 
     ]]></help>
     <expand macro="citations"/>
     <creator>
-        <person givenName="Paul" familyName="Zierep" email="zierep@informatik.uni-freiburg.de" />
+        <person givenName="Paul" familyName="Zierep" email="zierep@informatik.uni-freiburg.de"/>
     </creator>
 </tool>

--- a/tools/krakentools/macros.xml
+++ b/tools/krakentools/macros.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.2.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">21.01</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">25.0</token>
     <xml name="biotools">
         <xrefs>
             <xref type="bio.tools">krakentools</xref>
@@ -15,7 +14,7 @@
         </requirements>
     </xml>
     <xml name="version">
-        <version_command></version_command>
+        <version_command/>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Not sure yet if the remaining linter failure is valid. 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
