### PR TITLE
jbrowse2: Sanitize assembly label to handle / in genome descriptions

### DIFF
--- a/tools/jbrowse2/jbrowse2.py
+++ b/tools/jbrowse2/jbrowse2.py
@@ -354,6 +354,7 @@ class JbrowseConnector(object):
         return views
 
     def add_assembly(self, path, label, is_remote=False, cytobands=None, ref_name_aliases=None):
+        label = re.sub(r"[/\\]", " ", label)  # sanitize path-unsafe characters
 
         if not is_remote:
             # Find a non-existing filename for the new genome

--- a/tools/jbrowse2/macros.xml
+++ b/tools/jbrowse2/macros.xml
@@ -11,7 +11,7 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
 
     <xml name="general_options">
         <section name="jbgen" title="Advanced: general JBrowse options" expanded="false">

--- a/tools/jbrowse2/test-data/out/01_all_tracks/config.json
+++ b/tools/jbrowse2/test-data/out/01_all_tracks/config.json
@@ -55,18 +55,18 @@
           "assembly": "merlin.fa",
           "loc": "Merlin",
           "tracks": [
-            "a7e8fe627b3e52b4c1f8c3c886aa9e57_0_0",
-            "da7c1329ab838dfaeee1703c013a5bc0_1_0",
-            "f2b6c4173397b6b812014c2b32e822a1_2_0",
-            "dd9f9b6093c48d07509eee6176e1bb1a_2_1",
-            "c488f0dd81de5234363870aac1b6099e_3_0",
-            "48ffd6161c7eec8f82482fb614f08d13_4_0",
-            "8f850b3775e54706acf8e3ae3856c21e_5_0",
-            "f04ae7e29a15ee551a3d5cb1b7df6d9f_6_0",
-            "69acdc3612406c3cb0347062091c4228_6_1",
-            "780b1598e6368efa353cc705c9d08ab3_7_0",
-            "f329aa022d2aa8aea5316bfa9c7cc113_8_0",
-            "74b81aa00dec3d38a9ac2a1176c3cc7e_9_0",
+            "abe43ed3bae30474bf9c2e2f877a75da_0_0",
+            "dee268a5080528f2ea062207446432de_1_0",
+            "434fb117c1ec49db2da71bb6097d63e1_2_0",
+            "8775b93ca4bce2b455c50c880ee6fb97_2_1",
+            "07e43422409e45dfa45c1348d7ff5c91_3_0",
+            "bbdba74b77ff0a1b909fb7957822425e_4_0",
+            "61a400812f40577c6289eb7c16641eab_5_0",
+            "a9b91e9f7d410dae11ad58010baab61e_6_0",
+            "377a1cc489d7d9001617f24deee89861_6_1",
+            "955aaffbae4c4852232f404546706041_7_0",
+            "737e89b0f862222bc05792ad0c2ba40b_8_0",
+            "19ad2e7a7efb2c0b132f536748380100_9_0",
             "936a5285fbedf1c37f5daf26837035b2_10_0"
           ]
         }
@@ -76,17 +76,17 @@
   "tracks": [
     {
       "type": "FeatureTrack",
-      "trackId": "a7e8fe627b3e52b4c1f8c3c886aa9e57_0_0",
+      "trackId": "abe43ed3bae30474bf9c2e2f877a75da_0_0",
       "name": "merlin.gff",
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
-          "uri": "data/a7e8fe627b3e52b4c1f8c3c886aa9e57_0_0.gff.gz",
+          "uri": "data/abe43ed3bae30474bf9c2e2f877a75da_0_0.gff.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/a7e8fe627b3e52b4c1f8c3c886aa9e57_0_0.gff.gz.tbi",
+            "uri": "data/abe43ed3bae30474bf9c2e2f877a75da_0_0.gff.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -101,7 +101,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "a7e8fe627b3e52b4c1f8c3c886aa9e57_0_0_LinearBasicDisplay",
+          "displayId": "abe43ed3bae30474bf9c2e2f877a75da_0_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -119,15 +119,15 @@
         "depth": 1
       },
       "metadata": {
-        "dataset_id": "2a23db38ccbbc7de",
+        "dataset_id": "a61d9e91ddc269e4",
         "dataset_hid": "2",
         "dataset_size": "110.3 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_1975\">gff3</a>",
         "dataset_file_ext": "gff3",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "1228",
         "metadata_comment_lines": "2",
@@ -137,17 +137,17 @@
         "metadata_attributes": "4",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/2a23db38ccbbc7de/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/a61d9e91ddc269e4/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "FeatureTrack",
-      "trackId": "da7c1329ab838dfaeee1703c013a5bc0_1_0",
+      "trackId": "dee268a5080528f2ea062207446432de_1_0",
       "name": "merlin.gtf",
       "adapter": {
         "type": "GtfAdapter",
         "gtfLocation": {
-          "uri": "data/da7c1329ab838dfaeee1703c013a5bc0_1_0.gtf",
+          "uri": "data/dee268a5080528f2ea062207446432de_1_0.gtf",
           "locationType": "UriLocation"
         }
       },
@@ -160,7 +160,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "da7c1329ab838dfaeee1703c013a5bc0_1_0_LinearBasicDisplay",
+          "displayId": "dee268a5080528f2ea062207446432de_1_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -178,15 +178,15 @@
         "depth": 1
       },
       "metadata": {
-        "dataset_id": "0b7812b25f4cfb76",
+        "dataset_id": "21231a9d9f51801d",
         "dataset_hid": "3",
         "dataset_size": "25.0 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2306\">gtf</a>",
         "dataset_file_ext": "gtf",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "292",
         "metadata_comment_lines": "0",
@@ -196,22 +196,22 @@
         "metadata_attributes": "2",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/0b7812b25f4cfb76/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/21231a9d9f51801d/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "FeatureTrack",
-      "trackId": "f2b6c4173397b6b812014c2b32e822a1_2_0",
+      "trackId": "434fb117c1ec49db2da71bb6097d63e1_2_0",
       "name": "test-3.bed",
       "adapter": {
         "type": "BedTabixAdapter",
         "bedGzLocation": {
-          "uri": "data/f2b6c4173397b6b812014c2b32e822a1_2_0.bed.gz",
+          "uri": "data/434fb117c1ec49db2da71bb6097d63e1_2_0.bed.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/f2b6c4173397b6b812014c2b32e822a1_2_0.bed.gz.tbi",
+            "uri": "data/434fb117c1ec49db2da71bb6097d63e1_2_0.bed.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -226,7 +226,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "f2b6c4173397b6b812014c2b32e822a1_2_0_LinearBasicDisplay",
+          "displayId": "434fb117c1ec49db2da71bb6097d63e1_2_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -244,15 +244,15 @@
         "depth": 1
       },
       "metadata": {
-        "dataset_id": "bd91a97d652fafe1",
+        "dataset_id": "8e03caec7367853e",
         "dataset_hid": "4",
         "dataset_size": "49 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3003\">bed</a>",
         "dataset_file_ext": "bed",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "3",
         "metadata_comment_lines": "0",
@@ -267,22 +267,22 @@
         "metadata_viz_filter_cols": "4",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/bd91a97d652fafe1/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/8e03caec7367853e/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "FeatureTrack",
-      "trackId": "dd9f9b6093c48d07509eee6176e1bb1a_2_1",
+      "trackId": "8775b93ca4bce2b455c50c880ee6fb97_2_1",
       "name": "test-6.bed",
       "adapter": {
         "type": "BedTabixAdapter",
         "bedGzLocation": {
-          "uri": "data/dd9f9b6093c48d07509eee6176e1bb1a_2_1.bed.gz",
+          "uri": "data/8775b93ca4bce2b455c50c880ee6fb97_2_1.bed.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/dd9f9b6093c48d07509eee6176e1bb1a_2_1.bed.gz.tbi",
+            "uri": "data/8775b93ca4bce2b455c50c880ee6fb97_2_1.bed.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -297,7 +297,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "dd9f9b6093c48d07509eee6176e1bb1a_2_1_LinearBasicDisplay",
+          "displayId": "8775b93ca4bce2b455c50c880ee6fb97_2_1_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -315,15 +315,15 @@
         "depth": 1
       },
       "metadata": {
-        "dataset_id": "3aa468ce9e79eed2",
+        "dataset_id": "b7cdf06df7d3dd95",
         "dataset_hid": "5",
         "dataset_size": "180 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3003\">bed</a>",
         "dataset_file_ext": "bed",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "3",
         "metadata_comment_lines": "0",
@@ -338,22 +338,22 @@
         "metadata_viz_filter_cols": "4",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/3aa468ce9e79eed2/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/b7cdf06df7d3dd95/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "AlignmentsTrack",
-      "trackId": "c488f0dd81de5234363870aac1b6099e_3_0",
+      "trackId": "07e43422409e45dfa45c1348d7ff5c91_3_0",
       "name": "merlin-sample.bam",
       "adapter": {
         "type": "BamAdapter",
         "bamLocation": {
-          "uri": "data/c488f0dd81de5234363870aac1b6099e_3_0.bam",
+          "uri": "data/07e43422409e45dfa45c1348d7ff5c91_3_0.bam",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/c488f0dd81de5234363870aac1b6099e_3_0.bam.bai",
+            "uri": "data/07e43422409e45dfa45c1348d7ff5c91_3_0.bam.bai",
             "locationType": "UriLocation"
           },
           "indexType": "BAI"
@@ -383,19 +383,19 @@
       "displays": [
         {
           "type": "LinearAlignmentsDisplay",
-          "displayId": "c488f0dd81de5234363870aac1b6099e_3_0_LinearAlignmentsDisplay"
+          "displayId": "07e43422409e45dfa45c1348d7ff5c91_3_0_LinearAlignmentsDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "c8d274edba5d366b",
+        "dataset_id": "6eb7f4a3904a4f09",
         "dataset_hid": "6",
         "dataset_size": "12.9 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2572\">bam</a>",
         "dataset_file_ext": "bam",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_columns": "12",
         "metadata_column_names": "['QNAME', 'FLAG', 'RNAME', 'POS', 'MAPQ', 'CIGAR', 'MRNM', 'MPOS', 'ISIZE', 'SEQ', 'QUAL', 'OPT']",
@@ -407,17 +407,17 @@
         "metadata_bam_header": "{'HD': {'SO': 'coordinate', 'VN': '1.3'}, 'PG': [{'CL': 'minimap2 -a -x sr -t 1 reference.fa /net/datasrv3hs.sanbi.ac.za/datastore/cip0/software/galaxy/galaxy-ctb/galaxy/database/files/004/dataset_4697.dat', 'ID': 'minimap2', 'PN': 'minimap2', 'VN': '2.5-r572'}], 'SQ': [{'LN': 172788, 'SN': 'Merlin'}]}",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/c8d274edba5d366b/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/6eb7f4a3904a4f09/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "QuantitativeTrack",
-      "trackId": "48ffd6161c7eec8f82482fb614f08d13_4_0",
+      "trackId": "bbdba74b77ff0a1b909fb7957822425e_4_0",
       "name": "data.bw",
       "adapter": {
         "type": "BigWigAdapter",
         "bigWigLocation": {
-          "uri": "data/48ffd6161c7eec8f82482fb614f08d13_4_0.bw",
+          "uri": "data/bbdba74b77ff0a1b909fb7957822425e_4_0.bw",
           "locationType": "UriLocation"
         }
       },
@@ -430,38 +430,38 @@
       "displays": [
         {
           "type": "LinearWiggleDisplay",
-          "displayId": "48ffd6161c7eec8f82482fb614f08d13_4_0_LinearWiggleDisplay",
+          "displayId": "bbdba74b77ff0a1b909fb7957822425e_4_0_LinearWiggleDisplay",
           "defaultRendering": "xyplot"
         }
       ],
       "metadata": {
-        "dataset_id": "2f8b42de958784ae",
+        "dataset_id": "c974d8df6b0170de",
         "dataset_hid": "7",
         "dataset_size": "81.6 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3006\">bigwig</a>",
         "dataset_file_ext": "bigwig",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/2f8b42de958784ae/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/c974d8df6b0170de/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "AlignmentsTrack",
-      "trackId": "8f850b3775e54706acf8e3ae3856c21e_5_0",
+      "trackId": "61a400812f40577c6289eb7c16641eab_5_0",
       "name": "merlin-sample.cram",
       "adapter": {
         "type": "CramAdapter",
         "cramLocation": {
-          "uri": "data/8f850b3775e54706acf8e3ae3856c21e_5_0.cram",
+          "uri": "data/61a400812f40577c6289eb7c16641eab_5_0.cram",
           "locationType": "UriLocation"
         },
         "craiLocation": {
-          "uri": "data/8f850b3775e54706acf8e3ae3856c21e_5_0.cram.crai",
+          "uri": "data/61a400812f40577c6289eb7c16641eab_5_0.cram.crai",
           "locationType": "UriLocation"
         },
         "sequenceAdapter": {
@@ -489,34 +489,34 @@
       "displays": [
         {
           "type": "LinearAlignmentsDisplay",
-          "displayId": "8f850b3775e54706acf8e3ae3856c21e_5_0_LinearAlignmentsDisplay"
+          "displayId": "61a400812f40577c6289eb7c16641eab_5_0_LinearAlignmentsDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "76ca3a0a3de24f95",
+        "dataset_id": "e1e7f58235a6ee4e",
         "dataset_hid": "8",
         "dataset_size": "8.3 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3462\">cram</a>",
         "dataset_file_ext": "cram",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_cram_version": "3.0",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/76ca3a0a3de24f95/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/e1e7f58235a6ee4e/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "QuantitativeTrack",
-      "trackId": "f04ae7e29a15ee551a3d5cb1b7df6d9f_6_0",
+      "trackId": "a9b91e9f7d410dae11ad58010baab61e_6_0",
       "name": "data.bw",
       "adapter": {
         "type": "BigWigAdapter",
         "bigWigLocation": {
-          "uri": "data/f04ae7e29a15ee551a3d5cb1b7df6d9f_6_0.bw",
+          "uri": "data/a9b91e9f7d410dae11ad58010baab61e_6_0.bw",
           "locationType": "UriLocation"
         }
       },
@@ -529,34 +529,34 @@
       "displays": [
         {
           "type": "LinearWiggleDisplay",
-          "displayId": "f04ae7e29a15ee551a3d5cb1b7df6d9f_6_0_LinearWiggleDisplay",
+          "displayId": "a9b91e9f7d410dae11ad58010baab61e_6_0_LinearWiggleDisplay",
           "defaultRendering": "xyplot"
         }
       ],
       "metadata": {
-        "dataset_id": "2f8b42de958784ae",
+        "dataset_id": "c974d8df6b0170de",
         "dataset_hid": "7",
         "dataset_size": "81.6 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3006\">bigwig</a>",
         "dataset_file_ext": "bigwig",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/2f8b42de958784ae/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/c974d8df6b0170de/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "QuantitativeTrack",
-      "trackId": "69acdc3612406c3cb0347062091c4228_6_1",
+      "trackId": "377a1cc489d7d9001617f24deee89861_6_1",
       "name": "smaller2.bw",
       "adapter": {
         "type": "BigWigAdapter",
         "bigWigLocation": {
-          "uri": "data/69acdc3612406c3cb0347062091c4228_6_1.bw",
+          "uri": "data/377a1cc489d7d9001617f24deee89861_6_1.bw",
           "locationType": "UriLocation"
         }
       },
@@ -569,39 +569,39 @@
       "displays": [
         {
           "type": "LinearWiggleDisplay",
-          "displayId": "69acdc3612406c3cb0347062091c4228_6_1_LinearWiggleDisplay",
+          "displayId": "377a1cc489d7d9001617f24deee89861_6_1_LinearWiggleDisplay",
           "defaultRendering": "xyplot"
         }
       ],
       "metadata": {
-        "dataset_id": "fff5871153f6d061",
+        "dataset_id": "c2c5440559fb3167",
         "dataset_hid": "9",
         "dataset_size": "10.9 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3006\">bigwig</a>",
         "dataset_file_ext": "bigwig",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/fff5871153f6d061/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/c2c5440559fb3167/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "VariantTrack",
-      "trackId": "780b1598e6368efa353cc705c9d08ab3_7_0",
+      "trackId": "955aaffbae4c4852232f404546706041_7_0",
       "name": "test.vcf",
       "adapter": {
         "type": "VcfTabixAdapter",
         "vcfGzLocation": {
-          "uri": "data/780b1598e6368efa353cc705c9d08ab3_7_0.vcf.gz",
+          "uri": "data/955aaffbae4c4852232f404546706041_7_0.vcf.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/780b1598e6368efa353cc705c9d08ab3_7_0.vcf.gz.tbi",
+            "uri": "data/955aaffbae4c4852232f404546706041_7_0.vcf.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -616,20 +616,20 @@
       "displays": [
         {
           "type": "LinearVariantDisplay",
-          "displayId": "780b1598e6368efa353cc705c9d08ab3_7_0_LinearVariantDisplay"
+          "displayId": "955aaffbae4c4852232f404546706041_7_0_LinearVariantDisplay"
         }
       ],
       "formatDetails": {},
       "metadata": {
-        "dataset_id": "d68659e09db1368d",
+        "dataset_id": "09c518f6779b5519",
         "dataset_hid": "10",
         "dataset_size": "1.5 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3016\">vcf</a>",
         "dataset_file_ext": "vcf",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "5",
         "metadata_comment_lines": "18",
@@ -640,17 +640,17 @@
         "metadata_sample_names": "['NA00001', 'NA00002', 'NA00003']",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/d68659e09db1368d/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/09c518f6779b5519/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "HicTrack",
-      "trackId": "f329aa022d2aa8aea5316bfa9c7cc113_8_0",
+      "trackId": "737e89b0f862222bc05792ad0c2ba40b_8_0",
       "name": "merlin.hic",
       "adapter": {
         "type": "HicAdapter",
         "hicLocation": {
-          "uri": "data/f329aa022d2aa8aea5316bfa9c7cc113_8_0.hic",
+          "uri": "data/737e89b0f862222bc05792ad0c2ba40b_8_0.hic",
           "locationType": "UriLocation"
         }
       },
@@ -663,29 +663,29 @@
       "displays": [
         {
           "type": "LinearHicDisplay",
-          "displayId": "f329aa022d2aa8aea5316bfa9c7cc113_8_0_LinearHicDisplay"
+          "displayId": "737e89b0f862222bc05792ad0c2ba40b_8_0_LinearHicDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "6294e1cb82136e37",
+        "dataset_id": "e4a9bfd62c67b47c",
         "dataset_hid": "11",
         "dataset_size": "931 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2333\">hic</a>",
         "dataset_file_ext": "hic",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_version": "9",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/6294e1cb82136e37/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/e4a9bfd62c67b47c/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "MafTrack",
-      "trackId": "74b81aa00dec3d38a9ac2a1176c3cc7e_9_0",
+      "trackId": "19ad2e7a7efb2c0b132f536748380100_9_0",
       "name": "merlinlastz.maf",
       "adapter": {
         "type": "MafTabixAdapter",
@@ -699,11 +699,11 @@
           "Merlin6"
         ],
         "bedGzLocation": {
-          "uri": "data/74b81aa00dec3d38a9ac2a1176c3cc7e_9_0.maf.gz"
+          "uri": "data/19ad2e7a7efb2c0b132f536748380100_9_0.maf.gz"
         },
         "index": {
           "location": {
-            "uri": "data/74b81aa00dec3d38a9ac2a1176c3cc7e_9_0.maf.gz.tbi"
+            "uri": "data/19ad2e7a7efb2c0b132f536748380100_9_0.maf.gz.tbi"
           }
         }
       },
@@ -716,26 +716,26 @@
       "displays": [
         {
           "type": "LinearMafDisplay",
-          "displayId": "74b81aa00dec3d38a9ac2a1176c3cc7e_9_0_LinearMafDisplay"
+          "displayId": "19ad2e7a7efb2c0b132f536748380100_9_0_LinearMafDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "7217695b024bd3ec",
+        "dataset_id": "7cbf958f6a0094bd",
         "dataset_hid": "12",
         "dataset_size": "1.5 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3008\">maf</a>",
         "dataset_file_ext": "maf",
-        "history_id": "4d30d636fed0a9f6",
+        "history_id": "b4cb97627e8402ff",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/4d30d636fed0a9f6\">Tool Test History for jbrowse2/3.6.5+galaxy1-0</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/b4cb97627e8402ff\">Tool Test History for jbrowse2/3.7.0+galaxy1-0</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "0",
         "metadata_species": "Merlin,Merlin1,Merlin2,Merlin3,Merlin4,Merlin5,Merlin6",
         "metadata_blocks": "6",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/7217695b024bd3ec/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/7cbf958f6a0094bd/show_params\">__DATA_FETCH__</a>"
       }
     },
     {

--- a/tools/jbrowse2/test-data/out/01_all_tracks/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/01_all_tracks/galaxy.xml
@@ -9,20 +9,20 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/f/3/c/dataset_f3c0184e-59c4-433e-8dd8-681079b35a97.dat" label="merlin.fa">
+            <genome path="/tmp/tmp81tzotcx/files/f/d/1/dataset_fd194007-6d63-46a9-8ae1-dcfe55216ede.dat" label="merlin.fa">
             <metadata>
-                <dataset id="4d30d636fed0a9f6" hid="1"
+                <dataset id="b4cb97627e8402ff" hid="1"
                     size="171.6 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlin.fa" />
-                <history id="4d30d636fed0a9f6"
+                <history id="b4cb97627e8402ff"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                 <metadata
                         dbkey="?"
                         data_lines="2881"
@@ -40,16 +40,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/6/c/7/dataset_6c7ccdb8-be7f-4998-be93-92e5098e16ae.dat" ext="gff3" label="merlin.gff">
+                    <trackFile path="/tmp/tmp81tzotcx/files/e/2/3/dataset_e2361acb-dea2-465b-a697-0526c9e80742.dat" ext="gff3" label="merlin.gff">
                         <metadata>
-                        <dataset id="2a23db38ccbbc7de" hid="2"
+                        <dataset id="a61d9e91ddc269e4" hid="2"
                             size="110.3 KB"
                             edam_format="format_1975"
                             file_ext="gff3" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="1228"
@@ -95,16 +95,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/d/c/f/dataset_dcf75edc-7a03-4e95-b28c-47ae364af589.dat" ext="gtf" label="merlin.gtf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/a/e/9/dataset_ae9cf8d1-481e-4a86-bcbd-3e81714d01c0.dat" ext="gtf" label="merlin.gtf">
                         <metadata>
-                        <dataset id="0b7812b25f4cfb76" hid="3"
+                        <dataset id="21231a9d9f51801d" hid="3"
                             size="25.0 KB"
                             edam_format="format_2306"
                             file_ext="gtf" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="292"
@@ -150,16 +150,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/c/3/e/dataset_c3ee5cf0-0cb6-4585-a7d6-d5ddcded7371.dat" ext="bed" label="test-3.bed">
+                    <trackFile path="/tmp/tmp81tzotcx/files/d/8/b/dataset_d8be10c3-e881-4d73-b7e8-ae0dd673581a.dat" ext="bed" label="test-3.bed">
                         <metadata>
-                        <dataset id="bd91a97d652fafe1" hid="4"
+                        <dataset id="8e03caec7367853e" hid="4"
                             size="49 bytes"
                             edam_format="format_3003"
                             file_ext="bed" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="3"
@@ -180,16 +180,16 @@
                             />
                         </metadata>
                     </trackFile>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/7/2/0/dataset_72051c30-7fb8-4063-af07-c74536915fa9.dat" ext="bed" label="test-6.bed">
+                    <trackFile path="/tmp/tmp81tzotcx/files/8/0/f/dataset_80f99d0b-7eb3-47cb-b87d-281b7d7646ee.dat" ext="bed" label="test-6.bed">
                         <metadata>
-                        <dataset id="3aa468ce9e79eed2" hid="5"
+                        <dataset id="b7cdf06df7d3dd95" hid="5"
                             size="180 bytes"
                             edam_format="format_3003"
                             file_ext="bed" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="3"
@@ -240,16 +240,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/8/a/5/dataset_8a5eca75-b2e7-436a-8596-659ca480cfc2.dat" ext="bam" label="merlin-sample.bam">
+                    <trackFile path="/tmp/tmp81tzotcx/files/5/0/5/dataset_5054f770-3063-45dc-9557-20d5961edefd.dat" ext="bam" label="merlin-sample.bam">
                         <metadata>
-                        <dataset id="c8d274edba5d366b" hid="6"
+                        <dataset id="6eb7f4a3904a4f09" hid="6"
                             size="12.9 KB"
                             edam_format="format_2572"
                             file_ext="bam" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 columns="12"
@@ -281,7 +281,7 @@
 
                     <pileup>
                             <bam_indices>
-                                    <bam_index>/tmp/tmpiyg6gzbz/files/_metadata_files/2/1/b/metadata_21b9af11-e7ea-4393-ba2a-b79f92ff130c.dat</bam_index>
+                                    <bam_index>/tmp/tmp81tzotcx/files/_metadata_files/7/e/a/metadata_7ea593d1-266c-40e9-a0fd-83eba242645a.dat</bam_index>
                             </bam_indices>
                     </pileup>
             </options>
@@ -290,16 +290,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/7/8/e/dataset_78e8146d-3719-46af-acda-41f5a2678a26.dat" ext="bigwig" label="data.bw">
+                    <trackFile path="/tmp/tmp81tzotcx/files/4/5/f/dataset_45ffe5af-c794-4b7a-8ac1-b8bbfdae06c9.dat" ext="bigwig" label="data.bw">
                         <metadata>
-                        <dataset id="2f8b42de958784ae" hid="7"
+                        <dataset id="c974d8df6b0170de" hid="7"
                             size="81.6 KB"
                             edam_format="format_3006"
                             file_ext="bigwig" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                             />
@@ -330,16 +330,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/f/0/7/dataset_f07f766a-6f31-4207-85c3-0c86ff22b574.dat" ext="cram" label="merlin-sample.cram">
+                    <trackFile path="/tmp/tmp81tzotcx/files/3/5/3/dataset_3537cbdb-ebcb-4807-8420-8cf40c61f133.dat" ext="cram" label="merlin-sample.cram">
                         <metadata>
-                        <dataset id="76ca3a0a3de24f95" hid="8"
+                        <dataset id="e1e7f58235a6ee4e" hid="8"
                             size="8.3 KB"
                             edam_format="format_3462"
                             file_ext="cram" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 cram_version="3.0"
@@ -364,7 +364,7 @@
 
                     <cram>
                             <cram_indices>
-                                <cram_index>/tmp/tmpiyg6gzbz/files/_metadata_files/5/7/3/metadata_5734b699-7e5d-438c-bd25-c2736b084db4.dat</cram_index>
+                                <cram_index>/tmp/tmp81tzotcx/files/_metadata_files/f/3/d/metadata_f3dfd5d9-b31b-4ddb-8cd1-61cf0711813f.dat</cram_index>
                             </cram_indices>
                     </cram>
             </options>
@@ -373,16 +373,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/7/8/e/dataset_78e8146d-3719-46af-acda-41f5a2678a26.dat" ext="bigwig" label="data.bw">
+                    <trackFile path="/tmp/tmp81tzotcx/files/4/5/f/dataset_45ffe5af-c794-4b7a-8ac1-b8bbfdae06c9.dat" ext="bigwig" label="data.bw">
                         <metadata>
-                        <dataset id="2f8b42de958784ae" hid="7"
+                        <dataset id="c974d8df6b0170de" hid="7"
                             size="81.6 KB"
                             edam_format="format_3006"
                             file_ext="bigwig" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                             />
@@ -392,16 +392,16 @@
                             />
                         </metadata>
                     </trackFile>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/a/9/3/dataset_a9398956-bf32-43da-8bb1-047d817af62a.dat" ext="bigwig" label="smaller2.bw">
+                    <trackFile path="/tmp/tmp81tzotcx/files/5/0/6/dataset_5069660c-e684-45ff-8f91-2f8320a2378b.dat" ext="bigwig" label="smaller2.bw">
                         <metadata>
-                        <dataset id="fff5871153f6d061" hid="9"
+                        <dataset id="c2c5440559fb3167" hid="9"
                             size="10.9 KB"
                             edam_format="format_3006"
                             file_ext="bigwig" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                             />
@@ -432,16 +432,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/3/e/3/dataset_3e3ea273-7836-480f-a599-c0c8e3878ed7.dat" ext="vcf" label="test.vcf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/5/0/6/dataset_506e3e94-ea43-401c-b8d2-1ea8e83ff66d.dat" ext="vcf" label="test.vcf">
                         <metadata>
-                        <dataset id="d68659e09db1368d" hid="10"
+                        <dataset id="09c518f6779b5519" hid="10"
                             size="1.5 KB"
                             edam_format="format_3016"
                             file_ext="vcf" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="5"
@@ -476,16 +476,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/9/e/7/dataset_9e7fc4c4-f84c-436c-95d4-d1f26d102b1e.dat" ext="hic" label="merlin.hic">
+                    <trackFile path="/tmp/tmp81tzotcx/files/1/f/0/dataset_1f051eec-cf21-4a6d-989a-776c555737cd.dat" ext="hic" label="merlin.hic">
                         <metadata>
-                        <dataset id="6294e1cb82136e37" hid="11"
+                        <dataset id="e4a9bfd62c67b47c" hid="11"
                             size="931 bytes"
                             edam_format="format_2333"
                             file_ext="hic" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 version="9"
@@ -516,16 +516,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/6/d/8/dataset_6d887995-018c-4119-ae61-2bb8af89301f.dat" ext="maf" label="merlinlastz.maf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/7/8/1/dataset_781c132b-e3c2-47d5-9ef6-05ba31c40c08.dat" ext="maf" label="merlinlastz.maf">
                         <metadata>
-                        <dataset id="7217695b024bd3ec" hid="12"
+                        <dataset id="7cbf958f6a0094bd" hid="12"
                             size="1.5 KB"
                             edam_format="format_3008"
                             file_ext="maf" />
-                        <history id="4d30d636fed0a9f6"
+                        <history id="b4cb97627e8402ff"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-0"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-0"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="0"

--- a/tools/jbrowse2/test-data/out/02_remote/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/02_remote/galaxy.xml
@@ -9,7 +9,7 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
             <genome path="https://jbrowse.org/genomes/hg19/fasta/hg19.fa.gz" label="hg19" remote="true">

--- a/tools/jbrowse2/test-data/out/03_synteny/config.json
+++ b/tools/jbrowse2/test-data/out/03_synteny/config.json
@@ -118,7 +118,7 @@
               "assembly": "merlin.fa",
               "loc": "Merlin",
               "tracks": [
-                "82179179689d9c4c5bdef6eec72630d5_0_0"
+                "73b6070d221900b383a6fd51838265ca_0_0"
               ]
             }
           }
@@ -129,11 +129,11 @@
             "tracks": [
               {
                 "type": "SyntenyTrack",
-                "configuration": "2d3285aa6e070d75c8017044c0deaafd_0_0",
+                "configuration": "15cd0f1ad34fadc09e65649b9db2b24b_0_0",
                 "displays": [
                   {
                     "type": "LinearSyntenyDisplay",
-                    "configuration": "2d3285aa6e070d75c8017044c0deaafd_0_0_LinearSyntenyDisplay"
+                    "configuration": "15cd0f1ad34fadc09e65649b9db2b24b_0_0_LinearSyntenyDisplay"
                   }
                 ]
               }
@@ -146,11 +146,11 @@
             "tracks": [
               {
                 "type": "SyntenyTrack",
-                "configuration": "443bf95452978ab205004d18f01b7011_0_0",
+                "configuration": "116674289d00f34f48aad386c9b20321_0_0",
                 "displays": [
                   {
                     "type": "LinearSyntenyDisplay",
-                    "configuration": "443bf95452978ab205004d18f01b7011_0_0_LinearSyntenyDisplay"
+                    "configuration": "116674289d00f34f48aad386c9b20321_0_0_LinearSyntenyDisplay"
                   }
                 ]
               }
@@ -165,12 +165,12 @@
   "tracks": [
     {
       "type": "QuantitativeTrack",
-      "trackId": "82179179689d9c4c5bdef6eec72630d5_0_0",
+      "trackId": "73b6070d221900b383a6fd51838265ca_0_0",
       "name": "data.bw",
       "adapter": {
         "type": "BigWigAdapter",
         "bigWigLocation": {
-          "uri": "data/82179179689d9c4c5bdef6eec72630d5_0_0.bw",
+          "uri": "data/73b6070d221900b383a6fd51838265ca_0_0.bw",
           "locationType": "UriLocation"
         }
       },
@@ -183,29 +183,29 @@
       "displays": [
         {
           "type": "LinearWiggleDisplay",
-          "displayId": "82179179689d9c4c5bdef6eec72630d5_0_0_LinearWiggleDisplay",
+          "displayId": "73b6070d221900b383a6fd51838265ca_0_0_LinearWiggleDisplay",
           "defaultRendering": "xyplot"
         }
       ],
       "metadata": {
-        "dataset_id": "7a9728aeed7a3efa",
+        "dataset_id": "e9904f0b6a2e2103",
         "dataset_hid": "6",
         "dataset_size": "81.6 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3006\">bigwig</a>",
         "dataset_file_ext": "bigwig",
-        "history_id": "0b7812b25f4cfb76",
+        "history_id": "21231a9d9f51801d",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/0b7812b25f4cfb76\">Tool Test History for jbrowse2/3.6.5+galaxy1-2</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/21231a9d9f51801d\">Tool Test History for jbrowse2/3.7.0+galaxy1-2</a>",
         "metadata_dbkey": "?",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/7a9728aeed7a3efa/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/e9904f0b6a2e2103/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "SyntenyTrack",
-      "trackId": "2d3285aa6e070d75c8017044c0deaafd_0_0",
+      "trackId": "15cd0f1ad34fadc09e65649b9db2b24b_0_0",
       "name": "merlun_on_merlon.paf",
       "adapter": {
         "assemblyNames": [
@@ -214,11 +214,11 @@
         ],
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/2d3285aa6e070d75c8017044c0deaafd_0_0.pif.gz"
+          "uri": "data/15cd0f1ad34fadc09e65649b9db2b24b_0_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/2d3285aa6e070d75c8017044c0deaafd_0_0.pif.gz.tbi"
+            "uri": "data/15cd0f1ad34fadc09e65649b9db2b24b_0_0.pif.gz.tbi"
           }
         }
       },
@@ -232,29 +232,29 @@
       "displays": [
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "2d3285aa6e070d75c8017044c0deaafd_0_0_LinearSyntenyDisplay"
+          "displayId": "15cd0f1ad34fadc09e65649b9db2b24b_0_0_LinearSyntenyDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "e744a972b308a2d0",
+        "dataset_id": "e977441424966562",
         "dataset_hid": "2",
         "dataset_size": "227 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "0b7812b25f4cfb76",
+        "history_id": "21231a9d9f51801d",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/0b7812b25f4cfb76\">Tool Test History for jbrowse2/3.6.5+galaxy1-2</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/21231a9d9f51801d\">Tool Test History for jbrowse2/3.7.0+galaxy1-2</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "2",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/e744a972b308a2d0/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/e977441424966562/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "SyntenyTrack",
-      "trackId": "443bf95452978ab205004d18f01b7011_0_0",
+      "trackId": "116674289d00f34f48aad386c9b20321_0_0",
       "name": "merlon_on_merlin.paf",
       "adapter": {
         "assemblyNames": [
@@ -263,11 +263,11 @@
         ],
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/443bf95452978ab205004d18f01b7011_0_0.pif.gz"
+          "uri": "data/116674289d00f34f48aad386c9b20321_0_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/443bf95452978ab205004d18f01b7011_0_0.pif.gz.tbi"
+            "uri": "data/116674289d00f34f48aad386c9b20321_0_0.pif.gz.tbi"
           }
         }
       },
@@ -281,24 +281,24 @@
       "displays": [
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "443bf95452978ab205004d18f01b7011_0_0_LinearSyntenyDisplay"
+          "displayId": "116674289d00f34f48aad386c9b20321_0_0_LinearSyntenyDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "1f8c95c7204ee5b9",
+        "dataset_id": "4a7eaa5398f3e208",
         "dataset_hid": "4",
         "dataset_size": "127 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "0b7812b25f4cfb76",
+        "history_id": "21231a9d9f51801d",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/0b7812b25f4cfb76\">Tool Test History for jbrowse2/3.6.5+galaxy1-2</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/21231a9d9f51801d\">Tool Test History for jbrowse2/3.7.0+galaxy1-2</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "1",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/1f8c95c7204ee5b9/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/4a7eaa5398f3e208/show_params\">__DATA_FETCH__</a>"
       }
     }
   ],

--- a/tools/jbrowse2/test-data/out/03_synteny/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/03_synteny/galaxy.xml
@@ -9,20 +9,20 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/e/f/e/dataset_efe9082c-0a47-4f29-b471-263f76881e43.dat" label="merlun.fa">
+            <genome path="/tmp/tmp81tzotcx/files/4/5/a/dataset_45a9d62c-5ba2-4009-b754-2ee1f7d8c0e3.dat" label="merlun.fa">
             <metadata>
-                <dataset id="42ed1747fda63c08" hid="1"
+                <dataset id="3a62b48525bef3dc" hid="1"
                     size="158.8 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlun.fa" />
-                <history id="0b7812b25f4cfb76"
+                <history id="21231a9d9f51801d"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                 <metadata
                         dbkey="?"
                         data_lines="2666"
@@ -40,16 +40,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/5/8/c/dataset_58ca4b5e-c634-4686-86f5-8697451aef9b.dat" ext="paf" label="merlun_on_merlon.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/1/1/b/dataset_11ba0c5d-e32f-42b6-9183-add3f17e4d7e.dat" ext="paf" label="merlun_on_merlon.paf">
                         <metadata>
-                        <dataset id="e744a972b308a2d0" hid="2"
+                        <dataset id="e977441424966562" hid="2"
                             size="227 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="0b7812b25f4cfb76"
+                        <history id="21231a9d9f51801d"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="2"
@@ -79,17 +79,17 @@
     </tracks>
     </assembly>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/7/6/6/dataset_76654e69-cc8c-4461-8f92-ea2d9a7fa9c8.dat" label="merlon.fa">
+            <genome path="/tmp/tmp81tzotcx/files/f/c/8/dataset_fc845d5a-7d73-4ee8-ae66-9970a1fe8c38.dat" label="merlon.fa">
             <metadata>
-                <dataset id="1755c1ca08cd39a9" hid="3"
+                <dataset id="d58b9975b92b9754" hid="3"
                     size="155.3 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlon.fa" />
-                <history id="0b7812b25f4cfb76"
+                <history id="21231a9d9f51801d"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                 <metadata
                         dbkey="?"
                         data_lines="2608"
@@ -107,16 +107,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/b/2/0/dataset_b20f1b4c-528e-4b33-9f76-3158ecf3e64a.dat" ext="paf" label="merlon_on_merlin.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/2/9/8/dataset_2984ac63-9edd-4a4e-8154-88fa399619df.dat" ext="paf" label="merlon_on_merlin.paf">
                         <metadata>
-                        <dataset id="1f8c95c7204ee5b9" hid="4"
+                        <dataset id="4a7eaa5398f3e208" hid="4"
                             size="127 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="0b7812b25f4cfb76"
+                        <history id="21231a9d9f51801d"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="1"
@@ -146,17 +146,17 @@
     </tracks>
     </assembly>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/a/6/7/dataset_a67ee65b-0f84-4ad9-8984-3dc0baf46d35.dat" label="merlin.fa">
+            <genome path="/tmp/tmp81tzotcx/files/4/2/1/dataset_4216340c-25a1-4415-88a9-9d7e157aaab8.dat" label="merlin.fa">
             <metadata>
-                <dataset id="30deb7a376313549" hid="5"
+                <dataset id="5d74e9f9b0d7d569" hid="5"
                     size="171.6 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlin.fa" />
-                <history id="0b7812b25f4cfb76"
+                <history id="21231a9d9f51801d"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                 <metadata
                         dbkey="?"
                         data_lines="2881"
@@ -174,16 +174,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/8/5/9/dataset_85947fa0-916f-4366-8386-4681c41b6405.dat" ext="bigwig" label="data.bw">
+                    <trackFile path="/tmp/tmp81tzotcx/files/2/d/5/dataset_2d5a51e7-3f40-49af-b7f1-3af59c088e4a.dat" ext="bigwig" label="data.bw">
                         <metadata>
-                        <dataset id="7a9728aeed7a3efa" hid="6"
+                        <dataset id="e9904f0b6a2e2103" hid="6"
                             size="81.6 KB"
                             edam_format="format_3006"
                             file_ext="bigwig" />
-                        <history id="0b7812b25f4cfb76"
+                        <history id="21231a9d9f51801d"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-2"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-2"/>
                         <metadata
                                 dbkey="?"
                             />

--- a/tools/jbrowse2/test-data/out/04_synteny_remote/config.json
+++ b/tools/jbrowse2/test-data/out/04_synteny_remote/config.json
@@ -97,11 +97,11 @@
             "tracks": [
               {
                 "type": "SyntenyTrack",
-                "configuration": "80ba0000256d270f3eed70e2de2e9458_0_0",
+                "configuration": "4e45a76bd966bc353b7f70328b22d6a5_0_0",
                 "displays": [
                   {
                     "type": "LinearSyntenyDisplay",
-                    "configuration": "80ba0000256d270f3eed70e2de2e9458_0_0_LinearSyntenyDisplay"
+                    "configuration": "4e45a76bd966bc353b7f70328b22d6a5_0_0_LinearSyntenyDisplay"
                   }
                 ]
               }
@@ -116,7 +116,7 @@
   "tracks": [
     {
       "type": "SyntenyTrack",
-      "trackId": "80ba0000256d270f3eed70e2de2e9458_0_0",
+      "trackId": "4e45a76bd966bc353b7f70328b22d6a5_0_0",
       "name": "peach-grape-map.paf",
       "adapter": {
         "assemblyNames": [
@@ -125,11 +125,11 @@
         ],
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/80ba0000256d270f3eed70e2de2e9458_0_0.pif.gz"
+          "uri": "data/4e45a76bd966bc353b7f70328b22d6a5_0_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/80ba0000256d270f3eed70e2de2e9458_0_0.pif.gz.tbi"
+            "uri": "data/4e45a76bd966bc353b7f70328b22d6a5_0_0.pif.gz.tbi"
           }
         }
       },
@@ -143,24 +143,24 @@
       "displays": [
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "80ba0000256d270f3eed70e2de2e9458_0_0_LinearSyntenyDisplay"
+          "displayId": "4e45a76bd966bc353b7f70328b22d6a5_0_0_LinearSyntenyDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "5e7c5784e865b42d",
+        "dataset_id": "0f78b56d223f5e50",
         "dataset_hid": "1",
         "dataset_size": "238.1 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "bd91a97d652fafe1",
+        "history_id": "8e03caec7367853e",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/bd91a97d652fafe1\">Tool Test History for jbrowse2/3.6.5+galaxy1-3</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/8e03caec7367853e\">Tool Test History for jbrowse2/3.7.0+galaxy1-3</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "1911",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/5e7c5784e865b42d/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/0f78b56d223f5e50/show_params\">__DATA_FETCH__</a>"
       }
     }
   ],

--- a/tools/jbrowse2/test-data/out/04_synteny_remote/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/04_synteny_remote/galaxy.xml
@@ -9,7 +9,7 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
             <genome path="https://s3.amazonaws.com/jbrowse.org/genomes/peach/Ppersica_298_v2.0.fa.gz" label="Peach" remote="true">
@@ -21,16 +21,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/8/a/a/dataset_8aac4d06-9a9b-4d73-b231-2864581b0dfa.dat" ext="paf" label="peach-grape-map.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/3/a/9/dataset_3a9f22f0-0746-453d-a44c-56bca79b5889.dat" ext="paf" label="peach-grape-map.paf">
                         <metadata>
-                        <dataset id="5e7c5784e865b42d" hid="1"
+                        <dataset id="0f78b56d223f5e50" hid="1"
                             size="238.1 KB"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="bd91a97d652fafe1"
+                        <history id="8e03caec7367853e"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-3"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-3"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="1911"

--- a/tools/jbrowse2/test-data/out/05_synteny_full_remote/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/05_synteny_full_remote/galaxy.xml
@@ -9,7 +9,7 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
             <genome path="https://s3.amazonaws.com/jbrowse.org/genomes/peach/Ppersica_298_v2.0.fa.gz" label="Peach" remote="true">

--- a/tools/jbrowse2/test-data/out/06_various_options/config.json
+++ b/tools/jbrowse2/test-data/out/06_various_options/config.json
@@ -72,7 +72,7 @@
           "assembly": "merlin.fa",
           "loc": "Merlin:1000-2000",
           "tracks": [
-            "9164da821dd9f40efa61a737d8dbd031_0_0"
+            "d6788c34f9162d16c176b712fa331e5c_0_0"
           ]
         }
       }
@@ -81,17 +81,17 @@
   "tracks": [
     {
       "type": "FeatureTrack",
-      "trackId": "9164da821dd9f40efa61a737d8dbd031_0_0",
+      "trackId": "d6788c34f9162d16c176b712fa331e5c_0_0",
       "name": "merlin.gff",
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
-          "uri": "data/9164da821dd9f40efa61a737d8dbd031_0_0.gff.gz",
+          "uri": "data/d6788c34f9162d16c176b712fa331e5c_0_0.gff.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/9164da821dd9f40efa61a737d8dbd031_0_0.gff.gz.tbi",
+            "uri": "data/d6788c34f9162d16c176b712fa331e5c_0_0.gff.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -106,7 +106,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "9164da821dd9f40efa61a737d8dbd031_0_0_LinearBasicDisplay",
+          "displayId": "d6788c34f9162d16c176b712fa331e5c_0_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -133,17 +133,17 @@
     },
     {
       "type": "FeatureTrack",
-      "trackId": "b26da96d1d07207823e585f65ca15149_1_0",
+      "trackId": "eae61b0c3fc6042377bb473991b6fd02_1_0",
       "name": "1.gff",
       "adapter": {
         "type": "Gff3TabixAdapter",
         "gffGzLocation": {
-          "uri": "data/b26da96d1d07207823e585f65ca15149_1_0.gff.gz",
+          "uri": "data/eae61b0c3fc6042377bb473991b6fd02_1_0.gff.gz",
           "locationType": "UriLocation"
         },
         "index": {
           "location": {
-            "uri": "data/b26da96d1d07207823e585f65ca15149_1_0.gff.gz.tbi",
+            "uri": "data/eae61b0c3fc6042377bb473991b6fd02_1_0.gff.gz.tbi",
             "locationType": "UriLocation"
           },
           "indexType": "TBI"
@@ -158,7 +158,7 @@
       "displays": [
         {
           "type": "LinearArcDisplay",
-          "displayId": "b26da96d1d07207823e585f65ca15149_1_0_LinearArcDisplay",
+          "displayId": "eae61b0c3fc6042377bb473991b6fd02_1_0_LinearArcDisplay",
           "renderer": {
             "type": "ArcRenderer",
             "label": "jexl:get(feature,'score')",
@@ -170,15 +170,15 @@
         "depth": 1
       },
       "metadata": {
-        "dataset_id": "8d08779b916d2c74",
+        "dataset_id": "4a8494e425e29c5c",
         "dataset_hid": "6",
         "dataset_size": "2.3 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_1975\">gff3</a>",
         "dataset_file_ext": "gff3",
-        "history_id": "c8d274edba5d366b",
+        "history_id": "6eb7f4a3904a4f09",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/c8d274edba5d366b\">Tool Test History for jbrowse2/3.6.5+galaxy1-5</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/6eb7f4a3904a4f09\">Tool Test History for jbrowse2/3.7.0+galaxy1-5</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "27",
         "metadata_comment_lines": "19",
@@ -188,7 +188,7 @@
         "metadata_attributes": "6",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/8d08779b916d2c74/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/4a8494e425e29c5c/show_params\">__DATA_FETCH__</a>"
       }
     }
   ],

--- a/tools/jbrowse2/test-data/out/06_various_options/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/06_various_options/galaxy.xml
@@ -9,20 +9,20 @@
             <quaternary_color>#9fb11d</quaternary_color>
             <font_size>15</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/5/2/9/dataset_5296eab5-9843-40c5-9db9-4aa93249c833.dat" label="merlin.fa">
+            <genome path="/tmp/tmp81tzotcx/files/e/2/3/dataset_e2339176-05c5-457a-8406-ed65bf8163aa.dat" label="merlin.fa">
             <metadata>
-                <dataset id="09545c40d817e546" hid="1"
+                <dataset id="0d2e2bc724a6c37d" hid="1"
                     size="171.6 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlin.fa" />
-                <history id="c8d274edba5d366b"
+                <history id="6eb7f4a3904a4f09"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-5"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-5"/>
                 <metadata
                         dbkey="?"
                         data_lines="2881"
@@ -33,8 +33,8 @@
                     tool_version="0.1.0"
                     />
             </metadata>
-                <ref_name_aliases path="/tmp/tmpiyg6gzbz/files/1/1/5/dataset_1151e202-f9f3-4110-b64f-333acec46e55.dat" />
-                <cytobands path="/tmp/tmpiyg6gzbz/files/d/3/5/dataset_d3500267-21d7-4211-b238-9f11ef1a0e95.dat" />
+                <ref_name_aliases path="/tmp/tmp81tzotcx/files/7/e/c/dataset_7ec058ad-2f95-40f2-b13d-5a72b0ab2220.dat" />
+                <cytobands path="/tmp/tmp81tzotcx/files/e/3/f/dataset_e3fcba24-a294-41f6-8e0b-cabd84e7799c.dat" />
             </genome>
         <defaultLocation>Merlin:1000..2000</defaultLocation>
     <tracks>
@@ -42,9 +42,9 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/2/3/b/dataset_23b6b090-77a2-4dca-afb1-45c1f639ca3f.dat" ext="gff3" label="merlin.gff">
+                    <trackFile path="/tmp/tmp81tzotcx/files/2/3/5/dataset_23588ec7-a0b0-432c-856f-35f309937be1.dat" ext="gff3" label="merlin.gff">
                         <metadata>
-                            <bonus src="/tmp/tmpiyg6gzbz/files/8/a/a/dataset_8aa7709d-337e-4620-b838-7c4ea7cabf2f.dat" />
+                            <bonus src="/tmp/tmp81tzotcx/files/c/5/c/dataset_c5c1cbe8-9a9c-4dce-a119-e42b589fa49c.dat" />
                         </metadata>
                     </trackFile>
                     </files>
@@ -79,16 +79,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/a/9/e/dataset_a9e599f6-9e07-4ca5-9574-a46f79d83567.dat" ext="gff3" label="1.gff">
+                    <trackFile path="/tmp/tmp81tzotcx/files/d/8/6/dataset_d8643818-dfa3-4332-8d79-24445a12c360.dat" ext="gff3" label="1.gff">
                         <metadata>
-                        <dataset id="8d08779b916d2c74" hid="6"
+                        <dataset id="4a8494e425e29c5c" hid="6"
                             size="2.3 KB"
                             edam_format="format_1975"
                             file_ext="gff3" />
-                        <history id="c8d274edba5d366b"
+                        <history id="6eb7f4a3904a4f09"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-5"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-5"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="27"

--- a/tools/jbrowse2/test-data/out/07_synteny_mixed/config.json
+++ b/tools/jbrowse2/test-data/out/07_synteny_mixed/config.json
@@ -102,7 +102,7 @@
               "assembly": "merlun.fa",
               "loc": "Merlun",
               "tracks": [
-                "f27027d9cba656ee7279114b4764a1a9_1_0"
+                "2f2ca290ffea69b7e7ea3533c9aaa755_1_0"
               ]
             }
           },
@@ -112,7 +112,7 @@
               "assembly": "merlon.fa",
               "loc": "Merlon",
               "tracks": [
-                "9ab20cffedd38e60ca92f0454b9745db_1_0"
+                "7bbd6f32e0e1f641168d31cc2b20578e_1_0"
               ]
             }
           },
@@ -122,7 +122,7 @@
               "assembly": "merlin.fa",
               "loc": "Merlin",
               "tracks": [
-                "40c5d3cdfaa1318fd0d68918cd144f36_0_0"
+                "15fa823a97ac78fd0a6be7dea67070f7_0_0"
               ]
             }
           }
@@ -133,11 +133,11 @@
             "tracks": [
               {
                 "type": "SyntenyTrack",
-                "configuration": "f27027d9cba656ee7279114b4764a1a9_0_0",
+                "configuration": "2f2ca290ffea69b7e7ea3533c9aaa755_0_0",
                 "displays": [
                   {
                     "type": "LinearSyntenyDisplay",
-                    "configuration": "f27027d9cba656ee7279114b4764a1a9_0_0_LinearSyntenyDisplay"
+                    "configuration": "2f2ca290ffea69b7e7ea3533c9aaa755_0_0_LinearSyntenyDisplay"
                   }
                 ]
               }
@@ -150,11 +150,11 @@
             "tracks": [
               {
                 "type": "SyntenyTrack",
-                "configuration": "9ab20cffedd38e60ca92f0454b9745db_0_0",
+                "configuration": "7bbd6f32e0e1f641168d31cc2b20578e_0_0",
                 "displays": [
                   {
                     "type": "LinearSyntenyDisplay",
-                    "configuration": "9ab20cffedd38e60ca92f0454b9745db_0_0_LinearSyntenyDisplay"
+                    "configuration": "7bbd6f32e0e1f641168d31cc2b20578e_0_0_LinearSyntenyDisplay"
                   }
                 ]
               }
@@ -169,16 +169,16 @@
   "tracks": [
     {
       "type": "SyntenyTrack",
-      "trackId": "f27027d9cba656ee7279114b4764a1a9_1_0",
+      "trackId": "2f2ca290ffea69b7e7ea3533c9aaa755_1_0",
       "name": "merlun_on_merlon.paf",
       "adapter": {
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/f27027d9cba656ee7279114b4764a1a9_1_0.pif.gz"
+          "uri": "data/2f2ca290ffea69b7e7ea3533c9aaa755_1_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/f27027d9cba656ee7279114b4764a1a9_1_0.pif.gz.tbi"
+            "uri": "data/2f2ca290ffea69b7e7ea3533c9aaa755_1_0.pif.gz.tbi"
           }
         }
       },
@@ -191,7 +191,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "f27027d9cba656ee7279114b4764a1a9_1_0_LinearBasicDisplay",
+          "displayId": "2f2ca290ffea69b7e7ea3533c9aaa755_1_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -206,34 +206,34 @@
         }
       ],
       "metadata": {
-        "dataset_id": "0193a46a40878ddb",
+        "dataset_id": "f73667f7f6f9fc32",
         "dataset_hid": "2",
         "dataset_size": "227 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "2f8b42de958784ae",
+        "history_id": "c974d8df6b0170de",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/2f8b42de958784ae\">Tool Test History for jbrowse2/3.6.5+galaxy1-6</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/c974d8df6b0170de\">Tool Test History for jbrowse2/3.7.0+galaxy1-6</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "2",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/0193a46a40878ddb/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/f73667f7f6f9fc32/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "SyntenyTrack",
-      "trackId": "9ab20cffedd38e60ca92f0454b9745db_1_0",
+      "trackId": "7bbd6f32e0e1f641168d31cc2b20578e_1_0",
       "name": "merlon_on_merlin.paf",
       "adapter": {
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/9ab20cffedd38e60ca92f0454b9745db_1_0.pif.gz"
+          "uri": "data/7bbd6f32e0e1f641168d31cc2b20578e_1_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/9ab20cffedd38e60ca92f0454b9745db_1_0.pif.gz.tbi"
+            "uri": "data/7bbd6f32e0e1f641168d31cc2b20578e_1_0.pif.gz.tbi"
           }
         }
       },
@@ -246,7 +246,7 @@
       "displays": [
         {
           "type": "LinearBasicDisplay",
-          "displayId": "9ab20cffedd38e60ca92f0454b9745db_1_0_LinearBasicDisplay",
+          "displayId": "7bbd6f32e0e1f641168d31cc2b20578e_1_0_LinearBasicDisplay",
           "renderer": {
             "type": "SvgFeatureRenderer",
             "showLabels": true,
@@ -261,30 +261,30 @@
         }
       ],
       "metadata": {
-        "dataset_id": "4b6ef6ca3df7dc79",
+        "dataset_id": "ec7c463ecbb9bf1e",
         "dataset_hid": "4",
         "dataset_size": "127 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "2f8b42de958784ae",
+        "history_id": "c974d8df6b0170de",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/2f8b42de958784ae\">Tool Test History for jbrowse2/3.6.5+galaxy1-6</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/c974d8df6b0170de\">Tool Test History for jbrowse2/3.7.0+galaxy1-6</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "1",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/4b6ef6ca3df7dc79/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/ec7c463ecbb9bf1e/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "QuantitativeTrack",
-      "trackId": "40c5d3cdfaa1318fd0d68918cd144f36_0_0",
+      "trackId": "15fa823a97ac78fd0a6be7dea67070f7_0_0",
       "name": "data.bw",
       "adapter": {
         "type": "BigWigAdapter",
         "bigWigLocation": {
-          "uri": "data/40c5d3cdfaa1318fd0d68918cd144f36_0_0.bw",
+          "uri": "data/15fa823a97ac78fd0a6be7dea67070f7_0_0.bw",
           "locationType": "UriLocation"
         }
       },
@@ -297,29 +297,29 @@
       "displays": [
         {
           "type": "LinearWiggleDisplay",
-          "displayId": "40c5d3cdfaa1318fd0d68918cd144f36_0_0_LinearWiggleDisplay",
+          "displayId": "15fa823a97ac78fd0a6be7dea67070f7_0_0_LinearWiggleDisplay",
           "defaultRendering": "xyplot"
         }
       ],
       "metadata": {
-        "dataset_id": "956e46a817a35762",
+        "dataset_id": "bad56eccc99e1bed",
         "dataset_hid": "6",
         "dataset_size": "81.6 KB",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_3006\">bigwig</a>",
         "dataset_file_ext": "bigwig",
-        "history_id": "2f8b42de958784ae",
+        "history_id": "c974d8df6b0170de",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/2f8b42de958784ae\">Tool Test History for jbrowse2/3.6.5+galaxy1-6</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/c974d8df6b0170de\">Tool Test History for jbrowse2/3.7.0+galaxy1-6</a>",
         "metadata_dbkey": "?",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/956e46a817a35762/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/bad56eccc99e1bed/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "SyntenyTrack",
-      "trackId": "f27027d9cba656ee7279114b4764a1a9_0_0",
+      "trackId": "2f2ca290ffea69b7e7ea3533c9aaa755_0_0",
       "name": "merlun_on_merlon.paf",
       "adapter": {
         "assemblyNames": [
@@ -328,11 +328,11 @@
         ],
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/f27027d9cba656ee7279114b4764a1a9_0_0.pif.gz"
+          "uri": "data/2f2ca290ffea69b7e7ea3533c9aaa755_0_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/f27027d9cba656ee7279114b4764a1a9_0_0.pif.gz.tbi"
+            "uri": "data/2f2ca290ffea69b7e7ea3533c9aaa755_0_0.pif.gz.tbi"
           }
         }
       },
@@ -346,29 +346,29 @@
       "displays": [
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "f27027d9cba656ee7279114b4764a1a9_0_0_LinearSyntenyDisplay"
+          "displayId": "2f2ca290ffea69b7e7ea3533c9aaa755_0_0_LinearSyntenyDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "0193a46a40878ddb",
+        "dataset_id": "f73667f7f6f9fc32",
         "dataset_hid": "2",
         "dataset_size": "227 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "2f8b42de958784ae",
+        "history_id": "c974d8df6b0170de",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/2f8b42de958784ae\">Tool Test History for jbrowse2/3.6.5+galaxy1-6</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/c974d8df6b0170de\">Tool Test History for jbrowse2/3.7.0+galaxy1-6</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "2",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/0193a46a40878ddb/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/f73667f7f6f9fc32/show_params\">__DATA_FETCH__</a>"
       }
     },
     {
       "type": "SyntenyTrack",
-      "trackId": "9ab20cffedd38e60ca92f0454b9745db_0_0",
+      "trackId": "7bbd6f32e0e1f641168d31cc2b20578e_0_0",
       "name": "merlon_on_merlin.paf",
       "adapter": {
         "assemblyNames": [
@@ -377,11 +377,11 @@
         ],
         "type": "PairwiseIndexedPAFAdapter",
         "pifGzLocation": {
-          "uri": "data/9ab20cffedd38e60ca92f0454b9745db_0_0.pif.gz"
+          "uri": "data/7bbd6f32e0e1f641168d31cc2b20578e_0_0.pif.gz"
         },
         "index": {
           "location": {
-            "uri": "data/9ab20cffedd38e60ca92f0454b9745db_0_0.pif.gz.tbi"
+            "uri": "data/7bbd6f32e0e1f641168d31cc2b20578e_0_0.pif.gz.tbi"
           }
         }
       },
@@ -395,24 +395,24 @@
       "displays": [
         {
           "type": "LinearSyntenyDisplay",
-          "displayId": "9ab20cffedd38e60ca92f0454b9745db_0_0_LinearSyntenyDisplay"
+          "displayId": "7bbd6f32e0e1f641168d31cc2b20578e_0_0_LinearSyntenyDisplay"
         }
       ],
       "metadata": {
-        "dataset_id": "4b6ef6ca3df7dc79",
+        "dataset_id": "ec7c463ecbb9bf1e",
         "dataset_hid": "4",
         "dataset_size": "127 bytes",
         "dataset_edam_format": "<a target=\"_blank\" href=\"http://edamontology.org/format_2330\">paf</a>",
         "dataset_file_ext": "paf",
-        "history_id": "2f8b42de958784ae",
+        "history_id": "c974d8df6b0170de",
         "history_user_email": "<a href=\"mailto:planemo@galaxyproject.org\">planemo@galaxyproject.org</a>",
         "history_user_id": "1",
-        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:8080/history/view/2f8b42de958784ae\">Tool Test History for jbrowse2/3.6.5+galaxy1-6</a>",
+        "history_display_name": "<a target=\"_blank\" href=\"http://localhost:47019/history/view/c974d8df6b0170de\">Tool Test History for jbrowse2/3.7.0+galaxy1-6</a>",
         "metadata_dbkey": "?",
         "metadata_data_lines": "1",
         "tool_tool_id": "__DATA_FETCH__",
         "tool_tool_version": "0.1.0",
-        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:8080/datasets/4b6ef6ca3df7dc79/show_params\">__DATA_FETCH__</a>"
+        "tool_tool": "<a target=\"_blank\" href=\"http://localhost:47019/datasets/ec7c463ecbb9bf1e/show_params\">__DATA_FETCH__</a>"
       }
     }
   ],

--- a/tools/jbrowse2/test-data/out/07_synteny_mixed/galaxy.xml
+++ b/tools/jbrowse2/test-data/out/07_synteny_mixed/galaxy.xml
@@ -9,20 +9,20 @@
             <quaternary_color>#ffb11d</quaternary_color>
             <font_size>10</font_size>
         </general>
-        <galaxyUrl>http://localhost:8080</galaxyUrl>
+        <galaxyUrl>http://localhost:47019</galaxyUrl>
     </metadata>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/c/c/d/dataset_ccdaa782-b710-408d-b2f0-485e98d73d0c.dat" label="merlun.fa">
+            <genome path="/tmp/tmp81tzotcx/files/c/8/f/dataset_c8f411d5-8616-4f05-85fa-86ab7532119f.dat" label="merlun.fa">
             <metadata>
-                <dataset id="db035faa70b52d68" hid="1"
+                <dataset id="e3eb80b8f7bfbef8" hid="1"
                     size="158.8 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlun.fa" />
-                <history id="2f8b42de958784ae"
+                <history id="c974d8df6b0170de"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                 <metadata
                         dbkey="?"
                         data_lines="2666"
@@ -40,16 +40,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/9/c/c/dataset_9cc8d8bd-cfa4-46bf-ae31-cf6eab61a297.dat" ext="paf" label="merlun_on_merlon.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/f/f/9/dataset_ff91282f-de46-40c9-9658-bcbdfe561625.dat" ext="paf" label="merlun_on_merlon.paf">
                         <metadata>
-                        <dataset id="0193a46a40878ddb" hid="2"
+                        <dataset id="f73667f7f6f9fc32" hid="2"
                             size="227 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="2f8b42de958784ae"
+                        <history id="c974d8df6b0170de"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="2"
@@ -80,16 +80,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/9/c/c/dataset_9cc8d8bd-cfa4-46bf-ae31-cf6eab61a297.dat" ext="paf" label="merlun_on_merlon.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/f/f/9/dataset_ff91282f-de46-40c9-9658-bcbdfe561625.dat" ext="paf" label="merlun_on_merlon.paf">
                         <metadata>
-                        <dataset id="0193a46a40878ddb" hid="2"
+                        <dataset id="f73667f7f6f9fc32" hid="2"
                             size="227 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="2f8b42de958784ae"
+                        <history id="c974d8df6b0170de"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="2"
@@ -119,17 +119,17 @@
     </tracks>
     </assembly>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/a/2/3/dataset_a23e3ae0-cf0b-427c-a8fb-c9a7a93ba5e3.dat" label="merlon.fa">
+            <genome path="/tmp/tmp81tzotcx/files/0/b/5/dataset_0b5d278c-1e68-44ae-beb3-6abea9af4a12.dat" label="merlon.fa">
             <metadata>
-                <dataset id="4fedddb5f0b604f3" hid="3"
+                <dataset id="7dcbec087be2ae63" hid="3"
                     size="155.3 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlon.fa" />
-                <history id="2f8b42de958784ae"
+                <history id="c974d8df6b0170de"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                 <metadata
                         dbkey="?"
                         data_lines="2608"
@@ -147,16 +147,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/2/1/d/dataset_21dce734-5668-47ae-bdee-4b924bcea3c3.dat" ext="paf" label="merlon_on_merlin.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/5/e/4/dataset_5e4a50c0-51ca-49a4-b39d-cef46c558d86.dat" ext="paf" label="merlon_on_merlin.paf">
                         <metadata>
-                        <dataset id="4b6ef6ca3df7dc79" hid="4"
+                        <dataset id="ec7c463ecbb9bf1e" hid="4"
                             size="127 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="2f8b42de958784ae"
+                        <history id="c974d8df6b0170de"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="1"
@@ -187,16 +187,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/2/1/d/dataset_21dce734-5668-47ae-bdee-4b924bcea3c3.dat" ext="paf" label="merlon_on_merlin.paf">
+                    <trackFile path="/tmp/tmp81tzotcx/files/5/e/4/dataset_5e4a50c0-51ca-49a4-b39d-cef46c558d86.dat" ext="paf" label="merlon_on_merlin.paf">
                         <metadata>
-                        <dataset id="4b6ef6ca3df7dc79" hid="4"
+                        <dataset id="ec7c463ecbb9bf1e" hid="4"
                             size="127 bytes"
                             edam_format="format_2330"
                             file_ext="paf" />
-                        <history id="2f8b42de958784ae"
+                        <history id="c974d8df6b0170de"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                         <metadata
                                 dbkey="?"
                                 data_lines="1"
@@ -226,17 +226,17 @@
     </tracks>
     </assembly>
     <assembly>
-            <genome path="/tmp/tmpiyg6gzbz/files/3/2/c/dataset_32c64057-113d-4f64-b4cc-f4123cbefec6.dat" label="merlin.fa">
+            <genome path="/tmp/tmp81tzotcx/files/d/b/6/dataset_db61e8c4-19d0-44e3-a8ce-745d6a809cde.dat" label="merlin.fa">
             <metadata>
-                <dataset id="eb1e31c16c0fe718" hid="5"
+                <dataset id="27398a35ccd3994c" hid="5"
                     size="171.6 KB"
                     edam_format="format_1929"
                     file_ext="fasta"
                     dname = "merlin.fa" />
-                <history id="2f8b42de958784ae"
+                <history id="c974d8df6b0170de"
                     user_email="planemo@galaxyproject.org"
                     user_id="1"
-                    display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                    display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                 <metadata
                         dbkey="?"
                         data_lines="2881"
@@ -254,16 +254,16 @@
 
 
                     <files>
-                    <trackFile path="/tmp/tmpiyg6gzbz/files/8/6/a/dataset_86a329ba-72ee-4f3c-9e13-2bf70c513a57.dat" ext="bigwig" label="data.bw">
+                    <trackFile path="/tmp/tmp81tzotcx/files/e/b/1/dataset_eb16a93a-5801-47a3-abe9-04e39a7e61b4.dat" ext="bigwig" label="data.bw">
                         <metadata>
-                        <dataset id="956e46a817a35762" hid="6"
+                        <dataset id="bad56eccc99e1bed" hid="6"
                             size="81.6 KB"
                             edam_format="format_3006"
                             file_ext="bigwig" />
-                        <history id="2f8b42de958784ae"
+                        <history id="c974d8df6b0170de"
                             user_email="planemo@galaxyproject.org"
                             user_id="1"
-                            display_name="Tool Test History for jbrowse2/3.6.5+galaxy1-6"/>
+                            display_name="Tool Test History for jbrowse2/3.7.0+galaxy1-6"/>
                         <metadata
                                 dbkey="?"
                             />


### PR DESCRIPTION
## Summary
- Sanitize `label` in `add_assembly()` by replacing `/` and `\` with spaces
- Prevents `FileNotFoundError` when genome descriptions contain `/` characters

## Current
Galaxy genome description strings from `.loc` files can contain `/` characters (e.g., `BDGP Release 6 + ISO1 MT/dm6`). When passed to `add_assembly()`, the `/` breaks:
1. **File path construction** — `os.path.join` treats `/` as directory separator
2. **JBrowse2 assembly naming** — breaks internal URL routing

**Error:**
```
FileNotFoundError: [Errno 2] No such file or directory:
'.../data/D. melanogaster Aug. 2014 (BDGP Release 6 + ISO1 MT/dm6) (dm6).fasta'
```

## Adjustments
Single line at top of `add_assembly()`:
```python
label = re.sub(r"[/\\]", " ", label)  # sanitize path-unsafe characters
```

## Impact
| Metric | Count |
|--------|-------|
| Unique dbkeys affected | 603 |
| .loc files with `/` in descriptions | 29 |
| Total entries affected | 762 |
| Entries with multiple `/` | 27 |

## Evidence
- Failing history: https://usegalaxy.org/u/jen-galaxyproject/h/test-jbrowse2
- Error at line 456 in `add_assembly()` → `shutil.copy(path, copied_genome)`

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)