### PR TITLE
Drop legacy 'doi:' prefix from citations (fixes silent tool-load failures on Galaxy 26.1)

### DIFF
--- a/data_managers/data_manager_cat/data_manager/data_manager_cat.xml
+++ b/data_managers/data_manager_cat/data_manager/data_manager_cat.xml
@@ -52,9 +52,9 @@ or build new reference data using the CAT prepare application.
 This requires at least 100GB of RAM, 250GB of disk space, and 24 hours.
     ]]></help>
     <citations>
-        <citation type="doi">https://doi.org/10.1101/072868</citation>
-        <citation type="doi">https://doi.org/10.1186/s13059-019-1817-x</citation>
-        <citation type="doi">https://doi.org/10.1038/nmeth.3176</citation>
-        <citation type="doi">https://doi.org/10.1186/1471-2105-11-119</citation>
+        <citation type="doi">10.1101/072868</citation>
+        <citation type="doi">10.1186/s13059-019-1817-x</citation>
+        <citation type="doi">10.1038/nmeth.3176</citation>
+        <citation type="doi">10.1186/1471-2105-11-119</citation>
     </citations>
 </tool>

--- a/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
+++ b/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
@@ -75,7 +75,7 @@ the `gtdbtk classify_wf`. The meta options allows downloading only the metadata 
 corresponding DB, which is used by tools like `gtdb_to_taxdump`.
     </help>
     <citations>
-        <citation type="doi">doi.org/10.1038/s41587-020-0501-8</citation>
-        <citation type="doi">dx.doi.org/10.1038/nbt.4229</citation>
+        <citation type="doi">10.1038/s41587-020-0501-8</citation>
+        <citation type="doi">10.1038/nbt.4229</citation>
     </citations>
 </tool>

--- a/data_managers/data_manager_malt_index_builder/data_manager/malt_index_builder.xml
+++ b/data_managers/data_manager_malt_index_builder/data_manager/malt_index_builder.xml
@@ -126,6 +126,6 @@ sequences to taxonomic or functional classes or to locate genes in DNA reference
 
     </help>
     <citations>
-        <citation type="doi">https://doi.org/10.1101/050559</citation>
+        <citation type="doi">10.1101/050559</citation>
     </citations>
 </tool>

--- a/data_managers/data_manager_mapseq/data_manager/macros.xml
+++ b/data_managers/data_manager_mapseq/data_manager/macros.xml
@@ -16,9 +16,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.1093/nar/gkz1035
-            </citation>
+            <citation type="doi">10.1093/nar/gkz1035</citation>
         </citations>
     </xml>
     <xml name="creator">

--- a/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
+++ b/data_managers/data_manager_metaphlan_database_downloader/data_manager/data_manager_metaphlan_download.xml
@@ -71,6 +71,6 @@
 This tool downloads and builds the MetaPhlAn databases.
     ]]></help>
     <citations>
-        <citation type="doi">1101/2020.11.19.388223</citation>
+        <citation type="doi">10.1101/2020.11.19.388223</citation>
     </citations>
 </tool>

--- a/data_managers/data_manager_pharokka_database_fetcher/data_manager/macros.xml
+++ b/data_managers/data_manager_pharokka_database_fetcher/data_manager/macros.xml
@@ -22,9 +22,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.1093/bioinformatics/btac776
-            </citation>
+            <citation type="doi">10.1093/bioinformatics/btac776</citation>
         </citations>
     </xml>
     <xml name="creator">

--- a/data_managers/data_manager_salmon_index_builder/data_manager/salmon_index_builder.xml
+++ b/data_managers/data_manager_salmon_index_builder/data_manager/salmon_index_builder.xml
@@ -141,6 +141,6 @@ See also https://salmon.readthedocs.io/en/latest/salmon.html#preparing-transcrip
 ]]>
     </help>
     <citations>
-        <citation type="doi">https://doi.org/10.1038/nmeth.4197</citation>
+        <citation type="doi">10.1038/nmeth.4197</citation>
     </citations>
 </tool>

--- a/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
+++ b/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
@@ -82,9 +82,9 @@ Please refer to https://sites.google.com/site/jpopgen/dbNSFP for which citations
         <citation type="doi">DOI: 10.1002/humu.21517</citation>
         <citation type="doi">DOI: 10.1002/humu.22376</citation>
         <citation type="doi">DOI: 10.1002/humu.22932</citation>
-        <citation type="doi">doi: 10.1093/hmg/ddu733</citation>
-        <citation type="doi">doi: 10.1093/nar/gku1206</citation>
-        <citation type="doi">doi: 10.3389/fgene.2012.00035</citation>
+        <citation type="doi">10.1093/hmg/ddu733</citation>
+        <citation type="doi">10.1093/nar/gku1206</citation>
+        <citation type="doi">10.3389/fgene.2012.00035</citation>
     </citations>
 </tool>
 

--- a/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
+++ b/data_managers/data_manager_snpsift_dbnsfp/data_manager/data_manager_snpsift_dbnsfp.xml
@@ -79,9 +79,9 @@ Please refer to https://sites.google.com/site/jpopgen/dbNSFP for which citations
 
     </help>
     <citations>
-        <citation type="doi">DOI: 10.1002/humu.21517</citation>
-        <citation type="doi">DOI: 10.1002/humu.22376</citation>
-        <citation type="doi">DOI: 10.1002/humu.22932</citation>
+        <citation type="doi">10.1002/humu.21517</citation>
+        <citation type="doi">10.1002/humu.22376</citation>
+        <citation type="doi">10.1002/humu.22932</citation>
         <citation type="doi">10.1093/hmg/ddu733</citation>
         <citation type="doi">10.1093/nar/gku1206</citation>
         <citation type="doi">10.3389/fgene.2012.00035</citation>

--- a/deprecated/tool_collections/snpsift/snpsift_dbnsfp_generic/snpSift_dbnsfp.xml
+++ b/deprecated/tool_collections/snpsift/snpsift_dbnsfp_generic/snpSift_dbnsfp.xml
@@ -293,11 +293,11 @@ The procedure for preparing the dbNSFP data for use in SnpSift dbnsfp is in the 
 ]]>
     </help>
     <expand macro="citations">
-        <citation type="doi">DOI: 10.1002/humu.21517</citation>
-        <citation type="doi">DOI: 10.1002/humu.22376</citation>
-        <citation type="doi">DOI: 10.1002/humu.22932</citation>
-        <citation type="doi">doi: 10.1093/hmg/ddu733</citation>
-        <citation type="doi">doi: 10.1093/nar/gku1206</citation>
-        <citation type="doi">doi: 10.3389/fgene.2012.00035</citation>
+        <citation type="doi">10.1002/humu.21517</citation>
+        <citation type="doi">10.1002/humu.22376</citation>
+        <citation type="doi">10.1002/humu.22932</citation>
+        <citation type="doi">10.1093/hmg/ddu733</citation>
+        <citation type="doi">10.1093/nar/gku1206</citation>
+        <citation type="doi">10.3389/fgene.2012.00035</citation>
     </expand>
 </tool>

--- a/deprecated/tools/rglasso/rglasso_cox.xml
+++ b/deprecated/tools/rglasso/rglasso_cox.xml
@@ -905,8 +905,6 @@ licensed to you under the LGPL_ like other rgenetics artefacts
     url = {http://www.jstatsoft.org/v33/i01/}
   }
     </citation>
-    <citation type="doi">
-10.1093/bioinformatics/bts573
-    </citation>
+    <citation type="doi">10.1093/bioinformatics/bts573</citation>
 </citations>
 </tool>

--- a/tools/abyss/abyss-pe.xml
+++ b/tools/abyss/abyss-pe.xml
@@ -288,7 +288,7 @@ This Galaxy tool is Copyright © 2015-2021 `Earlham Institute`_
 .. _ABySS: https://github.com/bcgsc/abyss
     ]]></help>
     <citations>
-        <citation type="doi">doi:10.1101/gr.214346.116</citation>
+        <citation type="doi">10.1101/gr.214346.116</citation>
         <citation type="doi">10.1101/gr.089532.108</citation>
     </citations>
 </tool>

--- a/tools/astral/astral.xml
+++ b/tools/astral/astral.xml
@@ -145,6 +145,6 @@ Prior hyper-parameter
     For these, we currently arbitrarily set ML to 10 coalescent units (we might change this in future versions).
     ]]></help>
     <citations>
-        <citation type="doi">doi:10.1186/s12859-018-2129-y</citation>
+        <citation type="doi">10.1186/s12859-018-2129-y</citation>
     </citations>
 </tool>

--- a/tools/b2btools/b2btools_single_sequence.xml
+++ b/tools/b2btools/b2btools_single_sequence.xml
@@ -701,8 +701,8 @@ We also provide a set of online examples in Jupyter Notebook format that are ava
     </creator>
     <citations>
         <citation type="doi">10.1038/ncomms3741</citation>
-        <citation type="doi">10.1101&#47;2020.05.25.115253</citation>
-        <citation type="doi">10.1038&#47;s41598-017-08366-3</citation>
+        <citation type="doi">10.1101/2020.05.25.115253</citation>
+        <citation type="doi">10.1038/s41598-017-08366-3</citation>
         <citation type="doi">10.1093/bioinformatics/btz912</citation>
     </citations>
 </tool>

--- a/tools/bedops/sort-bed.xml
+++ b/tools/bedops/sort-bed.xml
@@ -61,6 +61,6 @@ Output
 Sort order is defined by a lexicographical sort on chromosome name, a numerical sort on start coordinates, a numerical sort on stop coordinates where there are start matches, and finally a lexicographical sort on the remainder of the BED element (if additional columns are present). Additional options may be specified to print only unique or duplicate elements.
     ]]></help>
     <citations>
-        <citation type="doi">https://doi.org/10.1093/bioinformatics/bts277</citation>
+        <citation type="doi">10.1093/bioinformatics/bts277</citation>
     </citations>
 </tool>

--- a/tools/cactus/macros.xml
+++ b/tools/cactus/macros.xml
@@ -11,9 +11,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                https://doi.org/10.1038/s41586-020-2871-y
-            </citation>
+            <citation type="doi">10.1038/s41586-020-2871-y</citation>
         </citations>
     </xml>
     <xml name="xrefs">

--- a/tools/cat/macros.xml
+++ b/tools/cat/macros.xml
@@ -389,10 +389,10 @@ If you have understood all this, or you do not plan to tune -r / --range at all 
 ]]></token>
     <xml name="citations">
         <citations>
-            <citation type="doi">https://doi.org/10.1101/072868</citation>
-            <citation type="doi">https://doi.org/10.1186/s13059-019-1817-x</citation>
-            <citation type="doi">https://doi.org/10.1038/nmeth.3176</citation>
-            <citation type="doi">https://doi.org/10.1186/1471-2105-11-119</citation>
+            <citation type="doi">10.1101/072868</citation>
+            <citation type="doi">10.1186/s13059-019-1817-x</citation>
+            <citation type="doi">10.1038/nmeth.3176</citation>
+            <citation type="doi">10.1186/1471-2105-11-119</citation>
             <yield />
         </citations>
     </xml>

--- a/tools/deepmicro/macros.xml
+++ b/tools/deepmicro/macros.xml
@@ -22,9 +22,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.1038/s41598-020-63159-5
-            </citation>
+            <citation type="doi">10.1038/s41598-020-63159-5</citation>
         </citations>
     </xml>
     <xml name="creator">

--- a/tools/diffbind/diffbind.xml
+++ b/tools/diffbind/diffbind.xml
@@ -616,6 +616,6 @@ Wrapper authors: Bjoern Gruening, Pavankumar Videm
 ]]>
     </help>
     <citations>
-        <citation type="doi">doi:10.1038/nature10730</citation>
+        <citation type="doi">10.1038/nature10730</citation>
     </citations>
 </tool>

--- a/tools/ena_upload/ena_upload.xml
+++ b/tools/ena_upload/ena_upload.xml
@@ -762,6 +762,6 @@ $samples.append({'title':str($sample.sample_title),'description':str($sample.sam
     
             The ENA upload tool won't work unless you have provided an ENA Webin ID in User > Preferences > Manage Information > ENA Webin account details.]]></help>
     <citations>
-        <citation type="doi">doi:10.1093/bioinformatics/btab421</citation>
+        <citation type="doi">10.1093/bioinformatics/btab421</citation>
     </citations>
 </tool>

--- a/tools/gubbins/gubbins.xml
+++ b/tools/gubbins/gubbins.xml
@@ -374,7 +374,7 @@ And others...
     
     
     <citations>
-        <citation type="doi">doi:10.1093/nar/gku1196</citation>
+        <citation type="doi">10.1093/nar/gku1196</citation>
     </citations>
 
 </tool>

--- a/tools/hybpiper/macros.xml
+++ b/tools/hybpiper/macros.xml
@@ -9,9 +9,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.3732/apps.1600016
-            </citation>
+            <citation type="doi">10.3732/apps.1600016</citation>
         </citations>
     </xml>
     <xml name="xrefs">

--- a/tools/integron_finder/macro.xml
+++ b/tools/integron_finder/macro.xml
@@ -31,7 +31,7 @@
 
     <xml name="citations">
         <citations>
-            <citation type="doi">10.1101/2022.02.28.482270 </citation>
+            <citation type="doi">10.1101/2022.02.28.482270</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/kallisto/macros.xml
+++ b/tools/kallisto/macros.xml
@@ -10,7 +10,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">doi:10.1038/nbt.3519</citation>
+            <citation type="doi">10.1038/nbt.3519</citation>
         </citations>
     </xml>
     <xml name="reference_input">

--- a/tools/malt/macros.xml
+++ b/tools/malt/macros.xml
@@ -22,7 +22,7 @@
     </macro>
     <xml name="citations">
         <citations>
-            <citation type="doi">https://doi.org/10.1101/050559</citation>
+            <citation type="doi">10.1101/050559</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/malt/malt_run.xml
+++ b/tools/malt/malt_run.xml
@@ -265,7 +265,7 @@ or BLASTX mode.
   **Include unaligned queries in RMA output file** - ensure that all unaligned queries are placed into the output RMA file. By default, only queries that have an alignment are included.
     </help>
     <citations>
-        <citation type="doi">https://doi.org/10.1101/050559</citation>
+        <citation type="doi">10.1101/050559</citation>
     </citations>
 </tool>
 

--- a/tools/mapseq/mapseq.xml
+++ b/tools/mapseq/mapseq.xml
@@ -321,11 +321,7 @@ License
         <person givenName="Paul" familyName="Zierep" url="https://github.com/paulzierep"/>
     </creator>
     <citations>
-        <citation type="doi">
-            10.1093/bioinformatics/btx517
-        </citation>
-        <citation type="doi">
-            10.1093/nar/gkac1080
-        </citation>
+        <citation type="doi">10.1093/bioinformatics/btx517</citation>
+        <citation type="doi">10.1093/nar/gkac1080</citation>
     </citations>
 </tool>

--- a/tools/metawrapmg/macros.xml
+++ b/tools/metawrapmg/macros.xml
@@ -9,9 +9,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                https://doi.org/10.1186/s40168-018-0541-1
-            </citation>
+            <citation type="doi">10.1186/s40168-018-0541-1</citation>
         </citations>
     </xml>
     <xml name="xrefs">

--- a/tools/mist_typing/macros.xml
+++ b/tools/mist_typing/macros.xml
@@ -9,7 +9,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">https://doi.org/10.1186/s12864-025-12324-z</citation>
+            <citation type="doi">10.1186/s12864-025-12324-z</citation>
         </citations>
         <yield/>
     </xml>

--- a/tools/mothur/chimera.slayer.xml
+++ b/tools/mothur/chimera.slayer.xml
@@ -170,6 +170,6 @@ It is not recommended to blindly discard all sequences flagged as chimeras. Some
 
     ]]></help>
     <expand macro="citations">
-        <citation type="doi">10.1101/gr.112730.110 </citation>
+        <citation type="doi">10.1101/gr.112730.110</citation>
     </expand>
 </tool>

--- a/tools/mothur/classify.seqs.xml
+++ b/tools/mothur/classify.seqs.xml
@@ -231,6 +231,6 @@ v1.22.0: Updated for Mothur 1.33. Added count parameter (1.28), added relabund p
     <expand macro="citations">
         <citation type="doi">10.1128/AEM.00062-07</citation>
         <citation type="doi">10.1093/nar/25.17.3389</citation>
-        <citation type="doi"> 10.1128/AEM.03006-05</citation>
+        <citation type="doi">10.1128/AEM.03006-05</citation>
     </expand>
 </tool>

--- a/tools/multigsea/macros.xml
+++ b/tools/multigsea/macros.xml
@@ -22,7 +22,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">doi:10.1186/s12859-020-03910-x.</citation>
+            <citation type="doi">10.1186/s12859-020-03910-x</citation>
         </citations>
     </xml>
     <xml name="xrefs">

--- a/tools/ncbi_datasets/macros.xml
+++ b/tools/ncbi_datasets/macros.xml
@@ -412,9 +412,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.1038/s41597-024-03571-y
-            </citation>
+            <citation type="doi">10.1038/s41597-024-03571-y</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/pharokka/macros.xml
+++ b/tools/pharokka/macros.xml
@@ -27,9 +27,7 @@
     </xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                10.1093/bioinformatics/btac776
-            </citation>
+            <citation type="doi">10.1093/bioinformatics/btac776</citation>
         </citations>
     </xml>
     <xml name="creator">

--- a/tools/qq_tools/qq_manhattan.xml
+++ b/tools/qq_tools/qq_manhattan.xml
@@ -27,6 +27,6 @@
         Simple manhattan plot wrapper usinng the qqman bioconductor package.
     ]]></help>
     <citations>
-        <citation type="doi">https://doi.org/10.1101/005165</citation>
+        <citation type="doi">10.1101/005165</citation>
     </citations>
 </tool>

--- a/tools/query_impc/impc_tool.xml
+++ b/tools/query_impc/impc_tool.xml
@@ -344,8 +344,8 @@
    .. _here: https://www.mousephenotype.org/impress/pipelines
   ]]></help>
   <citations>
-   <citation type="doi">https://doi.org/10.1093/nar/gku1193</citation>
-   <citation type="doi">https://doi.org/10.12688/f1000research.25369.1</citation>
-   <citation type="doi">https://doi.org/10.1038/nature19356</citation>
+   <citation type="doi">10.1093/nar/gku1193</citation>
+   <citation type="doi">10.12688/f1000research.25369.1</citation>
+   <citation type="doi">10.1038/nature19356</citation>
   </citations>
  </tool>

--- a/tools/quickmerge/quickmerge.xml
+++ b/tools/quickmerge/quickmerge.xml
@@ -351,6 +351,6 @@ Quickmerge was wrapped by the Galaxy Australia team.
 
   ]]></help>
   <citations>
-    <citation type="doi">https://doi.org/10.1093/nar/gkw654</citation>
+    <citation type="doi">10.1093/nar/gkw654</citation>
   </citations>
 </tool>

--- a/tools/rapidnj/rapidnj.xml
+++ b/tools/rapidnj/rapidnj.xml
@@ -77,6 +77,6 @@ Especially useful for large datasets where maximum-likelihood based phylogenetic
         ]]>
     </help>
     <citations>
-        <citation type="doi">doi:10.1007/978-3-540-87361-7_10</citation>
+        <citation type="doi">10.1007/978-3-540-87361-7_10</citation>
     </citations>
 </tool>

--- a/tools/revoluzer/distmat.xml
+++ b/tools/revoluzer/distmat.xml
@@ -137,7 +137,7 @@ A tabular file showing the distance matrix.
     ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btm468</citation>
-        <citation type="doi">10.1089/cmb.1998.5.555 </citation><!--Sankoff Blanchette-->
+        <citation type="doi">10.1089/cmb.1998.5.555</citation><!--Sankoff Blanchette-->
         <citation type="doi">10.1093/bioinformatics/18.suppl_2.s54</citation>
         <citation type="doi">10.1137/060651331</citation>
         <citation type="doi">10.1007/978-3-540-30219-3_2</citation>

--- a/tools/rnaquast/rna_quast.xml
+++ b/tools/rnaquast/rna_quast.xml
@@ -543,6 +543,6 @@ thresholds described above (50% and 95%) can be varied by the user.
 
     ]]>    </help>
     <citations>
-        <citation type="doi">10.1093/bioinformatics/btw218 </citation>
+        <citation type="doi">10.1093/bioinformatics/btw218</citation>
     </citations>
 </tool>

--- a/tools/rpfba/rpfba.xml
+++ b/tools/rpfba/rpfba.xml
@@ -196,6 +196,6 @@ Acknowledgments
     ]]></help>
     <citations>
         <citation type="doi">10.1186/1752-0509-7-74</citation>
-        <citation type="doi">10.1515/jib-2016-290 </citation>    
+        <citation type="doi">10.1515/jib-2016-290</citation>
     </citations>
 </tool>

--- a/tools/rptools/rpfba.xml
+++ b/tools/rptools/rpfba.xml
@@ -189,6 +189,6 @@ Acknowledgments
     </creator>
     <citations>
         <citation type="doi">10.1186/1752-0509-7-74</citation>
-        <citation type="doi">10.1515/jib-2016-290 </citation>    
+        <citation type="doi">10.1515/jib-2016-290</citation>
     </citations>
 </tool>

--- a/tools/sceasy/sceasy.xml
+++ b/tools/sceasy/sceasy.xml
@@ -222,6 +222,6 @@ Supports the following conversion:
 
     ]]></help>
     <citations>
-        <citation type="doi"> doi:10.1093/nargab/lqaa052</citation>
+        <citation type="doi">10.1093/nargab/lqaa052</citation>
     </citations>
 </tool>

--- a/tools/seqsero2/macros.xml
+++ b/tools/seqsero2/macros.xml
@@ -18,9 +18,7 @@
     </macro>
     <xml name="citations">
         <citations>
-            <citation type="doi">
-                https://doi.org/10.1128/AEM.01746-19
-            </citation>
+            <citation type="doi">10.1128/AEM.01746-19</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/slamdunk/macros.xml
+++ b/tools/slamdunk/macros.xml
@@ -30,8 +30,6 @@
         <param argument="--reference" type="data" format="bed" label="Reference 3'UTRs BED file" />
     </xml>
     <xml name="citations">
-        <citation type="doi">
-            10.1186/s12859-019-2849-7
-        </citation>
+        <citation type="doi">10.1186/s12859-019-2849-7</citation>
     </xml>
 </macros>

--- a/tools/spaln/spaln.xml
+++ b/tools/spaln/spaln.xml
@@ -183,6 +183,6 @@
         .. _Spaln: https://github.com/ogotoh/spaln
     ]]></help>
     <citations>
-        <citation type="doi">0.1093/nar/gkn105</citation>
+        <citation type="doi">10.1093/nar/gkn105</citation>
     </citations>
 </tool>

--- a/tools/transtermhp/transtermhp.xml
+++ b/tools/transtermhp/transtermhp.xml
@@ -74,6 +74,6 @@ python '$__tool_directory__/transtermhp.py' \$TRANSTERMHP
 Finds rho-independent transcription terminators in bacterial genomes.
 ]]></help>
     <citations>
-        <citation type="doi">doi:10.1186/gb-2007-8-2-r22</citation>
+        <citation type="doi">10.1186/gb-2007-8-2-r22</citation>
     </citations>
 </tool>

--- a/tools/tsebra/macros.xml
+++ b/tools/tsebra/macros.xml
@@ -2,7 +2,7 @@
     <token name="@TOOL_VERSION@">1.1.2.5</token>
     <xml name="citation">
         <citations>
-            <citation type="doi">/10.1186/s12859-021-04482-0</citation> 
+            <citation type="doi">10.1186/s12859-021-04482-0</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/upsetr/rcx_upsetplot.xml
+++ b/tools/upsetr/rcx_upsetplot.xml
@@ -166,6 +166,6 @@ Links
 
     ]]></help>
     <citations>
-        <citation type="doi">https://doi.org/10.1093/bioinformatics/btx364</citation>
+        <citation type="doi">10.1093/bioinformatics/btx364</citation>
     </citations>
 </tool>

--- a/tools/velvet/macros.xml
+++ b/tools/velvet/macros.xml
@@ -20,9 +20,7 @@
   </xml>
   <xml name="citation">
       <citations>
-          <citation type="doi">
-              10.1101/gr.074492.107
-          </citation>
+          <citation type="doi">10.1101/gr.074492.107</citation>
       </citations>
   </xml>
   <token name="@WHATITDOES@">


### PR DESCRIPTION
## Summary

Normalizes every `<citation type="doi">` in the repo whose content does not match the strict Crossref shape (`^10\.\d{4,9}/.+$`) enforced by the new pydantic `Citation` validator on Galaxy 26.1 (`lib/galaxy/tool_util_models/tool_source.py`). Reported upstream as galaxyproject/galaxy#22795 (with the recommendation that Galaxy should also normalize / demote the failure to a warning); this PR is the immediate fix on the tools-iuc side.

## Why it matters

The new validator is profile-gated in `lib/galaxy/tool_util/parser/xml.py:parse_citations`:

- **`profile >= 24.2`** → parse error is **fatal**: the tool is silently dropped from the toolbox.
- **`profile < 24.2`** → tolerated: the citation is silently discarded but the tool loads.

Currently broken on 26.1 (profile ≥ 24.2):
- `tools/abyss/abyss-pe.xml` (profile `24.2`) — absent from 26.1 CI runs.
- `tools/ena_upload/ena_upload.xml` (profile macro → `25.1`) — absent from 26.1 CI runs.

The other ~37 fixed tools have older profiles, so they loaded — but their citations were silently dropped at load time on 26.1.

## What's normalized

The cleanup is purely textual; no DOI is changed, just brought to the canonical form:

| Variant | Example before | After |
|---|---|---|
| URL form | `https://doi.org/10.1093/nar/gku1196` | `10.1093/nar/gku1196` |
| URL without scheme | `doi.org/10.1038/s41587-020-0501-8` | `10.1038/s41587-020-0501-8` |
| Legacy `dx.doi.org/` | `dx.doi.org/10.1038/nbt.4229` | `10.1038/nbt.4229` |
| `doi:` / `DOI:` prefix (optional whitespace) | `doi:10.1101/gr.214346.116`, `DOI: 10.1002/humu.21517` | `10.1101/gr.214346.116`, `10.1002/humu.21517` |
| HTML entity slash | `10.1101&#47;2020.05.25.115253` | `10.1101/2020.05.25.115253` |
| Leading slash typo | `/10.1186/s12859-021-04482-0` | `10.1186/s12859-021-04482-0` |
| Missing leading `1` | `0.1093/nar/gkn105` (spaln) | `10.1093/nar/gkn105` |
| Missing `10.` prefix | `1101/2020.11.19.388223` (metaphlan downloader) | `10.1101/2020.11.19.388223` |

Inner whitespace inside `<citation>` tags is also normalized to a single-line bare form for consistency.

## Out of scope (left untouched here)

Two `<citation type="doi">` entries are actually GitHub URLs rather than DOIs and need a different fix (`type="bibtex"` or removal), not a prefix strip:

- `tools/argnorm/argnorm.xml` → `https://github.com/BigDataBiology/argNorm`
- `tools/schicexplorer/macros.xml` → `https://github.com/joachimwolff/scHiCExplorer`

Happy to handle those in a follow-up if reviewers prefer.

## Verification

After this PR:

```sh
python3 -c "
import re, os
DOI_RE = re.compile(r'^10\.\d{4,9}/.+\$')
ct = re.compile(r'<citation\s+type=\"doi\"\s*>\s*(.*?)\s*</citation>', re.IGNORECASE | re.DOTALL)
for root, _, files in os.walk('.'):
    if '/.git' in root: continue
    for fn in files:
        if not fn.endswith('.xml'): continue
        for m in ct.finditer(open(os.path.join(root, fn), encoding='utf-8', errors='replace').read()):
            c = m.group(1).strip()
            if not DOI_RE.match(c):
                print(os.path.join(root, fn), '->', repr(c))
"
```

returns only the two GitHub URLs noted above.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass on `release_26.0` (no behavioural change expected)
- [ ] CI tests pass on `release_26.1` — `abyss-pe` and `ena_upload` should now appear in the test report
