### PR TITLE
Update nanoplot to 1.47.0 and fix lint error

### DIFF
--- a/tools/nanoplot/.lint_skip
+++ b/tools/nanoplot/.lint_skip
@@ -1,2 +1,0 @@
-TestsCaseValidation
-TestsParamInInputs

--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -327,7 +327,7 @@ NanoPlot
         <data name="log_read_length" format="png" from_work_dir="Non_weightedLogTransformed_HistogramReadlength.png" label="${tool.name} on ${on_string}: Log Transformed Histogram Read Length"/-->
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="3">
             <conditional name="mode">
                 <param name="choice" value="batch"/>
                 <conditional name="reads">
@@ -350,7 +350,7 @@ NanoPlot
             <output name="nanostats" file="NanoStats.txt" ftype="tabular"/>
             <output name="nanostats_post_filtering" file="NanoStats_post_filtering.txt" ftype="tabular"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <conditional name="mode">
                 <param name="choice" value="combined"/>
                 <conditional name="reads">
@@ -368,12 +368,12 @@ NanoPlot
             <output name="output_html" ftype="html">
                 <assert_contents>
                     <has_text text="html"/>
-                    <has_text text="Aligned read length vs Percent identity plot using dots"/>
+                    <has_text text="Aligned read lengths vs Sequenced read length dot plot"/>
                     <!-- bam report specific -->
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <!-- test with multiple input files -->
             <conditional name="mode">
                 <param name="choice" value="combined"/>
@@ -385,7 +385,7 @@ NanoPlot
             <output name="output_html" ftype="html">
                 <assert_contents>
                     <has_text text="html"/>
-                    <not_has_text text="Aligned read length vs Percent identity plot using dots"/>
+                    <not_has_text text="Aligned read lengths vs Sequenced read length dot plot"/>
                     <has_text text="&lt;td&gt;9&lt;/td&gt;"/>
                     <!--check both files were used 4+5 reads -->
                 </assert_contents>

--- a/tools/nanoplot/nanoplot.xml
+++ b/tools/nanoplot/nanoplot.xml
@@ -1,8 +1,9 @@
-<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="nanoplot" name="NanoPlot" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Plotting suite for Oxford Nanopore sequencing data and alignments</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.46.2</token>
-        <token name="@PROFILE@">22.05</token> 
+        <token name="@TOOL_VERSION@">1.47.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@PROFILE@">25.1</token> 
     </macros>
     <xrefs>
         <xref type="bio.tools">nanoplot</xref>
@@ -10,11 +11,6 @@
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">nanoplot</requirement>
     </requirements>
-    <!--stdio>
-        Not needed anymore, because we do not generate the static PNGs anymore.
-        I will leave this in, in the case we activate the PNGs at some point again.
-        <regex match="kaleido problem" source="stderr" level="fatal" description="No static plots are saved due to some kaleido problem"/>
-    </stdio-->
     <version_command>NanoPlot --version</version_command>
     <command detect_errors="exit_code"><![CDATA[
 #set $myfiles = $mode.reads.files if $mode.choice == 'combined' else [$mode.reads.files]
@@ -33,7 +29,7 @@
 #end for
 
 NanoPlot
-    --threads \${GALAXY_SLOTS:-4}
+    --threads "\${GALAXY_SLOTS:-4}"
     --tsv_stats
     --only-report
     --$mode.reads.type ${' '.join($reads_temp)}
@@ -364,7 +360,7 @@ NanoPlot
             </conditional>
             <section name="filter">
                 <param name="maxlength" value="2000"/>
-                <param name="minlenght" value="1000"/>
+                <param name="minlength" value="1000"/>
             </section>
             <section name="customization">
                 <param name="color" value="yellow"/>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
