### PR TITLE
Update upsetR plot tool to 1.4.1

### DIFF
--- a/tools/upsetr/.lint_skip
+++ b/tools/upsetr/.lint_skip
@@ -1,1 +1,0 @@
-TestsAssertionValidation

--- a/tools/upsetr/rcx_upsetplot.xml
+++ b/tools/upsetr/rcx_upsetplot.xml
@@ -96,7 +96,7 @@
                     <has_image_channels channels="1"/>
                     <has_image_height height="7200"/>
                     <has_image_width width="7200"/>
-                    <has_image_center_of_mass center_of_mass="3642.53, 3525.80" eps="0.1"/>
+                    <has_image_center_of_mass center_of_mass="3643.2859916352927, 3525.6472865413143" eps="0.1"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/upsetr/rcx_upsetplot.xml
+++ b/tools/upsetr/rcx_upsetplot.xml
@@ -1,41 +1,25 @@
-<tool id="rcx_upsetplot" name="upset plot" version="@TOOL_VERSION@+galaxy0" profile="23.0">
+<tool id="rcx_upsetplot" name="upset plot" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Upset plot visualization tool using UpSetR</description>
     <macros>
         <token name="@TOOL_VERSION@">1.4.1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@PROFILE@">25.0</token>
     </macros>
-
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">r-upsetr</requirement>
         <requirement type="package" version="24.0.0">r-arrow</requirement>
     </requirements>
-    <required_files>
-        <include path="utils.r" />
-    </required_files>
-
     <creator>
-        <person
-            givenName="Kristina"
-            familyName="Gomoryova"
-            url="https://github.com/KristinaGomoryova"
-            identifier="0000-0003-4407-3917" />
-        <person
-            givenName="Helge"
-            familyName="Hecht"
-            url="https://github.com/hechth"
-            identifier="0000-0001-6744-996X" />
-        <organization
-            url="https://www.recetox.muni.cz/"
-            email="GalaxyToolsDevelopmentandDeployment@space.muni.cz"
-            name="RECETOX MUNI" />
+        <person givenName="Kristina" familyName="Gomoryova" url="https://github.com/KristinaGomoryova" identifier="0000-0003-4407-3917"/>
+        <person givenName="Helge" familyName="Hecht" url="https://github.com/hechth" identifier="0000-0001-6744-996X"/>
+        <organization url="https://www.recetox.muni.cz/" email="GalaxyToolsDevelopmentandDeployment@space.muni.cz" name="RECETOX MUNI"/>
     </creator>
-
     <command detect_errors="exit_code"><![CDATA[
         Rscript '${run_script}'
         #if $export_R_script
         && cat ${run_script} >> $script
         #end if
     ]]></command>
-
     <configfiles>
         <configfile name="run_script"><![CDATA[
 
@@ -82,31 +66,26 @@
         dev.off()
         ]]></configfile>
     </configfiles>
-
     <inputs>
         <param name="input_data" type="data" format="csv,tsv,tabular,parquet" label="Input Data Table" help="Input file in a tabular/tsv/csv/parquet format containing the data for the UpSet plot."/>
         <param type="select" name="order_by" label="Sort Bars By" help="Choose how to sort the bars in the UpSet plot: by frequency (largest frequency first), degree (largest overlap first), or both.">
-            <option value="freq" selected="true">Frequency</option> 
+            <option value="freq" selected="true">Frequency</option>
             <option value="degree">Degree</option>
             <option value="both">Both</option>
         </param>
-        <param name="nsets" type="integer" min="0" max="100" value="5" label="Number of Sets to Include" 
-               help="Specify the number of sets to include in the plot. The largest sets will be visualized first. Default is 5." />
-        <param label="Number of Intersections to Plot" optional="true" name="nintersects" type="integer" value="0" help="Specify the number of intersections to display in the plot. If set to 0, all intersections will be plotted."/>  
-        <param name="group_by" type="boolean" checked="false" truevalue="sets" falsevalue="degree" label="Group Bars by Sets" help="Enable this option to group bars for each set based on their set size. Otherwise, bars will be grouped by degree."/>   
-        <param name="empty_intersections" type="boolean" checked="false" truevalue="TRUE" falsevalue="NULL" label="Include Empty Intersections" help="Enable this option to include empty intersections in the plot, up to the limit of the number of intersections. By default, empty intersections are omitted."/>   
-        <param name="cutoff" type="integer" min="0" label="Intersection Size Cutoff" optional="true" 
-               help="Specify a threshold for filtering intersections. Only intersections with a size greater than or equal to this value will be included in the plot. Leave empty to include all intersections." />
+        <param name="nsets" type="integer" min="0" max="100" value="5" label="Number of Sets to Include" help="Specify the number of sets to include in the plot. The largest sets will be visualized first. Default is 5."/>
+        <param label="Number of Intersections to Plot" optional="true" name="nintersects" type="integer" value="0" help="Specify the number of intersections to display in the plot. If set to 0, all intersections will be plotted."/>
+        <param name="group_by" type="boolean" checked="false" truevalue="sets" falsevalue="degree" label="Group Bars by Sets" help="Enable this option to group bars for each set based on their set size. Otherwise, bars will be grouped by degree."/>
+        <param name="empty_intersections" type="boolean" checked="false" truevalue="TRUE" falsevalue="NULL" label="Include Empty Intersections" help="Enable this option to include empty intersections in the plot, up to the limit of the number of intersections. By default, empty intersections are omitted."/>
+        <param name="cutoff" type="integer" min="0" label="Intersection Size Cutoff" optional="true" help="Specify a threshold for filtering intersections. Only intersections with a size greater than or equal to this value will be included in the plot. Leave empty to include all intersections."/>
         <param name="export_R_script" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Export R Script for Reproducibility" help="Enable this option to export the R script used to generate the plot. This allows you to reproduce the analysis offline. Note that file paths and dependencies must be managed manually."/>
     </inputs>
-
     <outputs>
-        <data name="upsetplot" format="png" label="Upset plot on ${on_string}" from_work_dir="upsetplot.png"/>        
+        <data name="upsetplot" format="png" label="Upset plot on ${on_string}" from_work_dir="upsetplot.png"/>
         <data name="script" format="txt" label="R script">
             <filter>export_R_script</filter>
         </data>
     </outputs>
-
     <tests>
         <test expect_num_outputs="1">
             <param name="input_data" value="upsetplot_test_data.txt" ftype="tabular"/>
@@ -116,13 +95,12 @@
                 <assert_contents>
                     <has_image_channels channels="1"/>
                     <has_image_height height="7200"/>
-                    <has_image_width width="7200" />
-                    <has_image_center_of_mass center_of_mass="3642.53, 3525.80" eps="0.1"/> 
+                    <has_image_width width="7200"/>
+                    <has_image_center_of_mass center_of_mass="3642.53, 3525.80" eps="0.1"/>
                 </assert_contents>
             </output>
         </test>
     </tests>
-
     <help><![CDATA[
 recetox-upsetplot Help
 ======================

--- a/tools/upsetr/rcx_upsetplot.xml
+++ b/tools/upsetr/rcx_upsetplot.xml
@@ -1,12 +1,12 @@
 <tool id="rcx_upsetplot" name="upset plot" version="@TOOL_VERSION@+galaxy0" profile="23.0">
     <description>Upset plot visualization tool using UpSetR</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.4.0</token>
+        <token name="@TOOL_VERSION@">1.4.1</token>
     </macros>
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">r-upsetr</requirement>
-        <requirement type="package" version="19.0.0">r-arrow</requirement>
+        <requirement type="package" version="24.0.0">r-arrow</requirement>
     </requirements>
     <required_files>
         <include path="utils.r" />


### PR DESCRIPTION
Closes: https://github.com/planemo-autoupdate/tools-iuc/pull/32
Closes: https://github.com/galaxyproject/tools-iuc/pull/8055

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
