### PR TITLE
dropletutils: change genes_out format from tsv to tabular

### DIFF
--- a/tools/dropletutils/dropletutils.xml
+++ b/tools/dropletutils/dropletutils.xml
@@ -171,7 +171,7 @@ seed.val=as.integer('$seed')
         <data name="barcodes_out" format="tsv" from_work_dir="@TXOUT@/barcodes.tsv" label="${tool.name} 10X Barcodes on ${on_string}">
             <filter>operation['use']=='filter' and operation['outformat'] == 'directory'</filter>
         </data>
-        <data name="genes_out" format="tsv" from_work_dir="@TXOUT@/genes.tsv" label="${tool.name} 10X Genes on ${on_string}">
+        <data name="genes_out" format="tabular" from_work_dir="@TXOUT@/genes.tsv" label="${tool.name} 10X Genes on ${on_string}">
             <filter>operation['use']=='filter' and operation['outformat'] == 'directory'</filter>
         </data>
         <data name="matrix_out" format="mtx" from_work_dir="@TXOUT@/matrix.mtx" label="${tool.name} 10X Matrices on ${on_string}">


### PR DESCRIPTION
## Problem

The `genes_out` output of the DropletUtils directory-mode filter (`dropletutils.xml` line 174) is declared as `format="tsv"`. The IWC `scanpy-clustering` workflow requires its genes input to be `tabular`. Galaxy treats `tsv` and `tabular` as distinct datatypes, so users who run DropletUtils → Scanpy find the genes dataset greyed out in the workflow run form and must manually retype it via Edit Attributes before the workflow can proceed.

## Fix

One-word change: `format="tsv"` → `format="tabular"` on the `genes_out` data element.

The underlying file content (tab-separated gene IDs, one per line) is identical — only the Galaxy datatype declaration changes.

## Evidence

Observed during reanalysis of Wang et al. 2024 (*Aedes aegypti* midgut scRNA-seq, GEO GSE246612) on usegalaxy.org. The datatype mismatch was reproducible; changing the type via Edit Attributes resolved it every time. Reported in the IWC scanpy-clustering workflow's README as a known manual workaround.

## Testing

No functional behaviour changes. Existing tests should pass without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)