### PR TITLE
StringTie: run hybrid --mix assembly in Mixed mode

### DIFF
--- a/tools/stringtie/.lint_skip
+++ b/tools/stringtie/.lint_skip
@@ -1,1 +1,0 @@
-TestsCaseValidation

--- a/tools/stringtie/macros.xml
+++ b/tools/stringtie/macros.xml
@@ -1,6 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">3.0.3</token>
     <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">25.1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">stringtie</requirement>

--- a/tools/stringtie/macros.xml
+++ b/tools/stringtie/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.0.3</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">stringtie</requirement>

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -1,4 +1,4 @@
-<tool id="stringtie" name="StringTie" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="22.05">
+<tool id="stringtie" name="StringTie" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>transcript assembly and quantification</description>
     <macros>
         <import>macros.xml</import>
@@ -288,7 +288,9 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="fraction" value="0.17"/>
+            <section name="adv">
+                <param name="fraction" value="0.17"/>
+            </section>
             <output name="output_gtf" file="stringtie_out2_re.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!--Ensure guide option works -->
@@ -297,9 +299,13 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+            </conditional>
             <output name="output_gtf" file="stringtie_out3_re.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!--Ensure guide with fraction works -->
@@ -308,10 +314,16 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
-            <param name="fraction" value="0.17"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.17"/>
+            </section>
             <output name="output_gtf" file="stringtie_out4_re.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!--Ensure coverage and output for Ballgown works -->
@@ -320,11 +332,17 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
-            <param name="special_outputs_select" value="ballgown"/>
-            <param name="coverage_file" value="true"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+                <conditional name="special_outputs">
+                    <param name="special_outputs_select" value="ballgown"/>
+                </conditional>
+                <param name="coverage_file" value="true"/>
+            </conditional>
             <output name="exon_expression" file="./ballgown/e_data.ctab" ftype="tabular"/>
             <output name="intron_expression" file="./ballgown/i_data.ctab" ftype="tabular"/>
             <output name="transcript_expression" file="./ballgown/t_data.ctab" ftype="tabular"/>
@@ -339,13 +357,19 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="special_outputs_select" value="deseq2"/>
-            <param name="input_estimation" value="true"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
-            <param name="coverage_file" value="true"/>
-            <param name="clustering" value="true"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+                <param name="input_estimation" value="true"/>
+                <conditional name="special_outputs">
+                    <param name="special_outputs_select" value="deseq2"/>
+                    <param name="clustering" value="true"/>
+                </conditional>
+                <param name="coverage_file" value="true"/>
+            </conditional>
             <output name="gene_counts" file="gene_counts_edger.tsv" ftype="tabular"/>
             <output name="transcript_counts" file="transcript_counts_edger.tsv" ftype="tabular"/>
             <output name="legend" file="legend.tsv" ftype="tabular"/>
@@ -358,11 +382,17 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
-            <param name="fraction" value="0.17"/>
-            <param name="abundance_estimation" value="true"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.17"/>
+                <param name="abundance_estimation" value="true"/>
+            </section>
             <output name="output_gtf" file="stringtie_out4_re.gtf" ftype="gtf" lines_diff="4"/>
             <output name="gene_abundance_estimation" file="stringtie_out7.tsv" ftype="tabular" lines_diff="4"/>
         </test>
@@ -372,10 +402,16 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="history"/>
-            <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
-            <param name="fraction" value="0.15"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="history"/>
+                    <param name="ref_hist" ftype="gtf" value="stringtie_in.gtf"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.15"/>
+            </section>
             <output name="output_gtf" file="stringtie_out8.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!--Ensure built-in GTFs work -->
@@ -384,9 +420,15 @@ $adv.multi_mapping
                 <param name="input_mode" value="short_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="cached"/>
-            <param name="fraction" value="0.15"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="cached"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.15"/>
+            </section>
             <output name="output_gtf" file="stringtie_out9.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!-- Test long reads input -->
@@ -395,9 +437,15 @@ $adv.multi_mapping
                 <param name="input_mode" value="long_reads"/>
                 <param name="input_bam" ftype="bam" value="stringtie_in1.bam"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="cached"/>
-            <param name="fraction" value="0.15"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="cached"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.15"/>
+            </section>
             <output name="output_gtf" file="stringtie_out10.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!-- Test error splice option -->
@@ -407,9 +455,15 @@ $adv.multi_mapping
                 <param name="input_bam" ftype="bam" value="long_reads.bam"/>
                 <param name="error_splice" value="30"/>
             </conditional>
-            <param name="use_guide" value="yes"/>
-            <param name="guide_gff_select" value="cached"/>
-            <param name="fraction" value="0.15"/>
+            <conditional name="guide">
+                <param name="use_guide" value="yes"/>
+                <conditional name="guide_source">
+                    <param name="guide_gff_select" value="cached"/>
+                </conditional>
+            </conditional>
+            <section name="adv">
+                <param name="fraction" value="0.15"/>
+            </section>
             <output name="output_gtf" file="stringtie_out11.gtf" ftype="gtf" lines_diff="4"/>
         </test>
         <!-- Test mixed reads input -->

--- a/tools/stringtie/stringtie.xml
+++ b/tools/stringtie/stringtie.xml
@@ -42,12 +42,13 @@ mkdir -p ./special_de_output/sample1/ &&
         && stringtie short_sorted.sam '$input_options.input_bam_long'
     #else if $input_options.input_bam_short.metadata.ftype in $compressed and $input_options.input_bam_long.metadata.ftype == 'sam':
         samtools sort -@ \${GALAXY_SLOTS:-1} '$input_options.input_bam_long' -T "\${TMPDIR:-.}" -o long_sorted.sam
-        && stringtie'$input_options.input_bam_short' long_sorted.sam
+        && stringtie '$input_options.input_bam_short' long_sorted.sam
     #else
         samtools sort -@ \${GALAXY_SLOTS:-1} '$input_options.input_bam_short' -T "\${TMPDIR:-.}" -o short_sorted.sam
         && samtools sort -@ \${GALAXY_SLOTS:-1} '$input_options.input_bam_long' -T "\${TMPDIR:-.}" -o long_sorted.sam
         && stringtie short_sorted.sam long_sorted.sam
     #end if
+    --mix
     -E $input_options.error_splice
 #end if
 
@@ -420,18 +421,20 @@ $adv.multi_mapping
             </conditional>
             <output name="output_gtf" ftype="gtf">
                 <assert_contents>
-                    <has_text text="5.043160"/>
+                    <has_text text="STRG.8.1"/>
                     <has_text text="StringTie version @TOOL_VERSION@"/>
-                    <has_n_lines n="87"/>
+                    <has_n_lines n="95"/>
                 </assert_contents>
             </output>
+            <assert_command>
+                <has_text text="--mix"/>
+            </assert_command>
         </test>
         <!-- Test cram input -->
         <test expect_num_outputs="1">
             <conditional name="input_options">
-                <param name="input_mode" value="mixed_reads"/>
-                <param name="input_bam_short" ftype="cram" value="stringtie_in.cram"/>
-                <param name="input_bam_long" ftype="cram" value="stringtie_in.cram"/>
+                <param name="input_mode" value="short_reads"/>
+                <param name="input_bam" ftype="cram" value="stringtie_in.cram"/>
             </conditional>
             <output name="output_gtf" ftype="gtf">
                 <assert_contents>
@@ -498,6 +501,12 @@ As an option, a reference annotation file in `GTF/GFF3`_ format can be provided 
 **Nascent transcript mode (StringTie3)**
 
 StringTie3 can model co-transcriptional splicing to separate nascent (incompletely spliced) transcripts from mature ones. It is primarily intended for short-read, rRNA-depleted (total / non-polyA) RNA-seq, where unspliced and partially-spliced transcripts are abundant. Under **Nascent transcript mode** above you can either apply nascent-aware modeling while reporting only mature transcripts (``-N``), or additionally output the assembled nascent intermediates in the GTF (``--nasc``). Nascent records are emitted with source ``nascentRNA`` and carry a ``nascent_parent`` attribute linking each to its mature parent transcript. Default: Off (existing behavior unchanged).
+
+-----
+
+**Mixed mode (short and long reads)**
+
+When **Mixed mode: short and long reads** is selected, StringTie assembles short- and long-read alignments together in a single hybrid run (StringTie's ``--mix`` option). The short-read alignments are passed as the first input and the long-read alignments as the second, as required by ``--mix``; the long reads help resolve full-length transcript structure while the short reads contribute coverage and splice-junction accuracy. For total or rRNA-depleted (non-polyA) RNA-seq, Mixed mode can be combined with **Nascent transcript mode** (``-N`` or ``--nasc``) to model the partially-spliced (nascent) transcripts that are abundant in such libraries alongside the mature transcripts resolved from the long reads.
 
 -----
 

--- a/tools/stringtie/stringtie_merge.xml
+++ b/tools/stringtie/stringtie_merge.xml
@@ -1,4 +1,4 @@
-<tool id="stringtie_merge" name="StringTie merge" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="stringtie_merge" name="StringTie merge" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>transcripts</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
### What
Makes the wrapper's **Mixed mode: short and long reads** pass StringTie's `--mix` flag, so it performs hybrid short+long assembly instead of pooling the two inputs.

### Why
Mixed mode has existed since the wrapper was bumped to StringTie 2.1.7 (#3964) but never emitted `--mix`. `--mix` has been available upstream since StringTie 2.1.6, so wiring it up is overdue.

### Changes
- Add `--mix` to the Mixed mode command (short reads first, long reads second, as `--mix` requires).
- Fix a shell-quoting bug in the mixed command (a missing space made `stringtie'<file>'` an invalid single token in the compressed-short + SAM-long case).
- Bump `@VERSION_SUFFIX@` 0 → 1 (`3.0.3+galaxy1`; tool version unchanged).
- Update the mixed-BAM test to the hybrid output and assert `--mix` is passed (`assert_command`).
- Move the CRAM input test out of Mixed mode into single-read mode.
- Document Mixed mode (and combining it with nascent mode) in the help.