### PR TITLE
Auto-move PRs to project board when ready for review

### DIFF
--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -148,22 +148,16 @@ jobs:
             });
             core.setOutput('labeled', 'true');
 
-      - name: Add PR to Project Board
+      - name: Move PR to "Needs Review" on Project Board
         if: steps.check-pr.outputs.labeled == 'true'
-        id: add-to-project
-        uses: actions/add-to-project@v2
-        with:
-          project-url: https://github.com/orgs/galaxyproject/projects/81
-          github-token: ${{ steps.app-token.outputs.token }}
-
-      - name: Set Project Status to "Needs Review"
-        if: steps.add-to-project.outputs.itemId
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const projectItemId = '${{ steps.add-to-project.outputs.itemId }}';
+            const org = 'galaxyproject';
+            const projectNumber = 81;
 
+            // Get project metadata
             const { organization } = await github.graphql(`
               query($org: String!, $number: Int!) {
                 organization(login: $org) {
@@ -181,12 +175,33 @@ jobs:
                   }
                 }
               }
-            `, { org: 'galaxyproject', number: 81 });
+            `, { org, number: projectNumber });
 
             const project = organization.projectV2;
             const statusField = project.fields.nodes.find(f => f.name === 'Status');
             const option = statusField.options.find(o => o.name === 'Needs Review');
 
+            // Find the PR's item ID on the project board
+            const prNodeId = context.payload.issue.node_id;
+            const { node } = await github.graphql(`
+              query($id: ID!) {
+                node(id: $id) {
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { id: prNodeId });
+
+            const item = node.projectItems.nodes.find(i => i.project.id === project.id);
+            if (!item) { console.log('PR not found on project board'); return; }
+
+            // Update status
             await github.graphql(`
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                 updateProjectV2ItemFieldValue(input: {
@@ -198,7 +213,7 @@ jobs:
               }
             `, {
               projectId: project.id,
-              itemId: projectItemId,
+              itemId: item.id,
               fieldId: statusField.id,
               optionId: option.id
             });

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -4,26 +4,35 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-and-label:
     if: |
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, 'please review')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
+      - name: Generate App Token (repo-scoped)
+        id: repo-token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Check PR Status and Apply Label
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.repo-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -148,11 +157,20 @@ jobs:
             });
             core.setOutput('labeled', 'true');
 
+      - name: Generate App Token (project-scoped)
+        if: steps.check-pr.outputs.labeled == 'true'
+        id: project-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-organization-projects: write
+
       - name: Move PR to "Needs Review" on Project Board
         if: steps.check-pr.outputs.labeled == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.project-token.outputs.token }}
           script: |
             const org = 'galaxyproject';
             const projectNumber = 81;

--- a/.github/workflows/ready-for-review.yaml
+++ b/.github/workflows/ready-for-review.yaml
@@ -20,6 +20,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check PR Status and Apply Label
+        id: check-pr
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -145,3 +146,61 @@ jobs:
               issue_number: pull_number,
               labels: ['ready-for-review']
             });
+            core.setOutput('labeled', 'true');
+
+      - name: Add PR to Project Board
+        if: steps.check-pr.outputs.labeled == 'true'
+        id: add-to-project
+        uses: actions/add-to-project@v2
+        with:
+          project-url: https://github.com/orgs/galaxyproject/projects/81
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set Project Status to "Needs Review"
+        if: steps.add-to-project.outputs.itemId
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const projectItemId = '${{ steps.add-to-project.outputs.itemId }}';
+
+            const { organization } = await github.graphql(`
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { org: 'galaxyproject', number: 81 });
+
+            const project = organization.projectV2;
+            const statusField = project.fields.nodes.find(f => f.name === 'Status');
+            const option = statusField.options.find(o => o.name === 'Needs Review');
+
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }) { projectV2Item { id } }
+              }
+            `, {
+              projectId: project.id,
+              itemId: projectItemId,
+              fieldId: statusField.id,
+              optionId: option.id
+            });
+
+            console.log('PR moved to "Needs Review".');


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

## What this PR does

Automatically adds PRs to the [SIG project board](https://github.com/orgs/galaxyproject/projects/81) and sets status to "Needs Review" when the `ready-for-review` label is applied.

Uses the official `actions/add-to-project@v2` action followed by a GraphQL mutation to update the status field.

## Prerequisites

The [GitHub App](https://github.com/apps/tools-iuc) needs **Organization projects: Read and write** permission. Please verify/update the app permissions before merging.