### PR TITLE
featureCounts: apply IUC tool_xml formatting conventions

### DIFF
--- a/tools/featurecounts/featurecounts.xml
+++ b/tools/featurecounts/featurecounts.xml
@@ -2,12 +2,12 @@
     <description>Measure gene expression in RNA-Seq experiments from SAM or BAM files</description>
     <macros>
         <token name="@TOOL_VERSION@">2.1.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
         <token name="@PROFILE@">25.0</token>
         <macro name="conditional_gff_opions">
-            <param name="gff_feature_type" type="text" value="exon" argument="-t" label="GFF feature type filter" help="Specify the feature type. Only rows which have the matched matched feature type in the provided GTF annotation file will be included for read counting. `exon' by default."/>
-            <param name="gff_feature_attribute" type="text" value="gene_id" argument="-g" label="GFF gene identifier" help="Specify the attribute type used to group features (eg. exons) into meta-features (eg. genes), when GTF annotation is provided. `gene_id' by default. This attribute type is usually the gene identifier. This argument is useful for the meta-feature level summarization. Ex: if the 9th column is 'gene_id &quot;ENSG00000223972&quot;; gene_name &quot;DDX11L1&quot; gene_source &quot;havana&quot;' (GTF) or 'gene_id=ENSG00000223972; gene_name=DDX11L1; gene_source=havana' (GFF), the available attributes for this feature are 'gene_id', 'gene_name' and 'gene_source'."/>
-            <param name="summarization_level" type="boolean" truevalue=" -f" falsevalue="" argument="-f" label="On feature level" help="If specified, read summarization will be performed at the feature level. By default (-f is not specified), the read summarization is performed at the meta-feature level."/>
+            <param name="gff_feature_type" argument="-t" type="text" value="exon" label="GFF feature type filter" help="Specify the feature type. Only rows which have the matched matched feature type in the provided GTF annotation file will be included for read counting. `exon' by default."/>
+            <param name="gff_feature_attribute" argument="-g" type="text" value="gene_id" label="GFF gene identifier" help="Specify the attribute type used to group features (eg. exons) into meta-features (eg. genes), when GTF annotation is provided. `gene_id' by default. This attribute type is usually the gene identifier. This argument is useful for the meta-feature level summarization. Ex: if the 9th column is 'gene_id &quot;ENSG00000223972&quot;; gene_name &quot;DDX11L1&quot; gene_source &quot;havana&quot;' (GTF) or 'gene_id=ENSG00000223972; gene_name=DDX11L1; gene_source=havana' (GFF), the available attributes for this feature are 'gene_id', 'gene_name' and 'gene_source'."/>
+            <param name="summarization_level" argument="-f" type="boolean" truevalue=" -f" falsevalue="" label="On feature level" help="If specified, read summarization will be performed at the feature level. By default (-f is not specified), the read summarization is performed at the meta-feature level."/>
         </macro>
     </macros>
     <xrefs>
@@ -133,9 +133,8 @@
         && sed -e 's|${alignment}|${alignment.element_identifier}|g' 'output.summary' > '${output_summary}'
     ]]></command>
     <inputs>
-        <param name="alignment" type="data" multiple="false" format="unsorted.bam,bam,sam" label="Alignment file" help="The input alignment file(s) where the gene expression has to be counted. The file can have a SAM or BAM format; but ALL files must be in the same format. Unless you are using a Gene annotation file from the History, these files must have the database/genome attribute already specified e.g. hg38, not the default: ?">
-        </param>
-        <param name="strand_specificity" type="select" label="Specify strand information" argument="-s" help="Indicate if the data is stranded and if strand-specific read counting should be performed. Strand setting must be the same as the strand settings used to produce the mapped BAM input(s)">
+        <param name="alignment" type="data" format="unsorted.bam,bam,sam" label="Alignment file" help="The input alignment file(s) where the gene expression has to be counted. The file can have a SAM or BAM format; but ALL files must be in the same format. Unless you are using a Gene annotation file from the History, these files must have the database/genome attribute already specified e.g. hg38, not the default: ?" multiple="false"/>
+        <param name="strand_specificity" argument="-s" type="select" label="Specify strand information" help="Indicate if the data is stranded and if strand-specific read counting should be performed. Strand setting must be the same as the strand settings used to produce the mapped BAM input(s)">
             <option value="0" selected="true">Unstranded</option>
             <option value="1">Stranded (Forward)</option>
             <option value="2">Stranded (Reverse)</option>
@@ -166,8 +165,7 @@
                 <expand macro="conditional_gff_opions"/>
             </when>
             <when value="history">
-                <param name="reference_gene_sets" format="gff,gtf,gff3" type="data" label="Gene annotation file" help="The program assumes that the provided annotation file is in GFF/GTF format. Make sure that the gene annotation file corresponds to the same reference genome as used for the alignment.">
-                </param>
+                <param name="reference_gene_sets" type="data" format="gff,gtf,gff3" label="Gene annotation file" help="The program assumes that the provided annotation file is in GFF/GTF format. Make sure that the gene annotation file corresponds to the same reference genome as used for the alignment."/>
                 <expand macro="conditional_gff_opions"/>
             </when>
         </conditional>
@@ -185,8 +183,8 @@
             </param>
             <when value="single_end"/>
             <when value="PE_individual">
-                <param name="only_both_ends" type="boolean" truevalue=" -B" falsevalue="" argument="-B" label="Only allow fragments with both reads aligned" help="If specified, only fragments that have both ends successfully aligned will be considered for summarization. This option is only applicable for paired-end reads."/>
-                <param name="exclude_chimerics" type="boolean" truevalue=" -C" falsevalue="" argument="-C" checked="true" label="Exclude chimeric fragments" help="If specified, the chimeric fragments (those fragments that have their two ends aligned to different chromosomes) will NOT be included for summarization. This option is only applicable for paired-end read data."/>
+                <param name="only_both_ends" argument="-B" type="boolean" truevalue=" -B" falsevalue="" label="Only allow fragments with both reads aligned" help="If specified, only fragments that have both ends successfully aligned will be considered for summarization. This option is only applicable for paired-end reads."/>
+                <param name="exclude_chimerics" argument="-C" type="boolean" truevalue=" -C" falsevalue="" checked="true" label="Exclude chimeric fragments" help="If specified, the chimeric fragments (those fragments that have their two ends aligned to different chromosomes) will NOT be included for summarization. This option is only applicable for paired-end read data."/>
             </when>
             <when value="PE_fragments">
                 <conditional name="check_distance_enabled">
@@ -195,24 +193,24 @@
                         <option value="false" selected="True">Do not check</option>
                     </param>
                     <when value="true">
-                        <param name="minimum_fragment_length" type="integer" value="50" min="0" argument="-d" label="Minimum fragment/template length."/>
-                        <param name="maximum_fragment_length" type="integer" value="600" min="1" argument="-D" label="Maximum fragment/template length."/>
+                        <param name="minimum_fragment_length" argument="-d" type="integer" min="0" value="50" label="Minimum fragment/template length."/>
+                        <param name="maximum_fragment_length" argument="-D" type="integer" min="1" value="600" label="Maximum fragment/template length."/>
                     </when>
                     <when value="false"/>
                 </conditional>
-                <param name="only_both_ends" type="boolean" truevalue=" -B" falsevalue="" argument="-B" label="Only allow fragments with both reads aligned" help="If specified, only fragments that have both ends successfully aligned will be considered for summarization. This option is only applicable for paired-end reads."/>
-                <param name="exclude_chimerics" type="boolean" truevalue=" -C" falsevalue="" argument="-C" checked="true" label="Exclude chimeric fragments" help="If specified, the chimeric fragments (those fragments that have their two ends aligned to different chromosomes) will NOT be included for summarization. This option is only applicable for paired-end read data."/>
+                <param name="only_both_ends" argument="-B" type="boolean" truevalue=" -B" falsevalue="" label="Only allow fragments with both reads aligned" help="If specified, only fragments that have both ends successfully aligned will be considered for summarization. This option is only applicable for paired-end reads."/>
+                <param name="exclude_chimerics" argument="-C" type="boolean" truevalue=" -C" falsevalue="" checked="true" label="Exclude chimeric fragments" help="If specified, the chimeric fragments (those fragments that have their two ends aligned to different chromosomes) will NOT be included for summarization. This option is only applicable for paired-end read data."/>
             </when>
         </conditional>
         <section name="read_filtering_parameters" title="Read filtering options">
-            <param name="mapping_quality" type="integer" value="0" min="0" argument="-Q" label="Minimum mapping quality per read" help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 0 by default."/>
-            <param name="splitonly" type="select" display="radio" label="Filter split alignments" help="Split alignments are alignments with CIGAR string containing 'N', e.g. exon spanning reads in RNASeq.">
+            <param name="mapping_quality" argument="-Q" type="integer" min="0" value="0" label="Minimum mapping quality per read" help="The minimum mapping quality score a read must satisfy in order to be counted. For paired-end reads, at least one end should satisfy this criteria. 0 by default."/>
+            <param name="splitonly" type="select" label="Filter split alignments" help="Split alignments are alignments with CIGAR string containing 'N', e.g. exon spanning reads in RNASeq." display="radio">
                 <option value="">No filtering: count split and non-split alignments</option>
                 <option value="--splitOnly">Count only split alignments (--splitOnly)</option>
                 <option value="--nonSplitOnly">Count only non-split alignments (--nonSplitOnly)</option>
             </param>
-            <param type="boolean" truevalue=" --primary" falsevalue="" argument="--primary" label="Only count primary alignments" help="If specified, only primary alignments will be counted. Primary and secondary alignments are identified using bit 0x100 in theFlag field of SAM/BAM files. All primary alignments in a dataset will be counted regardless of whether they are from multi-mapping reads or not ('-M' is ignored)."/>
-            <param name="ignore_dup" type="boolean" truevalue=" --ignoreDup" falsevalue="" argument="--ignoreDup" label="Ignore reads marked as duplicate" help="If specified, reads that were marked as duplicates will be ignored. Bit Ox400 in the FLAG field of a SAM/BAM file is used for identifying duplicate reads. In paired end data, the entire read pair will be ignored if at least one end is found to be a duplicate read."/>
+            <param argument="--primary" type="boolean" truevalue=" --primary" falsevalue="" label="Only count primary alignments" help="If specified, only primary alignments will be counted. Primary and secondary alignments are identified using bit 0x100 in theFlag field of SAM/BAM files. All primary alignments in a dataset will be counted regardless of whether they are from multi-mapping reads or not ('-M' is ignored)."/>
+            <param name="ignore_dup" argument="--ignoreDup" type="boolean" truevalue=" --ignoreDup" falsevalue="" label="Ignore reads marked as duplicate" help="If specified, reads that were marked as duplicates will be ignored. Bit Ox400 in the FLAG field of a SAM/BAM file is used for identifying duplicate reads. In paired end data, the entire read pair will be ignored if at least one end is found to be a duplicate read."/>
         </section>
         <section name="extended_parameters" title="Advanced options">
             <conditional name="multifeatures">
@@ -224,17 +222,17 @@
                 </param>
                 <when value=""/>
                 <when value="-M">
-                    <param type="boolean" truevalue="--fraction" falsevalue="" argument="--fraction" label="Assign fractions to multi-mapping reads" help="If specified, a fractional count 1/x will be generated for each multi-mapping read, where x is the number of alignments (indicated by 'NH' tag) reported for the read."/>
+                    <param argument="--fraction" type="boolean" truevalue="--fraction" falsevalue="" label="Assign fractions to multi-mapping reads" help="If specified, a fractional count 1/x will be generated for each multi-mapping read, where x is the number of alignments (indicated by 'NH' tag) reported for the read."/>
                 </when>
                 <when value="-O">
-                    <param type="boolean" truevalue="--fraction" falsevalue="" argument="--fraction" label="Assign fractions to multi-overlapping features" help="If specified, a fractional count 1/y will be generated for each multi-overlapping feature, where y is the number of features overlapping with the read."/>
+                    <param argument="--fraction" type="boolean" truevalue="--fraction" falsevalue="" label="Assign fractions to multi-overlapping features" help="If specified, a fractional count 1/y will be generated for each multi-overlapping feature, where y is the number of features overlapping with the read."/>
                 </when>
                 <when value="-O -M">
-                    <param type="boolean" truevalue="--fraction" falsevalue="" argument="--fraction" label="Assign fractions to both multi-mapping reads and multi-overlapping features" help="If specified, a fractional count 1/(x*y) will be generated, where x is the number of alignments (indicated by 'NH' tag) and y the number of overlapping features."/>
+                    <param argument="--fraction" type="boolean" truevalue="--fraction" falsevalue="" label="Assign fractions to both multi-mapping reads and multi-overlapping features" help="If specified, a fractional count 1/(x*y) will be generated, where x is the number of alignments (indicated by 'NH' tag) and y the number of overlapping features."/>
                 </when>
             </conditional>
             <conditional name="exon_exon_junction_read_counting_enabled">
-                <param name="count_exon_exon_junction_reads" type="select" argument="-J" label="Exon-exon junctions" help="Junctions are identified from those exon-spanning reads (containing ‘N’ in CIGAR string) in input data. The output result includes names of primary and secondary genes that overlap at least one of the two splice sites of a junction.">
+                <param name="count_exon_exon_junction_reads" argument="-J" type="select" label="Exon-exon junctions" help="Junctions are identified from those exon-spanning reads (containing ‘N’ in CIGAR string) in input data. The output result includes names of primary and secondary genes that overlap at least one of the two splice sites of a junction.">
                     <option value="-J">Count reads supporting each exon-exon junction.</option>
                     <option value="" selected="True">Do not count</option>
                 </param>
@@ -245,18 +243,18 @@
             </conditional>
             <param name="long_reads" argument="-L" type="boolean" truevalue="-L" falsevalue="" label="Long reads" help="If specified, long reads such as Nanopore and PacBio reads will be counted. Long read counting can only run in one thread and only reads (not read-pairs) can be counted."/>
             <param name="by_read_group" argument="--byReadGroup" type="boolean" truevalue="--byReadGroup" falsevalue="" label="Count reads by read group" help="If specified, reads are counted for each read group separately. The 'RG' tag must be present in the input BAM/SAM alignment files."/>
-            <param name="largest_overlap" type="boolean" truevalue=" --largestOverlap" falsevalue="" argument="--largestOverlap" label="Largest overlap" help="If specified, reads (or fragments) will be assigned to the target that has the largest number of overlapping bases"/>
-            <param name="min_overlap" type="integer" value="1" argument="--minOverlap" label="Minimum bases of overlap" help="Specify the minimum required number of overlapping bases between a read (or a fragment) and a feature. 1 by default. If a negative value is provided, the read will be extended from both ends."/>
-            <param name="frac_overlap" type="integer" value="0" min="0" max="1" argument="--fracOverlap" label="Minimum fraction (of read) overlapping a feature" help="Specify the minimum required fraction of overlapping bases between a read (or a fragment) and a feature. Value should be within range [0,1]. 0 by default. Number of overlapping bases is counted from both reads if paired end. Both this option and '--minOverlap' need to be satisfied for read assignment."/>
-            <param name="frac_overlap_feature" type="integer" value="0" min="0" max="1" argument="--fracOverlapFeature" label="Minimum fraction (of feature) overlapping a read" help="Specify the minimum required fraction of bases included in a feature overlapping bases between a read (or a read-pair). Value should be within range [0,1]. 0 by default."/>
-            <param name="read_extension_5p" type="integer" value="0" min="0" argument="--readExtension5" label="Read 5' extension" help="Reads are extended upstream by ... bases from their 5' end"/>
-            <param name="read_extension_3p" type="integer" value="0" min="0" argument="--readExtension3" label="Read 3' extension" help="Reads are extended upstream by ... bases from their 3' end"/>
-            <param name="read_reduction" type="select" label="Reduce read to single position" argument="--read2pos" help="The read is reduced to its 5' most base or 3'most base. Read summarization is then performed based on the single base the the read is reduced to.">
+            <param name="largest_overlap" argument="--largestOverlap" type="boolean" truevalue=" --largestOverlap" falsevalue="" label="Largest overlap" help="If specified, reads (or fragments) will be assigned to the target that has the largest number of overlapping bases"/>
+            <param name="min_overlap" argument="--minOverlap" type="integer" value="1" label="Minimum bases of overlap" help="Specify the minimum required number of overlapping bases between a read (or a fragment) and a feature. 1 by default. If a negative value is provided, the read will be extended from both ends."/>
+            <param name="frac_overlap" argument="--fracOverlap" type="integer" min="0" max="1" value="0" label="Minimum fraction (of read) overlapping a feature" help="Specify the minimum required fraction of overlapping bases between a read (or a fragment) and a feature. Value should be within range [0,1]. 0 by default. Number of overlapping bases is counted from both reads if paired end. Both this option and '--minOverlap' need to be satisfied for read assignment."/>
+            <param name="frac_overlap_feature" argument="--fracOverlapFeature" type="integer" min="0" max="1" value="0" label="Minimum fraction (of feature) overlapping a read" help="Specify the minimum required fraction of bases included in a feature overlapping bases between a read (or a read-pair). Value should be within range [0,1]. 0 by default."/>
+            <param name="read_extension_5p" argument="--readExtension5" type="integer" min="0" value="0" label="Read 5' extension" help="Reads are extended upstream by ... bases from their 5' end"/>
+            <param name="read_extension_3p" argument="--readExtension3" type="integer" min="0" value="0" label="Read 3' extension" help="Reads are extended upstream by ... bases from their 3' end"/>
+            <param name="read_reduction" argument="--read2pos" type="select" label="Reduce read to single position" help="The read is reduced to its 5' most base or 3'most base. Read summarization is then performed based on the single base the the read is reduced to.">
                 <option value="" selected="true">Leave the read as it is</option>
                 <option value="--read2pos 5">Reduce it to the 5' end</option>
                 <option value="--read2pos 3">Reduce it to the 3' end</option>
             </param>
-            <param type="boolean" truevalue="-R BAM" falsevalue="" argument="-R" label="Annotates the alignment file with 'XS:Z:'-tags to described per read or read-pair the corresponding assigned feature(s)." help=""/>
+            <param argument="-R" type="boolean" truevalue="-R BAM" falsevalue="" label="Annotates the alignment file with 'XS:Z:'-tags to described per read or read-pair the corresponding assigned feature(s)." help=""/>
         </section>
     </inputs>
     <outputs>
@@ -301,10 +299,10 @@
     </outputs>
     <tests>
         <test expect_num_outputs="3">
-            <param name="alignment" value="featureCounts_input1.bam" ftype="unsorted.bam" dbkey="hg38"/>
+            <param name="alignment" value="featureCounts_input1.bam" dbkey="hg38" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="history"/>
-                <param name="reference_gene_sets" value="featureCounts_guide.gff" ftype="gff" dbkey="hg38"/>
+                <param name="reference_gene_sets" value="featureCounts_guide.gff" dbkey="hg38" ftype="gff"/>
             </conditional>
             <param name="format" value="tabdel_medium"/>
             <param name="include_feature_length_file" value="true"/>
@@ -316,10 +314,10 @@
             </output>
         </test>
         <test expect_num_outputs="3">
-            <param name="alignment" value="featureCounts_input1.bam" ftype="unsorted.bam" dbkey="hg38"/>
+            <param name="alignment" value="featureCounts_input1.bam" dbkey="hg38" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="history"/>
-                <param name="reference_gene_sets" value="featureCounts_guide.gff" ftype="gff" dbkey="hg38"/>
+                <param name="reference_gene_sets" value="featureCounts_guide.gff" dbkey="hg38" ftype="gff"/>
             </conditional>
             <param name="format" value="tabdel_full"/>
             <param name="include_feature_length_file" value="true"/>
@@ -334,10 +332,10 @@
             </output>
         </test>
         <test expect_num_outputs="4">
-            <param name="alignment" value="featureCounts_input1.bam" ftype="unsorted.bam" dbkey="hg38"/>
+            <param name="alignment" value="featureCounts_input1.bam" dbkey="hg38" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="history"/>
-                <param name="reference_gene_sets" value="featureCounts_guide.gff" ftype="gff" dbkey="hg38"/>
+                <param name="reference_gene_sets" value="featureCounts_guide.gff" dbkey="hg38" ftype="gff"/>
             </conditional>
             <param name="format" value="tabdel_short"/>
             <param name="include_feature_length_file" value="true"/>
@@ -358,7 +356,7 @@
         </test>
         <!-- Ensure featureCounts built-in annotation works -->
         <test expect_num_outputs="3">
-            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" ftype="unsorted.bam" dbkey="hg19"/>
+            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" dbkey="hg19" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="builtin"/>
             </conditional>
@@ -377,7 +375,7 @@
         </test>
         <!-- Ensure fragment counting works -->
         <test expect_num_outputs="3">
-            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" ftype="unsorted.bam" dbkey="hg19"/>
+            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" dbkey="hg19" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="builtin"/>
             </conditional>
@@ -396,7 +394,7 @@
         </test>
         <!-- Ensure PE distance checking works (-P -d -D) -->
         <test expect_num_outputs="2">
-            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" ftype="unsorted.bam" dbkey="hg19"/>
+            <param name="alignment" value="pairend_strandspecific_51mer_hg19_chr1_1-100000.bam" dbkey="hg19" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="builtin"/>
             </conditional>
@@ -417,7 +415,7 @@
         </test>
         <!-- Ensure cached GTFs work -->
         <test expect_num_outputs="3">
-            <param name="alignment" value="featureCounts_input1.bam" ftype="unsorted.bam" dbkey="hg38"/>
+            <param name="alignment" value="featureCounts_input1.bam" dbkey="hg38" ftype="unsorted.bam"/>
             <conditional name="anno">
                 <param name="anno_select" value="cached"/>
             </conditional>


### PR DESCRIPTION
Applies the IUC `tool_xml` formatting conventions to featureCounts. Reworked after the earlier review: this revision is formatting-only and deliberately drops the things raised on the first pass.

What changed:
- normalize `<param>` attribute order to the [best-practices coding-style order](https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#coding-style) (`name`, `argument`, `type`, `min`/`max`, `value`, ...), and likewise `value`/`ftype`/`dbkey` order in the test params
- self-close empty elements

What this revision intentionally does NOT do, per the earlier feedback:
- **no profile change** (stays `25.0`)
- **no blank lines** between top-level sections
- **no XML declaration** added
- command-line quoting is limited to input and output files only (text params left alone)

The only non-formatting change is bumping `@VERSION_SUFFIX@` 1 → 2, which `planemo shed_lint` requires for a changed, already-published tool to republish. The command line is unchanged in behavior.