### PR TITLE
vg: fix help RST and apply IUC tool_xml formatting conventions

### DIFF
--- a/tools/vg/.lint_skip
+++ b/tools/vg/.lint_skip
@@ -1,2 +1,1 @@
 CitationsNoValid
-HelpInvalidRST

--- a/tools/vg/convert.xml
+++ b/tools/vg/convert.xml
@@ -1,5 +1,5 @@
-<tool id="vg_convert" name="vg convert" version="@TOOL_VERSION@">
-    <description></description>
+<tool id="vg_convert" name="vg convert" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <description/>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -14,7 +14,7 @@ $output_format
 > '$output'
     ]]></command>
     <inputs>
-        <param name="infile" type="data" format="vg,xg" label="Input file in vg or xg format" />
+        <param name="infile" type="data" format="vg,xg" label="Input file in vg or xg format"/>
         <param name="output_format" type="select" label="Choose your output format">
             <option value="--xg-out">XG format (--xg-out)</option>
             <!--option value="- -odgi-out">odgi format (- -odgi-out)</option-->
@@ -29,9 +29,9 @@ $output_format
     </outputs>
     <tests>
         <test>
-            <param name="infile" value="hla.vg" ftype="vg" />
-            <param name="output_format" value="--xg-out" />
-            <output name="output" file="hla.xg" ftype="xg" compare="sim_size" />
+            <param name="infile" value="hla.vg" ftype="vg"/>
+            <param name="output_format" value="--xg-out"/>
+            <output name="output" file="hla.xg" ftype="xg" compare="sim_size"/>
         </test>
         <!--test>
             <param name="infile" value="x.vg" ftype="vg" />
@@ -47,5 +47,5 @@ variation graph (vg) convert module
 This module is converting various variant graphs into each format.
 
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>

--- a/tools/vg/deconstruct.xml
+++ b/tools/vg/deconstruct.xml
@@ -1,4 +1,4 @@
-<tool id="vg_deconstruct" name="vg deconstruct" version="@TOOL_VERSION@+galaxy1">
+<tool id="vg_deconstruct" name="vg deconstruct" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>construct a dynamic succinct variation graph</description>
     <macros>
         <import>macros.xml</import>
@@ -28,55 +28,48 @@ $path_traversals  ## -e
 
     ]]></command>
     <inputs>
-        <param name="infile" type="data" format="xg,odgi" label="Graph files" />
-        <param argument="--path" type="text" value="" label="A reference path to deconstruct against"
-            help="comma-separated list accepted">
+        <param name="infile" type="data" format="xg,odgi" label="Graph files"/>
+        <param argument="--path" type="text" value="" label="A reference path to deconstruct against" help="comma-separated list accepted">
             <sanitizer>
                 <valid initial="string.printable">
-                    <remove value="&apos;"/>
+                    <remove value="'"/>
                 </valid>
             </sanitizer>
         </param>
-        <param argument="--path-prefix" type="text" value="" label="All paths beginning with this value used as reference"
-            help="comma-separated list accepted">
+        <param argument="--path-prefix" type="text" value="" label="All paths beginning with this value used as reference" help="comma-separated list accepted">
             <sanitizer>
                 <valid initial="string.printable">
-                    <remove value="&apos;"/>
+                    <remove value="'"/>
                 </valid>
             </sanitizer>
         </param>
-        <param argument="--alt-prefix" type="text" value="" label="Non-reference paths beginning with with this value get lumped together to same sample in VCF"
-            help="comma-separated list accepted">
+        <param argument="--alt-prefix" type="text" value="" label="Non-reference paths beginning with with this value get lumped together to same sample in VCF" help="comma-separated list accepted">
             <sanitizer>
                 <valid initial="string.printable">
-                    <remove value="&apos;"/>
+                    <remove value="'"/>
                 </valid>
             </sanitizer>
         </param>
-        <param argument="--snarls" type="data" format="xg,odgi" label="Snarls files" optional="true"
-            help="from `vg snarls` to avoid recomputing" />
-
-        <param argument="--path-traversals" type="boolean" truevalue="--path-traversals" falsevalue="" checked="false"
-            label="Only consider traversals that correspond to paths in the grpah" />
+        <param argument="--snarls" type="data" format="xg,odgi" optional="true" label="Snarls files" help="from `vg snarls` to avoid recomputing"/>
+        <param argument="--path-traversals" type="boolean" truevalue="--path-traversals" falsevalue="" checked="false" label="Only consider traversals that correspond to paths in the grpah"/>
     </inputs>
     <outputs>
-        <data name="output" format="vcf" />
+        <data name="output" format="vcf"/>
     </outputs>
     <tests>
         <test>
-            <param name="infile" value="hla.xg" />
-            <param name="path" value="gi|568815592:29791752-29792749" />
-            <param name="path_traversals" value="true" />
-            <output name="output" file="hla_variants.vcf" sort="true" />
+            <param name="infile" value="hla.xg"/>
+            <param name="path" value="gi|568815592:29791752-29792749"/>
+            <param name="path_traversals" value="true"/>
+            <output name="output" file="hla_variants.vcf" sort="true"/>
         </test>
     </tests>
     <help><![CDATA[
 variation graph (vg) deconstruct module
------------------------------------
+---------------------------------------
 
 Creates VCF records for Snarls present in a graph (relative to a chosen reference path).
 
     ]]></help>
-    <expand macro="citations">
-    </expand>
+    <expand macro="citations"/>
 </tool>

--- a/tools/vg/macros.xml
+++ b/tools/vg/macros.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <macros>
     <xml name="requirements">
         <requirements>
@@ -6,9 +5,10 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">1.23.0</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <xml name="citations">
         <citations>
-            <yield />
+            <yield/>
         </citations>
     </xml>
 </macros>

--- a/tools/vg/view.xml
+++ b/tools/vg/view.xml
@@ -1,5 +1,5 @@
-<tool id="vg_view" name="vg view" version="@TOOL_VERSION@">
-    <description></description>
+<tool id="vg_view" name="vg view" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    <description/>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -21,26 +21,24 @@ $output_format
                 <option value="--bam">BAM</option>
             </param>
             <when value="--vg-in">
-                <param name="infile" type="data" format="vg" label="Input file in variant graph format (vg)" />
+                <param name="infile" type="data" format="vg" label="Input file in variant graph format (vg)"/>
             </when>
             <when value="--gfa-in">
-                <param name="infile" type="data" format="gfa1" label="Input file in Graphical Fragment Assembly (gfa)" />
+                <param name="infile" type="data" format="gfa1" label="Input file in Graphical Fragment Assembly (gfa)"/>
             </when>
             <when value="--json-in">
-                <param name="infile" type="data" format="json" label="Input file in JSON" />
+                <param name="infile" type="data" format="json" label="Input file in JSON"/>
             </when>
             <when value="--bam">
-                <param name="infile" type="data" format="bam" label="Input file in BAM" />
+                <param name="infile" type="data" format="bam" label="Input file in BAM"/>
             </when>
         </conditional>
-
         <param name="output_format" type="select" label="Choose your output format">
             <option value="--vg">VG</option>
             <option value="--json">JSON</option>
             <option value="--gfa">GFA</option>
             <option value="--dot">dot</option>
         </param>
-
     </inputs>
     <outputs>
         <data name="output" format="vg">
@@ -54,27 +52,27 @@ $output_format
     <tests>
         <test>
             <conditional name="input_format">
-                <param name="input_format_selector" value="--gfa-in" />
-                <param name="infile" value="x.gfa" ftype="gfa1" />
+                <param name="input_format_selector" value="--gfa-in"/>
+                <param name="infile" value="x.gfa" ftype="gfa1"/>
             </conditional>
-            <param name="output_format" value="--vg" />
-            <output name="output" file="x.vg" ftype="vg" />
+            <param name="output_format" value="--vg"/>
+            <output name="output" file="x.vg" ftype="vg"/>
         </test>
         <test>
             <conditional name="input_format">
-                <param name="input_format_selector" value="--vg-in" />
-                <param name="infile" value="x.vg" ftype="vg" />
+                <param name="input_format_selector" value="--vg-in"/>
+                <param name="infile" value="x.vg" ftype="vg"/>
             </conditional>
-            <param name="output_format" value="--json" />
-            <output name="output" file="x.json" ftype="json" />
+            <param name="output_format" value="--json"/>
+            <output name="output" file="x.json" ftype="json"/>
         </test>
         <test>
             <conditional name="input_format">
-                <param name="input_format_selector" value="--json-in" />
-                <param name="infile" value="x.json" ftype="json" />
+                <param name="input_format_selector" value="--json-in"/>
+                <param name="infile" value="x.json" ftype="json"/>
             </conditional>
-            <param name="output_format" value="--vg" />
-            <output name="output" file="x.vg" ftype="vg" />
+            <param name="output_format" value="--vg"/>
+            <output name="output" file="x.vg" ftype="vg"/>
         </test>
     </tests>
     <help><![CDATA[
@@ -85,5 +83,5 @@ variation graph (vg) view module
 Inspect and convert variant graphs in different file formats.
 
     ]]></help>
-    <expand macro="citations" />
+    <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
Applies the IUC `tool_xml` formatting conventions to the vg suite, with the help/RST fix front and center. Reworked after the earlier review: the blank-line spacing that was questioned is gone.

- **`deconstruct.xml` help:** fixed the reStructuredText (the title underline was shorter than the title) and removed the now-resolved `HelpInvalidRST` from `.lint_skip`. `CitationsNoValid` is left as-is (not yet covered).
- **Formatting** across `convert.xml`, `deconstruct.xml`, `view.xml`, and `macros.xml`: attribute order, self-closing empty elements, single-line attributes, consistent indentation, and dropped the XML declaration from `macros.xml`. No blank-line spacing this time.
- **Version:** the three tools disagreed on the Galaxy suffix (`convert`/`view` had none, `deconstruct` had `+galaxy1`). Since the content changed, `planemo shed_lint` needs a version bump to republish; unified them via a shared `@VERSION_SUFFIX@` token (`+galaxy2`) in `macros.xml`.

No profile change. The command lines are unchanged in behavior.