### PR TITLE
Fix kaiju2table for multiple inputs & add full tax path option

### DIFF
--- a/tools/kaiju/kaiju2table.xml
+++ b/tools/kaiju/kaiju2table.xml
@@ -8,19 +8,18 @@
     <command detect_errors="exit_code"><![CDATA[
         #import re
 
+        #set $samples = []
         #for $kaiju_table in $kaiju_tables
-            ln -s '$kaiju_table' #echo re.sub('[^\w\-_]', '_', str($kaiju_table.element_identifier))
-            &&
+            #set $sample = re.sub('[^\w\-_]', '_', str($kaiju_table.element_identifier))
+            #silent $samples.append($sample)
+            ln -s '$kaiju_table' '$sample' &&
         #end for
 
-        kaiju2table 
+        kaiju2table
             -t '$reference.fields.path'/nodes.dmp
             -n '$reference.fields.path'/names.dmp
             -r $rank
             -o '$kaiju_summary'
-            #for $kaiju_table in $kaiju_tables
-                #echo re.sub('[^\w\-_]', '_', str($kaiju_table.element_identifier))
-            #end for
             #if str($optional.m)
                 -m $optional.m
             #end if
@@ -29,27 +28,36 @@
             #end if
             $optional.e
             $optional.u
-            #if $optional.l
+            #if str($optional.tax_path.report) == "full":
+                -p
+            #elif str($optional.tax_path.report) == "partial":
                 -l #echo ",".join($optional.l)
             #end if
+            #for $sample in $samples
+                $sample
+            #end for
     ]]></command>
     <inputs>
         <param name="kaiju_tables" type="data" format="tabular" multiple="true" optional="false" label="kaiju output tables"/>
         <expand macro="reference"/>
-        <param argument="-r" name="rank" type="select" label="rank">
-            <option value="phylum">phylum</option>
-            <option value="class">class</option>
-            <option value="order">order</option>
-            <option value="family">family</option>
-            <option value="genus">genus</option>
-            <option value="species">species</option>
-        </param>
+        <expand macro="r" optional="false" />
         <section name="optional" title="Optional arguments" expanded="false">
             <param argument="-m" type="float" min="0" max="100" optional="true" value="" label="Minimum reporting percentage" help="Can not be combined with -c" />
             <param argument="-c" type="integer" min="1" optional="true" value="" label="Minimum required number of reads" help="Can not be combined with -m" />
-            <param argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Expand viruses" help="which are always hown as full taxon path and read counts are not summarized in higher taxonomic levels" />
+            <param argument="-e" type="boolean" truevalue="-e" falsevalue="" checked="false" label="Expand viruses" help="which are always shown as full taxon path and read counts are not summarized in higher taxonomic levels" />
             <param argument="-u" type="boolean" truevalue="-u" falsevalue="" checked="false" label="Do not count unclassified reads" help="Disables counting unclassified reads towards the total number of reads when calculating percentages."/>
-            <expand macro="l"/>
+            <conditional name="tax_path">
+                <param name="report" type="select" label="Report taxonomic path instead of just the selected rank?">
+                    <option value="">No, just the rank please</option>
+                    <option value="full">Yes, report the full path</option>
+                    <option value="partial">Yes, but only select ranks along the path</option>
+                </param>
+                <when value="" />
+                <when value="full" />
+                <when value="partial">
+                    <expand macro="l" optional="false" />
+                </when>
+            </conditional>
         </section>
     </inputs>
     <outputs>
@@ -63,13 +71,24 @@
             <output name="kaiju_summary" value="kaiju2table.out"/>
         </test>
         <test>
+            <param name="kaiju_tables" value="kaiju.out,kaiju-taxnames.out"/>
+            <param name="reference" value="test"/>
+            <param name="rank" value="phylum"/>
+            <output name="kaiju_summary">
+                <assert_contents>
+                    <has_text text="kaiju_out" />
+                    <has_text text="kaiju-taxnames_out" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
             <param name="kaiju_tables" value="kaiju.out"/>
             <param name="reference" value="test"/>
             <param name="rank" value="order"/>
             <section name="optional">
                 <param name="e" value="true"/>
             </section>
-            <output name="kaiju_summary" value="kaiju2table.out" lines_diff="4">
+            <output name="kaiju_summary">
                 <assert_contents>
                     <has_text text="Severe acute respiratory syndrome coronavirus 2"/>
                     <has_text text="cannot be assigned to a (non-viral) order"/>

--- a/tools/kaiju/macros.xml
+++ b/tools/kaiju/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.10.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">23.2</token>
 
     <xml name="xrefs">
@@ -39,8 +39,8 @@
         </param>
     </xml>
 
-    <xml name="l">
-        <param argument="-l" type="select" multiple="true" optional="true" label="Print taxon path containing selected ranks ranks specified ">
+    <xml name="l" token_optional="true">
+        <param argument="-l" type="select" multiple="true" optional="@OPTIONAL@" label="Print taxon path containing just selected ranks">
             <option value="domain">Domain</option>
             <option value="realm">Realm</option>
             <option value="superkingdom">Superkingdom</option>


### PR DESCRIPTION
The previous version concatenated multiple sample names without separating spaces.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
