### PR TITLE
Tool update - clustering_from_distmat

### DIFF
--- a/tools/clustering_from_distmat/clustering_from_distmat.py
+++ b/tools/clustering_from_distmat/clustering_from_distmat.py
@@ -2,9 +2,38 @@ import argparse
 import sys
 from collections import Counter
 
-import scipy
+from scipy.spatial.distance import squareform
+from scipy.cluster import hierarchy
+from pandas import DataFrame
 
 
+"""
+Convert a hierarchical clustering linkage matrix to Newick tree format.
+
+This function transforms a scipy hierarchical clustering linkage matrix into a
+phylogenetic tree in Newick format, with branch lengths representing the
+distances from clustering steps.
+
+@param linkage A hierarchical clustering linkage matrix from scipy.cluster.hierarchy.linkage.
+               Each row contains [cluster_id_1, cluster_id_2, distance, n_samples].
+               The first len(tip_names) rows correspond to individual samples, and
+               subsequent rows correspond to merged clusters.
+@param tip_names A list of strings containing the names of leaf nodes (samples/tips).
+                 The order should correspond to the indices in the linkage matrix.
+
+@return A string in Newick format representing the hierarchical tree structure with
+        branch lengths and ending with a semicolon.
+        Format: (child1:distance1,child2:distance2)parent_name;
+
+Note: Branch lengths are computed as half the cluster distance to represent the
+      distance from each leaf to their most recent common ancestor.
+
+Example:
+    names = ['A', 'B', 'C']
+    linkage_data = [[0, 1, 0.5, 2], [2, 3, 1.0, 3]]
+    tree = linkage_as_newick(linkage_data, names)
+    print(tree)  # Output: ((A:0.25,B:0.25):0.5,C:0.5);
+"""
 def linkage_as_newick(linkage, tip_names):
     newick_parts = tip_names[::]
     within_cluster_distances = [0] * len(tip_names)
@@ -32,7 +61,10 @@ if __name__ == "__main__":
         'out_prefix',
         help="Output prefix"
     )
-    parser.add_argument
+    parser.add_argument(
+        '-nwk', '--newick', action='store_true',
+        help="Boolean indicating if the dendogram output should be converted to newick format"
+    )
     parser.add_argument(
         '-m', '--method', default="average",
         choices=[
@@ -150,13 +182,19 @@ if __name__ == "__main__":
     # this gives us further checks and raises ValueErrors if:
     # - the values on the diagonal aren't zero
     # - the upper and lower triangle of the matrix aren't identical
-    D = scipy.spatial.distance.squareform(matrix)
+    D = squareform(matrix)
 
     # perform the requested clustering and retrieve the result as a linkage object
-    linkage = scipy.cluster.hierarchy.linkage(D, args.method)
+    linkage = hierarchy.linkage(D, args.method)
 
-    with open(args.out_prefix + '.tree.newick', 'w') as o:
-        o.write(linkage_as_newick(linkage, col_names))
+    if args.newick:
+        with open(args.out_prefix + ".tree", 'w') as o:
+            o.write(linkage_as_newick(linkage, col_names))
+    else:
+        DataFrame(
+            linkage,
+            columns=["cluster1", "cluster2", "linkageValue", "newClusterSize"]
+        ).to_csv(args.out_prefix + ".tree", sep="\t", header=True,index=False)
 
     # cut the tree as specified and report sample to cluster assignments
     if args.n_clusters or args.height:
@@ -169,7 +207,7 @@ if __name__ == "__main__":
         header_cols = ["sample"] + [
             colname_template.format(x) for x in cut_values
         ]
-        cut_result = scipy.cluster.hierarchy.cut_tree(
+        cut_result = hierarchy.cut_tree(
             linkage,
             args.n_clusters,
             args.height

--- a/tools/clustering_from_distmat/clustering_from_distmat.py
+++ b/tools/clustering_from_distmat/clustering_from_distmat.py
@@ -2,39 +2,39 @@ import argparse
 import sys
 from collections import Counter
 
-from scipy.spatial.distance import squareform
-from scipy.cluster import hierarchy
 from pandas import DataFrame
+from scipy.cluster import hierarchy
+from scipy.spatial.distance import squareform
 
 
-"""
-Convert a hierarchical clustering linkage matrix to Newick tree format.
-
-This function transforms a scipy hierarchical clustering linkage matrix into a
-phylogenetic tree in Newick format, with branch lengths representing the
-distances from clustering steps.
-
-@param linkage A hierarchical clustering linkage matrix from scipy.cluster.hierarchy.linkage.
-               Each row contains [cluster_id_1, cluster_id_2, distance, n_samples].
-               The first len(tip_names) rows correspond to individual samples, and
-               subsequent rows correspond to merged clusters.
-@param tip_names A list of strings containing the names of leaf nodes (samples/tips).
-                 The order should correspond to the indices in the linkage matrix.
-
-@return A string in Newick format representing the hierarchical tree structure with
-        branch lengths and ending with a semicolon.
-        Format: (child1:distance1,child2:distance2)parent_name;
-
-Note: Branch lengths are computed as half the cluster distance to represent the
-      distance from each leaf to their most recent common ancestor.
-
-Example:
-    names = ['A', 'B', 'C']
-    linkage_data = [[0, 1, 0.5, 2], [2, 3, 1.0, 3]]
-    tree = linkage_as_newick(linkage_data, names)
-    print(tree)  # Output: ((A:0.25,B:0.25):0.5,C:0.5);
-"""
 def linkage_as_newick(linkage, tip_names):
+    """
+    Convert a hierarchical clustering linkage matrix to Newick tree format.
+
+    This function transforms a scipy hierarchical clustering linkage matrix into a
+    phylogenetic tree in Newick format, with branch lengths representing the
+    distances from clustering steps.
+
+    :param linkage: A hierarchical clustering linkage matrix from scipy.cluster.hierarchy.linkage.
+                   Each row contains [cluster_id_1, cluster_id_2, distance, n_samples].
+                   The first len(tip_names) rows correspond to individual samples, and
+                   subsequent rows correspond to merged clusters.
+    :param tip_names: A list of strings containing the names of leaf nodes (samples/tips).
+                     The order should correspond to the indices in the linkage matrix.
+
+    :return: A string in Newick format representing the hierarchical tree structure with
+            branch lengths and ending with a semicolon.
+            Format: (child1:distance1,child2:distance2)parent_name;
+
+    Note: Branch lengths are computed as half the cluster distance to represent the
+          distance from each leaf to their most recent common ancestor.
+
+    Example:
+        names = ['A', 'B', 'C']
+        linkage_data = [[0, 1, 0.5, 2], [2, 3, 1.0, 3]]
+        tree = linkage_as_newick(linkage_data, names)
+        print(tree)  # Output: ((A:0.25,B:0.25):0.5,C:0.5);
+    """
     newick_parts = tip_names[::]
     within_cluster_distances = [0] * len(tip_names)
     for step in linkage:
@@ -194,7 +194,7 @@ if __name__ == "__main__":
         DataFrame(
             linkage,
             columns=["cluster1", "cluster2", "linkageValue", "newClusterSize"]
-        ).to_csv(args.out_prefix + ".tree", sep="\t", header=True,index=False)
+        ).to_csv(args.out_prefix + ".tree", sep="\t", header=True, index=False)
 
     # cut the tree as specified and report sample to cluster assignments
     if args.n_clusters or args.height:

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -1,6 +1,9 @@
-<tool id="clustering_from_distmat" name="Distance matrix-based hierarchical clustering" version="1.1.2" profile="23.0">
+<tool id="clustering_from_distmat" name="Distance matrix-based hierarchical clustering" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>using Scipy</description>
     <macros>
+        <token name="@TOOL_VERSION@">1.1.2</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@PROFILE@">23.0</token>
         <xml name="cluster_assignment_options">
             <param name="min_cluster_size" type="integer" value="2" min="1" label="Mask clusters with less than this number of samples" help="Samples assigned to clusters smaller than this threshold will have '-' in the corresponding cluster ID column" />
             <param name="generate_dendrogram" type="boolean" label="Produce also the dendrogram of clustering results" />
@@ -53,7 +56,8 @@ python '$__tool_directory__/clustering_from_distmat.py'
             <option value="--nc">Each line specifies sample name in first column, first line is not special</option>
         </param>
         <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick ?"
-               help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."/>
+               help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."
+        />
         <conditional name="cluster_assignment">
             <param name="select" type="select" label="Generate cluster assignments?">
                 <option value="dendrogram-only">No, just generate the dendrogram of clustering results</option>
@@ -66,7 +70,9 @@ python '$__tool_directory__/clustering_from_distmat.py'
                 <expand macro="cluster_assignment_options" />
             </when>
             <when value="height">
-                <param name="height" type="float" value="5.0" label="Distance threshold for sample clustering" help="Samples that are LESS than this distance from each other will be assigned to the same cluster." />
+                <param name="height" type="float" value="5.0" label="Distance threshold for sample clustering"
+                       help="Samples that are LESS than this distance from each other will be assigned to the same cluster."
+                />
                 <expand macro="cluster_assignment_options" />
             </when>
         </conditional>

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -74,7 +74,7 @@ python '$__tool_directory__/clustering_from_distmat.py'
     <outputs>
         <data name="clustering_dendrogram" format="tabular" from_work_dir="result.tree" label="${tool.name} on ${on_string}: Dendrogram">
             <change_format>
-                <when input="format_as_newick" value="true" format="newick"/>
+                <when input="format_as_newick" value="--newick" format="newick"/>
             </change_format>
             <filter>cluster_assignment["select"] == "dendrogram-only" or cluster_assignment["generate_dendrogram"]</filter>
         </data>

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -55,7 +55,7 @@ python '$__tool_directory__/clustering_from_distmat.py'
             <option value="--nr">First line specifies sample names, subsequent lines only data</option>
             <option value="--nc">Each line specifies sample name in first column, first line is not special</option>
         </param>
-        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick ?" help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."/>
+        <param name="format_as_newick" type="boolean" checked="true" truevalue="--newick" falsevalue="" label="Format dendrogram output as Newick ?" help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."/>
         <conditional name="cluster_assignment">
             <param name="select" type="select" label="Generate cluster assignments?">
                 <option value="dendrogram-only">No, just generate the dendrogram of clustering results</option>

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -16,6 +16,7 @@
     <requirements>
         <requirement type="package" version="3.12">python</requirement>
         <requirement type="package" version="1.14.0">scipy</requirement>
+        <requirement type="package" version="2.3.3">pandas</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 python '$__tool_directory__/clustering_from_distmat.py'
@@ -23,6 +24,9 @@ python '$__tool_directory__/clustering_from_distmat.py'
   result
   --method $method
   $missing_names
+  #if $format_as_newick
+    --newick
+  #end if
   #if str($cluster_assignment.select) == 'n-cluster':
     --n-clusters $cluster_assignment.n_cluster
   #elif str($cluster_assignment.select) == 'height':
@@ -48,6 +52,7 @@ python '$__tool_directory__/clustering_from_distmat.py'
             <option value="--nr">First line specifies sample names, subsequent lines only data</option>
             <option value="--nc">Each line specifies sample name in first column, first line is not special</option>
         </param>
+        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick?" />
         <conditional name="cluster_assignment">
             <param name="select" type="select" label="Generate cluster assignments?">
                 <option value="dendrogram-only">No, just generate the dendrogram of clustering results</option>
@@ -66,7 +71,11 @@ python '$__tool_directory__/clustering_from_distmat.py'
         </conditional>
     </inputs>
     <outputs>
-        <data name="clustering_dendrogram" format="newick" from_work_dir="result.tree.newick" label="${tool.name} on ${on_string}: Dendrogram">
+        <data name="clustering_dendrogram" format="tabular" from_work_dir="result.tree"
+              label="${tool.name} on ${on_string}: Dendrogram">
+            <change_format>
+                <when input="format_as_newick" value="true" format="newick" />
+            </change_format>
             <filter>cluster_assignment["select"] == "dendrogram-only" or cluster_assignment["generate_dendrogram"]</filter>
         </data>
         <data name="clustering_assignment" format="tabular" from_work_dir="result.cluster_assignments.tsv" label="${tool.name} on ${on_string}: Cluster assignment">
@@ -78,6 +87,11 @@ python '$__tool_directory__/clustering_from_distmat.py'
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv"/>
             <output name="clustering_dendrogram" ftype="newick" file="test_tree_average.newick" />
+        </test>
+        <test expect_num_outputs="1">
+            <param name="distmat" value="test_matrix.tsv"/>
+            <param name="format_as_newick" value="false"/>
+            <output name="clustering_dendrogram" ftype="tabular" file="test_tree_average.tsv" />
         </test>
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv" />

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -27,9 +27,7 @@ python '$__tool_directory__/clustering_from_distmat.py'
   result
   --method $method
   $missing_names
-  #if $format_as_newick
-    --newick
-  #end if
+  $format_as_newick
   #if str($cluster_assignment.select) == 'n-cluster':
     --n-clusters $cluster_assignment.n_cluster
   #elif str($cluster_assignment.select) == 'height':

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -5,8 +5,8 @@
         <token name="@VERSION_SUFFIX@">0</token>
         <token name="@PROFILE@">23.0</token>
         <xml name="cluster_assignment_options">
-            <param name="min_cluster_size" type="integer" value="2" min="1" label="Mask clusters with less than this number of samples" help="Samples assigned to clusters smaller than this threshold will have '-' in the corresponding cluster ID column" />
-            <param name="generate_dendrogram" type="boolean" label="Produce also the dendrogram of clustering results" />
+            <param name="min_cluster_size" type="integer" value="2" min="1" label="Mask clusters with less than this number of samples" help="Samples assigned to clusters smaller than this threshold will have '-' in the corresponding cluster ID column"/>
+            <param name="generate_dendrogram" type="boolean" label="Produce also the dendrogram of clustering results"/>
         </xml>
     </macros>
     <edam_topics>
@@ -40,7 +40,7 @@ python '$__tool_directory__/clustering_from_distmat.py'
   #end if
     ]]></command>
     <inputs>
-        <param name="distmat" type="data" format="tabular" label="Distance matrix" />
+        <param name="distmat" type="data" format="tabular" label="Distance matrix"/>
         <param name="method" type="select" label="Clustering method">
             <option value="single">Nearest Point (scipy 'single' method)</option>
             <option value="complete">Farthest Point (scipy 'complete' method)</option>
@@ -55,33 +55,28 @@ python '$__tool_directory__/clustering_from_distmat.py'
             <option value="--nr">First line specifies sample names, subsequent lines only data</option>
             <option value="--nc">Each line specifies sample name in first column, first line is not special</option>
         </param>
-        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick ?"
-               help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."
-        />
+        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick ?" help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."/>
         <conditional name="cluster_assignment">
             <param name="select" type="select" label="Generate cluster assignments?">
                 <option value="dendrogram-only">No, just generate the dendrogram of clustering results</option>
                 <option value="n-cluster">Yes, and divide into specified number of clusters </option>
                 <option value="height">Yes, and use distance threshold to divide into clusters</option>
             </param>
-            <when value="dendrogram-only" />
+            <when value="dendrogram-only"/>
             <when value="n-cluster">
-                <param name="n_cluster" type="integer" value="5" min="1" label="How many clusters to divide into?" />
-                <expand macro="cluster_assignment_options" />
+                <param name="n_cluster" type="integer" value="5" min="1" label="How many clusters to divide into?"/>
+                <expand macro="cluster_assignment_options"/>
             </when>
             <when value="height">
-                <param name="height" type="float" value="5.0" label="Distance threshold for sample clustering"
-                       help="Samples that are LESS than this distance from each other will be assigned to the same cluster."
-                />
-                <expand macro="cluster_assignment_options" />
+                <param name="height" type="float" value="5.0" label="Distance threshold for sample clustering" help="Samples that are LESS than this distance from each other will be assigned to the same cluster."/>
+                <expand macro="cluster_assignment_options"/>
             </when>
         </conditional>
     </inputs>
     <outputs>
-        <data name="clustering_dendrogram" format="tabular" from_work_dir="result.tree"
-              label="${tool.name} on ${on_string}: Dendrogram">
+        <data name="clustering_dendrogram" format="tabular" from_work_dir="result.tree" label="${tool.name} on ${on_string}: Dendrogram">
             <change_format>
-                <when input="format_as_newick" value="true" format="newick" />
+                <when input="format_as_newick" value="true" format="newick"/>
             </change_format>
             <filter>cluster_assignment["select"] == "dendrogram-only" or cluster_assignment["generate_dendrogram"]</filter>
         </data>
@@ -93,66 +88,66 @@ python '$__tool_directory__/clustering_from_distmat.py'
         <!-- Test data and expected results taken from https://en.wikipedia.org/wiki/UPGMA#Working_example -->
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv"/>
-            <output name="clustering_dendrogram" ftype="newick" file="test_tree_average.newick" />
+            <output name="clustering_dendrogram" ftype="newick" file="test_tree_average.newick"/>
         </test>
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv"/>
             <param name="format_as_newick" value="false"/>
-            <output name="clustering_dendrogram" ftype="tabular" file="test_tree_average.tsv" />
-        </test>
-        <test expect_num_outputs="1">
-            <param name="distmat" value="test_matrix.tsv" />
-            <param name="method" value="complete" />
-            <output name="clustering_dendrogram" ftype="newick" file="test_tree_complete.newick" />
+            <output name="clustering_dendrogram" ftype="tabular" file="test_tree_average.tsv"/>
         </test>
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv"/>
-            <conditional name="cluster_assignment">
-                <param name="select" value="height" />
-                <param name="height" value="18" />
-                <param name="min_cluster_size" value="1" />
-            </conditional>
-            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_h18.tsv" />
+            <param name="method" value="complete"/>
+            <output name="clustering_dendrogram" ftype="newick" file="test_tree_complete.newick"/>
         </test>
         <test expect_num_outputs="1">
             <param name="distmat" value="test_matrix.tsv"/>
             <conditional name="cluster_assignment">
-                <param name="select" value="height" />
-                <param name="height" value="18" />
+                <param name="select" value="height"/>
+                <param name="height" value="18"/>
+                <param name="min_cluster_size" value="1"/>
             </conditional>
-            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_h18_s2.tsv" />
+            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_h18.tsv"/>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="distmat" value="test_matrix.tsv"/>
+            <conditional name="cluster_assignment">
+                <param name="select" value="height"/>
+                <param name="height" value="18"/>
+            </conditional>
+            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_h18_s2.tsv"/>
         </test>
         <test expect_num_outputs="2">
             <param name="distmat" value="test_matrix.tsv"/>
             <conditional name="cluster_assignment">
-                <param name="select" value="n-cluster" />
-                <param name="n_cluster" value="4" />
-                <param name="min_cluster_size" value="1" />
-                <param name="generate_dendrogram" value="true" />
+                <param name="select" value="n-cluster"/>
+                <param name="n_cluster" value="4"/>
+                <param name="min_cluster_size" value="1"/>
+                <param name="generate_dendrogram" value="true"/>
             </conditional>
-            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv" />
+            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv"/>
         </test>
         <test expect_num_outputs="2">
-            <param name="distmat" value="test_matrix_nr.tsv" />
-            <param name="missing_names" value="--nr" />
+            <param name="distmat" value="test_matrix_nr.tsv"/>
+            <param name="missing_names" value="--nr"/>
             <conditional name="cluster_assignment">
-                <param name="select" value="n-cluster" />
-                <param name="n_cluster" value="4" />
-                <param name="min_cluster_size" value="1" />
-                <param name="generate_dendrogram" value="true" />
+                <param name="select" value="n-cluster"/>
+                <param name="n_cluster" value="4"/>
+                <param name="min_cluster_size" value="1"/>
+                <param name="generate_dendrogram" value="true"/>
             </conditional>
-            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv" />
+            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv"/>
         </test>
         <test expect_num_outputs="2">
-            <param name="distmat" value="test_matrix_nc.tsv" />
-            <param name="missing_names" value="--nc" />
+            <param name="distmat" value="test_matrix_nc.tsv"/>
+            <param name="missing_names" value="--nc"/>
             <conditional name="cluster_assignment">
-                <param name="select" value="n-cluster" />
-                <param name="n_cluster" value="4" />
-                <param name="min_cluster_size" value="1" />
-                <param name="generate_dendrogram" value="true" />
+                <param name="select" value="n-cluster"/>
+                <param name="n_cluster" value="4"/>
+                <param name="min_cluster_size" value="1"/>
+                <param name="generate_dendrogram" value="true"/>
             </conditional>
-            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv" />
+            <output name="clustering_assignment" ftype="tabular" file="test_assignment_average_n4.tsv"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -1,4 +1,4 @@
-<tool id="clustering_from_distmat" name="Distance matrix-based hierarchical clustering" version="1.1.1" profile="23.0">
+<tool id="clustering_from_distmat" name="Distance matrix-based hierarchical clustering" version="1.1.2" profile="23.0">
     <description>using Scipy</description>
     <macros>
         <xml name="cluster_assignment_options">

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -52,7 +52,8 @@ python '$__tool_directory__/clustering_from_distmat.py'
             <option value="--nr">First line specifies sample names, subsequent lines only data</option>
             <option value="--nc">Each line specifies sample name in first column, first line is not special</option>
         </param>
-        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick?" />
+        <param name="format_as_newick" type="boolean" checked="true" label="Format dendrogram output as Newick ?"
+               help="If checked, the dendrogram will be formatted as a Newick tree string, if not the standard output from Scipy will be stored in a tabular file."/>
         <conditional name="cluster_assignment">
             <param name="select" type="select" label="Generate cluster assignments?">
                 <option value="dendrogram-only">No, just generate the dendrogram of clustering results</option>
@@ -154,11 +155,11 @@ python '$__tool_directory__/clustering_from_distmat.py'
 
 **What it does**
 
-This tool lets you perform hierarchical clustering of samples using the `scipy.cluster.hierarchy.linkage`_ function and any of the clustering methods supported by it.
+This tool lets you perform hierarchical clustering of samples using the `scipy.cluster.hierarchy.linkage`_ function and any of the linkage methods supported by it.
 
 As input it expects a symmetrical distance matrix with sample names on the first row and/or in the first column.
 
-The clustering result can be reported in the form of a dendrogram in newick format.
+The clustering result can be reported in the form of a dendrogram in newick format or in a tabular format (standard scipy output).
 
 Additionally, the tool can report the assignment of the samples to clusters "cut" from the clustering tree using the `scipy.cluster.hierarchy.cut_tree`_ function.
 Reflecting the parameters of that function, you can specify *how* to cut the tree by specifying either the number of clusters to cut into or a distance threshold, i.e., the height at which to cut the tree as SciPy calls it.

--- a/tools/clustering_from_distmat/clustering_from_distmat.xml
+++ b/tools/clustering_from_distmat/clustering_from_distmat.xml
@@ -3,7 +3,7 @@
     <macros>
         <token name="@TOOL_VERSION@">1.1.2</token>
         <token name="@VERSION_SUFFIX@">0</token>
-        <token name="@PROFILE@">23.0</token>
+        <token name="@PROFILE@">25.0</token>
         <xml name="cluster_assignment_options">
             <param name="min_cluster_size" type="integer" value="2" min="1" label="Mask clusters with less than this number of samples" help="Samples assigned to clusters smaller than this threshold will have '-' in the corresponding cluster ID column"/>
             <param name="generate_dendrogram" type="boolean" label="Produce also the dendrogram of clustering results"/>

--- a/tools/clustering_from_distmat/test-data/test_tree_average.tsv
+++ b/tools/clustering_from_distmat/test-data/test_tree_average.tsv
@@ -1,0 +1,5 @@
+cluster1	cluster2	linkageValue	newClusterSize
+0.0	1.0	17.0	2.0
+4.0	5.0	22.0	3.0
+2.0	3.0	28.0	2.0
+6.0	7.0	33.0	5.0


### PR DESCRIPTION
The goal of this PR is to enable the clustering_from_distmat tool to output the dendrogram result from the scipy.cluster.hierarchy.linkage function in tabular format, until now it only returns the output in newick format which is not the most used or accepted format in other Scipy or plotting packages of drendrograms.

The resulting behaviour from this update will make the tool keep outputing the drendrogam result as newick format by default but will enable the user to use the standard output from scipy in a tabular format.

An additional test is being provided

Documentation of a function in the python script has been added

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
