### PR TITLE
Adjust parameter constraints  for LexicMap search

### DIFF
--- a/tools/lexicmap/lexicmap.xml
+++ b/tools/lexicmap/lexicmap.xml
@@ -1,4 +1,4 @@
-<tool id="lexicmap_search" name="LexicMap Search" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE_VERSION@">
+<tool id="lexicmap_search" name="LexicMap Search" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE_VERSION@">
     <description>nucleotide sequence tool for querying genomes</description>
     <macros>
         <import>macros.xml</import>
@@ -98,7 +98,7 @@
             <param argument="-align-ext-len" min="0" value="1000" type="integer" label="Align extend length" help="Extend length of upstream and downstream of seed regions, for extracting query and target sequences for alignment. It should be &lt;= contig interval length in database." />
             <param argument="-align-max-gap" value="20" type="integer" label="Align max gap" help="Maximum gap in a HSP segment." />
             <param argument="--align-min-match-len" value="50" type="integer" label="Align min match length" help="Minimum aligned length in a HSP segment." />
-            <param argument="--align-min-match-pident" value="70" type="float" label="Align min match pident" help="Minimum base identity (percentage) in a HSP segment." />
+            <param argument="--align-min-match-pident" min="60" value="70" max="100" type="float" label="Align min match pident" help="Minimum base identity (percentage) in a HSP segment. Should be between 60 and 100." />
             <param argument="--all" type="boolean" truevalue="--all" falsevalue="" checked="false" label="All all columns" help="Output more columns, e.g., matched sequences. Use this if you want to output blast-style format with 'lexicmap utils 2blast'." />
             <param argument="--load-whole-seeds" type="boolean" truevalue="--load-whole-seeds" falsevalue="" checked="false" label="Load whole seeds" help="Load the whole seed data into memory for faster search" />
             <param argument="--max-evalue" value="10" type="float" label="Max evalue" help="Maximum evalue of a HSP segment." />


### PR DESCRIPTION
Fixes: https://github.com/galaxyproject/tools-iuc/issues/8058

https://github.com/shenwei356/LexicMap/blob/c6aabfe680023bfa1397cf87af4a1859136cb8b2/lexicmap/cmd/search.go#L218

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
