### PR TITLE
samestr DB builder: reconstruct MetaPhlAn markers from the bowtie2 index

### DIFF
--- a/data_managers/data_manager_samestr_db/data_manager/macros.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/macros.xml
@@ -1,12 +1,15 @@
 <macros>
     <token name="@TOOL_VERSION@">1.2025.111</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">25.0</token>
 
 
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">samestr</requirement>
+            <!-- Reconstruct MetaPhlAn marker FASTA from the bowtie2 index, which
+                 the MetaPhlAn installer keeps in place of the deleted *.fna. -->
+            <requirement type="package" version="2.5.4">bowtie2</requirement>
         </requirements>
     </xml>
         

--- a/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
@@ -21,8 +21,16 @@
             #set $destination_pkl = $samestr_db_dir + $db_value + '.pkl'
             cp '$source_pkl' '$destination_pkl' &&
 
+            ## MetaPhlAn's installer builds the bowtie2 index and then deletes the
+            ## marker FASTA, so a real MetaPhlAn database directory has no *.fna.
+            ## Use the raw markers when present (e.g. test fixtures); otherwise
+            ## reconstruct them from the bowtie2 index with bowtie2-inspect.
             #set $concatenated_fasta = $samestr_db_dir + '/' + 'mpa_markers.fna'
-            cat '${db_path}/${db_key}'*.fna > '$concatenated_fasta' &&
+            if ls '${db_path}/${db_key}'*.fna > /dev/null 2>&1; then
+                cat '${db_path}/${db_key}'*.fna > '$concatenated_fasta';
+            else
+                bowtie2-inspect '${db_path}/${db_key}' > '$concatenated_fasta';
+            fi &&
 
             #set $db_version_file = $samestr_db_dir + '/' + $version_file_name
             echo '$db_key' > '$db_version_file' &&


### PR DESCRIPTION
The MetaPhlAn installer (metaphlan --install, used both by byhand builds and the metaphlan data manager) builds the bowtie2 index and then deletes the marker FASTA, so a real MetaPhlAn database directory contains no *.fna. The data manager's `cat <db>/<dbkey>*.fna` therefore fails on every real database - it only ever worked against the hand-made .fna test fixture.

Reconstruct the markers with `bowtie2-inspect` when no *.fna is present, keeping the raw-FASTA path for fixtures; add the bowtie2 requirement. Bumps the tool version to 1.2025.111+galaxy2.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
