### PR TITLE
Add auto_tool_repositories to .shed.yml

### DIFF
--- a/tools/wgcna/.shed.yml
+++ b/tools/wgcna/.shed.yml
@@ -13,9 +13,11 @@ categories:
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/main/tools/wgcna
 homepage_url: https://github.com/cran/WGCNA
 type: unrestricted
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "{{ tool_name }}"
 suite:
   name: "suite_wgcna"
   description: "WGCNA – Weighted Gene Co-expression Network Analysis"
   long_description: |
-    WGCNA is a R package for weighted gene co-expression network analysis. It is used to identify modules of highly correlated
-    genes and to relate these modules to traits of interest.
+    WGCNA is a R package for weighted gene co-expression network analysis. It is used to identify modules of highly correlated genes and to relate these modules to traits of interest.


### PR DESCRIPTION
Added auto_tool_repositories section for tool repository management.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] Use of AI
  - [ ] The contribution is mostly AI generated
  - [X] The contribution has been assisted by AI
* [X] License permits unrestricted use (educational + commercial)
* [X] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
