### PR TITLE
Update spatialdata with correct dependencies

### DIFF
--- a/tools/spatialdata/macros.xml
+++ b/tools/spatialdata/macros.xml
@@ -293,9 +293,9 @@
             </param>
             <when value="no"/>
             <when value="yes">
-                <param name="vmin" type="float" optional="true" label="Min value" help="Values within the range [vmin, vmax] from the input data will be linearly mapped to [0, 1]. If either vmin or vmax is not provided, they default to the minimum and maximum values of the input, respectively."/>
-                <param name="vmax" type="float" optional="true" label="Max value" help="Values within the range [vmin, vmax] from the input data will be linearly mapped to [0, 1]. If either vmin or vmax is not provided, they default to the minimum and maximum values of the input, respectively."/>
-                <param name="clip" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Clip" help="If clipping is on, values below vmin are mapped to 0 and values above vmax are mapped to 1"/>
+                <param argument="vmin" type="float" optional="true" label="Min value" help="Values within the range [vmin, vmax] from the input data will be linearly mapped to [0, 1]. If either vmin or vmax is not provided, they default to the minimum and maximum values of the input, respectively."/>
+                <param argument="vmax" type="float" optional="true" label="Max value" help="Values within the range [vmin, vmax] from the input data will be linearly mapped to [0, 1]. If either vmin or vmax is not provided, they default to the minimum and maximum values of the input, respectively."/>
+                <param argument="clip" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Clip" help="If clipping is on, values below vmin are mapped to 0 and values above vmax are mapped to 1"/>
             </when>
         </conditional>
     </xml>
@@ -320,8 +320,8 @@
         <param name="input_spatialdata" type="data" format="spatialdata.zip" label="SpatialData object"/>
     </xml>
     <!-- Common parameter macros -->
-    <xml name="param_element_name" token_label="Element name" token_help="" token_optional="false">
-        <param name="element_name" type="text" label="@LABEL@" help="@HELP@" optional="@OPTIONAL@">
+    <xml name="param_element_name" token_label="Element name" token_help="" token_optional="false" token_argument="">
+        <param argument="@ARGUMENT@" name="elment_name" type="text" label="@LABEL@" help="@HELP@" optional="@OPTIONAL@">
             <expand macro="sanitize_query"/>
             <yield/>
         </param>
@@ -332,55 +332,55 @@
         </param>
     </xml>
     <xml name="param_table_name" token_value="table" token_optional="false" token_label="Table name" token_help="">
-        <param name="table_name" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+        <param argument="table_name" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_coordinate_system" token_value="global" token_label="Coordinate system" token_help="">
-        <param name="coordinate_system" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
+        <param argument="coordinate_system" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_target_coordinate_system" token_value="global" token_label="Target coordinate system" token_help="">
-        <param name="target_coordinate_system" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
+        <param argument="target_coordinate_system" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_axes" token_value="x,y" token_label="Axes" token_help="Comma-separated list of axes (e.g., 'x,y' or 'x,y,z')">
-        <param name="axes" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
+        <param argument="axes" type="text" value="@VALUE@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
-    <xml name="param_region_key" token_value="region" token_optional="false" token_label="Region key" token_help="">
-        <param name="region_key" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+    <xml name="param_region_key" token_value="region" token_optional="false" token_label="Region key" token_help="" token_argument="">
+        <param argument="@ARGUMENT@" name="region_key" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_instance_key" token_value="instance_id" token_optional="false" token_label="Instance key" token_help="">
-        <param name="instance_key" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+        <param argument="instance_key" type="text" value="@VALUE@" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_value_key" token_optional="false" token_label="Value key" token_help="">
-        <param name="value_key" type="text" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+        <param argument="value_key" type="text" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="coordinate_bounds_params">
-        <param name="min_coordinate" type="text" label="Minimum coordinates" help="Comma-separated (e.g., '0,0')">
+        <param argument="min_coordinate" type="text" label="Minimum coordinates" help="Comma-separated (e.g., '0,0')">
             <expand macro="sanitize_digits"/>
         </param>
-        <param name="max_coordinate" type="text" label="Maximum coordinates" help="Comma-separated (e.g., '100,100')">
+        <param argument="max_coordinate" type="text" label="Maximum coordinates" help="Comma-separated (e.g., '100,100')">
             <expand macro="sanitize_digits"/>
         </param>
     </xml>
-    <xml name="param_filter_label_pixels_bool">
-        <param name="filter_label_pixels_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Filter label pixels?" help="If Yes, pixels whose instance id is not present in the table are set to zero. If False, label elements are returned unfiltered."/>
+    <xml name="param_filter_label_pixels">
+        <param argument="filter_label_pixels" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Filter label pixels?" help="If Yes, pixels whose instance id is not present in the table are set to zero. If False, label elements are returned unfiltered."/>
     </xml>
     <!-- Common config -->
       <token name="@TOOL_VERSION@">0.8.0</token>
     <token name="@PIXEL_FILTER_WARNING@">
-#if str($operation_condi.filter_label_pixels_bool) == "False":
+#if str($operation_condi.filter_label_pixels) == "False":
 ##add a warning message to the user that the label pixels are not filtered
 print("Warning: The label pixels are not filtered. If you want to filter the label pixels, please set the 'Filter label pixels?' option to 'Yes'.")
 #end if
@@ -393,7 +393,7 @@ print("Warning: The label pixels are not filtered. If you want to filter the lab
         <option value="right_exclusive">Right Exclusive</option>
     </xml>
     <xml name="param_join_type" token_selected="left">
-        <param name="how" type="select" label="Join type">
+        <param argument="how" type="select" label="Join type">
             <option value="@SELECTED@" selected="true">@SELECTED@</option>
             <expand macro="join_type_options"/>
         </param>
@@ -404,35 +404,35 @@ print("Warning: The label pixels are not filtered. If you want to filter the lab
         <option value="count">Count</option>
     </xml>
     <xml name="param_agg_func" token_optional="false" token_selected="sum" token_help="">
-        <param name="agg_func" type="select" optional="@OPTIONAL@" label="Aggregation function">
+        <param argument="agg_func" type="select" optional="@OPTIONAL@" label="Aggregation function">
             <option value="@SELECTED@" selected="true">@SELECTED@</option>
             <expand macro="agg_func_options"/>
         </param>
     </xml>
     <xml name="param_table_layer" token_optional="true" token_label="Layer of the AnnData table to use for coloring if color is in table.var" token_help="If None, sdata.table.X of the default table is used for coloring.">
-        <param name="table_layer" type="text" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+        <param argument="table_layer" type="text" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_color" token_label="Color column" token_help="Column name from table.obs or table.var to use for coloring. Use comma to separate multiple keys. It can also be a color name.">
-        <param name="color" type="text" optional="true" label="@LABEL@" help="@HELP@">
+        <param argument="color" type="text" optional="true" label="@LABEL@" help="@HELP@">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_rendering_method" token_optional="true" token_label="Rendering method" token_help="When None, the method is chosen based on the size of the data.">
-        <param name="method" type="select" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
+        <param argument="method" type="select" optional="@OPTIONAL@" label="@LABEL@" help="@HELP@">
             <yield/>
             <option value="matplotlib">Matplotlib</option>
             <option value="datashader">Datashader</option>
         </param>
     </xml>
     <xml name="param_na_color" token_default="default">
-        <param name="na_color" type="text" value="@DEFAULT@" label="NA color" help="Color for NA values and non-matching labels/points. Accepts named color like 'red', hex string like '#000000ff', or and RGB/RGBA list">
+        <param argument="na_color" type="text" value="@DEFAULT@" label="NA color" help="Color for NA values and non-matching labels/points. Accepts named color like 'red', hex string like '#000000ff', or and RGB/RGBA list">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
     <xml name="param_colorbar" token_default="auto">
-        <param name="colorbar" type="select" label="Colorbar mode" help="Whether to request a colorbar for continuous colors.">
+        <param argument="colorbar" type="select" label="Colorbar mode" help="Whether to request a colorbar for continuous colors.">
             <option value="auto" selected="true">Auto</option>
             <option value="True">Show colorbar (True)</option>
             <option value="False">Hide colorbar (False)</option>
@@ -441,7 +441,7 @@ print("Warning: The label pixels are not filtered. If you want to filter the lab
         <!-- <param name="colorbar_params" type="data" format="json" optional="true" label="Colorbar parameters" help="JSON dictionary of parameters forwarded to Matplotlib's colorbar (e.g. {&quot;loc&quot;: &quot;right&quot;, &quot;width&quot;: 0.15})"/> -->
     </xml>
     <xml name="param_gene_symbols">
-        <param name="gene_symbols" type="text" optional="true" label="Key in sdata.table.var that stores the gene symbols column">
+        <param argument="gene_symbols" type="text" optional="true" label="Key in sdata.table.var that stores the gene symbols column">
             <expand macro="sanitize_query"/>
         </param>
     </xml>
@@ -452,7 +452,7 @@ print("Warning: The label pixels are not filtered. If you want to filter the lab
         </param>
     </xml> -->
     <xml name="param_datashader_reduction">
-        <param name="datashader_reduction" type="select" label="Downsample reduction method used by the datashader path">
+        <param argument="datashader_reduction" type="select" label="Downsample reduction method used by the datashader path">
             <option value="None" selected="true">Default</option>
             <option value="max">max</option>
             <option value="min">min</option>

--- a/tools/spatialdata/macros.xml
+++ b/tools/spatialdata/macros.xml
@@ -374,6 +374,17 @@
             <expand macro="sanitize_digits"/>
         </param>
     </xml>
+    <xml name="param_filter_label_pixels_bool">
+        <param name="filter_label_pixels_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Filter label pixels?" help="If Yes, pixels whose instance id is not present in the table are set to zero. If False, label elements are returned unfiltered."/>
+    </xml>
+    <!-- Common config -->
+      <token name="@TOOL_VERSION@">0.8.0</token>
+    <token name="@PIXEL_FILTER_WARNING@">
+#if str($operation_condi.filter_label_pixels_bool) == "False":
+##add a warning message to the user that the label pixels are not filtered
+print("Warning: The label pixels are not filtered. If you want to filter the label pixels, please set the 'Filter label pixels?' option to 'Yes'.")
+#end if
+    </token>
     <!-- Option group macros -->
     <xml name="join_type_options">
         <option value="left_exclusive">Left Exclusive</option>

--- a/tools/spatialdata/macros.xml
+++ b/tools/spatialdata/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7.3</token>
+    <token name="@TOOL_VERSION@">0.8.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
@@ -8,10 +8,10 @@
             <requirement type="package" version="0.7.0">spatialdata-io</requirement>
             <requirement type="package" version="0.4.0">spatialdata-plot</requirement>
             <!-- spatialdata is not compatible with ome-zarr > 0.13.0 check here: https://github.com/conda-forge/spatialdata-feedstock/pull/33-->
-            <!-- <requirement type="package" version="0.13.0">ome-zarr</requirement> -->
+            <requirement type="package" version="0.18.0">ome-zarr</requirement>
             <!-- The zarr writer in Previous anndata doesn't support serializing ArrowStringArray. pining anndata and pandas -->
-            <!-- <requirement type="package" version="0.12.10">anndata</requirement>
-            <requirement type="package" version="2.3.3">pandas</requirement> -->
+            <requirement type="package" version="0.12.10">anndata</requirement>
+            <requirement type="package" version="2.3.3">pandas</requirement>
             <requirement type="package" version="0.22.0">rioxarray</requirement>
             <requirement type="package" version="3.0">zip</requirement>
             <requirement type="package" version="6.0">unzip</requirement>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -78,7 +78,7 @@
         ## MERSCOPE
         #else if $method_condi.method == 'merscope':
             mkdir -p 'input/region/images' 'input/region/vpt_outputs' 'output' &&
-            #for $image in $method_condi.mosaic_images:
+            #for $image in $method_condi.mosaic_images_files:
                 #if $image.element_identifier.endswith('.tif'):
                     ln -s '$image' 'input/region/images/${image.element_identifier}' &&
                 #else:
@@ -97,7 +97,7 @@
                     ln -s '$vpt' 'input/region/detected_transcripts.csv' &&
                 #end if
             #end for
-            #for $parquet in $method_condi.cells_boundaries:
+            #for $parquet in $method_condi.cells_boundaries_file:
                 #if 'micron_space' in str($parquet.element_identifier):
                     ## the tool checks the file name, so the name is hardcoded here, but it does not necessarily have to be from cellpose
                     ln -s '$parquet' 'input/region/vpt_outputs/cellpose_micron_space.parquet' &&
@@ -107,16 +107,16 @@
         ## Visium
         #else if $method_condi.method == 'visium':
             mkdir -p 'input/spatial' 'output' &&
-            #if $method_condi.matrix_bool:
+            #if $method_condi.matrix:
                 ln -s '$method_condi.feature_bc_matrix' 'input/raw_feature_bc_matrix.h5' &&
             #else:
                 ln -s '$method_condi.feature_bc_matrix' 'input/filtered_feature_bc_matrix.h5' &&
             #end if
-            ln -s '$method_condi.scalefactors_json' 'input/scalefactors_json.json' &&
+            ln -s '$method_condi.scalefactors_file' 'input/scalefactors_file.json' &&
             ln -s '$method_condi.fullres_image_file' 'input/fullres_image.tif' &&
             ln -s '$method_condi.tissue_hires_image' 'input/spatial/tissue_hires_image.png' &&
             ln -s '$method_condi.tissue_lowres_image' 'input/spatial/tissue_lowres_image.png' &&
-            ln -s '$method_condi.tissue_positions_list' 'input/tissue_positions_list.csv' &&
+            ln -s '$method_condi.tissue_positions_file' 'input/tissue_positions_file.csv' &&
 
         ## Visium HD
         #else if $method_condi.method == 'visium_hd':
@@ -129,7 +129,7 @@
                 ## Bin 002um (required for nucleus segmentation if enabled)
                 #if $method_condi.include_binned_condi.bin002.feature_bc_matrix_002:
                     mkdir -p 'input/binned_outputs/square_002um/spatial' &&
-                    #if $method_condi.matrix_bool:
+                    #if $method_condi.matrix:
                         ln -s '$method_condi.include_binned_condi.bin002.feature_bc_matrix_002' 'input/binned_outputs/square_002um/raw_feature_bc_matrix.h5' &&
                     #else:
                         ln -s '$method_condi.include_binned_condi.bin002.feature_bc_matrix_002' 'input/binned_outputs/square_002um/filtered_feature_bc_matrix.h5' &&
@@ -141,7 +141,7 @@
                 ## Bin 008um
                 #if $method_condi.include_binned_condi.bin008.feature_bc_matrix_008:
                     mkdir -p 'input/binned_outputs/square_008um/spatial' &&
-                    #if $method_condi.matrix_bool:
+                    #if $method_condi.matrix:
                         ln -s '$method_condi.include_binned_condi.bin008.feature_bc_matrix_008' 'input/binned_outputs/square_008um/raw_feature_bc_matrix.h5' &&
                     #else:
                         ln -s '$method_condi.include_binned_condi.bin008.feature_bc_matrix_008' 'input/binned_outputs/square_008um/filtered_feature_bc_matrix.h5' &&
@@ -153,7 +153,7 @@
                 ## Bin 016um
                 #if $method_condi.include_binned_condi.bin016.feature_bc_matrix_016:
                     mkdir -p 'input/binned_outputs/square_016um/spatial' &&
-                    #if $method_condi.matrix_bool:
+                    #if $method_condi.matrix:
                         ln -s '$method_condi.include_binned_condi.bin016.feature_bc_matrix_016' 'input/binned_outputs/square_016um/raw_feature_bc_matrix.h5' &&
                     #else:
                         ln -s '$method_condi.include_binned_condi.bin016.feature_bc_matrix_016' 'input/binned_outputs/square_016um/filtered_feature_bc_matrix.h5' &&
@@ -173,7 +173,7 @@
             ## Segmented outputs (cell segmentation)
             #if str($method_condi.segmentation_conditional.enable_segmentation) == 'yes':
                 mkdir -p 'input/segmented_outputs/spatial' &&
-                #if $method_condi.matrix_bool:
+                #if $method_condi.matrix:
                     ln -s '$method_condi.segmentation_conditional.feature_bc_matrix_seg' 'input/segmented_outputs/raw_feature_cell_matrix.h5' &&
                 #else:
                     ln -s '$method_condi.segmentation_conditional.feature_bc_matrix_seg' 'input/segmented_outputs/filtered_feature_cell_matrix.h5' &&
@@ -207,14 +207,14 @@
         #else if $method_condi.method == 'xenium':
             mkdir -p 'input/region/morphology_focus/' 'output' &&
             ## ln -s does not work here.
-            #if $method_condi.cell_boundaries:
-                cp '$method_condi.cell_boundaries' 'input/region/cell_boundaries.parquet' &&
+            #if $method_condi.cells_boundaries:
+                cp '$method_condi.cells_boundaries' 'input/region/cell_boundaries.parquet' &&
             #end if
             cp '$method_condi.cell_feature_matrix' 'input/region/cell_feature_matrix.h5' &&
             cp '$method_condi.cells' 'input/region/cells.parquet' &&
             cp '$method_condi.cells_zarr' 'input/region/cells.zarr.zip' &&
             cp '$method_condi.experiment_xenium' 'input/region/experiment.xenium' &&
-            #for $image in $method_condi.morphology_focus:
+            #for $image in $method_condi.morphology_focus_files:
                 #if $image.element_identifier.endswith('.ome.tiff') or $image.element_identifier.endswith('.ome.tif'):
                     cp '$image' 'input/region/morphology_focus/${image.element_identifier}' &&
                 #else:
@@ -253,7 +253,7 @@
 from spatialdata_io import cosmx
 spdata = cosmx(path="./",
                dataset_id="$method_condi.dataset_id",
-               transcripts=$method_condi.transcripts_bool,
+               transcripts=$method_condi.transcripts,
                )
 
 #else if $method_condi.method == 'curio':
@@ -283,8 +283,8 @@ spdata = macsima(path="./input",
                 #end if
                 max_chunk_size=$method_condi.max_chunk_size,
                 c_chunks_size=$method_condi.c_chunks_size,
-                multiscale=$method_condi.multiscale_bool,
-                transformations=$method_condi.transformations_bool,
+                multiscale=$method_condi.multiscale,
+                transformations=$method_condi.transformations,
                 #if $method_condi.scale_factors:
                 #set scale_factors_list = [int(x.strip()) for x in str($method_condi.scale_factors).split(',')]
                 scale_factors=$scale_factors_list,
@@ -295,7 +295,7 @@ spdata = macsima(path="./input",
                 #else:
                 split_threshold_nuclei_channel=None,
                 #end if
-                include_cycle_in_channel_name=$method_condi.include_cycle_in_channel_name_bool,
+                include_cycle_in_channel_name=$method_condi.include_cycle_in_channel_name,
                 )
 
 #else if $method_condi.method == 'merscope':
@@ -307,24 +307,24 @@ spdata = merscope(path="./input/region",
                   region_name="$method_condi.region_name",
                   slide_name="$method_condi.slide_name",
                   backend="rioxarray",
-                  transcripts=$method_condi.transcripts_bool,
-                  cells_boundaries=$method_condi.cells_boundaries_bool,
-                  cells_table=$method_condi.cells_table_bool,
-                  mosaic_images=$method_condi.mosaic_images_bool,
+                  transcripts=$method_condi.transcripts,
+                  cells_boundaries=$method_condi.cells_boundaries,
+                  cells_table=$method_condi.cells_table,
+                  mosaic_images=$method_condi.mosaic_images,
                   )
 
 #else if $method_condi.method == 'visium':
 from spatialdata_io import visium
 spdata = visium(path="./input",
                 dataset_id="$method_condi.dataset_id",
-                #if $method_condi.matrix_bool:
+                #if $method_condi.matrix:
                 counts_file='raw_feature_bc_matrix.h5',
                 #else:
                 counts_file='filtered_feature_bc_matrix.h5',
                 #end if
                 fullres_image_file='fullres_image.tif',
-                tissue_positions_file='tissue_positions_list.csv',
-                scalefactors_file='scalefactors_json.json',
+                tissue_positions_file='tissue_positions_file.csv',
+                scalefactors_file='scalefactors_file.json',
                 var_names_make_unique=True,
                 )
 
@@ -335,7 +335,7 @@ from spatialdata_io import visium_hd
 #end if
 spdata = visium_hd(path="./input",
                    dataset_id="$method_condi.dataset_id",
-                   #if $method_condi.matrix_bool:
+                   #if $method_condi.matrix:
                    filtered_counts_file=False,
                    #else:
                    filtered_counts_file=True,
@@ -353,8 +353,8 @@ spdata = visium_hd(path="./input",
                    #if $method_condi.bin_size:
                    bin_size=$bin_size_list,
                    #end if
-                   bins_as_squares=$method_condi.bins_as_squares_bool,
-                   annotate_table_by_labels=$method_condi.annotate_table_by_labels_bool,
+                   bins_as_squares=$method_condi.bins_as_squares,
+                   annotate_table_by_labels=$method_condi.annotate_table_by_labels,
                    #if $method_condi.images.microscope_image:
                    fullres_image_file="./input/microscope_image/fullres_image.tiff",
                    #else:
@@ -365,8 +365,8 @@ spdata = visium_hd(path="./input",
                    #else:
                    load_all_images=False,
                    #end if
-                   var_names_make_unique=$method_condi.var_names_make_unique_bool,
-                   gex_only=$method_condi.gex_only_bool,
+                   var_names_make_unique=$method_condi.var_names_make_unique,
+                   gex_only=$method_condi.gex_only,
                    )
 
 #else if $method_condi.method == 'xenium':
@@ -383,23 +383,23 @@ spdata = xenium(path="./input/region",
                 #else:
                 nucleus_boundaries=False,
                 #end if
-                cells_as_circles=$method_condi.cells_as_circles_bool,
-                cells_labels=$method_condi.cells_labels_bool,
-                nucleus_labels=$method_condi.nucleus_labels_bool,
+                cells_as_circles=$method_condi.cells_as_circles,
+                cells_labels=$method_condi.cells_labels,
+                nucleus_labels=$method_condi.nucleus_labels,
                 #if $method_condi.transcripts:
                 transcripts=True,
                 #else:
                 transcripts=False,
                 #end if
-                morphology_mip=$method_condi.morphology_mip_bool,
-                morphology_focus=$method_condi.morphology_focus_bool,
+                morphology_mip=$method_condi.morphology_mip,
+                morphology_focus=$method_condi.morphology_focus,
                 #if str($method_condi.add_hne_condi.add_hne) == 'yes' or str($method_condi.add_if_condi.add_if) == 'yes':
                 aligned_images=True,
                 #else:
                 aligned_images=False,
                 #end if
-                cells_table=$method_condi.cells_table_bool,
-                gex_only=$method_condi.gex_only_bool,
+                cells_table=$method_condi.cells_table,
+                gex_only=$method_condi.gex_only,
                 n_jobs=int(os.getenv("GALAXY_SLOTS")),
                 )
 
@@ -441,7 +441,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="fov_positions_file" type="data" format="csv" label="FOV positions file"/>
                 <param name="metadata_file" type="data" format="csv" label="Metadata file"/>
                 <param name="tx_file" type="data" format="csv" label="Transcripts file"/>
-                <param name="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="It should match your input files name">
+                <param argument="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="It should match your input files name">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -449,13 +449,13 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param name="transcripts_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load transcripts information?"/>
+                <param argument="transcripts" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load transcripts information?"/>
             </when>
             <when value="dbit">
-                <param name="barcode_positions" type="data" format="tabular" label="Barcode positions file"/>
+                <param argument="barcode_positions" type="data" format="tabular" label="Barcode positions file"/>
                 <param name="counts" type="data" format="h5ad" label="Counts file"/>
                 <param name="tissue_lowres" type="data" optional="true" format="png" label="Tissue low resolution image"/>
-                <param name="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="It should match your input files name">
+                <param argument="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="It should match your input files name">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -463,24 +463,24 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param name="border" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Create a border" help="If True, the square is shrinked toward its center, leaving an empty border."/>
-                <param name="border_scale" type="float" value="1" label="Border scale factor" help="The factor by which the border is scaled. The default is 1. It corresponds to a border length of (0.125 * length of the square’s edge)"/>
+                <param argument="border" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Create a border" help="If True, the square is shrinked toward its center, leaving an empty border."/>
+                <param argument="border_scale" type="float" value="1" label="Border scale factor" help="The factor by which the border is scaled. The default is 1. It corresponds to a border length of (0.125 * length of the square’s edge)"/>
             </when>
             <when value="macsima">
                 <param name="tiff_files" type="data" format="tiff" multiple="true" label="MACSima TIFF images" help="OME-TIFF files from MACSima cyclic imaging experiment"/>
-                <param name="subset" type="integer" min="0" optional="true" label="Subset the image to the first ``subset`` pixels in x and y dimensions"/>
-                <param name="subset_c" type="integer" min="0" optional="true" label="Subset the image to the first ``c_subset`` channels"/>
-                <param name="max_chunk_size" type="integer" min="0" value="1024" label="Maximum chunk size for x and y dimension"/>
-                <param name="c_chunks_size" type="integer" min="0" value="1" label="Maximum chunk size for x and y dimension"/>
-                <param name="multiscale_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Create multiscale image?"/>
-                <param name="transformations_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Whether to add a transformation from pixels to microns to the image"/>
-                <param name="scale_factors" type="integer" min="0" optional="true" label="Scale factors to use for downsampling" help="If None, scale factors are calculated based on image size."/>
-                <param name="nuclei_channel_name" type="text" value="DAPI" label="Nuclei channel name"/>
-                <param name="split_threshold_nuclei_channel" type="integer" min="0" value="2" optional="true" label="Split threshold for nuclei channels" help="If the number of channels that include nuclei_channel_name is greater than this threshold, the nuclei channels are split into a separate stack.."/>
-                <param name="include_cycle_in_channel_name_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include cycle number in channel name?" help="If True, prepend cycle number to channel names (e.g., 'R1 DAPI')"/>
+                <param argument="subset" type="integer" min="0" optional="true" label="Subset the image to the first ``subset`` pixels in x and y dimensions"/>
+                <param argument="subset_c" type="integer" min="0" optional="true" label="Subset the image to the first ``c_subset`` channels"/>
+                <param argument="max_chunk_size" type="integer" min="0" value="1024" label="Maximum chunk size for x and y dimension"/>
+                <param argument="c_chunks_size" type="integer" min="0" value="1" label="Maximum chunk size for x and y dimension"/>
+                <param argument="multiscale" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Create multiscale image?"/>
+                <param argument="transformations" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Whether to add a transformation from pixels to microns to the image"/>
+                <param argument="scale_factors" type="integer" min="0" optional="true" label="Scale factors to use for downsampling" help="If None, scale factors are calculated based on image size."/>
+                <param argument="nuclei_channel_name" type="text" value="DAPI" label="Nuclei channel name"/>
+                <param argument="split_threshold_nuclei_channel" type="integer" min="0" value="2" optional="true" label="Split threshold for nuclei channels" help="If the number of channels that include nuclei_channel_name is greater than this threshold, the nuclei channels are split into a separate stack.."/>
+                <param argument="include_cycle_in_channel_name" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include cycle number in channel name?" help="If True, prepend cycle number to channel names (e.g., 'R1 DAPI')"/>
             </when>
             <when value="merscope">
-                <param name="slide_name" type="text" value="Galaxy" label="Dataset identifier" help="Prefix used to name the constructed SpatialData elements.">
+                <param argument="slide_name" type="text" value="Galaxy" label="Dataset identifier" help="Prefix used to name the constructed SpatialData elements.">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -488,7 +488,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param name="region_name" type="text" value="region" label="Region name" help="Region name appended to the dataset identifier in the MERSCOPE output.">
+                <param argument="region_name" type="text" value="region" label="Region name" help="Region name appended to the dataset identifier in the MERSCOPE output.">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -496,20 +496,20 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param argument="--z_layers" type="text" value="3" optional="false" label="Comma separated list of Indices of the z-layers to consider" help="By default, only the middle layer is considered (layer 3).">
+                <param argument="z_layers" type="text" value="3" optional="false" label="Comma separated list of Indices of the z-layers to consider" help="By default, only the middle layer is considered (layer 3).">
                     <expand macro="sanitize_digits"/>
                 </param>
-                <param argument="--mosaic-images" type="data" format="tiff" multiple="true" label="MEROSCOPE tiff images"/>
+                <param name="mosaic_images_files" type="data" format="tiff" multiple="true" label="MEROSCOPE tiff images"/>
                 <param name="input_micron_to_mosaic" type="data" format="csv" label="Micron to mosaic mapping file"/>
                 <param name="vpt_output" type="data_collection" collection_type="list" format="csv" label="VPT output" help="This should include cell_by_gene, cell_metadata, and detected_transcripts data."/>
-                <param name="cells_boundaries" type="data_collection" collection_type="list" format="parquet" label="Cell boundaries" help="Only micron_space will be used."/>
-                <param name="transcripts_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load transcripts information?"/>
-                <param name="cells_boundaries_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells boundaries?"/>
-                <param name="cells_table_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells table?"/>
-                <param name="mosaic_images_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load mosaic images?"/>
+                <param name="cells_boundaries_file" type="data_collection" collection_type="list" format="parquet" label="Cell boundaries" help="Only micron_space will be used."/>
+                <param argument="transcripts" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load transcripts information?"/>
+                <param argument="cells_boundaries" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells boundaries?"/>
+                <param argument="cells_table" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells table?"/>
+                <param argument="mosaic_images" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load mosaic images?"/>
             </when>
             <when value="visium">
-                <param name="dataset_id" type="text" value="Galaxy" label="Dataset identifier to name the constructed SpatialData elements">
+                <param argument="dataset_id" type="text" value="Galaxy" label="Dataset identifier to name the constructed SpatialData elements">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -517,16 +517,16 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param name="feature_bc_matrix" type="data" format="h5" label="feature BC matrix (Counts file)"/>
-                <param name="matrix_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Is the matrix input, raw?" help="If the matrix input is raw, set this to true."/>
-                <param name="scalefactors_json" type="data" format="json" label="Scale factors file"/>
-                <param name="fullres_image_file" type="data" format="tiff" label="Full resolution image"/>
+                <param argument="counts_file" name="feature_bc_matrix" type="data" format="h5" label="feature BC matrix (Counts file)"/>
+                <param name="matrix" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Is the matrix input, raw?" help="If the matrix input is raw, set this to true."/>
+                <param argument="scalefactors_file" type="data" format="json" label="Scale factors file"/>
+                <param argument="fullres_image_file" type="data" format="tiff" label="Full resolution image"/>
                 <param name="tissue_hires_image" type="data" format="png" label="Tissue high resolution image"/>
                 <param name="tissue_lowres_image" type="data" format="png" label="Tissue low resolution image"/>
-                <param name="tissue_positions_list" type="data" format="csv" label="Tissue positions file"/>
+                <param argument="tissue_positions_file" type="data" format="csv" label="Tissue positions file"/>
             </when>
             <when value="visium_hd">
-                <param name="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="Name for the constructed SpatialData elements">
+                <param argument="dataset_id" type="text" value="Galaxy" label="Dataset identifier" help="Name for the constructed SpatialData elements">
                     <sanitizer invalid_char="">
                         <valid initial="string.letters,string.digits">
                             <add value="_"/>
@@ -534,7 +534,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                     </sanitizer>
                     <validator type="regex">[0-9a-zA-Z_]+</validator>
                 </param>
-                <param name="matrix_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Is the matrix input, raw?" help="If the matrix input is raw, set this to true."/>
+                <param name="matrix" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Is the matrix input, raw?" help="If the matrix input is raw, set this to true."/>
                 <param name="feature_slice" type="data" format="h5" label="Feature slice file"/>
                 <conditional name="include_binned_condi">
                     <param name="include_binned" type="select" label="Include binned data?">
@@ -604,30 +604,30 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                         </when>
                     </conditional>
                 </section>
-                <param name="bins_as_squares_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load bins as squares?" help="If True, bins are represented as squares; if False, as circles"/>
-                <param name="annotate_table_by_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Annotate table by labels?" help="Annotate the AnnData table with cell/nucleus labels"/>
-                <param name="var_names_make_unique_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Make variable names unique?" help="If True, call .var_names_make_unique() on each AnnData table"/>
-                <param name="bin_size" type="text" optional="true" label="Bin sizes to load" help="Comma-separated list of bin sizes (e.g., 2,8,16) to load. Leave empty to load all available bin sizes.">
+                <param argument="bins_as_squares" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load bins as squares?" help="If True, bins are represented as squares; if False, as circles"/>
+                <param argument="annotate_table_by_labels" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Annotate table by labels?" help="Annotate the AnnData table with cell/nucleus labels"/>
+                <param argument="var_names_make_unique" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Make variable names unique?" help="If True, call .var_names_make_unique() on each AnnData table"/>
+                <param argument="bin_size" type="text" optional="true" label="Bin sizes to load" help="Comma-separated list of bin sizes (e.g., 2,8,16) to load. Leave empty to load all available bin sizes.">
                     <expand macro="sanitize_digits"/>
                 </param>
-                <param name="gex_only_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Load gene expression only?"/>
+                <param argument="gex_only" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Load gene expression only?"/>
             </when>
             <when value="xenium">
                 <param name="cell_feature_matrix" type="data" format="h5" label="Cell feature matrix"/>
                 <param name="cells" type="data" format="parquet" label="Cells metadata"/>
                 <param name="cells_zarr" type="data" format="zarr.zip" label="Cells zarr archive"/>
                 <param name="experiment_xenium" type="data" format="json" label="Experiment xenium file containing specifications"/>
-                <param name="morphology_focus" type="data" format="ome.tiff" multiple="true" label="Morphology focus images" help="Both MIP and Focus"/>
-                <param name="cell_boundaries" type="data" optional="true" format="parquet" label="Polygons of cell boundaries"/>
-                <param name="nucleus_boundaries" type="data" optional="true" format="parquet" label="Polygons of nucleus boundaries"/>
-                <param name="transcripts" type="data" optional="true" format="parquet" label="Transcripts"/>
-                <param name="cells_as_circles_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Represent cells as circles?" help="The center and the radius of each circle is computed from the corresponding labels cell"/>
-                <param name="cells_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells labels?"/>
-                <param name="nucleus_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load nucleus labels?"/>
-                <param name="morphology_mip_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load morphology MIP?"/>
-                <param name="morphology_focus_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load morphology focus?"/>
-                <param name="cells_table_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells annotation from AnnData?"/>
-                <param name="gex_only_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load gene expression only?"/>
+                <param name="morphology_focus_files" type="data" format="ome.tiff" multiple="true" label="Morphology focus images" help="Both MIP and Focus"/>
+                <param argument="cells_boundaries" type="data" optional="true" format="parquet" label="Polygons of cell boundaries"/>
+                <param argument="nucleus_boundaries" type="data" optional="true" format="parquet" label="Polygons of nucleus boundaries"/>
+                <param argument="transcripts" type="data" optional="true" format="parquet" label="Transcripts"/>
+                <param argument="cells_as_circles" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Represent cells as circles?" help="The center and the radius of each circle is computed from the corresponding labels cell"/>
+                <param argument="cells_labels" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells labels?"/>
+                <param argument="nucleus_labels" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load nucleus labels?"/>
+                <param argument="morphology_mip" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load morphology MIP?"/>
+                <param argument="morphology_focus" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load morphology focus?"/>
+                <param argument="cells_table" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load cells annotation from AnnData?"/>
+                <param argument="gex_only" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Load gene expression only?"/>
                 <conditional name="add_hne_condi">
                     <param name="add_hne" type="select" label="Add H&amp;E image?">
                         <option value="yes_accurate">Yes, with accurate alignment</option>
@@ -671,10 +671,10 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="method" value="merscope"/>
                 <param name="slide_name" value="Test_MERSCOPE"/>
                 <param name="region_name" value="sample_region"/>
-                <param name="mosaic_images" location="https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z3.tif"/>
+                <param name="mosaic_images_files" location="https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z3.tif"/>
                 <param name="z_layers" value="3"/>
                 <param name="input_micron_to_mosaic" location="https://zenodo.org/records/21358431/files/merscope_micron_to_mosaic_pixel_transform.csv"/>
-                <param name="cells_boundaries">
+                <param name="cells_boundaries_file">
                     <collection type="list">
                         <element name="cellpose2_micron_space" location="https://zenodo.org/records/21358431/files/merscope_cellpose2_micron_space.parquet"/>
                     </collection>
@@ -712,7 +712,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="metadata_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_metadata_file.csv"/>
                 <param name="tx_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_tx_file.csv"/>
                 <param name="dataset_id" value="cosmx_dummy"/>
-                <param name="transcripts_bool" value="True"/>
+                <param name="transcripts" value="True"/>
             </conditional>
             <output name="spatialdata_output">
                 <assert_contents>
@@ -769,12 +769,12 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="method" value="visium"/>
                 <param name="dataset_id" value="Test_Visium"/>
                 <param name="feature_bc_matrix" location="https://zenodo.org/records/21358431/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_filtered_feature_bc_matrix.h5"/>
-                <param name="matrix_bool" value="false"/>
-                <param name="scalefactors_json" location="https://zenodo.org/records/21358431/files/visium_scalefactors_json.json"/>
+                <param name="matrix" value="false"/>
+                <param name="scalefactors_file" location="https://zenodo.org/records/21358431/files/visium_scalefactors_json.json"/>
                 <param name="fullres_image_file" location="https://zenodo.org/records/21358431/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_image.tif"/>
                 <param name="tissue_hires_image" location="https://zenodo.org/records/21358431/files/visium_tissue_hires_image.png"/>
                 <param name="tissue_lowres_image" location="https://zenodo.org/records/21358431/files/visium_tissue_lowres_image.png"/>
-                <param name="tissue_positions_list" location="https://zenodo.org/records/21358431/files/visium_tissue_positions.csv"/>
+                <param name="tissue_positions_file" location="https://zenodo.org/records/21358431/files/visium_tissue_positions.csv"/>
             </conditional>
             <assert_stdout>
                 <has_text text="'Test_Visium': GeoDataFrame shape: (4194, 2)"/>
@@ -794,7 +794,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             <conditional name="method_condi">
                 <param name="method" value="visium_hd"/>
                 <param name="dataset_id" value="Test_VisiumHD"/>
-                <param name="matrix_bool" value="false"/>
+                <param name="matrix" value="false"/>
                 <param name="feature_slice" location="https://zenodo.org/records/21358431/files/visiumhd_feature_slice.h5"/>
                 <conditional name="include_binned_condi">
                     <param name="include_binned" value="yes"/>
@@ -833,9 +833,9 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                         <param name="cytassist_image" location="https://zenodo.org/records/21358431/files/visiumhd_cytassist_image.tiff"/>
                     </conditional>
                 </section>
-                <param name="bins_as_squares_bool" value="true"/>
-                <param name="annotate_table_by_labels_bool" value="false"/>
-                <param name="var_names_make_unique_bool" value="true"/>
+                <param name="bins_as_squares" value="true"/>
+                <param name="annotate_table_by_labels" value="false"/>
+                <param name="var_names_make_unique" value="true"/>
             </conditional>
             <assert_stdout>
                 <has_text text="'Test_VisiumHD"/>
@@ -858,8 +858,8 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="cells" location="https://zenodo.org/records/21358431/files/xenium_cells.parquet"/>
                 <param name="cells_zarr" location="https://zenodo.org/records/21358431/files/xenium_cells.zarr.zip"/>
                 <param name="experiment_xenium" location="https://zenodo.org/records/21358431/files/xenium_experiment.xenium"/>
-                <param name="morphology_focus" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
-                <param name="cell_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
+                <param name="morphology_focus_files" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
+                <param name="cells_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
                 <param name="nucleus_boundaries" location="https://zenodo.org/records/21358431/files/xenium_nucleus_boundaries.parquet"/>
                 <param name="transcripts" location="https://zenodo.org/records/21358431/files/xenium_transcripts.parquet"/>
                 <conditional name="add_hne_condi">
@@ -888,8 +888,8 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="cells" location="https://zenodo.org/records/21358431/files/xenium_cells.parquet"/>
                 <param name="cells_zarr" location="https://zenodo.org/records/21358431/files/xenium_cells.zarr.zip"/>
                 <param name="experiment_xenium" location="https://zenodo.org/records/21358431/files/xenium_experiment.xenium"/>
-                <param name="morphology_focus" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
-                <param name="cell_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
+                <param name="morphology_focus_files" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
+                <param name="cells_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
                 <param name="nucleus_boundaries" location="https://zenodo.org/records/21358431/files/xenium_nucleus_boundaries.parquet"/>
                 <param name="transcripts" location="https://zenodo.org/records/21358431/files/xenium_transcripts.parquet"/>
                 <conditional name="add_hne_condi">

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -207,7 +207,7 @@
         #else if $method_condi.method == 'xenium':
             mkdir -p 'input/region/morphology_focus/' 'output' &&
             ## ln -s does not work here.
-            #if str($method_condi.cell_boundaries) != '':
+            #if $method_condi.cell_boundaries:
                 cp '$method_condi.cell_boundaries' 'input/region/cell_boundaries.parquet' &&
             #end if
             cp '$method_condi.cell_feature_matrix' 'input/region/cell_feature_matrix.h5' &&
@@ -221,10 +221,10 @@
                     cp '$image' 'input/region/morphology_focus/${image.element_identifier}.ome.tif' &&
                 #end if
             #end for
-            #if str($method_condi.nucleus_boundaries) != '':
+            #if $method_condi.nucleus_boundaries:
                 cp '$method_condi.nucleus_boundaries' 'input/region/nucleus_boundaries.parquet' &&
             #end if
-            #if str($method_condi.transcripts) != '':
+            #if $method_condi.transcripts:
                 cp '$method_condi.transcripts' 'input/region/transcripts.parquet' &&
             #end if
             #if str($method_condi.add_hne_condi.add_hne) == 'yes' or str($method_condi.add_hne_condi.add_hne) == 'yes_accurate':
@@ -285,12 +285,12 @@ spdata = macsima(path="./input",
                 c_chunks_size=$method_condi.c_chunks_size,
                 multiscale=$method_condi.multiscale_bool,
                 transformations=$method_condi.transformations_bool,
-                #if str($method_condi.scale_factors) != '':
+                #if $method_condi.scale_factors:
                 #set scale_factors_list = [int(x.strip()) for x in str($method_condi.scale_factors).split(',')]
                 scale_factors=$scale_factors_list,
                 #end if
                 nuclei_channel_name="$method_condi.nuclei_channel_name",
-                #if str($method_condi.split_threshold_nuclei_channel) != '':
+                #if $method_condi.split_threshold_nuclei_channel:
                 split_threshold_nuclei_channel=$method_condi.split_threshold_nuclei_channel,
                 #else:
                 split_threshold_nuclei_channel=None,
@@ -373,12 +373,12 @@ spdata = visium_hd(path="./input",
 import os
 from spatialdata_io import xenium
 spdata = xenium(path="./input/region",
-                #if str($method_condi.cell_boundaries) != '':
+                #if $method_condi.cell_boundaries:
                 cells_boundaries=True,
                 #else:
                 cells_boundaries=False,
                 #end if
-                #if str($method_condi.nucleus_boundaries) != '':
+                #if $method_condi.nucleus_boundaries:
                 nucleus_boundaries=True,
                 #else:
                 nucleus_boundaries=False,
@@ -386,7 +386,7 @@ spdata = xenium(path="./input/region",
                 cells_as_circles=$method_condi.cells_as_circles_bool,
                 cells_labels=$method_condi.cells_labels_bool,
                 nucleus_labels=$method_condi.nucleus_labels_bool,
-                #if str($method_condi.transcripts) != '':
+                #if $method_condi.transcripts:
                 transcripts=True,
                 #else:
                 transcripts=False,

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -671,19 +671,19 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="method" value="merscope"/>
                 <param name="slide_name" value="Test_MERSCOPE"/>
                 <param name="region_name" value="sample_region"/>
-                <param name="mosaic_images" location="https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/18746346/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/18746346/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/18746346/files/mosaic_PolyT_z3.tif"/>
+                <param name="mosaic_images" location="https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound1_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound2_z3.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z2.tif,https://zenodo.org/records/21358431/files/mosaic_Cellbound3_z3.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z2.tif,https://zenodo.org/records/21358431/files/mosaic_DAPI_z3.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z2.tif,https://zenodo.org/records/21358431/files/mosaic_PolyT_z3.tif"/>
                 <param name="z_layers" value="3"/>
-                <param name="input_micron_to_mosaic" location="https://zenodo.org/records/18746346/files/merscope_micron_to_mosaic_pixel_transform.csv"/>
+                <param name="input_micron_to_mosaic" location="https://zenodo.org/records/21358431/files/merscope_micron_to_mosaic_pixel_transform.csv"/>
                 <param name="cells_boundaries">
                     <collection type="list">
-                        <element name="cellpose2_micron_space" location="https://zenodo.org/records/18746346/files/merscope_cellpose2_micron_space.parquet"/>
+                        <element name="cellpose2_micron_space" location="https://zenodo.org/records/21358431/files/merscope_cellpose2_micron_space.parquet"/>
                     </collection>
                 </param>
                 <param name="vpt_output">
                     <collection type="list">
-                        <element name="cell_by_gene" location="https://zenodo.org/records/18746346/files/merscope_cell_by_gene.csv"/>
-                        <element name="cell_metadata" location="https://zenodo.org/records/18746346/files/merscope_cell_metadata.csv"/>
-                        <element name="detected_transcripts" location="https://zenodo.org/records/18746346/files/merscope_detected_transcripts.csv"/>
+                        <element name="cell_by_gene" location="https://zenodo.org/records/21358431/files/merscope_cell_by_gene.csv"/>
+                        <element name="cell_metadata" location="https://zenodo.org/records/21358431/files/merscope_cell_metadata.csv"/>
+                        <element name="detected_transcripts" location="https://zenodo.org/records/21358431/files/merscope_detected_transcripts.csv"/>
                     </collection>
                 </param>
             </conditional>
@@ -705,12 +705,12 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
         <test>
             <conditional name="method_condi">
                 <param name="method" value="cosmx"/>
-                <param name="CellComposite" location="https://zenodo.org/records/18746346/files/cosmx_CellComposite_F001.jpg"/>
-                <param name="CellLabels" location="https://zenodo.org/records/18746346/files/cosmx_CellLabels_F001.tif"/>
-                <param name="exprMat_file" location="https://zenodo.org/records/18746346/files/cosmx_dummy_exprMat_file.csv"/>
-                <param name="fov_positions_file" location="https://zenodo.org/records/18746346/files/cosmx_dummy_fov_positions_file.csv"/>
-                <param name="metadata_file" location="https://zenodo.org/records/18746346/files/cosmx_dummy_metadata_file.csv"/>
-                <param name="tx_file" location="https://zenodo.org/records/18746346/files/cosmx_dummy_tx_file.csv"/>
+                <param name="CellComposite" location="https://zenodo.org/records/21358431/files/cosmx_CellComposite_F001.jpg"/>
+                <param name="CellLabels" location="https://zenodo.org/records/21358431/files/cosmx_CellLabels_F001.tif"/>
+                <param name="exprMat_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_exprMat_file.csv"/>
+                <param name="fov_positions_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_fov_positions_file.csv"/>
+                <param name="metadata_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_metadata_file.csv"/>
+                <param name="tx_file" location="https://zenodo.org/records/21358431/files/cosmx_dummy_tx_file.csv"/>
                 <param name="dataset_id" value="cosmx_dummy"/>
                 <param name="transcripts_bool" value="True"/>
             </conditional>
@@ -727,9 +727,9 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
         <test>
             <conditional name="method_condi">
                 <param name="method" value="dbit"/>
-                <param name="barcode_positions" location="https://zenodo.org/records/18746346/files/dbit_barcode_positions.txt"/>
-                <param name="counts" location="https://zenodo.org/records/18746346/files/dbit_counts.h5ad"/>
-                <param name="tissue_lowres" location="https://zenodo.org/records/18746346/files/dbit_tissue_lowres.png"/>
+                <param name="barcode_positions" location="https://zenodo.org/records/21358431/files/dbit_barcode_positions.txt"/>
+                <param name="counts" location="https://zenodo.org/records/21358431/files/dbit_counts.h5ad"/>
+                <param name="tissue_lowres" location="https://zenodo.org/records/21358431/files/dbit_tissue_lowres.png"/>
             </conditional>
             <assert_stdout>
                 <has_text text="'Galaxy': GeoDataFrame shape: (500, 1) (2D shapes)"/>
@@ -748,7 +748,7 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
         <test>
             <conditional name="method_condi">
                 <param name="method" value="macsima"/>
-                <param name="tiff_files" location="https://zenodo.org/records/18746346/files/macima_C-001_S-000_S_APC_R-01_W-D01_ROI-01_A-CD3_C-REA1151.tif,https://zenodo.org/records/18746346/files/macima_C-002_S-000_S_PE_R-01_W-D01_ROI-01_A-CD279_C-REA1165.tif,https://zenodo.org/records/18746346/files/macima_C-015_S-000_B_DAPI_R-01_W-D01_ROI-01_A-DAPI.tif,https://zenodo.org/records/18746346/files/macima_C-001_S-000_S_DAPI_R-01_W-D01_ROI-01_A-DAPI.tif,https://zenodo.org/records/18746346/files/macima_C-004_S-000_S_FITC_R-01_W-D01_ROI-01_A-CD66b_C-REA306.tif"/>
+                <param name="tiff_files" location="https://zenodo.org/records/21358431/files/macima_C-001_S-000_S_APC_R-01_W-D01_ROI-01_A-CD3_C-REA1151.tif,https://zenodo.org/records/21358431/files/macima_C-002_S-000_S_PE_R-01_W-D01_ROI-01_A-CD279_C-REA1165.tif,https://zenodo.org/records/21358431/files/macima_C-015_S-000_B_DAPI_R-01_W-D01_ROI-01_A-DAPI.tif,https://zenodo.org/records/21358431/files/macima_C-001_S-000_S_DAPI_R-01_W-D01_ROI-01_A-DAPI.tif,https://zenodo.org/records/21358431/files/macima_C-004_S-000_S_FITC_R-01_W-D01_ROI-01_A-CD66b_C-REA306.tif"/>
             </conditional>
             <assert_stdout>
                 <has_text text="'input_image': DataTree"/>
@@ -768,13 +768,13 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
             <conditional name="method_condi">
                 <param name="method" value="visium"/>
                 <param name="dataset_id" value="Test_Visium"/>
-                <param name="feature_bc_matrix" location="https://zenodo.org/records/18746346/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_filtered_feature_bc_matrix.h5"/>
+                <param name="feature_bc_matrix" location="https://zenodo.org/records/21358431/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_filtered_feature_bc_matrix.h5"/>
                 <param name="matrix_bool" value="false"/>
-                <param name="scalefactors_json" location="https://zenodo.org/records/18746346/files/visium_scalefactors_json.json"/>
-                <param name="fullres_image_file" location="https://zenodo.org/records/18746346/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_image.tif"/>
-                <param name="tissue_hires_image" location="https://zenodo.org/records/18746346/files/visium_tissue_hires_image.png"/>
-                <param name="tissue_lowres_image" location="https://zenodo.org/records/18746346/files/visium_tissue_lowres_image.png"/>
-                <param name="tissue_positions_list" location="https://zenodo.org/records/18746346/files/visium_tissue_positions.csv"/>
+                <param name="scalefactors_json" location="https://zenodo.org/records/21358431/files/visium_scalefactors_json.json"/>
+                <param name="fullres_image_file" location="https://zenodo.org/records/21358431/files/visium_CytAssist_FFPE_Protein_Expression_Human_Tonsil_image.tif"/>
+                <param name="tissue_hires_image" location="https://zenodo.org/records/21358431/files/visium_tissue_hires_image.png"/>
+                <param name="tissue_lowres_image" location="https://zenodo.org/records/21358431/files/visium_tissue_lowres_image.png"/>
+                <param name="tissue_positions_list" location="https://zenodo.org/records/21358431/files/visium_tissue_positions.csv"/>
             </conditional>
             <assert_stdout>
                 <has_text text="'Test_Visium': GeoDataFrame shape: (4194, 2)"/>
@@ -795,42 +795,42 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
                 <param name="method" value="visium_hd"/>
                 <param name="dataset_id" value="Test_VisiumHD"/>
                 <param name="matrix_bool" value="false"/>
-                <param name="feature_slice" location="https://zenodo.org/records/18746346/files/visiumhd_feature_slice.h5"/>
+                <param name="feature_slice" location="https://zenodo.org/records/21358431/files/visiumhd_feature_slice.h5"/>
                 <conditional name="include_binned_condi">
                     <param name="include_binned" value="yes"/>
                     <section name="bin008">
-                        <param name="feature_bc_matrix_008" location="https://zenodo.org/records/18746346/files/visiumhd_filtered_feature_bc_matrix_008.h5"/>
-                        <param name="tissue_positions_008" location="https://zenodo.org/records/18746346/files/visiumhd_tissue_positions_008.parquet"/>
-                        <param name="scalefactors_json_008" location="https://zenodo.org/records/18746346/files/visiumhd_scalefactors_json_008.json"/>
+                        <param name="feature_bc_matrix_008" location="https://zenodo.org/records/21358431/files/visiumhd_filtered_feature_bc_matrix_008.h5"/>
+                        <param name="tissue_positions_008" location="https://zenodo.org/records/21358431/files/visiumhd_tissue_positions_008.parquet"/>
+                        <param name="scalefactors_json_008" location="https://zenodo.org/records/21358431/files/visiumhd_scalefactors_json_008.json"/>
                     </section>
                     <section name="bin016">
-                        <param name="feature_bc_matrix_016" location="https://zenodo.org/records/18746346/files/visiumhd_filtered_feature_bc_matrix_016.h5"/>
-                        <param name="tissue_positions_016" location="https://zenodo.org/records/18746346/files/visiumhd_tissue_positions_016.parquet"/>
-                        <param name="scalefactors_json_016" location="https://zenodo.org/records/18746346/files/visiumhd_scalefactors_json_016.json"/>
+                        <param name="feature_bc_matrix_016" location="https://zenodo.org/records/21358431/files/visiumhd_filtered_feature_bc_matrix_016.h5"/>
+                        <param name="tissue_positions_016" location="https://zenodo.org/records/21358431/files/visiumhd_tissue_positions_016.parquet"/>
+                        <param name="scalefactors_json_016" location="https://zenodo.org/records/21358431/files/visiumhd_scalefactors_json_016.json"/>
                     </section>
                     <conditional name="include_nucleus_seg_condi">
                         <param name="include_nucleus_seg" value="yes"/>
                         <section name="bin002">
-                            <param name="feature_bc_matrix_002" location="https://zenodo.org/records/18746346/files/visiumhd_filtered_feature_bc_matrix_002.h5"/>
-                            <param name="tissue_positions_002" location="https://zenodo.org/records/18746346/files/visiumhd_tissue_positions_002.parquet"/>
-                            <param name="scalefactors_json_002" location="https://zenodo.org/records/18746346/files/visiumhd_scalefactors_json_002.json"/>
+                            <param name="feature_bc_matrix_002" location="https://zenodo.org/records/21358431/files/visiumhd_filtered_feature_bc_matrix_002.h5"/>
+                            <param name="tissue_positions_002" location="https://zenodo.org/records/21358431/files/visiumhd_tissue_positions_002.parquet"/>
+                            <param name="scalefactors_json_002" location="https://zenodo.org/records/21358431/files/visiumhd_scalefactors_json_002.json"/>
                         </section>
-                        <param name="nucleus_segmentation" location="https://zenodo.org/records/18746346/files/visiumhd_nucleus_segmentations.geojson"/>
-                        <param name="barcode_mappings" location="https://zenodo.org/records/18746346/files/visiumhd_barcode_mappings.parquet"/>
+                        <param name="nucleus_segmentation" location="https://zenodo.org/records/21358431/files/visiumhd_nucleus_segmentations.geojson"/>
+                        <param name="barcode_mappings" location="https://zenodo.org/records/21358431/files/visiumhd_barcode_mappings.parquet"/>
                     </conditional>
                 </conditional>
                 <conditional name="segmentation_conditional">
                     <param name="enable_segmentation" value="yes"/>
-                    <param name="feature_bc_matrix_seg" location="https://zenodo.org/records/18746346/files/visiumhd_filtered_feature_cell_matrix_seg.h5"/>
-                    <param name="cell_segmentation" location="https://zenodo.org/records/18746346/files/visiumhd_cell_segmentations.geojson"/>
-                    <param name="scalefactors_json_seg" location="https://zenodo.org/records/18746346/files/visiumhd_scalefactors_json_seg.json"/>
+                    <param name="feature_bc_matrix_seg" location="https://zenodo.org/records/21358431/files/visiumhd_filtered_feature_cell_matrix_seg.h5"/>
+                    <param name="cell_segmentation" location="https://zenodo.org/records/21358431/files/visiumhd_cell_segmentations.geojson"/>
+                    <param name="scalefactors_json_seg" location="https://zenodo.org/records/21358431/files/visiumhd_scalefactors_json_seg.json"/>
                 </conditional>
                 <section name="images">
-                    <param name="tissue_hires" location="https://zenodo.org/records/18746346/files/visiumhd_tissue_hires_image.png"/>
-                    <param name="tissue_lowres" location="https://zenodo.org/records/18746346/files/visiumhd_tissue_lowres_image.png"/>
+                    <param name="tissue_hires" location="https://zenodo.org/records/21358431/files/visiumhd_tissue_hires_image.png"/>
+                    <param name="tissue_lowres" location="https://zenodo.org/records/21358431/files/visiumhd_tissue_lowres_image.png"/>
                     <conditional name="cytassist_image_condi">
                         <param name="include_cytassist" value="yes"/>
-                        <param name="cytassist_image" location="https://zenodo.org/records/18746346/files/visiumhd_cytassist_image.tiff"/>
+                        <param name="cytassist_image" location="https://zenodo.org/records/21358431/files/visiumhd_cytassist_image.tiff"/>
                     </conditional>
                 </section>
                 <param name="bins_as_squares_bool" value="true"/>
@@ -854,17 +854,17 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
         <test>
             <conditional name="method_condi">
                 <param name="method" value="xenium"/>
-                <param name="cell_feature_matrix" location="https://zenodo.org/records/18746346/files/xenium_cell_feature_matrix.h5"/>
-                <param name="cells" location="https://zenodo.org/records/18746346/files/xenium_cells.parquet"/>
-                <param name="cells_zarr" location="https://zenodo.org/records/18746346/files/xenium_cells.zarr.zip"/>
-                <param name="experiment_xenium" location="https://zenodo.org/records/18746346/files/xenium_experiment.xenium"/>
-                <param name="morphology_focus" location="https://zenodo.org/records/18746346/files/ch0000_dapi.ome.tif,https://zenodo.org/records/18746346/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/18746346/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/18746346/files/ch0007_red_background.ome.tif,https://zenodo.org/records/18746346/files/ch0002_18s.ome.tif,https://zenodo.org/records/18746346/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/18746346/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/18746346/files/ch0009_vista.ome.tif,https://zenodo.org/records/18746346/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/18746346/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/18746346/files/ch0005_green_background.ome.tif,https://zenodo.org/records/18746346/files/ch0011_lag-3.ome.tif"/>
-                <param name="cell_boundaries" location="https://zenodo.org/records/18746346/files/xenium_cell_boundaries.parquet"/>
-                <param name="nucleus_boundaries" location="https://zenodo.org/records/18746346/files/xenium_nucleus_boundaries.parquet"/>
-                <param name="transcripts" location="https://zenodo.org/records/18746346/files/xenium_transcripts.parquet"/>
+                <param name="cell_feature_matrix" location="https://zenodo.org/records/21358431/files/xenium_cell_feature_matrix.h5"/>
+                <param name="cells" location="https://zenodo.org/records/21358431/files/xenium_cells.parquet"/>
+                <param name="cells_zarr" location="https://zenodo.org/records/21358431/files/xenium_cells.zarr.zip"/>
+                <param name="experiment_xenium" location="https://zenodo.org/records/21358431/files/xenium_experiment.xenium"/>
+                <param name="morphology_focus" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
+                <param name="cell_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
+                <param name="nucleus_boundaries" location="https://zenodo.org/records/21358431/files/xenium_nucleus_boundaries.parquet"/>
+                <param name="transcripts" location="https://zenodo.org/records/21358431/files/xenium_transcripts.parquet"/>
                 <conditional name="add_hne_condi">
                     <param name="add_hne" value="yes"/>
-                    <param name="hne_image" location="https://zenodo.org/records/18746346/files/xenium_he_image.ome.tif"/>
+                    <param name="hne_image" location="https://zenodo.org/records/21358431/files/xenium_he_image.ome.tif"/>
                 </conditional>
             </conditional>
             <assert_stdout>
@@ -884,18 +884,18 @@ spdata.write("./output/spatialdata.zarr", overwrite=True)
         <test>
             <conditional name="method_condi">
                 <param name="method" value="xenium"/>
-                <param name="cell_feature_matrix" location="https://zenodo.org/records/18746346/files/xenium_cell_feature_matrix.h5"/>
-                <param name="cells" location="https://zenodo.org/records/18746346/files/xenium_cells.parquet"/>
-                <param name="cells_zarr" location="https://zenodo.org/records/18746346/files/xenium_cells.zarr.zip"/>
-                <param name="experiment_xenium" location="https://zenodo.org/records/18746346/files/xenium_experiment.xenium"/>
-                <param name="morphology_focus" location="https://zenodo.org/records/18746346/files/ch0000_dapi.ome.tif,https://zenodo.org/records/18746346/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/18746346/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/18746346/files/ch0007_red_background.ome.tif,https://zenodo.org/records/18746346/files/ch0002_18s.ome.tif,https://zenodo.org/records/18746346/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/18746346/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/18746346/files/ch0009_vista.ome.tif,https://zenodo.org/records/18746346/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/18746346/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/18746346/files/ch0005_green_background.ome.tif,https://zenodo.org/records/18746346/files/ch0011_lag-3.ome.tif"/>
-                <param name="cell_boundaries" location="https://zenodo.org/records/18746346/files/xenium_cell_boundaries.parquet"/>
-                <param name="nucleus_boundaries" location="https://zenodo.org/records/18746346/files/xenium_nucleus_boundaries.parquet"/>
-                <param name="transcripts" location="https://zenodo.org/records/18746346/files/xenium_transcripts.parquet"/>
+                <param name="cell_feature_matrix" location="https://zenodo.org/records/21358431/files/xenium_cell_feature_matrix.h5"/>
+                <param name="cells" location="https://zenodo.org/records/21358431/files/xenium_cells.parquet"/>
+                <param name="cells_zarr" location="https://zenodo.org/records/21358431/files/xenium_cells.zarr.zip"/>
+                <param name="experiment_xenium" location="https://zenodo.org/records/21358431/files/xenium_experiment.xenium"/>
+                <param name="morphology_focus" location="https://zenodo.org/records/21358431/files/ch0000_dapi.ome.tif,https://zenodo.org/records/21358431/files/ch0006_yellow_background.ome.tif,https://zenodo.org/records/21358431/files/ch0001_atp1a1_cd45_e-cadherin.ome.tif,https://zenodo.org/records/21358431/files/ch0007_red_background.ome.tif,https://zenodo.org/records/21358431/files/ch0002_18s.ome.tif,https://zenodo.org/records/21358431/files/ch0008_pd-1.ome.tif,https://zenodo.org/records/21358431/files/ch0003_alphasma_vimentin.ome.tif,https://zenodo.org/records/21358431/files/ch0009_vista.ome.tif,https://zenodo.org/records/21358431/files/ch0004_blue_background.ome.tif,https://zenodo.org/records/21358431/files/ch0010_pd-l1.ome.tif,https://zenodo.org/records/21358431/files/ch0005_green_background.ome.tif,https://zenodo.org/records/21358431/files/ch0011_lag-3.ome.tif"/>
+                <param name="cell_boundaries" location="https://zenodo.org/records/21358431/files/xenium_cell_boundaries.parquet"/>
+                <param name="nucleus_boundaries" location="https://zenodo.org/records/21358431/files/xenium_nucleus_boundaries.parquet"/>
+                <param name="transcripts" location="https://zenodo.org/records/21358431/files/xenium_transcripts.parquet"/>
                 <conditional name="add_hne_condi">
                     <param name="add_hne" value="yes_accurate"/>
-                    <param name="hne_image" location="https://zenodo.org/records/18746346/files/xenium_he_image.ome.tif"/>
-                    <param name="image_alignment" location="https://zenodo.org/records/18746346/files/xenium_he_image_alignment.csv"/>
+                    <param name="hne_image" location="https://zenodo.org/records/21358431/files/xenium_he_image.ome.tif"/>
+                    <param name="image_alignment" location="https://zenodo.org/records/21358431/files/xenium_he_image_alignment.csv"/>
                 </conditional>
             </conditional>
             <assert_stdout>

--- a/tools/spatialdata/spatialdata_io.xml
+++ b/tools/spatialdata/spatialdata_io.xml
@@ -116,7 +116,7 @@
             ln -s '$method_condi.fullres_image_file' 'input/fullres_image.tif' &&
             ln -s '$method_condi.tissue_hires_image' 'input/spatial/tissue_hires_image.png' &&
             ln -s '$method_condi.tissue_lowres_image' 'input/spatial/tissue_lowres_image.png' &&
-            ln -s '$method_condi.tissue_positions_file' 'input/tissue_positions_file.csv' &&
+            ln -s '$method_condi.tissue_positions_file' 'input/tissue_positions.csv' &&
 
         ## Visium HD
         #else if $method_condi.method == 'visium_hd':
@@ -323,7 +323,7 @@ spdata = visium(path="./input",
                 counts_file='filtered_feature_bc_matrix.h5',
                 #end if
                 fullres_image_file='fullres_image.tif',
-                tissue_positions_file='tissue_positions_file.csv',
+                tissue_positions_file='tissue_positions.csv',
                 scalefactors_file='scalefactors_file.json',
                 var_names_make_unique=True,
                 )
@@ -373,7 +373,7 @@ spdata = visium_hd(path="./input",
 import os
 from spatialdata_io import xenium
 spdata = xenium(path="./input/region",
-                #if $method_condi.cell_boundaries:
+                #if $method_condi.cells_boundaries:
                 cells_boundaries=True,
                 #else:
                 cells_boundaries=False,

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -43,7 +43,7 @@ result = sd.bounding_box_query(
     min_coordinate=$min_coord_list,
     max_coordinate=$max_coord_list,
     target_coordinate_system='$operation_condi.target_coordinate_system',
-    filter_table=$operation_condi.filter_table_bool
+    filter_table=$operation_condi.filter_table
 )
 
 #else if $operation_condi.operation == 'polygon_query':
@@ -56,8 +56,8 @@ result = sd.polygon_query(
     sdata,
     polygon=polygon,
     target_coordinate_system='$operation_condi.target_coordinate_system',
-    filter_table=$operation_condi.filter_table_bool,
-    clip=$operation_condi.clip_shapes_bool
+    filter_table=$operation_condi.filter_table,
+    clip=$operation_condi.clip
 )
 
 #else if $operation_condi.operation == 'get_values':
@@ -79,19 +79,19 @@ result = sd.get_values(
 
 #else if $operation_condi.operation == 'get_element_instances':
 ## Get element instances
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
 result = sd.get_element_instances(
     element,
-    return_background=$operation_condi.return_background_bool
+    return_background=$operation_condi.return_background
 )
 
 #else if $operation_condi.operation == 'get_extent':
 ## Get extent
-    #if $operation_condi.element_name:
+    #if $operation_condi.elment_name:
 result = sd.get_extent(
-    sdata['$operation_condi.element_name'],
+    sdata['$operation_condi.elment_name'],
     coordinate_system='$operation_condi.coordinate_system',
-    exact=$operation_condi.exact_bool
+    exact=$operation_condi.exact
 )
     #else:
         #if $operation_condi.elements:
@@ -100,11 +100,11 @@ result = sd.get_extent(
 result = sd.get_extent(
     sdata,
     coordinate_system='$operation_condi.coordinate_system',
-    exact=$operation_condi.exact_bool,
-    has_images=$operation_condi.has_images_bool,
-    has_labels=$operation_condi.has_labels_bool,
-    has_points=$operation_condi.has_points_bool,
-    has_shapes=$operation_condi.has_shapes_bool,
+    exact=$operation_condi.exact,
+    has_images=$operation_condi.has_images,
+    has_labels=$operation_condi.has_labels,
+    has_points=$operation_condi.has_points,
+    has_shapes=$operation_condi.has_shapes,
     #if $operation_condi.elements:
     elements=$elements_list
     #end if
@@ -113,11 +113,11 @@ result = sd.get_extent(
 
 #else if $operation_condi.operation == 'get_centroids':
 ## Get centroids
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
 result_element = sd.get_centroids(
     element,
     coordinate_system='$operation_condi.coordinate_system',
-    return_background=$operation_condi.return_background_bool
+    return_background=$operation_condi.return_background
 )
 sanitized_name = sd.sanitize_name('$operation_condi.output_element_name')
 sdata[sanitized_name] = result_element
@@ -132,7 +132,7 @@ elements_dict, result_table = sd.join_spatialelement_table(
     table_name='$operation_condi.table_name',
     how='$operation_condi.how',
     match_rows='$operation_condi.match_rows',
-    filter_label_pixels=$operation_condi.filter_label_pixels_bool
+    filter_label_pixels=$operation_condi.filter_label_pixels
 )
 @PIXEL_FILTER_WARNING@
 ## Update sdata with filtered table
@@ -150,14 +150,14 @@ result = sdata
 
 #else if $operation_condi.operation == 'match_element_to_table':
 ## Match element to table
-    #set element_names_list = [str(x.strip()) for x in str($operation_condi.element_names).split(',')]
+    #set element_names_list = [str(x.strip()) for x in str($operation_condi.elment_name).split(',')]
 elements_dict, result_table = sd.match_element_to_table(
     sdata=sdata,
     element_name=$element_names_list,
     table_name='$operation_condi.table_name'
 )
 for elem_name, elem_data in elements_dict.items():
-    #if str($operation_condi.inplace_bool) == "True":
+    #if str($operation_condi.inplace) == "True":
     sdata[elem_name] = elem_data
     #else:
     sdata[f"matched_{elem_name}"] = elem_data
@@ -169,11 +169,11 @@ result = sdata
 ## Match table to element
 result_table = sd.match_table_to_element(
     sdata=sdata,
-    element_name='$operation_condi.element_name',
+    element_name='$operation_condi.elment_name',
     table_name='$operation_condi.table_name'
 )
 table_name = '$operation_condi.table_name'
-#if str($operation_condi.inplace_bool) == "True":
+#if str($operation_condi.inplace) == "True":
 sdata.tables[f"{table_name}"] = result_table
 #else:
 sdata.tables[f"matched_{table_name}"] = result_table
@@ -186,7 +186,7 @@ result = sd.match_sdata_to_table(
     sdata=sdata,
     table_name='$operation_condi.table_name',
     how='$operation_condi.how',
-    filter_label_pixels=$operation_condi.filter_label_pixels_bool
+    filter_label_pixels=$operation_condi.filter_label_pixels
 )
 @PIXEL_FILTER_WARNING@
 
@@ -197,7 +197,7 @@ import annsel as an
 result = sd.filter_by_table_query(
     sdata=sdata,
     table_name='$operation_condi.table_name',
-    filter_tables=$operation_condi.filter_tables_bool,
+    filter_tables=$operation_condi.filter_tables,
     #if $operation_condi.element_names:
         #set element_names_list = [str(x.strip()) for x in str($operation_condi.element_names).split(',')]
     element_names = $element_names_list,
@@ -223,7 +223,7 @@ result = sd.filter_by_table_query(
     layer = '$operation_condi.layer',
     #end if
     how='$operation_condi.how',
-    filter_label_pixels=$operation_condi.filter_label_pixels_bool
+    filter_label_pixels=$operation_condi.filter_label_pixels
 )
 @PIXEL_FILTER_WARNING@
 
@@ -248,10 +248,10 @@ result = sd.concatenate(
     #if $operation_condi.instance_key:
     instance_key='$operation_condi.instance_key',
     #end if
-    concatenate_tables=$operation_condi.concatenate_tables_bool,
-    obs_names_make_unique=$operation_condi.obs_names_make_unique_bool,
+    concatenate_tables=$operation_condi.concatenate_tables,
+    obs_names_make_unique=$operation_condi.obs_names_make_unique,
     modify_tables_inplace=False,
-    merge_coordinate_systems_on_name=$operation_condi.merge_coordinate_systems_on_name_bool
+    merge_coordinate_systems_on_name=$operation_condi.merge_coordinate_systems_on_name
     #if $operation_condi.attrs_merge:
     ,attrs_merge='$operation_condi.attrs_merge'
     #end if
@@ -259,7 +259,7 @@ result = sd.concatenate(
 
 #else if $operation_condi.operation == 'transform':
 ## Transform element
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
     #if $operation_condi.maintain_positioning_condi.maintain_positioning == 'yes':
 ## Apply transformation with maintain_positioning=True
         #if $operation_condi.maintain_positioning_condi.transformation_condi.transformation_type == 'identity':
@@ -325,7 +325,7 @@ result = sdata
     #set max_coord_list = [float(x.strip()) for x in str($operation_condi.max_coordinate).split(',')]
 
 rasterized = sd.rasterize(
-    data='$operation_condi.element_name',
+    data='$operation_condi.elment_name',
     axes=tuple($axes_list),
     min_coordinate=$min_coord_list,
     max_coordinate=$max_coord_list,
@@ -352,10 +352,10 @@ rasterized = sd.rasterize(
     #if $operation_condi.agg_func:
     agg_func='$operation_condi.agg_func',
     #end if
-    return_regions_as_labels=$operation_condi.return_regions_as_labels_bool,
-    return_single_channel=$operation_condi.return_single_channel_bool
+    return_regions_as_labels=$operation_condi.return_regions_as_labels,
+    return_single_channel=$operation_condi.return_single_channel
 )
-sdata.images['rasterized_' + '$operation_condi.element_name'] = rasterized
+sdata.images['rasterized_' + '$operation_condi.elment_name'] = rasterized
 result = sdata
 
 #else if $operation_condi.operation == 'rasterize_bins':
@@ -369,10 +369,10 @@ rasterized = sd.rasterize_bins(
     #if $operation_condi.value_key:
     value_key='$operation_condi.value_key',
     #end if
-    return_region_as_labels=$operation_condi.return_regions_as_labels_bool
+    return_region_as_labels=$operation_condi.return_regions_as_labels
 )
 
-#if str($operation_condi.return_regions_as_labels_bool) == "True":
+#if str($operation_condi.return_regions_as_labels) == "True":
 sdata.labels['rasterized_' + '$operation_condi.bins_element'] = rasterized
 #else:
 sdata.images['rasterized_' + '$operation_condi.bins_element'] = rasterized
@@ -391,7 +391,7 @@ result = sdata
 
 #else if $operation_condi.operation == 'to_circles':
 ## Convert to circles
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
     #if $operation_condi.radius:
 result_element = sd.to_circles(element, radius=$operation_condi.radius)
     #else:
@@ -407,7 +407,7 @@ result = sdata
 ##import dask
 ##dask.config.set(scheduler='processes')
 
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
     #if $operation_condi.buffer_resolution:
 result_element = sd.to_polygons(element, buffer_resolution=$operation_condi.buffer_resolution)
     #else:
@@ -436,10 +436,10 @@ result = sd.aggregate(
     #end if
     agg_func='$operation_condi.agg_func',
     target_coordinate_system='$operation_condi.target_coordinate_system',
-    fractions=$operation_condi.fractions_bool,
+    fractions=$operation_condi.fractions,
     region_key='$operation_condi.region_key',
     instance_key='$operation_condi.instance_key',
-    deepcopy=$operation_condi.deepcopy_bool,
+    deepcopy=$operation_condi.deepcopy,
     #if $operation_condi.table_name:
     table_name='$operation_condi.table_name',
     #end if
@@ -448,14 +448,14 @@ result = sd.aggregate(
 
 #else if $operation_condi.operation == 'map_raster':
 ## Map raster
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
 import importlib
 func_module, func_name = '$operation_condi.func_name'.rsplit('.', 1)
 func = getattr(importlib.import_module(func_module), func_name)
 mapped = sd.map_raster(
     data=element,
     func=func,
-    blockwise=$operation_condi.blockwise_bool,
+    blockwise=$operation_condi.blockwise,
     #if $operation_condi.depth:
     depth=$operation_condi.depth,
     #end if
@@ -482,23 +482,23 @@ mapped = sd.map_raster(
     #if $operation_condi.transformations:
     transformations=eval('$operation_condi.transformations'),
     #end if
-    relabel=$operation_condi.relabel_bool
+    relabel=$operation_condi.relabel
 )
-sdata.images['mapped_' + '$operation_condi.element_name'] = mapped
+sdata.images['mapped_' + '$operation_condi.elment_name'] = mapped
 result = sdata
 
 #else if $operation_condi.operation == 'unpad_raster':
 ## Unpad raster
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
 unpadded = sd.unpad_raster(element)
-sdata.images['unpadded_${operation_condi.element_name}'] = unpadded
+sdata.images['unpadded_${operation_condi.elment_name}'] = unpadded
 result = sdata
 
 #else if $operation_condi.operation == 'relabel_sequential':
 ## no good example to see how this should work and also when it works, the sdata can not be written
 ## Relabel sequential
 import dask.array as da
-element = sdata['$operation_condi.element_name']
+element = sdata['$operation_condi.elment_name']
 relabeled_arr = sd.relabel_sequential(element.data)
 relabeled = element.copy()
 relabeled.data = relabeled_arr
@@ -515,7 +515,7 @@ result = sd.are_extents_equal(extent1, extent2, atol=$operation_condi.atol)
 #else if $operation_condi.operation == 'get_pyramid_levels':
 ## no good example to see how this should work and also when it works, the sdata can not be written
 ## Get pyramid levels
-element = sdata.images['$operation_condi.element_name']
+element = sdata.images['$operation_condi.elment_name']
 result = sd.get_pyramid_levels(
     element,
     #if $operation_condi.attr:
@@ -525,7 +525,7 @@ result = sd.get_pyramid_levels(
     n=$operation_condi.n
     #end if
 )
-result[f"pyramid_{$operation_condi.element_name}"] = result.pop('pyramid')
+result[f"pyramid_{$operation_condi.elment_name}"] = result.pop('pyramid')
 
 #else if $operation_condi.operation == 'sanitize_table':
 ## Sanitize table
@@ -552,7 +552,7 @@ result = sdata
 ## Add shape to SpatialData
 from spatialdata.models import ShapesModel
 shape_data = ShapesModel.parse('$operation_condi.shape')
-element_name = sd.sanitize_name('$operation_condi.element_name')
+element_name = sd.sanitize_name('$operation_condi.elment_name')
 sdata[element_name] = shape_data
 result = sdata
 
@@ -639,19 +639,19 @@ print("\nOperation completed successfully!")
                 <option value="add_shape">Add a shape to a SpatialData object</option>
             </param>
             <when value="bounding_box_query">
-                <param name="axes" type="text" value="x,y" label="Axes" help="Comma-separated list of axes that min_coordinate and max_coordinate refer to (e.g., 'x,y' or 'x,y,z')">
+                <param argument="axes" type="text" value="x,y" label="Axes" help="Comma-separated list of axes that min_coordinate and max_coordinate refer to (e.g., 'x,y' or 'x,y,z')">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="min_coordinate" type="text" label="Minimum coordinates" help="Comma-separated minimum coordinates along all dimensions (e.g., '0,0')">
+                <param argument="min_coordinate" type="text" label="Minimum coordinates" help="Comma-separated minimum coordinates along all dimensions (e.g., '0,0')">
                     <expand macro="sanitize_digits"/>
                 </param>
-                <param name="max_coordinate" type="text" label="Maximum coordinates" help="Comma-separated maximum coordinates along all dimensions (e.g., '100,100')">
+                <param argument="max_coordinate" type="text" label="Maximum coordinates" help="Comma-separated maximum coordinates along all dimensions (e.g., '100,100')">
                     <expand macro="sanitize_digits"/>
                 </param>
-                <param name="target_coordinate_system" type="text" value="global" label="Target coordinate system" help="The coordinate system the bounding box is defined in">
+                <param argument="target_coordinate_system" type="text" value="global" label="Target coordinate system" help="The coordinate system the bounding box is defined in">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="filter_table_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter table?" help="If True, the table is filtered to only contain rows annotating regions within the bounding box"/>
+                <param argument="filter_table" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter table?" help="If True, the table is filtered to only contain rows annotating regions within the bounding box"/>
             </when>
             <when value="polygon_query">
                 <param name="polygon_coords" type="text" label="Polygon coordinates" help="Semicolon-separated list of coordinate pairs (x,y). Example: '0,0;100,0;100,100;0,100' for a square">
@@ -660,58 +660,58 @@ print("\nOperation completed successfully!")
                     </expand>
                 </param>
                 <expand macro="param_target_coordinate_system" help="The coordinate system of the polygon"/>
-                <param name="filter_table_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter table?" help="Filter tables to only include tables annotating elements in the query result"/>
-                <param name="clip_shapes_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Clip shapes?" help="If True, shapes are clipped to the polygon. This behavior is implemented only when querying polygons/multipolygons or circles, and it is ignored for other types of elements (images, labels, points). Importantly, when clipping is enabled, the circles will be converted to polygons before the clipping. This may affect downstream operations that rely on the circle radius or on performance, so it is recommended to disable clipping when querying circles or when querying a SpatialData object that contains circles."/>
+                <param argument="filter_table" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter table?" help="Filter tables to only include tables annotating elements in the query result"/>
+                <param argument="clip" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Clip shapes?" help="If True, shapes are clipped to the polygon. This behavior is implemented only when querying polygons/multipolygons or circles, and it is ignored for other types of elements (images, labels, points). Importantly, when clipping is enabled, the circles will be converted to polygons before the clipping. This may affect downstream operations that rely on the circle radius or on performance, so it is recommended to disable clipping when querying circles or when querying a SpatialData object that contains circles."/>
             </when>
             <when value="get_values">
-                <param name="value_key" type="text" optional="false" label="Value key" help="Column name(s) to retrieve values from">
+                <param argument="value_key" type="text" optional="false" label="Value key" help="Column name(s) to retrieve values from">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="element_name" type="text" label="Element name" help="Name of the element to get values from">
+                <param argument="element_name" type="text" label="Element name" help="Name of the element to get values from">
                     <validator type="empty_field"/>
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="table_name" type="text" optional="true" label="Table name (optional)" help="Name of table containing the value_key">
+                <param argument="table_name" type="text" optional="true" label="Table name (optional)" help="Name of table containing the value_key">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="table_layer" type="text" optional="true" label="Table layer (optional)" help="Layer of table to get values from. If None, values from X are used">
+                <param argument="table_layer" type="text" optional="true" label="Table layer (optional)" help="Layer of table to get values from. If None, values from X are used">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="return_obsm_as_is" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return_obsm_as_is" help="In case the value is in obsm the value of the key can be returned as is if return_obsm_as_is is True, otherwise creates a dataframe and returns it."/>
+                <param argument="return_obsm_as_is" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return_obsm_as_is" help="In case the value is in obsm the value of the key can be returned as is if return_obsm_as_is is True, otherwise creates a dataframe and returns it."/>
             </when>
             <when value="get_element_instances">
-                <expand macro="param_element_name" help="Name of the element to get instances from">
+                <expand macro="param_element_name" help="Name of the element to get instances from" argument="element">
                     <validator type="empty_field"/>
                 </expand>
-                <param name="return_background_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include background?" help="If True, background label (0) is included"/>
+                <param argument="return_background" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include background?" help="If True, background label (0) is included"/>
             </when>
             <when value="get_extent">
                 <expand macro="param_element_name" optional="true" label="Element name" help="Name of a specific element to get extent from. Leave empty to get extent of entire SpatialData object"/>
-                <param name="elements" type="text" optional="true" label="Comma-separated list of element names to restrict the extent calculation to">
+                <param argument="elements" type="text" optional="true" label="Comma-separated list of element names to restrict the extent calculation to">
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_coordinate_system"/>
-                <param name="exact_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Compute exact extent?" help="If False, an approximation faster to compute is given"/>
-                <param name="has_images_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include images?" help="Include images in extent computation (only for SpatialData objects)"/>
-                <param name="has_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include labels?" help="Include labels in extent computation (only for SpatialData objects)"/>
-                <param name="has_points_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include points?" help="Include points in extent computation (only for SpatialData objects)"/>
-                <param name="has_shapes_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include shapes?" help="Include shapes in extent computation (only for SpatialData objects)"/>
+                <param argument="exact" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Compute exact extent?" help="If False, an approximation faster to compute is given"/>
+                <param argument="has_images" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include images?" help="Include images in extent computation (only for SpatialData objects)"/>
+                <param argument="has_labels" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include labels?" help="Include labels in extent computation (only for SpatialData objects)"/>
+                <param argument="has_points" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include points?" help="Include points in extent computation (only for SpatialData objects)"/>
+                <param argument="has_shapes" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Include shapes?" help="Include shapes in extent computation (only for SpatialData objects)"/>
             </when>
             <when value="get_centroids">
                 <expand macro="param_element_name" help="Name of the element to get centroids from"/>
                 <expand macro="param_output_element_name" value="centroids_points" help="Name for the centroids points element"/>
                 <expand macro="param_coordinate_system"/>
-                <param name="return_background_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include background?" help="If True, centroid of background label (0) is included"/>
+                <param argument="return_background" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Include background?" help="If True, centroid of background label (0) is included"/>
             </when>
             <when value="join_spatialelement_table">
-                <param name="spatial_element_names" type="text" optional="false" label="Spatial element name(s)" help="Comma-separated list of element names to join with table">
+                <param argument="spatial_element_names" type="text" optional="false" label="Spatial element name(s)" help="Comma-separated list of element names to join with table">
                     <validator type="empty_field"/>
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_table_name"/>
                 <expand macro="param_region_key" value="" optional="true" help="The column in table.obs containing the rows specifying the SpatialElements being annotated. If None the current value for region_key in the annotation metadata of the table is used. If specified but different from the current region_key, the current region_key is overwritten."/>
                 <expand macro="param_join_type" selected="left"/>
-                <param name="match_rows" type="select" label="Match rows">
+                <param argument="match_rows" type="select" label="Match rows">
                     <option value="no" selected="true">No</option>
                     <option value="left">Left (element indices priority)</option>
                     <option value="right">Right (table instance IDs priority)</option>
@@ -719,79 +719,79 @@ print("\nOperation completed successfully!")
                 <param name="output_table_name" type="text" value="out_table" label="Output table name">
                     <expand macro="sanitize_query"/>
                 </param>
-                <expand macro="param_filter_label_pixels_bool"/>
+                <expand macro="param_filter_label_pixels"/>
             </when>
             <when value="match_element_to_table">
-                <param name="element_names" type="text" label="Element name(s)" help="Comma-separated list of element names to match to table">
+                <param argument="elment_name" type="text" label="Element name(s)" help="Comma-separated list of element names to match to table">
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_table_name"/>
-                <param name="inplace_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Overwrite existing element?" help="If True, the element is overwritten in-place. If False, a new element is created."/>
+                <param name="inplace" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Overwrite existing element?" help="If True, the element is overwritten in-place. If False, a new element is created."/>
             </when>
             <when value="match_table_to_element">
-                <expand macro="param_element_name" help="Name of element to match table to"/>
+                <expand macro="param_element_name" help="Name of element to match table to" argument="element_name"/>
                 <expand macro="param_table_name"/>
-                <param name="inplace_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Overwrite existing table?" help="If True, the table is overwritten in-place. If False, a new table is created."/>
+                <param name="inplace" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Overwrite existing table?" help="If True, the table is overwritten in-place. If False, a new table is created."/>
             </when>
             <when value="match_sdata_to_table">
                 <expand macro="param_table_name"/>
-                <param name="how" type="select" label="Join type">
+                <param argument="how" type="select" label="Join type">
                     <option value="right" selected="true">Right</option>
                     <option value="left">Left</option>
                     <option value="left_exclusive">Left Exclusive</option>
                     <option value="inner">Inner</option>
                     <option value="right_exclusive">Right Exclusive</option>
                 </param>
-                <expand macro="param_filter_label_pixels_bool"/>
+                <expand macro="param_filter_label_pixels"/>
             </when>
             <when value="filter_by_table_query">
                 <expand macro="param_table_name" value="table"/>
-                <param name="filter_tables_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter tables?" help="Filter table to contain only rows annotating regions in element_names"/>
-                <param name="element_names" type="text" optional="true" label="Element names (optional)" help="Comma-separated list of element names to filter by">
+                <param argument="filter_tables" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Filter tables?" help="Filter table to contain only rows annotating regions in element_names"/>
+                <param argument="element_names" type="text" optional="true" label="Element names (optional)" help="Comma-separated list of element names to filter by">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="obs_expr" type="text" optional="true" label="Obs expression (optional)" help="Narwhals expression to filter .obs (e.g., an.col('cell_type') == 'A' or an.col('region') == 'blobs_labels'). Use an.col() to reference columns.">
+                <param argument="obs_expr" type="text" optional="true" label="Obs expression (optional)" help="Narwhals expression to filter .obs (e.g., an.col('cell_type') == 'A' or an.col('region') == 'blobs_labels'). Use an.col() to reference columns.">
                     <sanitizer>
                         <valid initial="string.printable">
                         </valid>
                     </sanitizer>
                 </param>
-                <param name="var_expr" type="text" optional="true" label="Var expression (optional)" help="Narwhals expression to filter .var">
+                <param argument="var_expr" type="text" optional="true" label="Var expression (optional)" help="Narwhals expression to filter .var">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="x_expr" type="text" optional="true" label="X expression (optional)" help="Narwhals expression to filter .X expression matrix (e.g., an.col('channel_0_sum') &gt; 125). Use an.col() to reference columns.">
+                <param argument="x_expr" type="text" optional="true" label="X expression (optional)" help="Narwhals expression to filter .X expression matrix (e.g., an.col('channel_0_sum') &gt; 125). Use an.col() to reference columns.">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="obs_names_expr" type="text" optional="true" label="Obs names expression (optional)" help="Narwhals expression to filter .obs_names">
+                <param argument="obs_names_expr" type="text" optional="true" label="Obs names expression (optional)" help="Narwhals expression to filter .obs_names">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="var_names_expr" type="text" optional="true" label="Var names expression (optional)" help="Narwhals expression to filter .var_names">
+                <param argument="var_names_expr" type="text" optional="true" label="Var names expression (optional)" help="Narwhals expression to filter .var_names">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="layer" type="text" value="table" label="The layer of the anndata.AnnData to filter the SpatialData object by" help="Only used with x_expr">
+                <param argument="layer" type="text" value="table" label="The layer of the anndata.AnnData to filter the SpatialData object by" help="Only used with x_expr">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="how" type="select" label="Join type">
+                <param argument="how" type="select" label="Join type">
                     <option value="right" selected="true">Right</option>
                     <option value="left">Left</option>
                     <option value="left_exclusive">Left Exclusive</option>
                     <option value="inner">Inner</option>
                     <option value="right_exclusive">Right Exclusive</option>
                 </param>
-                <expand macro="param_filter_label_pixels_bool"/>
+                <expand macro="param_filter_label_pixels"/>
             </when>
             <when value="concatenate">
                 <param name="other_sdatas" type="data" format="spatialdata.zip" multiple="true" label="Other SpatialData objects to concatenate"/>
-                <param name="region_key" type="text" optional="true" label="Region key (optional)" help="The key to use for the region column in the concatenated object">
+                <param argument="region_key" type="text" optional="true" label="Region key (optional)" help="The key to use for the region column in the concatenated object">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="instance_key" type="text" optional="true" label="Instance key (optional)" help="The key to use for the instance column in the concatenated object">
+                <param argument="instance_key" type="text" optional="true" label="Instance key (optional)" help="The key to use for the instance column in the concatenated object">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="concatenate_tables_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Concatenate tables?" help="Whether to merge the tables in case of having the same element name"/>
-                <param name="obs_names_make_unique_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Make obs names unique?" help="Whether to make the obs_names unique"/>
-                <param name="merge_coordinate_systems_on_name_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Merge coordinate systems on name?" help="Whether to keep coordinate system names unchanged (True) or add suffixes (False)"/>
-                <param name="attrs_merge" type="select" optional="true" label="Attributes merge strategy (optional)">
+                <param argument="concatenate_tables" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Concatenate tables?" help="Whether to merge the tables in case of having the same element name"/>
+                <param argument="obs_names_make_unique" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Make obs names unique?" help="Whether to make the obs_names unique"/>
+                <param argument="merge_coordinate_systems_on_name" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Merge coordinate systems on name?" help="Whether to keep coordinate system names unchanged (True) or add suffixes (False)"/>
+                <param argument="attrs_merge" type="select" optional="true" label="Attributes merge strategy (optional)">
                     <option value="same">Same - all must be identical</option>
                     <option value="unique">Unique - keep values that appear only once</option>
                     <option value="first">First - use first non-missing value</option>
@@ -802,7 +802,7 @@ print("\nOperation completed successfully!")
                 <expand macro="param_element_name" help="Name of the element to transform"/>
                 <expand macro="param_output_element_name" value="transformed_element" help="Name for the transformed element"/>
                 <conditional name="maintain_positioning_condi">
-                    <param name="maintain_positioning" type="select" label="Maintain positioning?">
+                    <param argument="maintain_positioning" type="select" label="Maintain positioning?">
                         <option value="yes">Yes - Apply transformation while maintaining positioning in existing coordinate systems</option>
                         <option value="no" selected="true">No - Transform to a different coordinate system</option>
                     </param>
@@ -862,7 +862,7 @@ print("\nOperation completed successfully!")
                         </conditional>
                     </when>
                     <when value="no">
-                        <param name="to_coordinate_system" type="text" value="global" label="Target coordinate system" help="The coordinate system to which the data should be transformed. Must be present in the element.">
+                        <param argument="to_coordinate_system" type="text" value="global" label="Target coordinate system" help="The coordinate system to which the data should be transformed. Must be present in the element.">
                             <expand macro="sanitize_query"/>
                         </param>
                     </when>
@@ -873,92 +873,92 @@ print("\nOperation completed successfully!")
                 <expand macro="param_axes"/>
                 <expand macro="coordinate_bounds_params"/>
                 <expand macro="param_target_coordinate_system"/>
-                <param name="target_unit_to_pixels" type="float" optional="true" label="Target unit to pixels (optional)" help="Pixels per unit"/>
-                <param name="target_width" type="float" min="0" optional="true" label="Target width (optional)" help="Width of the rasterized image in pixels"/>
-                <param name="target_height" type="float" min="0" optional="true" label="Target height (optional)" help="Height of the rasterized image in pixels"/>
-                <param name="target_depth" type="float" min="0" optional="true" label="Target depth (optional)" help="Depth of the rasterized image in pixels. Only used for 3D rasterization"/>
+                <param argument="target_unit_to_pixels" type="float" optional="true" label="Target unit to pixels (optional)" help="Pixels per unit"/>
+                <param argument="target_width" type="float" min="0" optional="true" label="Target width (optional)" help="Width of the rasterized image in pixels"/>
+                <param argument="target_height" type="float" min="0" optional="true" label="Target height (optional)" help="Height of the rasterized image in pixels"/>
+                <param argument="target_depth" type="float" min="0" optional="true" label="Target depth (optional)" help="Depth of the rasterized image in pixels. Only used for 3D rasterization"/>
                 <expand macro="param_value_key" optional="true" label="Value key (optional)" help="Column name containing values to aggregate"/>
                 <expand macro="param_table_name" value="" optional="true" label="Table name (optional)" help="The table optionally containing the value_key and the name of the table in the returned SpatialData object"/>
                 <expand macro="param_agg_func" optional="true" help="Available only when rasterizing points and shapes."/>
-                <param name="return_regions_as_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return as labels?" help="Return as labels (y,x) instead of image (c,y,x)"/>
-                <param name="return_single_channel_bool" type="boolean" truevalue="True" falsevalue="None" checked="false" label="Return single channel?" help="Only used when rasterizing points and shapes and when value_key refers to a categorical column. If False, each category will be rasterized in a separate channel."/>
+                <param argument="return_regions_as_labels" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return as labels?" help="Return as labels (y,x) instead of image (c,y,x)"/>
+                <param argument="return_single_channel" type="boolean" truevalue="True" falsevalue="None" checked="false" label="Return single channel?" help="Only used when rasterizing points and shapes and when value_key refers to a categorical column. If False, each category will be rasterized in a separate channel."/>
             </when>
             <when value="rasterize_bins">
-                <param name="bins_element" type="text" label="Bins element name" help="Name of grid-like binned element">
+                <param argument="bins" name="bins_element" type="text" label="Bins element name" help="Name of grid-like binned element">
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_table_name"/>
-                <param name="col_key" type="text" label="Column key" help="Column in table.obs with column indices">
+                <param argument="col_key" type="text" label="Column key" help="Column in table.obs with column indices">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="row_key" type="text" label="Row key" help="Column in table.obs with row indices">
+                <param argument="row_key" type="text" label="Row key" help="Column in table.obs with row indices">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="value_key" type="text" optional="true" label="Value key(s) (optional)" help="Obs columns or var names to rasterize. If None, all the var names will be used, and the returned object will be lazily constructed. Ignored if return_regions_as_labels_bool is True">
+                <param argument="value_key" type="text" optional="true" label="Value key(s) (optional)" help="Obs columns or var names to rasterize. If None, all the var names will be used, and the returned object will be lazily constructed. Ignored if return_regions_as_labels is True">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="return_regions_as_labels_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return as labels?" help="If False this function returns a xarray.DataArray of shape (c, y, x) with dimension of c equal to the number of key(s) specified in value_key, or the number of var names in table_name if value_key is None. If True, will return labels of shape (y, x), where each bin of the bins element will be represented as a pixel."/>
+                <param argument="return_regions_as_labels" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Return as labels?" help="If False this function returns a xarray.DataArray of shape (c, y, x) with dimension of c equal to the number of key(s) specified in value_key, or the number of var names in table_name if value_key is None. If True, will return labels of shape (y, x), where each bin of the bins element will be represented as a pixel."/>
             </when>
             <when value="rasterize_bins_link_table_to_labels">
                 <expand macro="param_table_name"/>
-                <param name="rasterized_labels_name" type="text" label="Rasterized labels element name" help="Name of the rasterized labels element created by rasterize_bins">
+                <param argument="rasterized_labels_name" type="text" label="Rasterized labels element name" help="Name of the rasterized labels element created by rasterize_bins">
                     <expand macro="sanitize_query"/>
                 </param>
             </when>
             <when value="to_circles">
                 <expand macro="param_element_name" help="Name of the element to convert to circles"/>
                 <expand macro="param_output_element_name" value="circle_element"/>
-                <param name="radius" type="float" min="0" optional="true" label="Radius (optional)" help="Radius for circles. Required for points, automatic for other elements"/>
+                <param argument="radius" type="float" min="0" optional="true" label="Radius (optional)" help="Radius for circles. Required for points, automatic for other elements"/>
             </when>
             <when value="to_polygons">
                 <expand macro="param_element_name" help="Name of the element to convert to polygons"/>
                 <expand macro="param_output_element_name" value="polygon_element" help="Name for the polygons element"/>
-                <param name="buffer_resolution" type="integer" optional="true" min="1" label="Buffer resolution" help="Resolution for converting circles to polygons"/>
+                <param argument="buffer_resolution" type="integer" optional="true" min="1" label="Buffer resolution" help="Resolution for converting circles to polygons"/>
             </when>
             <when value="aggregate">
-                <param name="values_element" type="text" label="Values element name" help="Name of the element of spatialdata containing values to aggregate">
+                <param argument="values" name="values_element" type="text" label="Values element name" help="Name of the element of spatialdata containing values to aggregate">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="by_element" type="text" label="Regions element name" help="Name of the element defining regions to aggregate by">
+                <param argument="by" name="by_element" type="text" label="Regions element name" help="Name of the element defining regions to aggregate by">
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_value_key" optional="true" label="Comma-separated column names containing values to aggregate"/>
                 <expand macro="param_agg_func" optional="false"/>
                 <expand macro="param_target_coordinate_system"/>
-                <param name="fractions_bool" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Adjust for partial overlap?" help="If True, values are weighted by overlap fraction"/>
+                <param argument="fractions" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Adjust for partial overlap?" help="If True, values are weighted by overlap fraction"/>
                 <expand macro="param_region_key" help="Name for the region column in output table"/>
                 <expand macro="param_instance_key" help="Name for the instance ID column in output table"/>
                 <expand macro="param_table_name" value="" optional="true" label="Table name (optional)" help="Table containing the value_key"/>
-                <param name="deepcopy_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Deep copy shapes?" help="Whether to deepcopy shapes in result"/>
-                <param name="buffer_resolution" type="integer" min="0" value="16" label="Resolution" help=" A higher value results in a more accurate representation of the circle, but also in a more complex polygon and computation."/>
+                <param argument="deepcopy" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Deep copy shapes?" help="Whether to deepcopy shapes in result"/>
+                <param argument="buffer_resolution" type="integer" min="0" value="16" label="Resolution" help=" A higher value results in a more accurate representation of the circle, but also in a more complex polygon and computation."/>
             </when>
             <when value="map_raster">
                 <expand macro="param_element_name" label="Raster element name"/>
-                <param name="func_name" type="text" label="Function name" help="Name of numpy/scipy function to apply (e.g., 'numpy.mean')">
+                <param argument="func" name="func_name" type="text" label="Function name" help="Name of numpy/scipy function to apply (e.g., 'numpy.mean')">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="blockwise_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Process blockwise?" help="If True, func will be distributed with dask.array.map_overlap() or dask.array.map_blocks(), otherwise func is applied to the full data. If False, depth and chunks are ignored."/>
-                <param name="depth" type="integer" min="0" optional="true" label="Overlap between chunks (optional)" help="the number of elements that each chunk should share with its neighboring chunks"/>
-                <param name="chunks" type="text" optional="true" label="Chunks (optional)" help="Chunk shape of resulting blocks if the callable does not preserve the data shape. Format: nested tuples like '((1,),(100,),(100,))' for shape (1,100,100). Passed to dask.array.map_overlap() or dask.array.map_blocks(). Ignored if blockwise is False.">
+                <param argument="blockwise" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Process blockwise?" help="If True, func will be distributed with dask.array.map_overlap() or dask.array.map_blocks(), otherwise func is applied to the full data. If False, depth and chunks are ignored."/>
+                <param argument="depth" type="integer" min="0" optional="true" label="Overlap between chunks (optional)" help="the number of elements that each chunk should share with its neighboring chunks"/>
+                <param argument="chunks" type="text" optional="true" label="Chunks (optional)" help="Chunk shape of resulting blocks if the callable does not preserve the data shape. Format: nested tuples like '((1,),(100,),(100,))' for shape (1,100,100). Passed to dask.array.map_overlap() or dask.array.map_blocks(). Ignored if blockwise is False.">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="c_coords" type="text" optional="true" label="Channel coordinates (optional)" help="Comma-separated channel coordinates for output data (integers or strings). If not provided, input channel coordinates are used. Required if func changes number of channels.">
+                <param argument="c_coords" type="text" optional="true" label="Channel coordinates (optional)" help="Comma-separated channel coordinates for output data (integers or strings). If not provided, input channel coordinates are used. Required if func changes number of channels.">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="dims" type="text" optional="true" label="Output dimensions (optional)" help="Comma-separated dimensions of output data (e.g., 'c,y,x' or 'y,x'). If not provided, input dimensions are used. Must be specified if callable changes dimensions.">
+                <param argument="dims" type="text" optional="true" label="Output dimensions (optional)" help="Comma-separated dimensions of output data (e.g., 'c,y,x' or 'y,x'). If not provided, input dimensions are used. Must be specified if callable changes dimensions.">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="transformations" type="text" optional="true" label="Transformations JSON (optional)" help="JSON string for output transformations. If not provided, input transformations are copied. Should be specified if callable changes transformations.">
+                <param argument="transformations" type="text" optional="true" label="Transformations JSON (optional)" help="JSON string for output transformations. If not provided, input transformations are copied. Should be specified if callable changes transformations.">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="relabel_bool" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Relabel blocks?" help="Whether to relabel blocks of output data. Ignored when output is not a labels layer. Recommended if func returns labels not unique across chunks."/>
+                <param argument="relabel" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Relabel blocks?" help="Whether to relabel blocks of output data. Ignored when output is not a labels layer. Recommended if func returns labels not unique across chunks."/>
             </when>
             <when value="unpad_raster">
                 <expand macro="param_element_name" label="Raster element name" help="Name of raster element to unpad"/>
             </when>
             <!-- no good example to see how this should work and also when it works, the sdata can not be written
             <when value="relabel_sequential">
-                <param name="element_name" type="text" label="Labels element name" help="Name of labels element to relabel. Note that currently if a cell or entity to be labeled is split across adjacent chunks the same label is not assigned to the cell across blocks.">
+                <param name="elment_name" type="text" label="Labels element name" help="Name of labels element to relabel. Note that currently if a cell or entity to be labeled is split across adjacent chunks the same label is not assigned to the cell across blocks.">
                     <expand macro="sanitize_query"/>
                 </param>
                 <param name="output_element_name" type="text" value="relabeled_element" label="Output element name">
@@ -966,18 +966,18 @@ print("\nOperation completed successfully!")
                 </param>
             </when> -->
             <when value="are_extents_equal">
-                <param name="element1_name" type="text" label="First element name">
+                <param argument="extent0" name="element1_name" type="text" label="First element name">
                     <expand macro="sanitize_query"/>
                 </param>
-                <param name="element2_name" type="text" label="Second element name">
+                <param argument="extent1" name="element2_name" type="text" label="Second element name">
                     <expand macro="sanitize_query"/>
                 </param>
                 <expand macro="param_coordinate_system"/>
-                <param name="atol" type="float" value="0.1" label="Absolute tolerance"/>
+                <param argument="atol" type="float" value="0.1" label="Absolute tolerance"/>
             </when>
             <!-- no good example to see how this should work and also when it works, the sdata can not be written
             <when value="get_pyramid_levels">
-                <param name="element_name" type="text" label="Multiscale image element name">
+                <param name="elment_name" type="text" label="Multiscale image element name">
                     <expand macro="sanitize_query"/>
                 </param>
                 <param name="attr" type="text" optional="true" label="Attribute name (optional)" help="Return specific attribute instead of data.  If None, return the data of the pyramid level as a DataArray, if not None, return the specified attribute within the DataArray data.">
@@ -1089,8 +1089,8 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_element_instances"/>
-                <param name="element_name" value="cell_labels"/>
-                <param name="return_background_bool" value="false"/>
+                <param name="elment_name" value="cell_labels"/>
+                <param name="return_background" value="false"/>
             </conditional>
             <assert_stdout>
                 <has_text text="get_element_instances"/>
@@ -1127,7 +1127,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_centroids"/>
-                <param name="element_name" value="cell_labels"/>
+                <param name="elment_name" value="cell_labels"/>
                 <param name="output_element_name" value="cell_centroids"/>
                 <param name="coordinate_system" value="global"/>
             </conditional>
@@ -1175,7 +1175,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="match_element_to_table"/>
-                <param name="element_names" value="Test_Visium"/>
+                <param name="elment_name" value="Test_Visium"/>
                 <param name="table_name" value="table"/>
             </conditional>
             <assert_stdout>
@@ -1198,7 +1198,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="match_table_to_element"/>
-                <param name="element_name" value="Test_Visium"/>
+                <param name="elment_name" value="Test_Visium"/>
                 <param name="table_name" value="table"/>
             </conditional>
             <assert_stdout>
@@ -1241,7 +1241,7 @@ print("\nOperation completed successfully!")
             <conditional name="operation_condi">
                 <param name="operation" value="filter_by_table_query"/>
                 <param name="table_name" value="table"/>
-                <param name="filter_tables_bool" value="true"/>
+                <param name="filter_tables" value="true"/>
                 <param name="obs_expr" value="an.col('region') == 'cell_labels'"/>
                 <param name="how" value="right"/>
             </conditional>
@@ -1283,7 +1283,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="transform"/>
-                <param name="element_name" value="cell_labels"/>
+                <param name="elment_name" value="cell_labels"/>
                 <param name="output_element_name" value="transformed_labels"/>
                 <conditional name="maintain_positioning_condi">
                     <param name="maintain_positioning" value="yes"/>
@@ -1313,7 +1313,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="rasterize"/>
-                <param name="element_name" value="cell_labels"/>
+                <param name="elment_name" value="cell_labels"/>
                 <param name="axes" value="x,y"/>
                 <param name="min_coordinate" value="0,0"/>
                 <param name="max_coordinate" value="100,100"/>
@@ -1344,7 +1344,7 @@ print("\nOperation completed successfully!")
                 <param name="col_key" value="array_col"/>
                 <param name="row_key" value="array_row"/>
                 <param name="value_key" value="location_id"/>
-                <param name="return_regions_as_labels_bool" value="false"/>
+                <param name="return_regions_as_labels" value="false"/>
             </conditional>
             <assert_stdout>
                 <has_text text="rasterize_bins"/>
@@ -1370,7 +1370,7 @@ print("\nOperation completed successfully!")
                 <param name="col_key" value="array_col"/>
                 <param name="row_key" value="array_row"/>
                 <param name="value_key" value="location_id"/>
-                <param name="return_regions_as_labels_bool" value="true"/>
+                <param name="return_regions_as_labels" value="true"/>
             </conditional>
             <assert_stdout>
                 <has_text text="rasterize_bins"/>
@@ -1413,7 +1413,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="to_circles"/>
-                <param name="element_name" value="cell_labels"/>
+                <param name="elment_name" value="cell_labels"/>
                 <param name="output_element_name" value="cell_circles"/>
             </conditional>
             <assert_stdout>
@@ -1435,7 +1435,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="to_polygons"/>
-                <param name="element_name" value="cell_labels"/>
+                <param name="elment_name" value="cell_labels"/>
                 <param name="output_element_name" value="cell_polygons"/>
             </conditional>
             <assert_stdout>
@@ -1482,9 +1482,9 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="map_raster"/>
-                <param name="element_name" value="morphology_focus"/>
+                <param name="elment_name" value="morphology_focus"/>
                 <param name="func_name" value="numpy.log1p"/>
-                <param name="blockwise_bool" value="true"/>
+                <param name="blockwise" value="true"/>
             </conditional>
             <assert_stdout>
                 <has_text text="map_raster"/>
@@ -1505,7 +1505,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="unpad_raster"/>
-                <param name="element_name" value="morphology_focus"/>
+                <param name="elment_name" value="morphology_focus"/>
             </conditional>
             <assert_stdout>
                 <has_text text="unpad_raster"/>
@@ -1527,7 +1527,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="relabel_sequential"/>
-                <param name="element_name" value="Test_Visium_hires_image"/>
+                <param name="elment_name" value="Test_Visium_hires_image"/>
                 <param name="output_element_name" value="image_relabeled"/>
             </conditional>
             <assert_stdout>
@@ -1566,7 +1566,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_pyramid_levels"/>
-                <param name="element_name" value="morphology_focus"/>
+                <param name="elment_name" value="morphology_focus"/>
             </conditional>
             <assert_stdout>
                 <has_text text="get_pyramid_levels"/>
@@ -1639,7 +1639,7 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="add_shape"/>
-                <param name="element_name" value="new_shapes"/>
+                <param name="elment_name" value="new_shapes"/>
                 <param name="shape" location="https://zenodo.org/records/21358431/files/visiumhd_cell_segmentations.geojson"/>
             </conditional>
             <assert_stdout>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -393,7 +393,7 @@ result = sdata
 #else if $operation_condi.operation == 'to_circles':
 ## Convert to circles
 element = sdata['$operation_condi.element_name']
-    #if str($operation_condi.radius) != '':
+    #if $operation_condi.radius:
 result_element = sd.to_circles(element, radius=$operation_condi.radius)
     #else:
 result_element = sd.to_circles(element)

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -131,8 +131,10 @@ elements_dict, result_table = sd.join_spatialelement_table(
     spatial_element_names=$element_names_list,
     table_name='$operation_condi.table_name',
     how='$operation_condi.how',
-    match_rows='$operation_condi.match_rows'
+    match_rows='$operation_condi.match_rows',
+    filter_label_pixels=$operation_condi.filter_label_pixels_bool
 )
+@PIXEL_FILTER_WARNING@
 ## Update sdata with filtered table
 table = sdata.update_annotated_regions_metadata(table=result_table,
                                             #if $operation_condi.region_key:
@@ -183,8 +185,10 @@ result = sdata
 result = sd.match_sdata_to_table(
     sdata=sdata,
     table_name='$operation_condi.table_name',
-    how='$operation_condi.how'
+    how='$operation_condi.how',
+    filter_label_pixels=$operation_condi.filter_label_pixels_bool
 )
+@PIXEL_FILTER_WARNING@
 
 #else if $operation_condi.operation == 'filter_by_table_query':
 ## Filter by table query
@@ -218,8 +222,11 @@ result = sd.filter_by_table_query(
     #if $operation_condi.layer:
     layer = '$operation_condi.layer',
     #end if
-    how='$operation_condi.how'
+    how='$operation_condi.how',
+    filter_by_table_query,
+    filter_label_pixels=$operation_condi.filter_label_pixels_bool
 )
+@PIXEL_FILTER_WARNING@
 
 #else if $operation_condi.operation == 'concatenate':
 ## Concatenate multiple SpatialData objects
@@ -713,6 +720,7 @@ print("\nOperation completed successfully!")
                 <param name="output_table_name" type="text" value="out_table" label="Output table name">
                     <expand macro="sanitize_query"/>
                 </param>
+                <expand macro="param_filter_label_pixels_bool"/>
             </when>
             <when value="match_element_to_table">
                 <param name="element_names" type="text" label="Element name(s)" help="Comma-separated list of element names to match to table">
@@ -735,6 +743,7 @@ print("\nOperation completed successfully!")
                     <option value="inner">Inner</option>
                     <option value="right_exclusive">Right Exclusive</option>
                 </param>
+                <expand macro="param_filter_label_pixels_bool"/>
             </when>
             <when value="filter_by_table_query">
                 <expand macro="param_table_name" value="table"/>
@@ -770,6 +779,7 @@ print("\nOperation completed successfully!")
                     <option value="inner">Inner</option>
                     <option value="right_exclusive">Right Exclusive</option>
                 </param>
+                <expand macro="param_filter_label_pixels_bool"/>
             </when>
             <when value="concatenate">
                 <param name="other_sdatas" type="data" format="spatialdata.zip" multiple="true" label="Other SpatialData objects to concatenate"/>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -223,7 +223,6 @@ result = sd.filter_by_table_query(
     layer = '$operation_condi.layer',
     #end if
     how='$operation_condi.how',
-    filter_by_table_query,
     filter_label_pixels=$operation_condi.filter_label_pixels_bool
 )
 @PIXEL_FILTER_WARNING@
@@ -1024,21 +1023,21 @@ print("\nOperation completed successfully!")
                 <param name="operation" value="bounding_box_query"/>
                 <param name="axes" value="x,y"/>
                 <param name="min_coordinate" value="0,0"/>
-                <param name="max_coordinate" value="100,100"/>
+                <param name="max_coordinate" value="1000,1000"/>
                 <param name="target_coordinate_system" value="global"/>
             </conditional>
             <assert_stdout>
                 <has_text text="bounding_box_query"/>
                 <has_text text="axes=tuple(['x', 'y'])"/>
                 <has_text text="min_coordinate=[0.0, 0.0]"/>
-                <has_text text="max_coordinate=[100.0, 100.0]"/>
+                <has_text text="max_coordinate=[1000.0, 1000.0]"/>
                 <has_text text="target_coordinate_system='global'"/>
                 <has_text text="target_coordinate_system='global'"/>
                 <has_text text="filter_table=True"/>
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_size value="56000" delta="1000"/>
+                    <has_size value="844000" delta="1000"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -1009,7 +1009,7 @@ print("\nOperation completed successfully!")
     <tests>
         <!-- Test 1: bounding_box_query -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="bounding_box_query"/>
                 <param name="axes" value="x,y"/>
@@ -1034,7 +1034,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 2: polygon_query -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="polygon_query"/>
                 <param name="polygon_coords" value="0,0;100,0;100,100;0,100"/>
@@ -1055,7 +1055,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 3: get_values -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_values"/>
                 <param name="value_key" value="ABCC11,ACE2"/>
@@ -1077,7 +1077,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 4: get_element_instances -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_element_instances"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1096,7 +1096,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 5: get_extent -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_extent"/>
                 <param name="coordinate_system" value="global"/>
@@ -1115,7 +1115,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 6: get_centroids -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_centroids"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1138,7 +1138,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 7: join_spatialelement_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="join_spatialelement_table"/>
                 <param name="spatial_element_names" value="cell_labels"/>
@@ -1163,7 +1163,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 8: match_element_to_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="match_element_to_table"/>
                 <param name="element_names" value="Test_Visium"/>
@@ -1186,7 +1186,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 9: match_table_to_element -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="match_table_to_element"/>
                 <param name="element_name" value="Test_Visium"/>
@@ -1209,7 +1209,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 10: match_sdata_to_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="match_sdata_to_table"/>
                 <param name="table_name" value="table"/>
@@ -1228,7 +1228,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 11: filter_by_table_query -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="filter_by_table_query"/>
                 <param name="table_name" value="table"/>
@@ -1248,10 +1248,10 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 12: concatenate -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="concatenate"/>
-                <param name="other_sdatas" location="https://zenodo.org/records/18746346/files/visium_spatialdata.spatialdata.zip"/>
+                <param name="other_sdatas" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             </conditional>
             <assert_stdout>
                 <has_text text="concatenate"/>
@@ -1271,7 +1271,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 13: transform with translation -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="transform"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1301,7 +1301,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 14: rasterize -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="rasterize"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1327,7 +1327,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 15: rasterize_bins -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_hd_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_hd_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="rasterize_bins"/>
                 <param name="bins_element" value="Test_VisiumHD_square_002um"/>
@@ -1353,7 +1353,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 16: rasterize_bins as labels-->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_hd_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_hd_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="rasterize_bins"/>
                 <param name="bins_element" value="Test_VisiumHD_square_002um"/>
@@ -1379,7 +1379,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 17: rasterize_bins_link_table_to_labels -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_hd_rasterized_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_hd_rasterized_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="rasterize_bins_link_table_to_labels"/>
                 <param name="table_name" value="square_002um"/>
@@ -1401,7 +1401,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 18: to_circles -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="to_circles"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1423,7 +1423,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 19: to_polygons -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="to_polygons"/>
                 <param name="element_name" value="cell_labels"/>
@@ -1470,7 +1470,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 21: map_raster -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="map_raster"/>
                 <param name="element_name" value="morphology_focus"/>
@@ -1493,7 +1493,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 22: unpad_raster -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="unpad_raster"/>
                 <param name="element_name" value="morphology_focus"/>
@@ -1515,7 +1515,7 @@ print("\nOperation completed successfully!")
         <!-- Test 23: relabel_sequential -->
         <!-- no good example to see how this should work and also when it works, the sdata can not be written
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/visium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/visium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="relabel_sequential"/>
                 <param name="element_name" value="Test_Visium_hires_image"/>
@@ -1533,7 +1533,7 @@ print("\nOperation completed successfully!")
         </test> -->
         <!-- Test 23: are_extents_equal -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="are_extents_equal"/>
                 <param name="element1_name" value="cell_labels"/>
@@ -1554,7 +1554,7 @@ print("\nOperation completed successfully!")
         <!-- Test 24: get_pyramid_levels -->
         <!-- no good example to see how this should work and also when it works, the sdata can not be written
         <test expect_num_outputs="2">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="get_pyramid_levels"/>
                 <param name="element_name" value="morphology_focus"/>
@@ -1571,7 +1571,7 @@ print("\nOperation completed successfully!")
         </test> -->
         <!-- Test 24: sanitize_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="sanitize_table"/>
                 <param name="table_name" value="table"/>
@@ -1588,7 +1588,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 25: export_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="export_table"/>
                 <param name="table_name" value="table"/>
@@ -1606,7 +1606,7 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 26: import_table -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="import_table"/>
                 <param name="table_name" value="imported_table"/>
@@ -1627,11 +1627,11 @@ print("\nOperation completed successfully!")
         </test>
         <!-- Test 27: add_shape -->
         <test expect_num_outputs="1">
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="add_shape"/>
                 <param name="element_name" value="new_shapes"/>
-                <param name="shape" location="https://zenodo.org/records/18746346/files/visiumhd_cell_segmentations.geojson"/>
+                <param name="shape" location="https://zenodo.org/records/21358431/files/visiumhd_cell_segmentations.geojson"/>
             </conditional>
             <assert_stdout>
                 <has_text text="Operation completed successfully"/>
@@ -1643,6 +1643,24 @@ print("\nOperation completed successfully!")
                         <has_text text="&quot;zarr_format&quot;: 3"/>
                         <has_text text="shapes/new_shapes"/>
                     </has_archive_member>
+                </assert_contents>
+            </output>
+        </test>
+        <!-- Test 28: export_table with Xenium data from 10X -->
+        <test expect_num_outputs="1">
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/Xenium_V2_Human_Breast_Gene_Expression.spatialdata.zip"/>
+            <conditional name="operation_condi">
+                <param name="operation" value="export_table"/>
+                <param name="table_name" value="table"/>
+            </conditional>
+            <assert_stdout>
+                <has_text text="Operation completed successfully"/>
+            </assert_stdout>
+            <output name="result_adata">
+                <assert_contents>
+                    <has_size value="1240000" delta="40000"/>
+                    <has_h5_keys keys="obs/cell_id,obs/nucleus_count"/>
+                    <has_h5_keys keys="obsm/spatial"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spatialdata/spatialdata_operation.xml
+++ b/tools/spatialdata/spatialdata_operation.xml
@@ -1046,19 +1046,19 @@ print("\nOperation completed successfully!")
             <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <conditional name="operation_condi">
                 <param name="operation" value="polygon_query"/>
-                <param name="polygon_coords" value="0,0;100,0;100,100;0,100"/>
+                <param name="polygon_coords" value="0,0;1000,0;1000,1000;0,1000"/>
                 <param name="target_coordinate_system" value="global"/>
             </conditional>
             <assert_stdout>
                 <has_text text="polygon_query"/>
                 <has_text text="from shapely.geometry import Polygon"/>
-                <has_text text="0,0;100,0;100,100;0,100"/>
+                <has_text text="0,0;1000,0;1000,1000;0,1000"/>
                 <has_text text="clip=False"/>
                 <has_text text="Operation completed successfully"/>
             </assert_stdout>
             <output name="spatialdata_output">
                 <assert_contents>
-                    <has_size value="50000" delta="10000"/>
+                    <has_size value="840000" delta="10000"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -624,7 +624,7 @@ print("Plot saved successfully")
     <tests>
         <!-- test 1 - render images -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <repeat name="render_images">
                 <param name="image_element" value="he_image"/>
             </repeat>
@@ -643,7 +643,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 2 - render labels -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <repeat name="render_labels">
                 <param name="labels_element" value="cell_labels"/>
                 <param name="color" value="total_counts"/>
@@ -670,7 +670,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 3 - render points -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/merscope_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/merscope_spatialdata.spatialdata.zip"/>
             <repeat name="render_points">
                 <param name="points_element" value="slide_name_region_transcripts"/>
                 <param name="color" value="fov"/>
@@ -695,7 +695,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 4 - render shapes -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/merscope_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/merscope_spatialdata.spatialdata.zip"/>
             <repeat name="render_shapes">
                 <param name="shapes_element" value="slide_name_region_polygons"/>
                 <param name="color" value="EntityID"/>
@@ -727,7 +727,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 5 - combination: image + labels (xenium) -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/xenium_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/xenium_spatialdata.spatialdata.zip"/>
             <repeat name="render_images">
                 <param name="image_element" value="morphology_focus"/>
             </repeat>
@@ -754,7 +754,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 6 - combination: points + shapes (merscope) -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/merscope_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/merscope_spatialdata.spatialdata.zip"/>
             <repeat name="render_points">
                 <param name="points_element" value="slide_name_region_transcripts"/>
                 <param name="alpha" value="0.5"/>
@@ -787,7 +787,7 @@ print("Plot saved successfully")
         </test>
         <!-- test 7 - combination: image + points + shapes (merscope) -->
         <test>
-            <param name="input_spatialdata" location="https://zenodo.org/records/18746346/files/merscope_spatialdata.spatialdata.zip"/>
+            <param name="input_spatialdata" location="https://zenodo.org/records/21358431/files/merscope_spatialdata.spatialdata.zip"/>
             <repeat name="render_images">
                 <param name="image_element" value="slide_name_region_z3"/>
             </repeat>

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -664,7 +664,7 @@ print("Plot saved successfully")
                     <has_image_center_of_mass center_of_mass="155,245" eps="5"/>
                     <has_image_channels channels="3"/>
                     <has_image_height height="491"/>
-                    <has_image_width width="321"/>
+                    <has_image_width width="320" delta="5"/>
                 </assert_contents>
             </output>
         </test>
@@ -816,10 +816,10 @@ print("Plot saved successfully")
             </assert_stdout>
             <output name="plot_output" ftype="jpg">
                 <assert_contents>
-                    <has_image_center_of_mass center_of_mass="230, 242" eps="5"/>
+                    <has_image_center_of_mass center_of_mass="235, 242" eps="5"/>
                     <has_image_channels channels="3"/>
                     <has_image_height height="491"/>
-                    <has_image_width width="491"/>
+                    <has_image_width width="492" delta="5"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -408,46 +408,46 @@ print("Plot saved successfully")
     <inputs>
         <expand macro="input_spatialdata"/>
         <repeat name="render_images" min="0" title="Render Images">
-            <param name="image_element" type="text" optional="true" label="Image element name" help="Name of the image element to render. Leave empty to render all images.">
+            <param argument="element" name="image_element" type="text" optional="true" label="Image element name" help="Name of the image element to render. Leave empty to render all images.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="channel" type="text" optional="true" label="Channel(s)" help="Comma-separated list of channel names or indices to plot. Leave empty for all channels.">
+            <param argument="channel" type="text" optional="true" label="Channel(s)" help="Comma-separated list of channel names or indices to plot. Leave empty for all channels.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="cmap_or_palette_condi"/>
             <expand macro="normalize_condi"/>
-            <param name="alpha" type="float" value="1.0" min="0.0" max="1.0" label="Alpha (opacity)" help="Transparency level (0=transparent, 1=opaque)"/>
-            <param name="scale" type="text" optional="true" label="Scale" help="Resolution control: leave empty for auto, 'full' for highest resolution, or specify a scale name. Please note that full resolution, takes more time to render.">
+            <param argument="alpha" type="float" value="1.0" min="0.0" max="1.0" label="Alpha (opacity)" help="Transparency level (0=transparent, 1=opaque)"/>
+            <param argument="scale" type="text" optional="true" label="Scale" help="Resolution control: leave empty for auto, 'full' for highest resolution, or specify a scale name. Please note that full resolution, takes more time to render.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="grayscale" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Convert the image to grayscale before rendering using luminance weights?"/>
+            <param argument="grayscale" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Convert the image to grayscale before rendering using luminance weights?"/>
             <!-- we can enable this later if we got user request -->
             <!-- <expand macro="param_transfunc"/> -->
             <expand macro="param_colorbar"/>
-            <param name="channels_as_legend" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Show channels as legend?" help="When Yes and rendering multiple channels, show a categorical legend mapping each channel name to its compositing color."/>
+            <param argument="channels_as_legend" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Show channels as legend?" help="When Yes and rendering multiple channels, show a categorical legend mapping each channel name to its compositing color."/>
             <expand macro="param_rendering_method" help="Whether to use matplotlib or datashader for the downsampling step.">
                 <option value="None">Default</option>
             </expand>
             <expand macro="param_datashader_reduction"/>
         </repeat>
         <repeat name="render_labels" min="0" title="Render Labels">
-            <param name="labels_element" type="text" optional="true" label="Labels element name" help="Name of the labels element to render. Leave empty to render all labels.">
+            <param argument="element" name="labels_element" type="text" optional="true" label="Labels element name" help="Name of the labels element to render. Leave empty to render all labels.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="param_color"/>
-            <param name="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
+            <param argument="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="cmap_or_palette_condi"/>
-            <param name="contour_px" type="integer" value="3" min="0" label="Contour width (pixels)" help="Width of contour to draw for each segment. 0 fills entire segment."/>
+            <param argument="contour_px" type="integer" value="3" min="0" label="Contour width (pixels)" help="Width of contour to draw for each segment. 0 fills entire segment."/>
             <expand macro="normalize_condi"/>
             <expand macro="param_na_color"/>
-            <param name="outline_alpha" type="float" value="0.0" min="0.0" max="1.0" label="Alpha value for the outline of the labels"/>
-            <param name="fill_alpha" type="float" optional="true" min="0.0" max="1.0" label="Alpha value for the fill of the labels." help="By default, it is set to 0.4 or, if a color is given that implies an alpha, that value is used for fill_alpha."/>
-            <param name="outline_color" type="text" optional="true" label="Outline color" help="Accepts named color, hex string, RGB/RGBA list, or None. If None, outlines inherit from the color parameter.">
+            <param argument="outline_alpha" type="float" value="0.0" min="0.0" max="1.0" label="Alpha value for the outline of the labels"/>
+            <param argument="fill_alpha" type="float" optional="true" min="0.0" max="1.0" label="Alpha value for the fill of the labels." help="By default, it is set to 0.4 or, if a color is given that implies an alpha, that value is used for fill_alpha."/>
+            <param argument="outline_color" type="text" optional="true" label="Outline color" help="Accepts named color, hex string, RGB/RGBA list, or None. If None, outlines inherit from the color parameter.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="scale" type="text" optional="true" label="Scale" help="Resolution control: leave empty for auto, 'full' for highest resolution, or specify a scale name. Please note that full resolution, takes more time to render.">
+            <param argument="scale" type="text" optional="true" label="Scale" help="Resolution control: leave empty for auto, 'full' for highest resolution, or specify a scale name. Please note that full resolution, takes more time to render.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="param_colorbar"/>
@@ -458,18 +458,18 @@ print("Plot saved successfully")
             <!-- <expand macro="param_transfunc"/> -->
         </repeat>
         <repeat name="render_points" min="0" title="Render Points">
-            <param name="points_element" type="text" optional="true" label="Points element name" help="Name of the points element to render. Leave empty to render all points.">
+            <param argument="element" name="points_element" type="text" optional="true" label="Points element name" help="Name of the points element to render. Leave empty to render all points.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="param_color"/>
-            <param name="alpha" type="float" optional="true" min="0.0" max="1.0" label="Alpha (opacity)"/>
-            <param name="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
+            <param argument="alpha" type="float" optional="true" min="0.0" max="1.0" label="Alpha (opacity)"/>
+            <param argument="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="cmap_or_palette_condi"/>
             <expand macro="normalize_condi"/>
             <expand macro="param_na_color"/>
-            <param name="size" type="float" value="1.0" min="0.0" label="Point size"/>
+            <param argument="size" type="float" value="1.0" min="0.0" label="Point size"/>
             <expand macro="param_rendering_method" help="Whether to use matplotlib or datashader. When Auto, chosen automatically based on the size of the data.">
                 <option value="None">Auto</option>
             </expand>
@@ -478,8 +478,8 @@ print("Plot saved successfully")
             <expand macro="param_gene_symbols"/>
             <expand macro="param_colorbar"/>
             <expand macro="param_datashader_reduction"/>
-            <param name="density" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Render as 2D density?" help="Render the points as a 2-D count density via datashader instead of plotting individual markers."/>
-            <param name="density_how" type="select" label="Density mapping method" help="How datashader maps aggregated counts to color intensity. Ignored when density is False.">
+            <param argument="density" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Render as 2D density?" help="Render the points as a 2-D count density via datashader instead of plotting individual markers."/>
+            <param argument="density_how" type="select" label="Density mapping method" help="How datashader maps aggregated counts to color intensity. Ignored when density is False.">
                 <option value="linear" selected="true">linear</option>
                 <option value="log">log</option>
                 <option value="cbrt">cbrt</option>
@@ -489,12 +489,12 @@ print("Plot saved successfully")
             <!-- <expand macro="param_transfunc"/> -->
         </repeat>
         <repeat name="render_shapes" min="0" title="Render Shapes">
-            <param name="shapes_element" type="text" optional="true" label="Shapes element name" help="Name of the shapes element to render. Leave empty to render all shapes.">
+            <param argument="element" name="shapes_element" type="text" optional="true" label="Shapes element name" help="Name of the shapes element to render. Leave empty to render all shapes.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="param_color"/>
-            <param name="fill_alpha" type="float" optional="true" min="0.0" max="1.0" label="Fill alpha" help="By default, it is set to 1.0 or, if a color is given that implies an alpha, that value is used for fill_alpha."/>
-            <param name="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
+            <param argument="fill_alpha" type="float" optional="true" min="0.0" max="1.0" label="Fill alpha" help="By default, it is set to 1.0 or, if a color is given that implies an alpha, that value is used for fill_alpha."/>
+            <param argument="groups" type="text" optional="true" label="Groups to show" help="When using color and the key represents discrete labels, groups can be used to show only a subset of them. Other values are set to NA. The list can contain multiple discrete labels to be visualized.">
                 <expand macro="sanitize_query"/>
             </param>
             <expand macro="cmap_or_palette_condi"/>
@@ -527,14 +527,14 @@ print("Plot saved successfully")
                 </when>
             </conditional>
             <expand macro="normalize_condi"/>
-            <param name="scale" type="float" min="0" value="1.0" label="Scale factor" help="Value to scale shapes (circles and polygons)."/>
+            <param argument="scale" type="float" min="0" value="1.0" label="Scale factor" help="Value to scale shapes (circles and polygons)."/>
             <expand macro="param_rendering_method" help="When Auto, the method is chosen based on the size of the data.">
                 <option value="None">Auto</option>
             </expand>
             <expand macro="param_table_name" value="" optional="true"/>
             <expand macro="param_table_layer"/>
             <expand macro="param_gene_symbols"/>
-            <param name="shape" type="select" optional="true" label="Convert shapes to" help="If Auto, the shapes are rendered as they are">
+            <param argument="shape" type="select" optional="true" label="Convert shapes to" help="If Auto, the shapes are rendered as they are">
                 <option value="None">Keep original shapes</option>
                 <option value="circle">Circle</option>
                 <option value="hex">Hexagon</option>
@@ -547,20 +547,20 @@ print("Plot saved successfully")
             <!-- <expand macro="param_transfunc"/> -->
         </repeat>
         <section name="show_params" title="Plot Display Parameters" expanded="true">
-            <param name="coordinate_systems" type="text" optional="true" label="Coordinate system(s)" help="Comma-separated list of coordinate systems to plot. Leave empty for all.  If a coordinate system doesn't contain any relevant elements (as specified in the render_* calls), it is automatically not plotted.">
+            <param argument="coordinate_systems" type="text" optional="true" label="Coordinate system(s)" help="Comma-separated list of coordinate systems to plot. Leave empty for all.  If a coordinate system doesn't contain any relevant elements (as specified in the render_* calls), it is automatically not plotted.">
                 <expand macro="sanitize_query"/>
             </param>
             <param name="figsize_width" type="float" value="6.4" min="0.1" label="Figure width (inches)"/>
             <param name="figsize_height" type="float" value="4.8" min="0.1" label="Figure height (inches)"/>
-            <param name="dpi" type="integer" value="100" min="1" label="DPI (resolution)" help="Dots per inch for the output image"/>
-            <param name="ncols" type="integer" value="4" min="1" label="Number of columns"/>
-            <param name="legend_fontsize" type="integer" optional="true" min="1" label="Legend font size"/>
-            <param name="legend_fontweight" type="select" label="Legend font weight">
+            <param argument="dpi" type="integer" value="100" min="1" label="DPI (resolution)" help="Dots per inch for the output image"/>
+            <param argument="ncols" type="integer" value="4" min="1" label="Number of columns"/>
+            <param argument="legend_fontsize" type="integer" optional="true" min="1" label="Legend font size"/>
+            <param argument="legend_fontweight" type="select" label="Legend font weight">
                 <option value="bold" selected="true">Bold</option>
                 <option value="normal">Normal</option>
                 <option value="light">Light</option>
             </param>
-            <param name="legend_loc" type="select" label="Legend location">
+            <param argument="legend_loc" type="select" label="Legend location">
                 <option value="right margin" selected="true">Right margin</option>
                 <option value="upper right">Upper right</option>
                 <option value="upper left">Upper left</option>
@@ -568,37 +568,37 @@ print("Plot saved successfully")
                 <option value="lower right">Lower right</option>
                 <option value="center">Center</option>
             </param>
-            <param name="legend_fontoutline" type="integer" optional="true" min="1" label="Legend font outline width" help="Stroke width for a white outline around legend text."/>
-            <param name="na_in_legend" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Show NA values in legend?"/>
-            <param name="colorbar" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Enable colorbars?" help="Global switch to enable/disable all colorbars."/>
+            <param argument="legend_fontoutline" type="integer" optional="true" min="1" label="Legend font outline width" help="Stroke width for a white outline around legend text."/>
+            <param argument="na_in_legend" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Show NA values in legend?"/>
+            <param argument="colorbar" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Enable colorbars?" help="Global switch to enable/disable all colorbars."/>
             <!-- we can enable this later if we got user request -->
-            <!-- <param name="colorbar_params" type="text" optional="true" label="Global colorbar overrides (JSON)" help="JSON dictionary of global overrides passed to all colorbars (e.g. {&quot;loc&quot;: &quot;right&quot;, &quot;width&quot;: 0.15})">
+            <!-- <param argument="colorbar_params" type="text" optional="true" label="Global colorbar overrides (JSON)" help="JSON dictionary of global overrides passed to all colorbars (e.g. {&quot;loc&quot;: &quot;right&quot;, &quot;width&quot;: 0.15})">
                 <expand macro="sanitize_query"/>
             </param> -->
-            <param name="legend_title" type="text" optional="true" label="Fill legend title" help="Title for the fill categorical legend.">
+            <param argument="legend_title" type="text" optional="true" label="Fill legend title" help="Title for the fill categorical legend.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="outline_legend_title" type="text" optional="true" label="Outline legend title" help="Title for the outline categorical legend.">
+            <param argument="outline_legend_title" type="text" optional="true" label="Outline legend title" help="Title for the outline categorical legend.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="wspace" type="float" optional="true" label="Horizontal spacing between panels" help="Passed to matplotlib.gridspec.GridSpec."/>
-            <param name="hspace" type="float" value="0.25" label="Vertical spacing between panels" help="Passed to matplotlib.gridspec.GridSpec."/>
-            <param name="frameon" type="select" label="Draw axes frame">
+            <param argument="wspace" type="float" optional="true" label="Horizontal spacing between panels" help="Passed to matplotlib.gridspec.GridSpec."/>
+            <param argument="hspace" type="float" value="0.25" label="Vertical spacing between panels" help="Passed to matplotlib.gridspec.GridSpec."/>
+            <param argument="frameon" type="select" label="Draw axes frame">
                 <option value="default" selected="true">Auto (hide for multi-panel)</option>
                 <option value="True">Yes (True)</option>
                 <option value="False">No (False)</option>
             </param>
-            <param name="title" type="text" optional="true" label="Plot title" help="If not provided the plot will have the name of the coordinate system as title.">
+            <param argument="title" type="text" optional="true" label="Plot title" help="If not provided the plot will have the name of the coordinate system as title.">
                 <expand macro="sanitize_query"/>
             </param>
-            <param name="pad_extent" type="float" value="0.0" label="Padding around extent" help="Padding added around the computed spatial extent on all sides."/>
-            <param name="scalebar_dx" type="float" optional="true" label="Scalebar physical size" help="Physical size of one axes-unit in scalebar_units (e.g. 1.0 if axes in micrometers). If empty, no scalebar is drawn."/>
-            <param name="scalebar_units" type="text" value="um" label="Scalebar units" help="Unit string for the scalebar. Only takes effect if scalebar physical size is set.">
+            <param argument="pad_extent" type="float" value="0.0" label="Padding around extent" help="Padding added around the computed spatial extent on all sides."/>
+            <param argument="scalebar_dx" type="float" optional="true" label="Scalebar physical size" help="Physical size of one axes-unit in scalebar_units (e.g. 1.0 if axes in micrometers). If empty, no scalebar is drawn."/>
+            <param argument="scalebar_units" type="text" value="um" label="Scalebar units" help="Unit string for the scalebar. Only takes effect if scalebar physical size is set.">
                 <expand macro="sanitize_query"/>
             </param>
             <!-- we can enable this later if we got user request -->
-            <!-- <param name="scalebar_params" type="data" format="json" optional="true" label="Scalebar extra parameters" help="JSON dictionary of extra kwargs passed to ScaleBar (e.g. {&quot;location&quot;: &quot;lower right&quot;, &quot;color&quot;: &quot;white&quot;})"/> -->
-            <!-- <param name="legend_params" type="data" format="json" optional="true" label="Bundled legend options (JSON)" help="JSON dictionary of options overriding legend_* flat parameters."/> -->
+            <!-- <param argument="scalebar_params" type="data" format="json" optional="true" label="Scalebar extra parameters" help="JSON dictionary of extra kwargs passed to ScaleBar (e.g. {&quot;location&quot;: &quot;lower right&quot;, &quot;color&quot;: &quot;white&quot;})"/> -->
+            <!-- <param argument="legend_params" type="data" format="json" optional="true" label="Bundled legend options (JSON)" help="JSON dictionary of options overriding legend_* flat parameters."/> -->
             <param name="format" type="select" label="Image format">
                 <option value="eps">EPS</option>
                 <option value="jpg" selected="true">JPG</option>

--- a/tools/spatialdata/spatialdata_plot.xml
+++ b/tools/spatialdata/spatialdata_plot.xml
@@ -45,8 +45,8 @@ spdata = spdata.pl.render_images(
     #end if
     #if str($img.normalize_condi.normalize) == 'yes':
     norm=Normalize(
-        vmin=$img.normalize_condi.vmin if str($img.normalize_condi.vmin) != '' else None,
-        vmax=$img.normalize_condi.vmax if str($img.normalize_condi.vmax) != '' else None,
+        vmin=$img.normalize_condi.vmin if $img.normalize_condi.vmin else None,
+        vmax=$img.normalize_condi.vmax if $img.normalize_condi.vmax else None,
         clip=$img.normalize_condi.clip
     ),
     #end if
@@ -60,9 +60,9 @@ spdata = spdata.pl.render_images(
     #end if
     grayscale=$img.grayscale,
     <!-- we can enable this later if we got user request -->
-    <!-- #if $img.transfunc: -->
-    <!-- transfunc=eval('$img.transfunc'), -->
-    <!-- #end if -->
+            <!-- #if $img.transfunc: -->
+            <!-- transfunc=eval('$img.transfunc'), -->
+            <!-- #end if -->
     #if $img.colorbar == 'True':
     colorbar=True,
     #elif $img.colorbar == 'False':
@@ -71,9 +71,9 @@ spdata = spdata.pl.render_images(
     colorbar='auto',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $img.colorbar_params:  -->
-    <!-- colorbar_params=json.loads('$img.colorbar_params'),  -->
-    <!-- #end if -->
+            <!-- #if $img.colorbar_params:  -->
+            <!-- colorbar_params=json.loads('$img.colorbar_params'),  -->
+            <!-- #end if -->
     channels_as_legend=$img.channels_as_legend,
     #if $img.method and str($img.method) != 'None':
     method='$img.method',
@@ -114,8 +114,8 @@ spdata = spdata.pl.render_labels(
     #end if
     #if str($lbl.normalize_condi.normalize) == 'yes':
     norm=Normalize(
-        vmin=$lbl.normalize_condi.vmin if str($lbl.normalize_condi.vmin) != '' else None,
-        vmax=$lbl.normalize_condi.vmax if str($lbl.normalize_condi.vmax) != '' else None,
+        vmin=$lbl.normalize_condi.vmin if $lbl.normalize_condi.vmin else None,
+        vmax=$lbl.normalize_condi.vmax if $lbl.normalize_condi.vmax else None,
         clip=$lbl.normalize_condi.clip
     ),
     #end if
@@ -144,9 +144,9 @@ spdata = spdata.pl.render_labels(
     colorbar='auto',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $lbl.colorbar_params: -->
-    <!-- colorbar_params=json.loads('$lbl.colorbar_params'), -->
-    <!-- #end if -->
+            <!-- #if $lbl.colorbar_params: -->
+            <!-- colorbar_params=json.loads('$lbl.colorbar_params'), -->
+            <!-- #end if -->
     #if $lbl.table_name:
     table_name='$lbl.table_name',
     #else
@@ -161,9 +161,9 @@ spdata = spdata.pl.render_labels(
     gene_symbols='$lbl.gene_symbols',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $lbl.transfunc: -->
-    <!-- transfunc=eval('$lbl.transfunc'), -->
-    <!-- #end if -->
+            <!-- #if $lbl.transfunc: -->
+            <!-- transfunc=eval('$lbl.transfunc'), -->
+            <!-- #end if -->
 )
 #end for
 
@@ -178,7 +178,7 @@ spdata = spdata.pl.render_points(
     #if $pt.color:
     color='$pt.color',
     #end if
-    #if str($pt.alpha) != '':
+    #if $pt.alpha:
     alpha=$pt.alpha,
     #end if
     #if $pt.groups:
@@ -199,8 +199,8 @@ spdata = spdata.pl.render_points(
     #end if
     #if str($pt.normalize_condi.normalize) == 'yes':
     norm=Normalize(
-        vmin=$pt.normalize_condi.vmin if str($pt.normalize_condi.vmin) != '' else None,
-        vmax=$pt.normalize_condi.vmax if str($pt.normalize_condi.vmax) != '' else None,
+        vmin=$pt.normalize_condi.vmin if $pt.normalize_condi.vmin else None,
+        vmax=$pt.normalize_condi.vmax if $pt.normalize_condi.vmax else None,
         clip=$pt.normalize_condi.clip
     ),
     #end if
@@ -231,9 +231,9 @@ spdata = spdata.pl.render_points(
     colorbar='auto',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $pt.colorbar_params: -->
-    <!-- colorbar_params=json.loads('$pt.colorbar_params'), -->
-    <!-- #end if -->
+            <!-- #if $pt.colorbar_params: -->
+            <!-- colorbar_params=json.loads('$pt.colorbar_params'), -->
+            <!-- #end if -->
     #if $pt.datashader_reduction and str($pt.datashader_reduction) != 'None':
     datashader_reduction='$pt.datashader_reduction',
     #else:
@@ -242,9 +242,9 @@ spdata = spdata.pl.render_points(
     density=$pt.density,
     density_how='$pt.density_how',
     <!-- we can enable this later if we got user request -->
-    <!-- #if $pt.transfunc: -->
-    <!-- transfunc=eval('$pt.transfunc'), -->
-    <!-- #end if -->
+            <!-- #if $pt.transfunc: -->
+            <!-- transfunc=eval('$pt.transfunc'), -->
+            <!-- #end if -->
 )
 #end for
 
@@ -259,10 +259,10 @@ spdata = spdata.pl.render_shapes(
     #if $shp.color:
     color='$shp.color',
     #end if
-    #if str($shp.fill_alpha) != '':
+    #if $shp.fill_alpha:
     fill_alpha=$shp.fill_alpha,
     #end if
-    #if str($shp.groups) != '':
+    #if $shp.groups:
         #set $groups_list = [str(x.strip()) for x in str($shp.groups).split(',')]
     groups=$groups_list,
     #end if
@@ -295,8 +295,8 @@ spdata = spdata.pl.render_shapes(
     #end if
     #if str($shp.normalize_condi.normalize) == 'yes':
     norm=Normalize(
-        vmin=$shp.normalize_condi.vmin if str($shp.normalize_condi.vmin) != '' else None,
-        vmax=$shp.normalize_condi.vmax if str($shp.normalize_condi.vmax) != '' else None,
+        vmin=$shp.normalize_condi.vmin if $shp.normalize_condi.vmin else None,
+        vmax=$shp.normalize_condi.vmax if $shp.normalize_condi.vmax else None,
         clip=$shp.normalize_condi.clip
     ),
     #end if
@@ -332,18 +332,18 @@ spdata = spdata.pl.render_shapes(
     colorbar='auto',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $shp.colorbar_params: -->
-    <!-- colorbar_params=json.loads('$shp.colorbar_params'), -->
-    <!-- #end if -->
+            <!-- #if $shp.colorbar_params: -->
+            <!-- colorbar_params=json.loads('$shp.colorbar_params'), -->
+            <!-- #end if -->
     #if $shp.datashader_reduction and str($shp.datashader_reduction) != 'None':
     datashader_reduction='$shp.datashader_reduction',
     #else:
     datashader_reduction=None,
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $shp.transfunc: -->
-    <!-- transfunc=eval('$shp.transfunc'), -->
-    <!-- #end if -->
+            <!-- #if $shp.transfunc: -->
+            <!-- transfunc=eval('$shp.transfunc'), -->
+            <!-- #end if -->
 )
 #end for
 
@@ -356,27 +356,27 @@ spdata.pl.show(
     figsize=($show_params.figsize_width, $show_params.figsize_height),
     dpi=$show_params.dpi,
     ncols=$show_params.ncols,
-    #if str($show_params.legend_fontsize) != '':
+    #if $show_params.legend_fontsize:
     legend_fontsize=$show_params.legend_fontsize,
     #end if
     legend_fontweight='$show_params.legend_fontweight',
     legend_loc='$show_params.legend_loc',
-    #if str($show_params.legend_fontoutline) != '':
+    #if $show_params.legend_fontoutline:
     legend_fontoutline=$show_params.legend_fontoutline,
     #end if
     na_in_legend=$show_params.na_in_legend,
     colorbar=$show_params.colorbar,
     <!-- we can enable this later if we got user request -->
-    <!-- #if $show_params.colorbar_params: -->
-    <!-- colorbar_params=json.loads('$show_params.colorbar_params'), -->
-    <!-- #end if -->
+            <!-- #if $show_params.colorbar_params: -->
+            <!-- colorbar_params=json.loads('$show_params.colorbar_params'), -->
+            <!-- #end if -->
     #if $show_params.legend_title:
     legend_title='$show_params.legend_title',
     #end if
     #if $show_params.outline_legend_title:
     outline_legend_title='$show_params.outline_legend_title',
     #end if
-    #if str($show_params.wspace) != '':
+    #if $show_params.wspace:
     wspace=$show_params.wspace,
     #end if
     hspace=$show_params.hspace,
@@ -387,18 +387,18 @@ spdata.pl.show(
     title='$show_params.title',
     #end if
     pad_extent=$show_params.pad_extent,
-    #if str($show_params.scalebar_dx) != '':
+    #if $show_params.scalebar_dx:
     scalebar_dx=$show_params.scalebar_dx,
     scalebar_units='$show_params.scalebar_units',
     #end if
     <!-- we can enable this later if we got user request -->
-    <!-- #if $show_params.scalebar_params: -->
-    <!-- scalebar_params=json.loads('$show_params.scalebar_params'), -->
-    <!-- #end if -->
-    <!-- we can enable this later if we got user request -->
-    <!-- #if $show_params.legend_params: -->
-    <!-- legend_params=json.loads('$show_params.legend_params'), -->
-    <!-- #end if -->
+            <!-- #if $show_params.scalebar_params: -->
+            <!-- scalebar_params=json.loads('$show_params.scalebar_params'), -->
+            <!-- #end if -->
+            <!-- we can enable this later if we got user request -->
+            <!-- #if $show_params.legend_params: -->
+            <!-- legend_params=json.loads('$show_params.legend_params'), -->
+            <!-- #end if -->
     save='plot.${show_params.format}'
 )
 


### PR DESCRIPTION
I tried the tool with Xenium data on the EU, and it failed. I am fixing it now.
the error was:
```
            Traceback (most recent call last):
  File "/data/jwd06/main/000/107/963/107963520/working/spdata_operation.py", line 4, in <module>
    sdata = sd.read_zarr("./input/spatialdata.zarr")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/spatialdata/_io/io_zarr.py", line 226, in read_zarr
    sdata = SpatialData(
            ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/spatialdata/_core/spatialdata.py", line 170, in __init__
    self.validate_table_in_spatialdata(v)
  File "/usr/local/lib/python3.12/site-packages/spatialdata/_core/spatialdata.py", line 193, in validate_table_in_spatialdata
    TableModel.validate(table)
  File "/usr/local/lib/python3.12/site-packages/spatialdata/models/models.py", line 1121, in validate
    validate_table_attr_keys(data)
  File "/usr/local/lib/python3.12/site-packages/spatialdata/_core/validation.py", line 248, in validate_table_attr_keys
    check_all_keys_case_insensitively_unique(getattr(data, attr).keys(), location=attr_path)
  File "/usr/local/lib/python3.12/site-packages/spatialdata/_core/validation.py", line 153, in check_all_keys_case_insensitively_unique
    normalized_key = key.lower()
                     ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```
and it is related to ome_zarr version

It also fixes the logic in the tool.

Most of the `name`s are changed to `argument`, so it is easier for the user to find the respective argument on the API

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
