### PR TITLE
Update wfmash

### DIFF
--- a/tools/wfmash/macros.xml
+++ b/tools/wfmash/macros.xml
@@ -1,15 +1,14 @@
-<?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">0.24.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">26.1</token>
+    <token name="@PROFILE@">26.0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">wfmash</requirement>
             <requirement type="package" version="1.21">samtools</requirement>
         </requirements>
     </xml>
-    <xml name="version_command">wfmash --version 2>&amp;1 | head -1</xml>
+    <xml name="version_command">wfmash --version 2&gt;&amp;1 | head -1</xml>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1093/bioinformatics/btaa777</citation>

--- a/tools/wfmash/macros.xml
+++ b/tools/wfmash/macros.xml
@@ -12,7 +12,8 @@
     <xml name="version_command">wfmash --version 2>&amp;1 | head -1</xml>
     <xml name="citations">
         <citations>
-            <citation type="doi">10.1093/bioinformatics/btae155</citation>
+            <citation type="doi">10.1093/bioinformatics/btaa777</citation>
+            <citation type="doi">10.1093/bioinformatics/btad074</citation>
             <citation type="bibtex"><![CDATA[
 @misc{wfmash,
   author = {Guarracino, Andrea and Mwaniki, Njagi and Marco-Sola, Santiago and Garrison, Erik},

--- a/tools/wfmash/macros.xml
+++ b/tools/wfmash/macros.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0"?>
 <macros>
+    <token name="@TOOL_VERSION@">0.24.2</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">26.1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">wfmash</requirement>
-            <requirement type="package" version="1.20">samtools</requirement>
+            <requirement type="package" version="1.21">samtools</requirement>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">0.14.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">25.0</token>
+    <xml name="version_command">wfmash --version 2>&amp;1 | head -1</xml>
     <xml name="citations">
         <citations>
-	    <citation type="bibtex"><![CDATA[
+            <citation type="doi">10.1093/bioinformatics/btae155</citation>
+            <citation type="bibtex"><![CDATA[
 @misc{wfmash,
   author = {Guarracino, Andrea and Mwaniki, Njagi and Marco-Sola, Santiago and Garrison, Erik},
   title = {wfmash: whole-chromosome pairwise alignment using the hierarchical wavefront algorithm},
@@ -19,7 +21,7 @@
   month = {9},
   url = {https://github.com/ekg/wfmash}
 }
-	    ]]></citation>
+            ]]></citation>
         </citations>
     </xml>
 </macros>

--- a/tools/wfmash/wfmash.xml
+++ b/tools/wfmash/wfmash.xml
@@ -13,19 +13,19 @@
 #set $query_fasta_filename = "query.fa"
 
 #if str($reference.ext).endswith('gz')
-    gunzip -c '$reference' > '$reference_fasta_filename' &&
+    gunzip -c '${reference}' > '${reference_fasta_filename}' &&
 #else
-    ln -s -f '$reference' '$reference_fasta_filename' &&
+    ln -s -f '${reference}' '${reference_fasta_filename}' &&
 #end if
-samtools faidx '$reference_fasta_filename' &&
+samtools faidx '${reference_fasta_filename}' &&
 
 #if str($query_source.query_mode) == "two_fasta"
     #if str($query_source.query.ext).endswith('gz')
-        gunzip -c '$query_source.query' > '$query_fasta_filename' &&
+        gunzip -c '${query_source.query}' > '${query_fasta_filename}' &&
     #else
-        ln -s -f '$query_source.query' '$query_fasta_filename' &&
+        ln -s -f '${query_source.query}' '${query_fasta_filename}' &&
     #end if
-    samtools faidx '$query_fasta_filename' &&
+    samtools faidx '${query_fasta_filename}' &&
 #end if
 
 wfmash
@@ -42,7 +42,7 @@ wfmash
         --block-length=$block_length
     #end if
     #if str($group_prefix).strip()
-        --group-prefix='$group_prefix'
+        --group-prefix='${group_prefix}'
     #end if
     $approx_mapping
     $no_split
@@ -52,11 +52,11 @@ wfmash
     #if str($sam) == "--sam"
         $md_tag
     #end if
-    '$reference_fasta_filename'
+    '${reference_fasta_filename}'
     #if str($query_source.query_mode) == "two_fasta"
-        '$query_fasta_filename'
+        '${query_fasta_filename}'
     #end if
-    > '$output_paf'
+    > '${output_paf}'
     ]]></command>
     <inputs>
         <param name="reference" type="data" format="fasta,fasta.gz" label="Reference sequence"

--- a/tools/wfmash/wfmash.xml
+++ b/tools/wfmash/wfmash.xml
@@ -26,8 +26,8 @@ samtools faidx '${reference_fasta_filename}' &&
 #end if
 
 wfmash
-    --threads=\${GALAXY_SLOTS:-1}
-    -p $pct_identity
+    --threads "\${GALAXY_SLOTS:-1}"
+    -p $p
     --kmer-size=$kmer_size
     #if str($sketch_size).strip()
         --sketch-size=$sketch_size
@@ -41,10 +41,10 @@ wfmash
     #if str($group_prefix).strip()
         --group-prefix='${group_prefix}'
     #end if
-    $approx_mapping
-    $no_split
-    $self_maps
-    $lower_triangular
+    $m
+    $N
+    $X
+    $L
     $sam
     #if str($sam) == "--sam"
         $md_tag
@@ -56,8 +56,7 @@ wfmash
     > '${output_paf}'
     ]]></command>
     <inputs>
-        <param name="reference" type="data" format="fasta,fasta.gz" label="Reference sequence"
-               help="Target sequences for alignment."/>
+        <param name="reference" type="data" format="fasta,fasta.gz" label="Reference sequence" help="Target sequences for alignment."/>
         <conditional name="query_source">
             <param name="query_mode" type="select" label="Mapping mode">
                 <option value="self_map" selected="true">Self-map (one FASTA, all-vs-all)</option>
@@ -65,56 +64,33 @@ wfmash
             </param>
             <when value="self_map"/>
             <when value="two_fasta">
-                <param name="query" type="data" format="fasta,fasta.gz" label="Query sequence"
-                       help="Query sequences to align against reference."/>
+                <param name="query" type="data" format="fasta,fasta.gz" label="Query sequence" help="Query sequences to align against reference."/>
             </when>
         </conditional>
-        <param argument="-p" name="pct_identity" type="float" min="50" max="100" value="90"
-               label="Minimum identity %"
-               help="MashMap identity threshold. 90 for intra-species, 70-80 for inter-species pangenome panels."/>
-        <param argument="--kmer-size" type="integer" min="5" max="31" value="15"
-               label="k-mer size" help="Default 15."/>
-        <param argument="--sketch-size" type="text" value=""
-               label="Sketch size (blank = auto)"
-               help="MashMap sketch size. Leave blank for the default heuristic.">
+        <param argument="-p" type="float" min="50" max="100" value="90" label="Minimum identity %" help="MashMap identity threshold. 90 for intra-species, 70-80 for inter-species pangenome panels."/>
+        <param argument="--kmer-size" type="integer" min="5" max="31" value="15" label="k-mer size" help="Default 15."/>
+        <param argument="--sketch-size" type="text" value="" label="Sketch size (blank = auto)" help="MashMap sketch size. Leave blank for the default heuristic.">
             <validator type="regex" message="Integer or blank">[0-9]*</validator>
         </param>
-        <param argument="--mappings" type="text" value=""
-               label="Mappings per segment (blank = unlimited)"
-               help="Plane-sweep cap on mappings per segment.">
+        <param argument="--mappings" type="text" value="" label="Mappings per segment (blank = unlimited)" help="Plane-sweep cap on mappings per segment.">
             <validator type="regex" message="Integer or blank">[0-9]*</validator>
         </param>
-        <param argument="--block-length" type="text" value=""
-               label="Minimum block length (blank = 0)"
-               help="Discard mappings shorter than this.">
+        <param argument="--block-length" type="text" value="" label="Minimum block length (blank = 0)" help="Discard mappings shorter than this.">
             <validator type="regex" message="Integer or blank">[0-9]*</validator>
         </param>
-        <param argument="--group-prefix" type="text" value=""
-               label="PanSN group-prefix delimiter (blank = off)"
-               help="Group sequences by everything up to the last occurrence of this delimiter (typically '#' for PanSN). Same value passed to pggb's -Y.">
+        <param argument="--group-prefix" type="text" value="" label="PanSN group-prefix delimiter (blank = off)" help="Group sequences by everything up to the last occurrence of this delimiter (typically '#' for PanSN). Same value passed to pggb's -Y.">
             <sanitizer invalid_char="">
                 <valid initial="string.printable">
-                    <remove value="&apos;"/>
+                    <remove value="'"/>
                 </valid>
             </sanitizer>
         </param>
-        <param argument="-m" name="approx_mapping" type="boolean" truevalue="-m" falsevalue=""
-               checked="false" label="Approximate mapping"
-               help="Skip base-level WFA alignment, output PAF mappings only."/>
-        <param argument="-N" name="no_split" type="boolean" truevalue="-N" falsevalue=""
-               checked="false" label="No split"
-               help="Disable splitting of input sequences."/>
-        <param argument="-X" name="self_maps" type="boolean" truevalue="-X" falsevalue=""
-               checked="false" label="Include self-mappings"
-               help="Keep mappings of a sequence to itself."/>
-        <param argument="-L" name="lower_triangular" type="boolean" truevalue="-L" falsevalue=""
-               checked="false" label="Lower-triangular only"
-               help="Only map seq_i to seq_j when i &gt; j."/>
-        <param argument="--sam" type="boolean" truevalue="--sam" falsevalue=""
-               checked="false" label="SAM output (default PAF)"/>
-        <param argument="--md-tag" type="boolean" truevalue="--md-tag" falsevalue=""
-               checked="false" label="Include MD tag"
-               help="SAM-only; ignored for PAF output."/>
+        <param argument="-m" type="boolean" truevalue="-m" falsevalue="" checked="false" label="Approximate mapping" help="Skip base-level WFA alignment, output PAF mappings only."/>
+        <param argument="-N" type="boolean" truevalue="-N" falsevalue="" checked="false" label="No split" help="Disable splitting of input sequences."/>
+        <param argument="-X" type="boolean" truevalue="-X" falsevalue="" checked="false" label="Include self-mappings" help="Keep mappings of a sequence to itself."/>
+        <param argument="-L" type="boolean" truevalue="-L" falsevalue="" checked="false" label="Lower-triangular only" help="Only map seq_i to seq_j when i &gt; j."/>
+        <param argument="--sam" type="boolean" truevalue="--sam" falsevalue="" checked="false" label="SAM output (default PAF)"/>
+        <param argument="--md-tag" type="boolean" truevalue="--md-tag" falsevalue="" checked="false" label="Include MD tag" help="SAM-only; ignored for PAF output."/>
     </inputs>
     <outputs>
         <data name="output_paf" format="paf" label="${tool.name} on ${on_string}: PAF">
@@ -130,7 +106,7 @@ wfmash
                 <param name="query_mode" value="two_fasta"/>
                 <param name="query" ftype="fasta" value="ecoli_o157.fa"/>
             </conditional>
-            <param name="pct_identity" value="70"/>
+            <param name="p" value="70"/>
             <output name="output_paf" file="expected_output_ecoli.paf" compare="sim_size"/>
         </test>
         <test expect_num_outputs="1">
@@ -139,7 +115,7 @@ wfmash
                 <param name="query_mode" value="two_fasta"/>
                 <param name="query" ftype="fasta" value="ecoli_o157.fa"/>
             </conditional>
-            <param name="pct_identity" value="70"/>
+            <param name="p" value="70"/>
             <output name="output_paf">
                 <assert_contents>
                     <has_size min="100"/>
@@ -152,8 +128,8 @@ wfmash
             <conditional name="query_source">
                 <param name="query_mode" value="self_map"/>
             </conditional>
-            <param name="pct_identity" value="95"/>
-            <param name="approx_mapping" value="true"/>
+            <param name="p" value="95"/>
+            <param name="m" value="true"/>
             <output name="output_paf">
                 <assert_contents>
                     <has_size min="0"/>

--- a/tools/wfmash/wfmash.xml
+++ b/tools/wfmash/wfmash.xml
@@ -3,9 +3,6 @@
     <macros>
         <import>macros.xml</import>
     </macros>
-    <xrefs>
-        <xref type="bio.tools">wfmash</xref>
-    </xrefs>
     <expand macro="requirements"/>
     <expand macro="version_command"/>
     <command detect_errors="aggressive"><![CDATA[

--- a/tools/wfmash/wfmash.xml
+++ b/tools/wfmash/wfmash.xml
@@ -3,63 +3,194 @@
     <macros>
         <import>macros.xml</import>
     </macros>
+    <xrefs>
+        <xref type="bio.tools">wfmash</xref>
+    </xrefs>
     <expand macro="requirements"/>
-    <command detect_errors="exit_code"><![CDATA[
+    <expand macro="version_command"/>
+    <command detect_errors="aggressive"><![CDATA[
 #set $reference_fasta_filename = "reference.fa"
 #set $query_fasta_filename = "query.fa"
 
 #if str($reference.ext).endswith('gz')
-    gunzip -c '${reference}' > '${reference_fasta_filename}' &&
+    gunzip -c '$reference' > '$reference_fasta_filename' &&
 #else
-    ln -s -f '${reference}' '${reference_fasta_filename}' &&
+    ln -s -f '$reference' '$reference_fasta_filename' &&
+#end if
+samtools faidx '$reference_fasta_filename' &&
+
+#if str($query_source.query_mode) == "two_fasta"
+    #if str($query_source.query.ext).endswith('gz')
+        gunzip -c '$query_source.query' > '$query_fasta_filename' &&
+    #else
+        ln -s -f '$query_source.query' '$query_fasta_filename' &&
+    #end if
+    samtools faidx '$query_fasta_filename' &&
 #end if
 
-    samtools faidx '${reference_fasta_filename}' &&
-
-#if str($query.ext).endswith('gz')
-gunzip -c '${query}' > '${query_fasta_filename}' &&
-#else
-ln -s -f '${query}' '${query_fasta_filename}' &&
-#end if
-samtools faidx '${query_fasta_filename}' &&
-
-wfmash 
-    --threads="\${GALAXY_SLOTS:-1}" 
-    -s $segment_length 
-    -p $pct_identity 
-    $approx_mapping 
-    $no_split 
-    '${reference_fasta_filename}' 
-    '${query_fasta_filename}' 
-    > '${output_paf}' 
+wfmash
+    --threads=\${GALAXY_SLOTS:-1}
+    -p $pct_identity
+    --kmer-size=$kmer_size
+    #if str($sketch_size).strip()
+        --sketch-size=$sketch_size
+    #end if
+    #if str($mappings).strip()
+        --mappings=$mappings
+    #end if
+    #if str($block_length).strip()
+        --block-length=$block_length
+    #end if
+    #if str($group_prefix).strip()
+        --group-prefix='$group_prefix'
+    #end if
+    $approx_mapping
+    $no_split
+    $self_maps
+    $lower_triangular
+    $sam
+    #if str($sam) == "--sam"
+        $md_tag
+    #end if
+    '$reference_fasta_filename'
+    #if str($query_source.query_mode) == "two_fasta"
+        '$query_fasta_filename'
+    #end if
+    > '$output_paf'
     ]]></command>
     <inputs>
-        <param name="reference" type="data" format="fasta,fasta.gz" label="Reference sequence" help="FASTA format" />
-        <param name="query" type="data" format="fasta,fasta.gz" label="Query sequence" help="FASTA format"/>
-        <param argument="-s" name="segment_length" type="integer" min="100" value="1000" label="Segment Length" help="Minimum seed length, must be >= 100 bp."/>
-        <param argument="-p" name="pct_identity" type="float" min="0" max="100" value="90" label="Minimum Identity %" help="Percent identity in the mashmap step"/>
-        <param argument="-m" name="approx_mapping" type="boolean" truevalue="-m" falsevalue="" label="Approximate mapping" help="Skip base-level alignment"/>
-        <param argument="-N" name="no_split" type="boolean" optional="true" truevalue="-N" falsevalue="" label="No split" help="Disable splitting of input sequences during mapping (Default: enabled)"/>
+        <param name="reference" type="data" format="fasta,fasta.gz" label="Reference sequence"
+               help="Target sequences for alignment."/>
+        <conditional name="query_source">
+            <param name="query_mode" type="select" label="Mapping mode">
+                <option value="self_map" selected="true">Self-map (one FASTA, all-vs-all)</option>
+                <option value="two_fasta">Query vs target (two FASTAs)</option>
+            </param>
+            <when value="self_map"/>
+            <when value="two_fasta">
+                <param name="query" type="data" format="fasta,fasta.gz" label="Query sequence"
+                       help="Query sequences to align against reference."/>
+            </when>
+        </conditional>
+        <param argument="-p" name="pct_identity" type="float" min="50" max="100" value="90"
+               label="Minimum identity %"
+               help="MashMap identity threshold. 90 for intra-species, 70-80 for inter-species pangenome panels."/>
+        <param argument="--kmer-size" type="integer" min="5" max="31" value="15"
+               label="k-mer size" help="Default 15."/>
+        <param argument="--sketch-size" type="text" value=""
+               label="Sketch size (blank = auto)"
+               help="MashMap sketch size. Leave blank for the default heuristic.">
+            <validator type="regex" message="Integer or blank">[0-9]*</validator>
+        </param>
+        <param argument="--mappings" type="text" value=""
+               label="Mappings per segment (blank = unlimited)"
+               help="Plane-sweep cap on mappings per segment.">
+            <validator type="regex" message="Integer or blank">[0-9]*</validator>
+        </param>
+        <param argument="--block-length" type="text" value=""
+               label="Minimum block length (blank = 0)"
+               help="Discard mappings shorter than this.">
+            <validator type="regex" message="Integer or blank">[0-9]*</validator>
+        </param>
+        <param argument="--group-prefix" type="text" value=""
+               label="PanSN group-prefix delimiter (blank = off)"
+               help="Group sequences by everything up to the last occurrence of this delimiter (typically '#' for PanSN). Same value passed to pggb's -Y.">
+            <sanitizer invalid_char="">
+                <valid initial="string.printable">
+                    <remove value="&apos;"/>
+                </valid>
+            </sanitizer>
+        </param>
+        <param argument="-m" name="approx_mapping" type="boolean" truevalue="-m" falsevalue=""
+               checked="false" label="Approximate mapping"
+               help="Skip base-level WFA alignment, output PAF mappings only."/>
+        <param argument="-N" name="no_split" type="boolean" truevalue="-N" falsevalue=""
+               checked="false" label="No split"
+               help="Disable splitting of input sequences."/>
+        <param argument="-X" name="self_maps" type="boolean" truevalue="-X" falsevalue=""
+               checked="false" label="Include self-mappings"
+               help="Keep mappings of a sequence to itself."/>
+        <param argument="-L" name="lower_triangular" type="boolean" truevalue="-L" falsevalue=""
+               checked="false" label="Lower-triangular only"
+               help="Only map seq_i to seq_j when i &gt; j."/>
+        <param argument="--sam" type="boolean" truevalue="--sam" falsevalue=""
+               checked="false" label="SAM output (default PAF)"/>
+        <param argument="--md-tag" type="boolean" truevalue="--md-tag" falsevalue=""
+               checked="false" label="Include MD tag"
+               help="SAM-only; ignored for PAF output."/>
     </inputs>
-    
     <outputs>
-        <data name="output_paf" format="paf" label="${tool.name} on ${on_string}:  PAF"/>
+        <data name="output_paf" format="paf" label="${tool.name} on ${on_string}: PAF">
+            <change_format>
+                <when input="sam" value="--sam" format="sam"/>
+            </change_format>
+        </data>
     </outputs>
-
     <tests>
         <test expect_num_outputs="1">
-            <param name="reference" ftype="fasta" value="ecoli_k12.fa"/> 
-            <param name="query" ftype="fasta" value="ecoli_o157.fa"/>        
+            <param name="reference" ftype="fasta" value="ecoli_k12.fa"/>
+            <conditional name="query_source">
+                <param name="query_mode" value="two_fasta"/>
+                <param name="query" ftype="fasta" value="ecoli_o157.fa"/>
+            </conditional>
             <param name="pct_identity" value="70"/>
-            <output name="output_paf" file="expected_output_ecoli.paf" sort="true"/>
+            <output name="output_paf" file="expected_output_ecoli.paf" compare="sim_size"/>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="reference" ftype="fasta" value="ecoli_k12.fa"/>
+            <conditional name="query_source">
+                <param name="query_mode" value="two_fasta"/>
+                <param name="query" ftype="fasta" value="ecoli_o157.fa"/>
+            </conditional>
+            <param name="pct_identity" value="70"/>
+            <output name="output_paf">
+                <assert_contents>
+                    <has_size min="100"/>
+                    <has_line_matching expression="^[^\t]+\t\d+\t\d+\t\d+\t[\+\-]\t.+"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="reference" ftype="fasta" value="ecoli_k12.fa"/>
+            <conditional name="query_source">
+                <param name="query_mode" value="self_map"/>
+            </conditional>
+            <param name="pct_identity" value="95"/>
+            <param name="approx_mapping" value="true"/>
+            <output name="output_paf">
+                <assert_contents>
+                    <has_size min="0"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
-    
-    <help><![CDATA[
-wfmash is designed to make whole genome alignment easy. It can handle high sequence divergence. 
+    <help format="markdown"><![CDATA[
+**wfmash** — pangenome-scale aligner.
 
-By default, wfmash automatically determines an appropriate identity threshold based on the ANI (Average Nucleotide Identity) distribution of your input sequences. 
+A whole-genome aligner combining MashMap-style mapping with WFA (wavefront)
+base-level alignment. Used as the mapping front-end of `pggb`.
+
+-----
+
+**Modes**
+
+- *Self-map*: one FASTA, all-vs-all mappings (good for building a
+  pangenome graph from PanSN-renamed multifasta).
+- *Query vs target*: two FASTAs, mappings of query onto target.
+
+**Key parameters**
+
+- `-p` (`--map-pct-id`) — MashMap identity threshold (90 for intra-species,
+  70-80 for inter-species).
+- `--group-prefix` — PanSN delimiter (typically `#`). Sequences sharing a
+  prefix are treated as one haplotype group.
+- `--mappings` — plane-sweep cap (`inf` by default).
+- `--block-length` — discard short mappings.
+
+-----
+
+The output is PAF by default (the format expected by `seqwish`). Switch to
+SAM for downstream BAM-pipeline use.
     ]]></help>
-    
     <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
Upgrades wfmash from 0.14.0 to 0.24.2

Breaking change: -s (segment_length) removed — wfmash 0.24.x dropped this flag upstream. Existing workflows using this param need updating.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
