### PR TITLE
Update kmindex query to support multiple indices simultaneously

### DIFF
--- a/tools/kmindex/kmindex_query.xml
+++ b/tools/kmindex/kmindex_query.xml
@@ -1,4 +1,4 @@
-<tool id="kmindex_query" name="kmindex query" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="kmindex_query" name="kmindex query" version="@TOOL_VERSION@+galaxy3" profile="@PROFILE@">
     <description>query k-mer index with sequencing data</description>
     <macros>
         <import>macros.xml</import>
@@ -23,21 +23,33 @@
             #set $safe_name = $safe_name + '.fq'
         #end if
         #if $db_opts.db_opts_selector == "histdb"
-            #set INDEX = $db_opts.histdb.extra_files_path
+            #set INDICES = [db.extra_files_path for db in $db_opts.histdb]
         #else
-            #set INDEX = $db_opts.kmindex.fields.path
+            #set INDICES = $db_opts.kmindex.fields.path.split(",")
         #end if
         ln -s '$fastx' '$safe_name' &&
-        kmindex query2
-            --index '$INDEX'
-            --fastx '$safe_name'
-            --zvalue $zvalue
-            --threshold $threshold
-            --output query_output
-            --format $format
-            $fast
-            --threads "\${GALAXY_SLOTS:-1}"
-            --verbose '$verbose'
+        #for $i, $INDEX in enumerate($INDICES):
+            #if $i > 0:
+                &&
+            #end if
+            kmindex query2
+                --index '$INDEX'
+                --fastx '$safe_name'
+                --zvalue $zvalue
+                --threshold $threshold
+                --output query_output_${i}
+                --format $format
+                $fast
+                --threads "\${GALAXY_SLOTS:-1}"
+                --verbose '$verbose'
+        #end for
+        && mkdir -p query_output &&
+        #for $i in range(len($INDICES)):
+            #if $i > 0:
+                &&
+            #end if
+            cp -r query_output_${i}/* query_output/
+        #end for
     ]]></command>
     <inputs>
         <conditional name="db_opts">
@@ -46,10 +58,10 @@
                 <option value="db" selected="true">Locally installed kmindex indexes</option>
             </param>
             <when value="histdb">
-                <param name="histdb" type="data" format="kmindex" label="Kmindex" />
+                <param name="histdb" type="data" format="kmindex" multiple="true" label="Kmindex index(es)" />
             </when>
             <when value="db">
-                <param name="kmindex" type="select" label="kmindex">
+                <param name="kmindex" type="select" multiple="true" label="kmindex index(es)">
                     <options from_data_table="kmindex"/>
                 </param>
             </when>
@@ -169,15 +181,29 @@
                 <element name="index2" ftype="tabular" value="expected_query2_index2_register.tsv" />
             </output_collection>
         </test>
+        <!-- Test 8: query multiple selected indices simultaneously, JSON output -->
+        <test expect_num_outputs="1">
+            <conditional name="db_opts">
+                <param name="db_opts_selector" value="db"/>
+                <param name="kmindex" value="index1,index2" />
+            </conditional>
+            <param name="fastx" value="query1.fasta"/>
+            <param name="format" value="json"/>
+            <param name="zvalue" value="0"/>
+            <output_collection name="output" type="list" count="2">
+                <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
+                <element name="test_index" ftype="json" value="expected_query_t6.json" />
+            </output_collection>
+        </test>
     </tests>
     <help><![CDATA[
 **What it does**
 
-kmindex query2 searches a pre-built k-mer index to find the percentage of shared k-mers between query sequences and indexed samples.
+kmindex query2 searches one or more pre-built k-mer indices to find the percentage of shared k-mers between query sequences and indexed samples. Multiple indices can be queried simultaneously in a single run.
 
 **Input**
 
-- A k-mer index (created by kmindex build) or kmindex register
+- One or more k-mer indices (created by kmindex build) or a kmindex register
 - Query sequences in FASTA or FASTQ format (can be gzipped)
 
 **Output**


### PR DESCRIPTION
- Make index selection multipick for both history and locally installed indices
- Loop kmindex query2 calls per index with separate output dirs, then combine
- Update help text to describe multi-index querying
- Add test 8 for querying multiple selected indices
- Bump version to galaxy3

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
