### PR TITLE
samestr DB builder: don't copy build-time inputs into the built database (+galaxy3)

### DIFF
--- a/data_managers/data_manager_samestr_db/data_manager/macros.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.2025.111</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">25.0</token>
 
 

--- a/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
@@ -17,15 +17,19 @@
             #set $samestr_db_dir = $out_file.extra_files_path + '/samestr_db/' + $db_value
             mkdir -p '$samestr_db_dir' &&
 
-            #set $source_pkl = $db_path + '/' + $db_key + '.pkl'
-            #set $destination_pkl = $samestr_db_dir + $db_value + '.pkl'
-            cp '$source_pkl' '$destination_pkl' &&
+            ## The MetaPhlAn pkl is only read by `samestr db` to map markers to
+            ## clades; that mapping ends up in db_clades.json/db_taxonomy.tsv, and
+            ## nothing reads the pkl from the built database afterwards. Point at
+            ## the MetaPhlAn copy instead of duplicating it into the output.
+            #set $markers_info = $db_path + '/' + $db_key + '.pkl'
 
             ## MetaPhlAn's installer builds the bowtie2 index and then deletes the
             ## marker FASTA, so a real MetaPhlAn database directory has no *.fna.
             ## Use the raw markers when present (e.g. test fixtures); otherwise
             ## reconstruct them from the bowtie2 index with bowtie2-inspect.
-            #set $concatenated_fasta = $samestr_db_dir + '/' + 'mpa_markers.fna'
+            ## This is a build-time input as well, so keep it in the job working
+            ## directory rather than in the published database.
+            #set $concatenated_fasta = 'mpa_markers.fna'
             if ls '${db_path}/${db_key}'*.fna > /dev/null 2>&1; then
                 cat '${db_path}/${db_key}'*.fna > '$concatenated_fasta';
             else
@@ -36,7 +40,7 @@
             echo '$db_key' > '$db_version_file' &&
 
             samestr db
-            --markers-info '$destination_pkl'
+            --markers-info '$markers_info'
             --markers-fasta '$concatenated_fasta'
             --db-version '$db_version_file'
             --output-dir '$samestr_db_dir'


### PR DESCRIPTION
### What

`data_manager_samestr_db` wrote two files into the published database directory that `samestr db` only ever consumes as *inputs*:

* the MetaPhlAn `.pkl`, copied in with

  ```
  #set $samestr_db_dir = $out_file.extra_files_path + '/samestr_db/' + $db_value
  #set $destination_pkl = $samestr_db_dir + $db_value + '.pkl'
  ```

  `$samestr_db_dir` already ends in `…/samestr_db/<db_value>` with no trailing slash, so this produced a **doubled-name sibling** of the DB dir — `…/samestr_db/<v><v>.pkl` — instead of a file inside it. Observed while building `mpa_vJan21_CHOCOPhlAnSGB_202103` on test.galaxyproject.org.
* `mpa_markers.fna`, the concatenated (or `bowtie2-inspect`-reconstructed) marker FASTA, written inside the DB dir.

### Neither belongs in the built database

`samestr db` reads both once at build time and writes everything it needs into the database itself:

* `db/generate_db.py:107,148-166` loads the pkl and uses only `markers_info['markers'][m]['clade']` and `['taxon']`, which end up in `db_clades.json` and `db_taxonomy.tsv`;
* the marker FASTA is split into the per-clade files under `db_markers/`.

Afterwards nothing reads either file. Every command that takes `--marker-dir` (`convert`, `extract`, `filter`, `merge`, `stats`, `compare`) opens only:

* `db_manifest.json`, `db_clades.json`, `db_taxonomy.tsv` — `utils/utilities.py:load_samestr_db_manifest`
* `db_markers/<…>/<clade>.{contig_map.txt.gz,gene_file.txt.gz,markers.fa.gz,positions.txt.gz}` — `convert/concatenate_gene_files.py:45-46`, `extract/ref2freq.py:483`, `filter/filter_freqs.py:139`

and `samestr db --db-check` verifies exactly those four suffixes. Outside `samestr db`, `pkl`/`pickle.load` does not appear in the SameStr source at all, and the pkl path is never recorded in `db_manifest.json`. SameStr's external dependencies — samtools, muscle/mafft, makeblastdb/blastn — have no use for a MetaPhlAn pickle either; SameStr never invokes MetaPhlAn, it consumes MetaPhlAn's BAM and text profile.

Re the `.pkl` inside `tools/samestr/test-data/samestr_db/mpa_test-db-without-one-marker/` that I pointed at earlier: that is a build-time leftover, not a required layout. The fixture's own `command_log.json` shows `--output-dir` pointing at the very directory the pkl had been copied into, so it ended up there incidentally.

### Fix

* Pass the MetaPhlAn pkl straight from the MetaPhlAn data table (`$db_path/$db_key.pkl`) to `--markers-info` — no copy.
* Build `mpa_markers.fna` in the job working directory instead of inside the published DB.
* Bump to `+galaxy3`.

This also makes the MetaPhlAn branch consistent with the mOTUs branch, which already passes `--markers-info`/`--markers-fasta` through from the source database and copies nothing but the version file. The version file stays in the DB dir, since the data table's `version_file` column points at it.

Net effect: no stray `<v><v>.pkl`, and the published bundle no longer carries the pkl or the full concatenated marker FASTA.

### Answering my earlier questions — no rebuild needed

@xens25 @SaimMomin12 — to close the loop on the two questions in the original description: the pkl is **not** required in the published DB, so the databases already built with galaxy0/1/2 (including those on usegalaxy.eu) are fine and do **not** need rebuilding. They contain everything the consumer tools read; the misplaced pkl was only wasted disk space.
