### PR TITLE
data_manager_checkm2: fix TAB separator in test-data loc

### DIFF
--- a/data_managers/data_manager_checkm2/data_manager/checkm2_datamanager.xml
+++ b/data_managers/data_manager_checkm2/data_manager/checkm2_datamanager.xml
@@ -3,7 +3,7 @@
     <macros>
         <!-- on update run a local test setting `test` to something else than "true" -->
         <token name="@TOOL_VERSION@">1.1.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">23.1</token>
     </macros>
     <requirements>

--- a/data_managers/data_manager_checkm2/test-data/checkm2.loc
+++ b/data_managers/data_manager_checkm2/test-data/checkm2.loc
@@ -1,2 +1,2 @@
 
-1.0.2   1.0.2	CheckM2 diamond DB downloaded with version 1.0.2	1.0.2	/tmp/tmpf_hplx2a/galaxy-dev/tool-data/checkm2/1.0.2/uniref100.KO.1.dmnd
+1.0.2	1.0.2	CheckM2 diamond DB downloaded with version 1.0.2	1.0.2	/tmp/tmpf_hplx2a/galaxy-dev/tool-data/checkm2/1.0.2/uniref100.KO.1.dmnd


### PR DESCRIPTION
> 🤖 Posted by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored by them personally.

## What

The single data row in `data_managers/data_manager_checkm2/test-data/checkm2.loc` separates the `value` and `dbkey` fields with **spaces** instead of a TAB. The `checkm2` table declares 5 columns (`value, dbkey, name, version, path`), but the malformed row parses as only **4** TAB-separated fields, so Galaxy's tabular loader rejects it as a bad row.

```diff
-1.0.2   1.0.2<TAB>CheckM2 diamond DB downloaded with version 1.0.2<TAB>1.0.2<TAB>/tmp/...
+1.0.2<TAB>1.0.2<TAB>CheckM2 diamond DB downloaded with version 1.0.2<TAB>1.0.2<TAB>/tmp/...
```

(The two leading `1.0.2` tokens were joined by three spaces; they're now TAB-separated → 5 fields, matching the schema.)

## How it was found

Flagged by a work-in-progress repository-level data-table linter for data managers / tool data tables — tracking issue galaxyproject/planemo#1672. It reuses Galaxy's `TabularToolDataTable` row parser to catch loc rows that can't supply every declared column.

Linter output on this repo, before → after:

```
before:  .. ERROR (LocRowShape): Line 2 in tool data table 'checkm2' is invalid
                (HINT: '<TAB>' characters must be used to separate fields): ...
after:   .. CHECK (LocRowShape): All loc rows supply every declared column
```

Linter branch (galaxy): https://github.com/jmchilton/galaxy/tree/data_validation

## Notes (intentionally left out of this diff to keep it minimal)

- The `tool-data/checkm2.loc.sample` header's own format example uses spaces between the first columns, which likely propagated the mistake — worth a follow-up doc cleanup.
- The row's `path` still points at a captured `/tmp/tmpf_hplx2a/...` temp path from a test run; it isn't asserted by the data-manager test, so it's left as-is here.
