### PR TITLE
data_manager_dram_database_downloader: fix tab separators in loc test data

### DIFF
--- a/data_managers/data_manager_dram_database_downloader/data_manager/data_manager_dram_download.xml
+++ b/data_managers/data_manager_dram_database_downloader/data_manager/data_manager_dram_download.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_dram_download" name="DRAM: Download databases" version="1.3.5" tool_type="manage_data" profile="21.05">
+<tool id="data_manager_dram_download" name="DRAM: Download databases" version="1.3.5+galaxy1" tool_type="manage_data" profile="21.05">
     <description>required by the DRAM suite of tools</description>
     <requirements>
         <requirement type="package" version="1.3.5">dram</requirement>
@@ -203,7 +203,9 @@ python '$__tool_directory__/data_manager_dram_download.py'
         <test expect_failure="true">
             <param name="kofam_hmm_loc" value="profiles.tar.gz"/>
             <param name="kofam_ko_list_loc" value="ko_list.gz"/>
-            <param name="skip_uniref" value="yes"/>
+            <conditional name="skip_uniref_cond">
+                <param name="skip_uniref" value="yes"/>
+            </conditional>
             <param name="pfam_loc" value="Pfam-A.full.gz"/>
             <param name="pfam_hmm_dat" value="Pfam-A.hmm.dat.gz"/>
             <param name="dbcan_loc" value="dbCAN-HMMdb-V9.txt"/>

--- a/data_managers/data_manager_dram_database_downloader/test-data/dram_databases.loc
+++ b/data_managers/data_manager_dram_database_downloader/test-data/dram_databases.loc
@@ -9,4 +9,4 @@
 # then the gtdbtk_databases.loc entry would look like this:
 #
 # 3.5.1	DRAM database	/depot/data2/galaxy/dram
-3.5.1   DRAM 3.5.1 databases    ${__HERE__}
+3.5.1	DRAM 3.5.1 databases	${__HERE__}


### PR DESCRIPTION
> **Note:** Opened by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored personally.

`test-data/dram_databases.loc` had its data row separated by spaces instead of tabs. Galaxy's `.loc` parser is tab-delimited, so the row parsed as a single field for the 3-column `dram_databases` table (`value, name, path`) — the display name and `${__HERE__}` path were unrecoverable. The comment block right above the row already documents the correct tab-separated format.

Found with a repository data-table linter built for galaxyproject/planemo#1672 (working branch: https://github.com/jmchilton/galaxy/tree/data_validation):

```
.. ERROR (LocRowShape): Line 12 in tool data table 'dram_databases' is invalid
   (HINT: '<TAB>' characters must be used to separate fields):
   3.5.1   DRAM 3.5.1 databases    .../test-data
```

While here:
- Bumped the version suffix to `+galaxy1` to satisfy the Tool Shed publish gate (`ShedVersion`).
- Wrapped the test's `skip_uniref` param in its `skip_uniref_cond` conditional so it validates against the tool inputs (was a `TestsCaseValidation` warning).