### PR TITLE
data_manager_hisat2_index_builder: drop stray bwa_mem_indexes table

### DIFF
--- a/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
+++ b/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
@@ -2,7 +2,7 @@
     <description>builder</description>
     <macros>
         <token name="@WRAPPER_VERSION@">2.2.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <requirement type="package" version="@WRAPPER_VERSION@">hisat2</requirement>

--- a/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
+++ b/data_managers/data_manager_hisat2_index_builder/data_manager/hisat2_index_builder.xml
@@ -138,7 +138,7 @@ involving indels and supports a paired-end alignment mode. Multiple processors
 can be used simultaneously to achieve greater alignment speed. HISAT outputs
 alignments in `SAM <http://samtools.sourceforge.net/SAM1.pdf>`__ format, enabling
 interoperation with a large number of other tools (e.g. `SAMtools <http://samtools.sourceforge.net>`__,
-`GATK <http://www.broadinstitute.org/gsa/wiki/index.php/The_Genome_Analysis_Toolkit>`__)
+`GATK <https://github.com/broadinstitute/gatk>`__)
 that use SAM. HISAT is distributed under the `GPLv3 license <http://www.gnu.org/licenses/gpl-3.0.html>`__,
 and it runs on the command line under Linux, Mac OS X and Windows.
 ]]>

--- a/data_managers/data_manager_hisat2_index_builder/tool_data_table_conf.xml.test
+++ b/data_managers/data_manager_hisat2_index_builder/tool_data_table_conf.xml.test
@@ -8,8 +8,4 @@
         <columns>value, dbkey, name, path</columns>
         <file path="${__HERE__}/test-data/hisat2_indexes.loc" />
     </table>
-    <table name="bwa_mem_indexes" comment_char="#">
-        <columns>value, dbkey, name, path</columns>
-        <file path="${__HERE__}/test-data/bwa_mem_index.loc" />
-    </table>
 </tables>


### PR DESCRIPTION
> **Note:** Opened by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored personally.

`tool_data_table_conf.xml.test` declared a `bwa_mem_indexes` table — a leftover from a BWA index-builder template. It points at `test-data/bwa_mem_index.loc`, which does not exist in the repo, and this data manager never populates that table (it produces `hisat2_indexes` and consumes `all_fasta`). The dangling reference emitted a Galaxy loader warning on every test run:

```
galaxy.tool_util.data WARNING: Cannot find index file '.../test-data/bwa_mem_index.loc'
   for tool data table 'bwa_mem_indexes'
```

Found with a repository data-table linter built for galaxyproject/planemo#1672 (working branch: https://github.com/jmchilton/galaxy/tree/data_validation):

```
.. ERROR (MissingLocFixture): Data table 'bwa_mem_indexes' references loc file
   [.../test-data/bwa_mem_index.loc] which does not exist
```

Removing the stray table clears the warning. Version suffix bumped to `+galaxy2` to satisfy the Tool Shed publish gate (`ShedVersion`).