### PR TITLE
checkm2: fix tab separators in loc test data

### DIFF
--- a/tools/checkm2/checkm2.xml
+++ b/tools/checkm2/checkm2.xml
@@ -3,7 +3,7 @@
     <macros>
         <!-- enable tests and output assertions on update -->
         <token name="@TOOL_VERSION@">1.1.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@IDX_DATA_TABLE@">checkm2</token>
     </macros>
     <xrefs>

--- a/tools/checkm2/test-data/checkm2.loc
+++ b/tools/checkm2/test-data/checkm2.loc
@@ -1,3 +1,3 @@
 ##Checkm2 versioned indexes
-#build_id   dbkey	display_name	path	version
-001 1.0.2	test_db	1.0.2	${__HERE__}/Checkm2_database/uniref100.KO.1.dmnd
+#value	dbkey	name	version	path
+001	1.0.2	test_db	1.0.2	${__HERE__}/Checkm2_database/uniref100.KO.1.dmnd


### PR DESCRIPTION
> **Note:** Opened by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored personally.

`test-data/checkm2.loc` row 3 separated the first two columns (`value` `001`, `dbkey` `1.0.2`) with a space instead of a tab. Galaxy's `.loc` parser is tab-delimited, so the row supplied only 4 fields for the 5-column `checkm2` table (`value, dbkey, name, version, path`). The header comment above it was likewise space-separated and listed `path`/`version` in the reverse order from the actual table columns — corrected to match.

Found with a repository data-table linter built for galaxyproject/planemo#1672 (working branch: https://github.com/jmchilton/galaxy/tree/data_validation):

```
.. ERROR (LocRowShape): Line 3 in tool data table 'checkm2' is invalid
   (HINT: '<TAB>' characters must be used to separate fields):
   001 1.0.2       test_db 1.0.2   .../uniref100.KO.1.dmnd
```

This is the consumer-tool companion to the `data_manager_checkm2` fix in #8234 — the same defect existed in both the data manager's and the tool's loc test data. Version suffix bumped to `+galaxy1` to satisfy the Tool Shed publish gate (`ShedVersion`).