### PR TITLE
coverm: drop stray truncated row in all_fasta loc test data

### DIFF
--- a/tools/coverm/macros.xml
+++ b/tools/coverm/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.8.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.01</token>
     <xml name="requirements">
         <requirements>

--- a/tools/coverm/test-data/all_fasta.loc
+++ b/tools/coverm/test-data/all_fasta.loc
@@ -29,4 +29,3 @@
 #hg19full	hg19	Human (Homo sapiens): hg19 Full	/depot/data2/galaxy/hg19/hg19full.fasta
 500kb_value	50kb_dbkey	500kb_name	${__HERE__}/500kb.fna
 1mbp_value	1mbp_dbkey	1mbp_name	${__HERE__}/1mbp.fna
-1mbp


### PR DESCRIPTION
> **Note:** Opened by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored personally.

`test-data/all_fasta.loc` ended with a stray `1mbp` fragment on its own line — a single field left over from an incomplete edit, right after the complete `1mbp_value  1mbp_dbkey  1mbp_name  ${__HERE__}/1mbp.fna` entry. It's invalid for the 4-column `all_fasta` table.

Found with a repository data-table linter built for galaxyproject/planemo#1672 (working branch: https://github.com/jmchilton/galaxy/tree/data_validation):

```
.. ERROR (LocRowShape): Line 32 in tool data table 'all_fasta' is invalid
   (HINT: '<TAB>' characters must be used to separate fields):
   1mbp
```

The existing `1mbp` output assertion in `coverm_genome.xml` is a substring match still satisfied by the complete `1mbp_value` row, so tests are unaffected. Version suffix bumped to `+galaxy1` to satisfy the Tool Shed publish gate (`ShedVersion`).