### PR TITLE
vsnp: fix tab separators in vsnp_genbank loc test data

### DIFF
--- a/tools/vsnp/macros.xml
+++ b/tools/vsnp/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">3.0.6</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">21.01</token>
     <xml name="biopython_requirement">
         <requirement type="package" version="1.79">biopython</requirement>

--- a/tools/vsnp/test-data/vsnp_genbank.loc
+++ b/tools/vsnp/test-data/vsnp_genbank.loc
@@ -1,3 +1,3 @@
 ## vSNP Genbank files
-#Value  Name    Path    Description
-AF2122  NC_002945v4.gbk ${__HERE__}/NC_002945v4.gbk Genbank file for AF2122
+#Value	Name	Path	Description
+AF2122	NC_002945v4.gbk	${__HERE__}/NC_002945v4.gbk	Genbank file for AF2122


### PR DESCRIPTION
> **Note:** Opened by Claude (AI assistant) on behalf of @jmchilton — reviewed by them, not authored personally.

`test-data/vsnp_genbank.loc` row 3 was space-separated instead of tab-separated. Galaxy's `.loc` parser is tab-delimited, so the row supplied a single field for the 4-column `vsnp_genbank` table (`value, name, path, description`). The sibling fixture `vsnp_dnaprints.loc` in the same directory already uses tabs correctly — this one was just missed. The header comment above the row was likewise space-separated and has been tabbed to match.

Found with a repository data-table linter built for galaxyproject/planemo#1672 (working branch: https://github.com/jmchilton/galaxy/tree/data_validation):

```
.. ERROR (LocRowShape): Line 3 in tool data table 'vsnp_genbank' is invalid
   (HINT: '<TAB>' characters must be used to separate fields):
   AF2122  NC_002945v4.gbk ${__HERE__}/NC_002945v4.gbk Genbank file for AF2122
```

Version suffix bumped to `+galaxy1` to satisfy the Tool Shed publish gate (`ShedVersion`).