### PR TITLE
Update tools/compleasm to 0.2.9 adding odb10 support

### DIFF
--- a/tools/compleasm/compleasm.xml
+++ b/tools/compleasm/compleasm.xml
@@ -13,17 +13,12 @@
     <command><![CDATA[
     ## compleasm rebuilds the lineage name as "<taxon>_<odb>", so --odb has to agree with
     ## the suffix of the cached lineage or it will try to fetch a different OrthoDB release.
+    ## compleasm v0.2.9 now supports odb10, odb12 and odb12.2 lineages (https://github.com/huangnengCSU/compleasm/releases/tag/v0.2.9), so the suffix is
+    ## passed through as-is (e.g. odb10, odb12, odb12.2).
     #set $odb = str($lineage_dataset).split('_')[-1]
-    ## compleasm >=0.2.7 expects the OrthoDB 12 HMM naming scheme. Against an odb10 lineage it
-    ## still exits 0 but discards every hmmsearch hit, reporting 100% missing BUSCOs. The lineage
-    ## dropdown already filters odb10 out; this is a backstop for values reaching the tool by
-    ## another route (e.g. a workflow) so we fail loudly instead of returning silently wrong scores.
-    #if $odb.startswith('odb10'):
-        >&2 echo 'The selected lineage "$lineage_dataset" is an OrthoDB 10 dataset, which compleasm @TOOL_VERSION@ does not support - it would report 100% missing BUSCOs. Please select or ask your Galaxy administrator to install an OrthoDB 12 BUSCO dataset.' && exit 1 &&
-    #end if
     mkdir -p 'galaxy_db/' &&
     ln -s '${busco_database.fields.path}/lineages/${lineage_dataset}/' 'galaxy_db/${lineage_dataset}' &&
-    ## Create a compleasm-specific empty file to avoid redownloading the lineage data (https://github.com/huangnengCSU/compleasm/blob/v0.2.8/compleasm.py#L155)
+    ## Create a compleasm-specific empty file to avoid redownloading the lineage data (https://github.com/huangnengCSU/compleasm/blob/v0.2.9/compleasm.py#L155)
     touch 'galaxy_db/${lineage_dataset}.done' &&
     ## Placement files are only used for auto-lineage/SEPP, which this tool never runs, so mark
     ## them present to skip a large (~30 MB) download on every job.
@@ -70,9 +65,7 @@
         <param name="lineage_dataset" type="select" label="Lineage">
             <options from_data_table="busco_database_options">
                 <filter type="param_value" column="2" ref="busco_database"/>
-                <!-- compleasm @TOOL_VERSION@ only works with OrthoDB 12 lineages; hide odb10 (and older) datasets -->
-                <filter type="regexp" column="0" value=".*_odb12" keep="true"/>
-                <validator message="No OrthoDB 12 lineage is available for this database - compleasm @TOOL_VERSION@ requires odb12. Please ask your Galaxy administrator to install an odb12 BUSCO dataset." type="no_options"/>
+                <validator message="No BUSCO lineage is available for this database - please ask your Galaxy administrator to install a BUSCO dataset." type="no_options"/>
             </options>
         </param>
     </inputs>
@@ -145,13 +138,18 @@
                 <has_text text="S:0.30%, 1"/>
             </assert_stdout>
         </test>
-        <!-- odb10 lineages are filtered out of the dropdown, so selecting one must fail
-             (empty option list) rather than run and report a silently-wrong 100% missing result -->
-        <test expect_failure="true">
+        <!-- compleasm v0.2.9 restored OrthoDB 10 support, so an odb10 lineage must
+             now produce real BUSCO results rather than a silently-wrong 100% missing result -->
+        <test expect_num_outputs="1">
             <param name="input" value="small_genome.fasta"/>
             <param name="outputs" value="summary"/>
             <param name="busco_database" value="entomoplasmatales_odb10"/>
             <param name="lineage_dataset" value="entomoplasmatales_odb10"/>
+            <output name="summary">
+                <assert_contents>
+                    <has_text text="## lineage: entomoplasmatales_odb10"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[
@@ -160,10 +158,10 @@
 
     **OrthoDB version**
 
-    From version 0.2.7 on, compleasm only supports OrthoDB 12 (``odb12``) lineages. Running it
-    against an older ``odb10`` lineage reports every BUSCO as missing, so the Lineage list only
-    offers ``odb12`` datasets. If no lineage is available, ask your Galaxy administrator to
-    install the odb12 BUSCO datasets with the BUSCO data manager.
+    compleasm 0.2.9 is compatible with OrthoDB 10 (``odb10``), OrthoDB 12 (``odb12``) and
+    OrthoDB 12.2 (``odb12.2``) lineages. The Lineage list offers whichever BUSCO datasets are
+    installed. If no lineage is available, ask your Galaxy administrator to install BUSCO
+    datasets with the BUSCO data manager.
 
     The evaluation mode ("busco" / "lite") that earlier versions of this tool exposed no longer
     exists upstream; compleasm always runs the hmmsearch-based evaluation now.

--- a/tools/compleasm/macros.xml
+++ b/tools/compleasm/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.2.8</token>
+    <token name="@TOOL_VERSION@">0.2.9</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="citation">


### PR DESCRIPTION
Closes: https://github.com/galaxyproject/tools-iuc/pull/8226

The recent compleasm v0.2.9 [release](https://github.com/huangnengCSU/compleasm/releases/tag/v0.2.9) adds support for ODB10 lineage datasets. This PR updates the tool to incorporate the required changes and ensure compatibility with the new behaviour.

---
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
