### PR TITLE
More test modernizations allowing stricter testing workflow

### DIFF
--- a/data_managers/data_manager_genomic_super_signature_ravmodels/data_manager/data_manager_genomic_super_signature_ravmodels.xml
+++ b/data_managers/data_manager_genomic_super_signature_ravmodels/data_manager/data_manager_genomic_super_signature_ravmodels.xml
@@ -70,8 +70,10 @@
             <param name="rav_name" value=""/>
             <param name="rav_id" value=""/>
             <param name="rav_dbkey" value="hg38"/>
-            <param name="dbkey_source|reference_source_selector" value="prior"/>
-            <param name="dbkey_source|prior_name" value="C2"/>
+            <conditional name="reference_source">
+                <param name="reference_source_selector" value="prior"/>
+                <param name="prior_name" value="C2"/>
+            </conditional>
             <output name="out_file" file="RAVmodel_prior_C2.data_manager_json"/>
         </test>
     </tests>

--- a/tool_collections/biotradis/bacteria_tradis.xml
+++ b/tool_collections/biotradis/bacteria_tradis.xml
@@ -95,9 +95,7 @@
             <param name="input_fastq" ftype="fastq" value="tiny.fastq.gz"/>
             <param name="input_ref" ftype="fasta" value="tiny_ref.fasta"/>
             <param name="map_options" value="default"/>
-            <param name="min_quality" ftype="float" value="0"/>
             <param name="use" value="no"/>
-            <param name="set" ftype="select" value="no"/>
             <output name="Statistics" file="file.stats" lines_diff="2"  />
             <output name="Counts" file="tiny.out.gz.CP009273.1_60_120.insert_site_plot.gz" compare="diff" decompress="true" lines_diff="0" />
         </test>

--- a/tool_collections/kraken/kraken.xml
+++ b/tool_collections/kraken/kraken.xml
@@ -100,10 +100,10 @@
         <expand macro="input_database" />
     </inputs>
     <outputs>
-        <data name="classified_out" format_source="input_sequences" label="${tool.name} on ${on_string}: Classified reads">
+        <data name="classified_out" format_source="single_paired|input_sequences" label="${tool.name} on ${on_string}: Classified reads">
             <filter>(split_reads)</filter>
         </data>
-        <data name="unclassified_out" format_source="input_sequences" label="${tool.name} on ${on_string}: Unclassified reads">
+        <data name="unclassified_out" format_source="single_paired|input_sequences" label="${tool.name} on ${on_string}: Unclassified reads">
             <filter>(split_reads)</filter>
         </data>
         <data name="output" format="tabular" label="${tool.name} on ${on_string}: Classification"/>
@@ -116,7 +116,7 @@
             <param name="input_sequences" value="kraken/kraken_test1.fa" ftype="fasta"/>
             <param name="split_reads" value="false"/>
             <param name="quick" value="no"/>
-            <param name="only-classified-output" value="false"/>
+            <param name="only_classified_output" value="false"/>
             <param name="kraken_database" value="old_style_test_entry"/>
             <output name="output" file="kraken/kraken_test1_output.tab" ftype="tabular"/>
         </test>
@@ -125,7 +125,7 @@
             <param name="input_sequences" value="kraken/kraken_test1.fa" ftype="fasta"/>
             <param name="split_reads" value="false"/>
             <param name="quick" value="no"/>
-            <param name="only-classified-output" value="false"/>
+            <param name="only_classified_output" value="false"/>
             <param name="kraken_database" value="new_style_test_entry"/>
             <output name="output" file="kraken/kraken_test1_output.tab" ftype="tabular"/>
         </test>

--- a/tools/coverm/coverm_contig.xml
+++ b/tools/coverm/coverm_contig.xml
@@ -156,7 +156,6 @@ coverm
                         </param>
                     </conditional>
                     <param name="reference" value="7seqs.fna" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -197,7 +196,6 @@ coverm
                         <param name="read2" value="reads_for_seq1_and_seq2.2.fq.gz" ftype="fastqsanger.gz"/>
                     </conditional>
                     <param name="reference" value="7seqs.fna" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -242,7 +240,6 @@ coverm
                         </param>
                     </conditional>
                     <param name="reference" value="7seqs.fna" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -282,7 +279,6 @@ coverm
                         <param name="single" value="bad_reads.interleaved.fq"/>
                     </conditional>
                     <param name="reference" value="2seqs.fasta" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -322,7 +318,6 @@ coverm
                         <param name="interleaved" value="bad_reads.all.interleaved.fa"/>
                     </conditional>
                     <param name="reference" value="2seqs.fasta" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -379,7 +374,6 @@ coverm
                         </conditional>
                     </repeat>
                     <param name="reference" value="2seqs.fasta" />
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -387,7 +381,7 @@ coverm
                 <param name="min_read_percent_identity" value="0.95" />
                 <param name="min_read_aligned_percent" value="0" />
                 <conditional name="proper_pairs_only">
-                    <param name="proper_pairs-only" value=""/>
+                    <param name="proper_pairs_only" value=""/>
                 </conditional>
                 <param name="exclude_supplementary" value=""/>
             </section>
@@ -417,7 +411,6 @@ coverm
                 <conditional name="mode">
                     <param name="mode" value="co"/>
                     <param name="bam_files" value="tpm_test.bam"/>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -425,7 +418,7 @@ coverm
                 <param name="min_read_percent_identity" value="0.95" />
                 <param name="min_read_aligned_percent" value="0" />
                 <conditional name="proper_pairs_only">
-                    <param name="proper_pairs-only" value=""/>
+                    <param name="proper_pairs_only" value=""/>
                 </conditional>
                 <param name="exclude_supplementary" value=""/>
             </section>
@@ -456,7 +449,6 @@ coverm
                 <conditional name="mode">
                     <param name="mode" value="co"/>
                     <param name="bam_files" value="tpm_test.bam"/>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <section name="alignment">
@@ -464,7 +456,7 @@ coverm
                 <param name="min_read_percent_identity" value="0.95" />
                 <param name="min_read_aligned_percent" value="0" />
                 <conditional name="proper_pairs_only">
-                    <param name="proper_pairs-only" value=""/>
+                    <param name="proper_pairs_only" value=""/>
                 </conditional>
                 <param name="exclude_supplementary" value=""/>
             </section>

--- a/tools/coverm/coverm_genome.xml
+++ b/tools/coverm/coverm_genome.xml
@@ -339,7 +339,6 @@ coverm
                             </conditional>
                         </conditional>
                     </conditional>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <param name="exclude_genomes_from_deshard" value="false"/>
@@ -389,18 +388,16 @@ coverm
                 <conditional name="mode">
                     <param name="mode" value="co"/>
                     <param name="bam_files" value="7seqs.reads_for_seq1_and_seq2.bam"/>
-                    <param name="sharded" value="" />
-                    <conditional name="genome">
-                        <param name="ref_or_genome" value="contigs"/>
-                        <conditional name="cond_single_genome">
-                            <param name="single_genome" value=""/>
-                            <conditional name="genome_contig_definition">
-                                <param name="choice" value="separator"/>
-                                <param name="separator" value="~"/>
-                            </conditional>
+                </conditional>
+                <conditional name="genome">
+                    <param name="ref_or_genome" value="contigs"/>
+                    <conditional name="cond_single_genome">
+                        <param name="single_genome" value=""/>
+                        <conditional name="genome_contig_definition">
+                            <param name="choice" value="separator"/>
+                            <param name="separator" value="~"/>
                         </conditional>
                     </conditional>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <param name="exclude_genomes_from_deshard" value="false"/>
@@ -457,7 +454,6 @@ coverm
                             <param name="genome_fasta_files" value="500kb_name,1mbp_name"/>
                         </conditional>
                     </conditional>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <param name="exclude_genomes_from_deshard" value="false"/>
@@ -530,7 +526,6 @@ coverm
                             <param name="genome_fasta_files" value="genome1.fna,genome2.fna,genome3.fna"/>
                         </conditional>
                     </conditional>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <param name="exclude_genomes_from_deshard" value="false"/>
@@ -611,7 +606,6 @@ coverm
                 <conditional name="mode">
                     <param name="mode" value="co"/>
                     <param name="bam_files" value="2seqs.bad_read.1.with_supplementary.bam"/>
-                    <param name="sharded" value="" />
                     <conditional name="genome">
                         <param name="ref_or_genome" value="contigs"/>
                         <conditional name="cond_single_genome">
@@ -621,7 +615,6 @@ coverm
                             </conditional>
                         </conditional>
                     </conditional>
-                    <param name="sharded" value="" />
                 </conditional>
             </conditional>
             <param name="exclude_genomes_from_deshard" value="false"/>

--- a/tools/dimet/dimet_metabologram.xml
+++ b/tools/dimet/dimet_metabologram.xml
@@ -122,8 +122,8 @@
             <param name="stat_test" value="Tt"/>
             <repeat name="deg_list">
                 <param name="input" ftype="tabular" value="DEG_comparison_1.csv"/>
-                <param name="idcol" ftype="integer" value="2"/>
-                <param name="valuecol" ftype="integer" value="3"/>
+                <param name="idcol" value="2"/>
+                <param name="valuecol" value="3"/>
                 <param name="timepoint" value='T0'/>
                 <repeat name="factor_list">
                     <param name="condition" value="L-Cycloserine"/>
@@ -133,10 +133,7 @@
                 </repeat>
             </repeat>
             <section name="output_options">
-                <param name="show_values" value="false"/>
                 <param name="figure_format" value="svg"/>
-                <param name="figure_width" value="7"/>
-                <param name="figure_height" value="7"/>
                 <param name="font_size" value="12"/>
             </section>
             <output_collection name="report" type="list" count="3">

--- a/tools/dimet/dimet_timecourse_analysis.xml
+++ b/tools/dimet/dimet_timecourse_analysis.xml
@@ -82,10 +82,10 @@
             <param name="qualityDistanceOverSpan" value="-0.3"/>
             <param name="statistical_test_type" value="parametric"/>
             <param name="stat_test" value="Tt"/>
-            <repeat name="plot_factor_list">
+            <repeat name="factor_list">
                 <param name="condition" value="Control"/>
             </repeat>
-            <repeat name="plot_factor_list">
+            <repeat name="factor_list">
                 <param name="condition" value="L-Cycloserine"/>
             </repeat>
             <output_collection name="report" type="list" count="4">

--- a/tools/dimet/macros.xml
+++ b/tools/dimet/macros.xml
@@ -208,7 +208,7 @@
             <options from_dataset="metadata_path">
                 <column name="condition" index="1"/>
                 <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
+                <filter type="unique_value" column="condition"/>
                 <filter type="remove_value" value="condition"/>
             </options>
             <sanitizer>
@@ -226,7 +226,7 @@
             <options from_dataset="metadata_path">
                 <column name="condition" index="1"/>
                 <column name="value" index="1"/>
-                <filter type="unique_value" name="condition" column="condition"/>
+                <filter type="unique_value" column="condition"/>
                 <filter type="remove_value" value="condition"/>
             </options>
             <sanitizer>
@@ -244,9 +244,9 @@
             <options from_dataset="metadata_path">
                 <column name="timepoint" index="2"/>
                 <column name="value" index="2"/>
-                <filter type="unique_value" name="timepoint" column="2"/>
+                <filter type="unique_value" column="2"/>
                 <filter type="remove_value" value="timepoint"/>
-                <filter type="sort_by" name="timepoint" column="1"/>
+                <filter type="sort_by" column="1"/>
             </options>
             <sanitizer>
                 <valid initial="default">
@@ -263,9 +263,9 @@
             <options from_dataset="metadata_path">
                 <column name="timepoint" index="2"/>
                 <column name="value" index="2"/>
-                <filter type="unique_value" name="timepoint" column="2"/>
+                <filter type="unique_value" column="2"/>
                 <filter type="remove_value" value="timepoint"/>
-                <filter type="sort_by" name="timepoint" column="1"/>
+                <filter type="sort_by" column="1"/>
             </options>
             <sanitizer>
                 <valid initial="default">
@@ -302,7 +302,7 @@
             <options from_dataset="metadata_path">
                 <column name="compartment" index="4"/>
                 <column name="value" index="4"/>
-                <filter type="unique_value" name="compartment" column="4"/>
+                <filter type="unique_value" column="4"/>
                 <filter type="remove_value" value="compartment"/>
             </options>
             <sanitizer>
@@ -321,7 +321,7 @@
             <options from_dataset="metadata_path">
                 <column name="compartment" index="4"/>
                 <column name="value" index="4"/>
-                <filter type="unique_value" name="compartment" column="4"/>
+                <filter type="unique_value" column="4"/>
                 <filter type="remove_value" value="compartment"/>
             </options>
             <sanitizer>
@@ -340,7 +340,7 @@
             <options from_dataset="metadata_path">
                 <column name="compartment" index="4"/>
                 <column name="value" index="4"/>
-                <filter type="unique_value" name="compartment" column="4"/>
+                <filter type="unique_value" column="4"/>
                 <filter type="remove_value" value="compartment"/>
             </options>
             <sanitizer>
@@ -359,7 +359,7 @@
             <options from_dataset="metadata_path">
                 <column name="compartment" index="4"/>
                 <column name="value" index="4"/>
-                <filter type="unique_value" name="compartment" column="4"/>
+                <filter type="unique_value" column="4"/>
                 <filter type="remove_value" value="compartment"/>
             </options>
             <sanitizer>
@@ -379,7 +379,7 @@
             <options from_dataset="abundance_file">
                 <column name="metabolite_or_isotopologue" index="0"/>
                 <column name="value" index="0"/>
-                <filter type="unique_value" name="metabolite_or_isotopologue" column="0"/>
+                <filter type="unique_value" column="0"/>
                 <filter type="remove_value" value="metabolite_or_isotopologue"/>
             </options>
             <sanitizer>
@@ -399,7 +399,7 @@
             <options from_dataset="me_or_frac_contrib_file">
                 <column name="ID" index="0"/>
                 <column name="value" index="0"/>
-                <filter type="unique_value" name="ID" column="0"/>
+                <filter type="unique_value" column="0"/>
                 <filter type="remove_value" value="ID"/>
             </options>
             <sanitizer>
@@ -419,7 +419,7 @@
             <options from_dataset="isotop_prop_file">
                 <column name="ID" index="0"/>
                 <column name="value" index="0"/>
-                <filter type="unique_value" name="ID" column="0"/>
+                <filter type="unique_value" column="0"/>
                 <filter type="remove_value" value="ID"/>
             </options>
             <sanitizer>
@@ -441,9 +441,9 @@
                 <options from_dataset="metadata_path">
                     <column name="timepoint" index="2"/>
                     <column name="value" index="2"/>
-                    <filter type="unique_value" name="timepoint" column="2"/>
+                    <filter type="unique_value" column="2"/>
                     <filter type="remove_value" value="timepoint"/>
-                    <filter type="sort_by" name="timepoint" column="1"/>
+                    <filter type="sort_by" column="1"/>
                 </options>
                 <sanitizer>
                     <valid initial="default">
@@ -459,7 +459,7 @@
                     <options from_dataset="metadata_path">
                         <column name="condition" index="1"/>
                         <column name="value" index="1"/>
-                        <filter type="unique_value" name="condition" column="condition"/>
+                        <filter type="unique_value" column="condition"/>
                         <filter type="remove_value" value="condition"/>
                     </options>
                     <sanitizer>
@@ -481,7 +481,7 @@
                 <options from_dataset="metadata_path">
                     <column name="condition" index="1"/>
                     <column name="value" index="1"/>
-                    <filter type="unique_value" name="condition" column="condition"/>
+                    <filter type="unique_value" column="condition"/>
                     <filter type="remove_value" value="condition"/>
                 </options>
                 <sanitizer>
@@ -501,7 +501,7 @@
                 <options from_dataset="metadata_path">
                     <column name="condition" index="1"/>
                     <column name="value" index="1"/>
-                    <filter type="unique_value" name="condition" column="condition"/>
+                    <filter type="unique_value" column="condition"/>
                     <filter type="remove_value" value="condition"/>
                 </options>
                 <sanitizer>
@@ -521,7 +521,7 @@
                 <options from_dataset="metadata_path">
                     <column name="condition" index="1"/>
                     <column name="value" index="1"/>
-                    <filter type="unique_value" name="condition" column="condition"/>
+                    <filter type="unique_value" column="condition"/>
                     <filter type="remove_value" value="condition"/>
                 </options>
                 <sanitizer>

--- a/tools/dropletutils/dropletutils.xml
+++ b/tools/dropletutils/dropletutils.xml
@@ -287,7 +287,6 @@ seed.val=as.integer('$seed')
                     <param name="use" value="defaultdrops"/>
                     <param name="expected" value="2000"/>
                     <param name="upperquant" value="0.85"/>
-                    <param name="lowerpopr" value="0.2"/>
                 </conditional>
             </conditional>
             <output name="genes_out" file="in_genes.tsv" ftype="tsv"/>

--- a/tools/emboss_5/emboss_sirna.xml
+++ b/tools/emboss_5/emboss_sirna.xml
@@ -92,7 +92,6 @@
       <param name="tt" value="no"/>
       <param name="polybase" value="yes"/>
       <param name="context" value="no"/>
-      <param name="mismatchpercent" value="0"/>
       <param name="out_format1" value="gff"/>
       <param name="out_format2" value="fasta"/>
       <output name="ofile2" file="emboss_sirna_out.fasta"/>

--- a/tools/episcanpy/cluster_embed.xml
+++ b/tools/episcanpy/cluster_embed.xml
@@ -245,8 +245,6 @@ adata.write('anndata.h5ad')
                 <param name="lazy_pp_pca" value="True"/>
                 <param name="lazy_svd_solver" value="arpack"/>
                 <param name="lazy_nb_pcs" value="5"/>
-                <param name="lazy_pp_n_neighbors" value="15"/>
-                <param name="lazy_pp_perplexity" value="30"/>
                 <param name="lazy_method" value="umap"/>
                 <param name="lazy_metric" value="euclidean"/>
                 <param name="lazy_min_dist" value="0.5"/>
@@ -295,14 +293,11 @@ adata.write('anndata.h5ad')
             <param name="adata" value="krumsiek11.pp.lazy.tl.louvain.h5ad" />
             <conditional name="method">
                 <param name="method" value="tl.get_n_clusters"/>
-                <param name="get_n_clusters_n_clusters" value="3"/>
                 <param name="get_n_clusters_method" value="louvain"/>
                 <param name="get_n_clusters_range_min" value="0"/>
                 <param name="get_n_clusters_range_max" value="3"/>
                 <param name="get_n_clusters_max_steps" value="20"/>
-                <conditional name="get_n_clusters_obs_key">
-                    <param name="get_n_clusters_key_added" value="None"/>
-                </conditional>
+                <param name="get_n_clusters_key_added" value="None"/>
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true" />

--- a/tools/episcanpy/preprocess.xml
+++ b/tools/episcanpy/preprocess.xml
@@ -411,7 +411,6 @@ esc.tl.find_genes(
                 <param name="method" value="pp.variability_features"/>
                 <param name="min_score" value="0.75" />
                 <param name="nb_features" value="8" />
-                <param name="log" value="log10" />
             </conditional>
             <section name="advanced_common">
                 <param name="show_log" value="true" />

--- a/tools/gatk4/gatk4_Mutect2.xml
+++ b/tools/gatk4/gatk4_Mutect2.xml
@@ -622,9 +622,6 @@
             <param name="reference_sequence" ftype="fasta" value="reference.fa" />
             <param name="gzipped_output" value="false" />
             <param name="reference_source_selector" value="history" />
-            <param name="read_filter" value="AmbiguousBaseReadFilter,FirstOfPairReadFilter,GoodCigarReadFilter" />
-            <param name="seqdict_source_selector" value="history" />
-            <param name="seqdict_sequence" value="Mutect2-in2.dict" />
             <param name="optional_parameters" value="no" />
             <param name="advanced_parameters" value="no" />
             <param name="output_parameters" value="no" />

--- a/tools/gubbins/.shed.yml
+++ b/tools/gubbins/.shed.yml
@@ -1,6 +1,7 @@
 categories:
 - Sequence Analysis
 description: Gubbins - bacterial recombination detection
+homepage_url: https://github.com/nickjcroucher/gubbins
 long_description: |
    Creates a gff of recombination events in closely related bacterial strains from a whole genome alignment
 name: gubbins

--- a/tools/gubbins/gubbins.xml
+++ b/tools/gubbins/gubbins.xml
@@ -235,7 +235,6 @@
             <param name="alignment_file" value="multiple_recombinations.aln" ftype="fasta" />
             <param name="outfiles" value="ftree,gff,vcf,recomb_embl,fpoly,ppoly,stats,baseb"/>
             <section name="adv">
-                <param name="expensive_research" value="true"/>
             </section>
             <section name="really_adv">
                 <param name="tree_builder" value="fasttree"/>

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -528,7 +528,6 @@
             <param name="mode_selector" value="standard"/>
             <conditional name="advanced_options">
                 <param name="advanced_selector" value="set"/>
-                <param name="max_kooc" value="21000"/>
             </conditional>
             <output name="raw_unitigs" file="hifiasm-out6-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out6-processed.gfa" ftype="gfa1"/>
@@ -554,7 +553,7 @@
             <param name="mode_selector" value="standard"/>
             <conditional name="assembly_options">
                 <param name="assembly_selector" value="set"/>
-                <param name="hom-cov" value="1000"/>
+                <param name="hom_cov" value="1000"/>
             </conditional>
             <output name="raw_unitigs" file="hifiasm-out8-raw.gfa" ftype="gfa1"/>
             <output name="processed_unitigs" file="hifiasm-out8-processed.gfa" ftype="gfa1"/>

--- a/tools/hmmer3/.lint_skip
+++ b/tools/hmmer3/.lint_skip
@@ -1,1 +1,2 @@
 TestsCaseValidation
+TestsMultipleSelectEmptyValue

--- a/tools/hmmer3/hmmemit.xml
+++ b/tools/hmmer3/hmmemit.xml
@@ -101,7 +101,6 @@ hmmemit
     <test>
       <param name="hmmfile" value="globins4.hmm"/>
       <param name="oformat_select" value="fasta"/>
-      <param name="N_aln" value="10"/>
       <expand macro="seed_test" />
       <output name="output" file="globins4-emit-1.sto" ftype="fasta" compare="sim_size">
           <assert_contents>

--- a/tools/humann/humann.xml
+++ b/tools/humann/humann.xml
@@ -482,11 +482,9 @@ humann
             <section name="out">
                 <!-- intermediate files -->
                 <param name="output_basename" value="humann"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="tsv"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" 
                     value="metaphlan_bowtie2,metaphlan_bugs_list,bowtie2_alignment,bowtie2_reduced_alignment,bowtie2_unaligned,custom_chocophlan_database,diamond_aligned,diamond_unaligned"/>
             </section>
@@ -621,11 +619,9 @@ humann
             <section name="out">
                 <!-- Biom -->
                 <param name="output_basename" value="humann"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="biom"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" value=""/>
             </section>
             <output name="gene_families_biom" ftype="biom1">
@@ -700,11 +696,9 @@ humann
             </section>
             <section name="out">
                 <param name="output_basename" value="humann"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="tsv"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" value=""/>
             </section>
             <output name="gene_families_tsv" ftype="tabular">
@@ -782,11 +776,9 @@ humann
             </section>
             <section name="out">
                 <param name="output_basename" value="humann"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="tsv"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" value=""/>
             </section>
             <output name="gene_families_tsv" ftype="tabular">
@@ -878,11 +870,9 @@ humann
             </section>
             <section name="out">
                 <param name="output_basename" value="humann"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="tsv"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" value=""/>
             </section>
             <output name="gene_families_tsv" ftype="tabular">
@@ -950,11 +940,9 @@ humann
             </section>
             <section name="out">
                 <param name="output_basename" value="newname"/>
-                <param name="log_level" value="DEBUG"/>
                 <param name="output_format" value="tsv"/>
                 <param name="output_max_decimals" value="10"/>
                 <param name="remove_column_description_output" value="false"/>
-                <param name="remove_statified_output" value="false"/>
                 <param name="intermediate_temp" value=""/>
             </section>
             <output name="gene_families_tsv" ftype="tabular">

--- a/tools/jbrowse/jbrowse.xml
+++ b/tools/jbrowse/jbrowse.xml
@@ -1151,7 +1151,6 @@ $trackxml &&
     <test>
         <!-- data_table -->
         <param name="reference_genome|genome_type_select" value="indexed"/>
-        <param name="reference_genome|genome" value="merlin"/>
         <param name="gencode" value="1" />
         <param name="standalone" value="data" />
         <param name="uglyTestingHack" value="enabled" />

--- a/tools/jellyfish/jellyfish.xml
+++ b/tools/jellyfish/jellyfish.xml
@@ -189,7 +189,7 @@
     <tests>
         <test expect_num_outputs="1">
             <conditional name="commands">
-                <param name="commands" value="count"/>
+                <param name="command" value="count"/>
                 <param name="input" value="test.fastq"/>
                 <param name="mer_len" value="22"/>
                 <param name="size" value="16"/>
@@ -199,7 +199,7 @@
         </test>
         <test expect_num_outputs="1">
             <conditional name="commands">
-                <param name="commands" value="count"/>
+                <param name="command" value="count"/>
                 <param name="input" value="test.fastq"/>
                 <param name="mer_len" value="22"/>
                 <param name="size" value="16"/>
@@ -210,8 +210,6 @@
                     <param name="bf_fp" value="0.01"/>
                 </conditional>
                 <param name="text" value="text"/>
-                <param name="lower" value="1"/>
-                <param name="upper" value="20"/>
             </conditional>
             <output name="jellyfish_db_txt">
                 <assert_contents>

--- a/tools/kallisto/kallisto_pseudo.xml
+++ b/tools/kallisto/kallisto_pseudo.xml
@@ -144,7 +144,6 @@ cell1	$single_paired.collection.fastq_umi.forward $single_paired.collection.fast
             <param name="reference_transcriptome_source" value="history" />
             <param name="reference" ftype="fasta" value="mm10_chrM.fa" />
             <param name="single_paired_selector" value="single" />
-            <param name="collection_selector" value="collection" />
             <param name="reads" ftype="fastq.gz" value="mm10_chrM-1.f.fq.gz" />
             <output name="sample">
                 <discovered_dataset designation="Pseudoalignments.tabular" file="kallisto_pseudo_out3.tab" ftype="tabular" />

--- a/tools/kofamscan/kofamscan.xml
+++ b/tools/kofamscan/kofamscan.xml
@@ -257,7 +257,6 @@ $ap.f_cond.reportannotation
                 <param name="p_sel" value="cached"/>
                 <param name="kofam" value="test_value"/>
             </conditional>
-            <param name="k" value="ko"/>
             <section name="ap">
                 <conditional name="f_cond">
                     <param name="f_sel" value="mapper-one-line"/>
@@ -278,7 +277,6 @@ $ap.f_cond.reportannotation
                 <param name="kofam" value="test_value"/>
                 <param name="kofam_subset" value="SUBSET"/>
             </conditional>
-            <param name="k" value="ko"/>
             <section name="ap">
                 <conditional name="f_cond">
                     <param name="f_sel" value="mapper-one-line"/>

--- a/tools/mlst/mlst.xml
+++ b/tools/mlst/mlst.xml
@@ -300,7 +300,6 @@
             <param name="advanced" value="advanced"/>
             <param name="set_scheme" value="auto"/>
             <param name="exclude" value="saureus"/>
-            <param name="legacy" value="false"/>
             <output name="report" ftype="tabular" file="output_mrsa_exclude.txt"/>
         </test>
 

--- a/tools/multigsea/multigsea.xml
+++ b/tools/multigsea/multigsea.xml
@@ -140,11 +140,17 @@
                 <param name="transcriptomics" value="transcriptome.tsv"/>
                 <param name="transcriptome_ids" value="SYMBOL"/>
             </conditional>
+            <conditional name="proteomics_data">
+                <param name="selector" value="false"/>
+            </conditional>
+            <conditional name="metabolomics_data">
+                <param name="selector" value="false"/>
+            </conditional>
             <output name="output">
                 <assert_contents>
-                    <has_size value="43574" delta="300"/>
+                    <has_size value="29542" delta="300"/>
                     <has_n_lines n="327"/>
-                    <has_n_columns n="9"/>
+                    <has_n_columns n="5"/>
                     <has_text text="Ubiquinone and other terpenoid-quinone biosynthesis"/>
                 </assert_contents>
             </output>

--- a/tools/mummer4/nucmer.xml
+++ b/tools/mummer4/nucmer.xml
@@ -185,7 +185,6 @@
             <conditional name="outform">
                 <param name="out_format" value="bam-long" />
             </conditional>
-            <param name="seq_input" value="yes" />
             <param name="reference_sequence" ftype="fasta" value="human_aqp3.fasta"/>
             <param name="query_sequence" ftype="fasta" value="mouse_aqp3.fasta" />
             <output name="sam_output" ftype="bam" compare="sim_size" value="out.bam" />
@@ -195,7 +194,6 @@
             <conditional name="outform">
                 <param name="out_format" value="cram-long" />
             </conditional>
-            <param name="seq_input" value="yes" />
             <param name="reference_sequence" ftype="fasta" value="human_aqp3.fasta"/>
             <param name="query_sequence" ftype="fasta" value="mouse_aqp3.fasta" />
             <output name="sam_output" ftype="cram" compare="sim_size" value="out.cram" />

--- a/tools/pathview/pathview.xml
+++ b/tools/pathview/pathview.xml
@@ -297,9 +297,6 @@ ls .
             </conditional>
             <conditional name="cpd_data">
                 <param name="cpd" value="false"/>
-                <param name="tabular" value="cpd_data.tabular"/>
-                <param name="header" value="false"/>
-                <param name="idtype" value="kegg"/>
             </conditional>
             <param name="multi_state" value="true" />
             <param name="match_data" value="true"/>

--- a/tools/polypolish/.shed.yml
+++ b/tools/polypolish/.shed.yml
@@ -1,5 +1,6 @@
 name: "polypolish"
 owner: "iuc"
+description: "Polish genome assemblies using short-read alignments"
 long_description: |
   "Polypolish is a tool for polishing genome assemblies with short reads.
   Polypolish uses SAM files where each read has been aligned to all possible locations (not just a single best location).

--- a/tools/polypolish/polypolish.xml
+++ b/tools/polypolish/polypolish.xml
@@ -250,12 +250,12 @@
                     <param name="sam_selector" value="paired"/>
                     <param name="R1_sam" value="aligned_test_file/alignement_R1.sam"/>
                     <param name="R2_sam" value="aligned_test_file/alignement_R2.sam"/>
+                    <conditional name="insert_filter">
+                        <param name="filter_select" value="non_filter"/>
+                    </conditional>
                 </conditional>
             </section>
             <section name="options">
-                <conditional name="insert_filter">
-                    <param name="filter_select" value="non_filter"/>
-                </conditional>
                 <param name="debug" value="false"/>
                 <param name="keep_logfile" value="false"/>
             </section>

--- a/tools/query_tabular/filter_tabular.xml
+++ b/tools/query_tabular/filter_tabular.xml
@@ -171,7 +171,6 @@
             <repeat name="linefilters">
                 <conditional name="filter">
                     <param name="filter_type" value="skip"/>
-                    <param name="skiplines" value=""/>
                 </conditional>
             </repeat>
             <output name="output" file="math_input.tsv"/>

--- a/tools/recentrifuge/recentrifuge.xml
+++ b/tools/recentrifuge/recentrifuge.xml
@@ -234,7 +234,6 @@
                 <param name="filetype" value="kraken"/>
             </conditional>
             <section name="output_option">
-                <param name="output_type" value="default_type"/>
             </section>
             <section name="more_advanced_option">
                 <param name="summary" value="AVOID"/>

--- a/tools/rgrnastar/rg_rnaStar.xml
+++ b/tools/rgrnastar/rg_rnaStar.xml
@@ -653,7 +653,6 @@ with Cufflinks if your sequences come from an unstranded library preparation.">
                 <conditional name="params">
                     <param name="settingsType" value="full" />
                     <section name="seed">
-                        <param name="seed_select" value="yes" />
                         <param name="seedSearchStartLmax" value="25" />
                     </section>
                 </conditional>

--- a/tools/rgrnastar/rg_rnaStarSolo.xml
+++ b/tools/rgrnastar/rg_rnaStarSolo.xml
@@ -1464,8 +1464,6 @@
                 <conditional name="params">
                     <param name="settingsType" value="full" />
                     <section name="seed">
-                        <param name="seed_select" value="yes" />
-                        <param name="seedSearchStartLmax" value="25" />
                         <param name="seedSearchStartLmax" value="25" />
                     </section>
                     <section name="align">

--- a/tools/seurat/plot.xml
+++ b/tools/seurat/plot.xml
@@ -1192,7 +1192,6 @@ ggsave('plot.eps',
             <param name="plot_format" value="tex"/>
             <conditional name="method">
                 <param name="method" value="DimPlot"/>
-                <param name="dims" value="1, 2"/>
                 <param name="reduction" value="umap"/>
             </conditional>
             <section name="advanced_common">
@@ -1270,7 +1269,6 @@ ggsave('plot.eps',
             <conditional name="method">
                 <param name="method" value="FeaturePlot"/>
                 <param name="features" value="Obox6"/>
-                <param name="dims" value="1, 2"/>
                 <param name="reduction" value="umap"/>
                 <section name="plot">
                     <param name="cols_2" value="blue"/>

--- a/tools/seurat/reduce_dimensions.xml
+++ b/tools/seurat/reduce_dimensions.xml
@@ -315,7 +315,7 @@ seurat_obj<-RunUMAP(
             <param name="seurat_rds" location="https://zenodo.org/records/13732784/files/clusters.rds"/>
             <conditional name="method">
                 <param name="method" value="RunTSNE"/>
-                <param name="seed.use" value="1"/>
+                <param name="seed_use" value="1"/>
                 <param name="tsne_method" value="Rtsne"/>
                 <param name="dim_embed" value="2"/>
                 <param name="reduction_key" value="tSNE_"/>
@@ -339,7 +339,7 @@ seurat_obj<-RunUMAP(
             <param name="seurat_rds" location="https://zenodo.org/records/13732784/files/clusters.rds"/>
             <conditional name="method">
                 <param name="method" value="RunTSNE"/>
-                <param name="seed.use" value="1"/>
+                <param name="seed_use" value="1"/>
                 <param name="tsne_method" value="FIt-SNE"/>
                 <param name="dim_embed" value="2"/>
                 <param name="reduction_key" value="tSNE_"/>

--- a/tools/shasta/shasta.xml
+++ b/tools/shasta/shasta.xml
@@ -695,7 +695,6 @@ ${assembly.write_reads_by_assembled_segment}
                 <param name="generation_method" value="0"/>
                 <param name="k" value="10"/>
                 <param name="probability" value="0.1"/>
-                <param name="enrichmentThreshold" value="100"/>
                 <!-- <param name="file" value=""/> -->
             </section>
             <section name="minhash">

--- a/tools/sniffles/sniffles.xml
+++ b/tools/sniffles/sniffles.xml
@@ -122,8 +122,7 @@ sniffles
             <param name="input" value="reads_region.bam"/>
             <conditional name="reference_genome">
                 <param name="genome_type_select" value="history"/>
-                <param name="genome" value="humsamp.fa"/>
-                <param name="genome.ext" value="fasta"/>
+                <param name="genome" value="humsamp.fa" ftype="fasta"/>
             </conditional>
             <output name="output" file="expected_outcome6.vcf" lines_diff="4"/>
         </test>

--- a/tools/snipit/snipit.xml
+++ b/tools/snipit/snipit.xml
@@ -274,7 +274,6 @@
             </conditional>
             <conditional name="plot">
                 <param name="format" value="jpg" />
-                <param name="transparent_background" value="true" />
             </conditional>
             <output name="snp_plot" ftype="jpg" file="snp_plot.jpg" compare="sim_size" />
         </test>

--- a/tools/snp-sites/snp-sites.xml
+++ b/tools/snp-sites/snp-sites.xml
@@ -132,7 +132,6 @@ snp-sites
          <param name='input_fasta' value='input.fasta' ftype='fasta' />
          <conditional name="out_type">
             <param name="ot_select" value="counts" />
-            <param name='C' value='True' />
          </conditional>
          <output name='output_counts' value='output_counts.tabular' ftype='tabular' />
       </test>

--- a/tools/spapros/evaluation.xml
+++ b/tools/spapros/evaluation.xml
@@ -550,7 +550,6 @@ save='plot.$format'
             <conditional name="method">
                 <param name="method" value="plot_marker_corr"/>
                 <param name="set_ids" value="all"/>
-                <param name="use_marker_corr" value="True"/>
                 <param name="markerset" value="marker.tsv"/>
                 <param name="header_markerset" value="not_included"/>
                 <param name="per_celltype" value="True"/>

--- a/tools/table_compute/.lint_skip
+++ b/tools/table_compute/.lint_skip
@@ -1,3 +1,4 @@
 CitationsNoValid
 TestsExpectNumOutputsFailing
 TestsCaseValidation
+TestsMultipleSelectEmptyValue

--- a/tools/table_compute/table_compute.xml
+++ b/tools/table_compute/table_compute.xml
@@ -1324,7 +1324,6 @@ Data = {
                     </conditional>
                     <conditional name="element" >
                         <param name="mode" value="replace" />
-                        <param name="scale_op" value="mod" />
                         <param name="replace_value" value="a'+'b" />
                     </conditional>
                 </conditional>

--- a/tools/taxonomy_filter_refseq/taxonomy_filter_refseq.xml
+++ b/tools/taxonomy_filter_refseq/taxonomy_filter_refseq.xml
@@ -94,9 +94,6 @@
             <param name="taxonomy_table" value="2019-01-01" />
             <param name="refseq_source" value="cached" />
             <param name="cached_refseq" value="refseq_sample" />
-            <param name="nodes" ftype="txt" value="sample_tree_nodes.dmp" />
-            <param name="names" ftype="txt" value="sample_tree_names.dmp" />
-            <param name="history_refseq" ftype="fasta" value="sample_refseq.fasta" />
             <param name="ancestor_name" value="unclassified bacterial viruses" />
             <param name="no_predicted" value="false" />
             <param name="no_curated" value="false" />

--- a/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
+++ b/tools/taxonomy_krona_chart/taxonomy_krona_chart.xml
@@ -105,7 +105,6 @@
     <test><!-- test with tabular inputs and multiple datasets -->
       <param name="type_of_data_selector" value="text"/>
       <param name="input" value="pampa-small.tsv,anguil-small.tsv" ftype="tabular" />
-      <param name="max_rank" value="Genus"/>
       <param name="root_name" value="Root"/>
       <param name="combine_inputs" value="False"/>
       <output name="output" ftype="html">

--- a/tools/trimmomatic/trimmomatic.xml
+++ b/tools/trimmomatic/trimmomatic.xml
@@ -222,19 +222,19 @@ ${from_text_area}</configfile>
     <param name="output_err" type="boolean" label="Output trimmomatic log messages?" truevalue="yes" falsevalue="no" checked="False" help="these are the messages written to stderr (eg. for use in MultiQC)" />
   </inputs>
   <outputs>
-    <data name="fastq_out_r1_paired" default_identifier_source="readtype|fastq_r1_in" label="${tool.name} on ${readtype.fastq_r1_in.name} (R1 paired)" format_source="fastq_r1_in">
+    <data name="fastq_out_r1_paired" default_identifier_source="readtype|fastq_r1_in" label="${tool.name} on ${readtype.fastq_r1_in.name} (R1 paired)" format_source="readtype|fastq_r1_in">
       <filter>readtype['single_or_paired'] == "pair_of_files"</filter>
     </data>
-    <data name="fastq_out_r2_paired" default_identifier_source="readtype|fastq_r2_in" label="${tool.name} on ${readtype.fastq_r2_in.name} (R2 paired)" format_source="fastq_r2_in">
+    <data name="fastq_out_r2_paired" default_identifier_source="readtype|fastq_r2_in" label="${tool.name} on ${readtype.fastq_r2_in.name} (R2 paired)" format_source="readtype|fastq_r2_in">
       <filter>readtype['single_or_paired'] == "pair_of_files"</filter>
     </data>
-    <data name="fastq_out_r1_unpaired" default_identifier_source="readtype|fastq_r1_in" label="${tool.name} on ${readtype.fastq_r1_in.name} (R1 unpaired)" format_source="fastq_r1_in">
+    <data name="fastq_out_r1_unpaired" default_identifier_source="readtype|fastq_r1_in" label="${tool.name} on ${readtype.fastq_r1_in.name} (R1 unpaired)" format_source="readtype|fastq_r1_in">
       <filter>readtype['single_or_paired'] == "pair_of_files"</filter>
     </data>
-    <data name="fastq_out_r2_unpaired" default_identifier_source="readtype|fastq_r2_in" label="${tool.name} on ${readtype.fastq_r2_in.name} (R2 unpaired)" format_source="fastq_r2_in">
+    <data name="fastq_out_r2_unpaired" default_identifier_source="readtype|fastq_r2_in" label="${tool.name} on ${readtype.fastq_r2_in.name} (R2 unpaired)" format_source="readtype|fastq_r2_in">
       <filter>readtype['single_or_paired'] == "pair_of_files"</filter>
     </data>
-    <data name="fastq_out" default_identifier_source="readtype|fastq_in" label="${tool.name} on ${readtype.fastq_in.name}" format_source="fastq_in">
+    <data name="fastq_out" default_identifier_source="readtype|fastq_in" label="${tool.name} on ${readtype.fastq_in.name}" format_source="readtype|fastq_in">
       <filter>readtype['single_or_paired'] == 'se'</filter>
     </data>
     <collection name="fastq_out_paired" type="paired" label="${tool.name} on ${on_string}: paired">
@@ -404,7 +404,6 @@ ${from_text_area}</configfile>
       <param name="standard_or_custom" value="custom"/>
       <param name="adapter_text"
              value=">PrefixPE/1&#10;AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT&#10;>PrefixPE/2&#10;CAAGCAGAAGACGGCATACGAGATCGGTCTCGGCATTCCTGCTGAACCGCTCTTCCGATCT&#10;>PCR_Primer1&#10;AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT&#10;>PCR_Primer1_rc&#10;AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT&#10;>PCR_Primer2&#10;CAAGCAGAAGACGGCATACGAGATCGGTCTCGGCATTCCTGCTGAACCGCTCTTCCGATCT&#10;>PCR_Primer2_rc&#10;AGATCGGAAGAGCGGTTCAGCAGGAATGCCGAGACCGATCTCGTATGCCGTCTTCTGCTTG&#10;>FlowCell1&#10;TTTTTTTTTTAATGATACGGCGACCACCGAGATCTACAC&#10;>FlowCell2&#10;TTTTTTTTTTCAAGCAGAAGACGGCATACGA&#10;"/>
-      <param name="adapter_fasta" value="TruSeq2-PE.fa"/>
       <param name="operations_0|operation|name" value="SLIDINGWINDOW" />
       <output name="fastq_out_r1_paired" file="trimmomatic_pe_r1_paired_out1_clip.fastq" />
       <output name="fastq_out_r1_unpaired" file="trimmomatic_pe_r1_unpaired_out1.fastq" />

--- a/tools/trycycler/trycycler_reconcile_msa.xml
+++ b/tools/trycycler/trycycler_reconcile_msa.xml
@@ -75,9 +75,6 @@
         <test>
             <param name='input_cluster' value='cluster_01.fasta' />
             <param name="reads" value="reads.fastq.gz" />
-            <section name="initial_check">
-                <param name="max_mash_dist" value="0.3" />
-            </section>
             <section name="circularisation">
                 <param name="max_add_seq_percent" value="7" />
                 <param name="max_trim_seq" value="47000" />
@@ -94,9 +91,6 @@
         <test>
             <param name='input_cluster' value='cluster_01.fasta' />
             <param name="reads" value="reads.fastq.gz" />
-            <section name="initial_check">
-                <param name="max_mash_dist" value="0.3" />
-            </section>
             <section name="circularisation">
                 <param name="max_add_seq" value="900" />
                 <param name="max_trim_seq" value="45000" />
@@ -113,7 +107,7 @@
         <test>
             <param name='input_cluster' value='cluster_01.fasta' />
             <param name="reads" value="reads.fastq.gz" />
-            <section name="initial_check">
+            <section name="initial_ckeck">
                 <param name="max_length_diff" value="1.2" />
             </section>
             <section name="circularisation">
@@ -133,11 +127,7 @@
         <test>
             <param name='input_cluster' value='cluster_01.fasta' />
             <param name="reads" value="reads.fastq.gz" />
-            <section name="initial_check">
-                <param name="max_mash_dist" value="0.3" />
-            </section>
             <section name="circularisation">
-                <param name="max_add_seq_percentage" value="8" />
                 <param name="max_trim_seq" value="45300" />
             </section>
             <section name="final_check">
@@ -154,11 +144,7 @@
             <!-- Use similar collection elmement file id as input (wihout extension)-->
             <param name='input_cluster' value='cluster_01' />
             <param name="reads" value="reads.fastq.gz" />
-            <section name="initial_check">
-                <param name="max_mash_dist" value="0.3" />
-            </section>
             <section name="circularisation">
-                <param name="max_add_seq_percentage" value="8" />
                 <param name="max_trim_seq" value="45300" />
             </section>
             <section name="final_check">

--- a/tools/verkko/verkko.xml
+++ b/tools/verkko/verkko.xml
@@ -246,7 +246,7 @@
                     <param name="h2" value="2.meryldb"/>
                     <param name="type" value="trio"/>
                 </conditional>
-                <param name="no-correction" value=""/>
+                <param name="no_correction" value=""/>
             </section>
             <assert_command>
                 <has_text_matching expression="verkko --hifi"/>

--- a/tools/winnowmap/winnowmap.xml
+++ b/tools/winnowmap/winnowmap.xml
@@ -377,9 +377,10 @@
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fasta1.fa"/>
             <param name="highfreq_kmers" ftype="tabular" value="repetitive_k15.txt"/>
             <param name="analysis_type_selector" value="map-ont"/>
-            <param name="min_occ_floor" value="1000"/>
-            <section name="alignment_options">
+            <section name="mapping_options">
                 <param name="min_occ_floor" value="1000"/>
+            </section>
+            <section name="alignment_options">
                 <param name="A" value="2"/>
                 <param name="B" value="8"/>
                 <param name="O" value="12"/>
@@ -450,8 +451,10 @@
             <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fasta1.fa"/>
             <param name="highfreq_kmers" ftype="tabular" value="repetitive_k15.txt"/>
             <param name="analysis_type_selector" value="map-ont"/>
-            <section name="alignment_options">
+            <section name="mapping_options">
                 <param name="min_occ_floor" value="1000"/>
+            </section>
+            <section name="alignment_options">
                 <param name="A" value="2"/>
                 <param name="B" value="8"/>
                 <param name="O" value="12"/>


### PR DESCRIPTION
Stricter test-request resolution on the async /api/jobs path no longer synthesizes bare parameter names for inputs nested in sections, conditionals, or repeats. This PR makes the affected tests explicit. Test behavior and expected test outputs are unchanged, except for multigsea, see details below.

| Tool | Fix |
|---|---|
| data_manager_genomic_super_signature_ravmodels | Qualify test param prefix `dbkey_source\|` → `reference_source\|` to match the conditional |
| bacteria_tradis | Drop stray test params (`min_quality`, `set`); remove invalid `ftype` on non-data params |
| kraken | Rename `only-classified-output` → `only_classified_output`; qualify output `format_source` → `single_paired\|input_sequences` ¹ |
| coverm_contig | Drop stray `sharded` params; rename `proper_pairs-only` → `proper_pairs_only` |
| coverm_genome | Drop stray `sharded`; move genome conditional params into their selected branch |
| dimet_metabologram | Remove invalid `ftype="integer"` from `data_column` test params |
| dimet_timecourse_analysis | Rename test repeat `plot_factor_list` → `factor_list` |
| dimet (macros) | Drop unused `name` attribute from `unique_value`/`sort_by` option filters ² |
| dropletutils | Drop stray test param (`lowerpopr`) |
| emboss_sirna | Drop stray test param (`mismatchpercent`) |
| episcanpy cluster_embed | Unnest `get_n_clusters` conditional test params |
| episcanpy preprocess | Drop stray test param (`log`) |
| gatk4_Mutect2 | Drop cross-branch stray params (`read_filter`, `seqdict_*`) |
| gubbins | Drop stray test param (`expensive_research`); add `homepage_url` to `.shed.yml` ² |
| hifiasm | Rename `hom-cov` → `hom_cov`; drop stray `max_kooc` |
| hmmemit | Drop stray test param (`N_aln`) |
| humann | Drop stray test params (`log_level`, `remove_statified_output`) |
| jbrowse | Drop stray test param (`reference_genome\|genome`) |
| jellyfish | Rename `commands` → `command`; drop stray (`lower`, `upper`) |
| kallisto_pseudo | Drop stray test param (`collection_selector`) |
| kofamscan | Drop stray test param (`k`) |
| mlst | Drop stray test param (`legacy`) |
| multigsea | Explicitly disable proteomics/metabolomics conditionals; update expected `has_size` 29542 / 5 columns |
| nucmer | Drop stray test param (`seq_input`) |
| pathview | Drop stray test params (`tabular`, `header`, `idtype`) |
| polypolish | Nest `insert_filter` conditional test param; add `description` to `.shed.yml` ² |
| filter_tabular | Drop stray test param (`skiplines`) |
| recentrifuge | Drop stray test param (`output_type`) |
| rg_rnaStar | Drop stray test param (`seed_select`) |
| rg_rnaStarSolo | Drop stray test params (`seed_select`, `seedSearchStartLmax`) |
| seurat plot | Drop stray test param (`dims`) |
| seurat reduce_dimensions | Rename `seed.use` → `seed_use` |
| shasta | Drop stray test param (`enrichmentThreshold`) |
| sniffles | Replace `genome.ext` param with `ftype="fasta"` attribute |
| snipit | Drop stray test param (`transparent_background`) |
| snp-sites | Drop stray test param (`C`) |
| spapros evaluation | Drop stray test param (`use_marker_corr`) |
| table_compute | Drop stray test param (`scale_op`) |
| taxonomy_filter_refseq | Remove `ftype` from data test params (`nodes`, `names`, `history_refseq`) |
| taxonomy_krona_chart | Drop stray test param (`max_rank`) |
| trimmomatic | Qualify output `format_source` → `readtype\|…`; drop stray test param (`adapter_fasta`) ¹ |
| trycycler_reconcile_msa | Match test section name to the tool's inputs (`initial_ckeck`) |
| verkko | Rename `no-correction` → `no_correction` |
| winnowmap | Rename section `alignment_options` → `mapping_options`; drop stray `min_occ_floor` |


FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
