### PR TITLE
Test against Galaxy release_26.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     types: [run-all-tool-tests-command]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 40
 jobs:
   setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:


### PR DESCRIPTION
Bump `GALAXY_BRANCH` in `pr.yaml` and `ci.yaml` from `release_26.0` to `release_26.1`, so tool tests run against the current Galaxy release.