### PR TITLE
Fix tools/diamond: make --id and --approx-id mutually exclusive

### DIFF
--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -78,8 +78,11 @@
             --min-score '$filter_score.min_score'
         #end if
 
-        --id '$id'
-        --approx-id '$approx_id'    
+        #if str($filter_id.filter_id_select) == 'id':
+            --id '$filter_id.id'
+        #else if str($filter_id.filter_id_select) == 'approx-id':
+            --approx-id '$filter_id.approx_id'
+        #end if
         --query-cover '$query_cover'
         --subject-cover '$subject_cover'
         --block-size '$sens_cond.block_size'
@@ -421,7 +424,9 @@
                 <param name="filter_score_select" value="evalue"/>
                 <param name="evalue" value="0.001"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -474,7 +479,9 @@
                 <param name="filter_score_select" value="evalue"/>
                 <param name="evalue" value="0.001"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -513,7 +520,9 @@
                 <param name="filter_score_select" value="min-score"/>
                 <param name="min_score" value="1"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -573,7 +582,9 @@
                 <param name="filter_score_select" value="min-score"/>
                 <param name="min_score" value="1"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -857,7 +868,9 @@
                 <param name="filter_score_select" value="evalue"/>
                 <param name="evalue" value="0.001"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -909,7 +922,9 @@
                 <param name="filter_score_select" value="evalue"/>
                 <param name="evalue" value="0.001"/>
             </conditional>
-            <param name="id" value="0"/>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="none"/>
+            </conditional>
             <param name="query_cover" value="0"/>
             <conditional name="sens_cond">
                 <param name="block_size" value="2"/>
@@ -944,6 +959,66 @@
                     <has_text text="hspnum"/>
                 </assert_contents>
             </output>
+        </test>
+        <!--Test 20 identity filter (id), must not emit approx-id -->
+        <test expect_num_outputs="1">
+            <conditional name="method_cond">
+                <param name="method_select" value="blastp"/>
+            </conditional>
+            <param name="query" value="protein.fasta" ftype="fasta"/>
+            <conditional name="ref_db_source">
+                <param name="db_source" value="history"/>
+                <param name="reference_database" value="db-wtax.dmnd"/>
+            </conditional>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="id"/>
+                <param name="id" value="90"/>
+            </conditional>
+            <section name="output_section">
+                <conditional name="output">
+                    <param name="outfmt" value="6"/>
+                    <param name="fields" value="qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore"/>
+                </conditional>
+            </section>
+            <output name="blast_tabular">
+                <assert_contents>
+                    <has_n_columns n="12"/>
+                </assert_contents>
+            </output>
+            <assert_command>
+                <has_text text="--id '90.0'"/>
+                <has_text text="--approx-id" negate="true"/>
+            </assert_command>
+        </test>
+        <!--Test 21 approximate identity filter (approx-id), must not emit id -->
+        <test expect_num_outputs="1">
+            <conditional name="method_cond">
+                <param name="method_select" value="blastp"/>
+            </conditional>
+            <param name="query" value="protein.fasta" ftype="fasta"/>
+            <conditional name="ref_db_source">
+                <param name="db_source" value="history"/>
+                <param name="reference_database" value="db-wtax.dmnd"/>
+            </conditional>
+            <conditional name="filter_id">
+                <param name="filter_id_select" value="approx-id"/>
+                <param name="approx_id" value="90"/>
+            </conditional>
+            <section name="output_section">
+                <conditional name="output">
+                    <param name="outfmt" value="6"/>
+                    <param name="fields" value="qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore"/>
+                </conditional>
+            </section>
+            <output name="blast_tabular">
+                <assert_contents>
+                    <has_n_columns n="12"/>
+                </assert_contents>
+            </output>
+            <assert_command>
+                <has_text text="--approx-id '90.0'"/>
+                <has_text text=" --id " negate="true"/>
+            </assert_command>
         </test>
     </tests>
     <help>

--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -360,7 +360,7 @@
         </section>
         <section name="advanced_section" title="Advanced options" expanded="false">
             <param argument="--seed-cut" type="float" min="0" optional="true" label="Set a complexity cutoff for indexed seeds"/>
-            <param argument="--freq-masking" type="boolean" truevalue="--freq-masking" falsevalue="" checked="false" label="Enable masking seeds based on frequency" help="This option is incompatible with --sed-cut"/>
+            <param argument="--freq-masking" type="boolean" truevalue="--freq-masking" falsevalue="" checked="false" label="Enable masking seeds based on frequency" help="This option is incompatible with --seed-cut"/>
             <param argument="--soft-masking" type="select" label="Soft Masking" help="Select type of soft masking">
                 <option value="0" selected="True">Disbled</option>
                 <option value="seg">seg</option>

--- a/tools/diamond/macros.xml
+++ b/tools/diamond/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.2.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">25.0</token>
     <token name="@LICENSE@">GPL-3.0</token>
     <xml name="requirements">
@@ -129,8 +129,20 @@
                 <param argument="--top" type="integer" value="0" min="0" max="100" label="Keep alignments within the given percentage range of the top alignment score for a query" help="For example, setting this to 10 will report all alignments whose score is at most 10% lower than the best alignment score for a query."/>
             </when>
         </conditional>
-        <param argument="--id" type="float" value="0" min="0" max="100" label="Minimum identity percentage to report an alignment" help="Report only alignments above the given percentage of sequence identity"/>
-        <param argument="--approx-id" type="float" value="0" min="0" max="100" label="Minimum approx. identity% to report an alignment"/>
+        <conditional name="filter_id">
+            <param name="filter_id_select" type="select" label="Filter by identity percentage?" help="DIAMOND cannot apply both filters at the same time (--id/--approx-id)">
+                <option value="none" selected="true">No identity filter</option>
+                <option value="id">Minimum identity percentage</option>
+                <option value="approx-id">Minimum approximate identity percentage</option>
+            </param>
+            <when value="none"/>
+            <when value="id">
+                <param argument="--id" type="float" value="0" min="0" max="100" label="Minimum identity percentage to report an alignment" help="Report only alignments above the given percentage of sequence identity"/>
+            </when>
+            <when value="approx-id">
+                <param argument="--approx-id" type="float" value="0" min="0" max="100" label="Minimum approx. identity percentage to report an alignment" help="Faster, approximate variant of the identity filter"/>
+            </when>
+        </conditional>
         <param argument="--query-cover" type="float" value="0" min="0" max="100" label="Minimum query cover percentage to report an alignment" help="Report only alignments above the given percentage of query cover"/>
         <param argument="--subject-cover" type="float" value="0" min="0" max="100" label="Minimum subject cover percentage to report an alignment" help="Report only alignments above the given percentage of subject cover"/>
     </xml>


### PR DESCRIPTION

#### Problem

Based on user bug report, every Diamond job that sets a minimum identity percentage fails with:

`Error: Incompatible options: --approx-id, --id.`

#### Fix
`--id` and `--approx-id` are now a mutually exclusive `filter_id conditional` in `hit_filter_macro` (no filter / --id / --approx-id), mirroring the existing filter_score and hit_filter conditionals. Only the selected flag is emitted, so the invalid combination can no longer be built. Added Two new tests (one per identity filter) assert via <assert_command> that only their own flag is passed. No new test data.

---
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
