### PR TITLE
Document empty loc files with a column-format header (planemo#869)

### DIFF
--- a/data_managers/data_manager_bowtie_index_builder/test-data/bowtie_indices.loc
+++ b/data_managers/data_manager_bowtie_index_builder/test-data/bowtie_indices.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_build_bracken_database/test-data/bracken_databases.loc
+++ b/data_managers/data_manager_build_bracken_database/test-data/bracken_databases.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_build_bracken_database/tool-data/bracken_databases.loc.sample
+++ b/data_managers/data_manager_build_bracken_database/tool-data/bracken_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_build_kma_index/test-data/kma_index.loc
+++ b/data_managers/data_manager_build_kma_index/test-data/kma_index.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_build_kraken2_database/tool-data/kraken2_databases.loc.sample
+++ b/data_managers/data_manager_build_kraken2_database/tool-data/kraken2_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_build_kraken_database/tool-data/kraken_databases.loc.sample
+++ b/data_managers/data_manager_build_kraken_database/tool-data/kraken_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_bwa_mem2_index_builder/test-data/bwa_mem2_index.loc
+++ b/data_managers/data_manager_bwa_mem2_index_builder/test-data/bwa_mem2_index.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_bwa_mem_index_builder/test-data/bwa_mem_index.loc
+++ b/data_managers/data_manager_bwa_mem_index_builder/test-data/bwa_mem_index.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_bwameth_index_builder/test-data/bwameth_indexes.loc
+++ b/data_managers/data_manager_bwameth_index_builder/test-data/bwameth_indexes.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_celltypist_models/test-data/celltypist_models.loc
+++ b/data_managers/data_manager_celltypist_models/test-data/celltypist_models.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<date>	<path>

--- a/data_managers/data_manager_fetch_gene_annotation/tool-data/gene_annotation.loc.sample
+++ b/data_managers/data_manager_fetch_gene_annotation/tool-data/gene_annotation.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_gtdbtk_database_installer/test-data/gtdbtk_database_versioned.loc
+++ b/data_managers/data_manager_gtdbtk_database_installer/test-data/gtdbtk_database_versioned.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<version>	<path>

--- a/data_managers/data_manager_hisat2_index_builder/test-data/hisat2_indexes.loc
+++ b/data_managers/data_manager_hisat2_index_builder/test-data/hisat2_indexes.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_malt_index_builder/test-data/malt_indices.loc
+++ b/data_managers/data_manager_malt_index_builder/test-data/malt_indices.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_mash_sketch_builder/tool-data/mash_sketches.loc.sample
+++ b/data_managers/data_manager_mash_sketch_builder/tool-data/mash_sketches.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/data_managers/data_manager_picard_index_builder/test-data/picard_index.loc
+++ b/data_managers/data_manager_picard_index_builder/test-data/picard_index.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_plant_tribes_scaffolds_downloader/test-data/plant_tribes_scaffolds.loc
+++ b/data_managers/data_manager_plant_tribes_scaffolds_downloader/test-data/plant_tribes_scaffolds.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>	<description>

--- a/data_managers/data_manager_rsync_g2/test-data/all_fasta.loc
+++ b/data_managers/data_manager_rsync_g2/test-data/all_fasta.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_sam_fasta_index_builder/test-data/fasta_indexes.loc
+++ b/data_managers/data_manager_sam_fasta_index_builder/test-data/fasta_indexes.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>

--- a/data_managers/data_manager_selection_background/tool-data/selection_background.loc.sample
+++ b/data_managers/data_manager_selection_background/tool-data/selection_background.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<label>	<path>

--- a/data_managers/data_manager_star_index_builder/test-data/rnastar_index2x_versioned.loc
+++ b/data_managers/data_manager_star_index_builder/test-data/rnastar_index2x_versioned.loc
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>	<with_gene_model>	<version>

--- a/data_managers/data_manager_vsnp_dnaprints/test-data/vsnp_dnaprints.loc
+++ b/data_managers/data_manager_vsnp_dnaprints/test-data/vsnp_dnaprints.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>	<description>

--- a/data_managers/data_manager_vsnp_excel/test-data/vsnp_excel.loc
+++ b/data_managers/data_manager_vsnp_excel/test-data/vsnp_excel.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>	<description>

--- a/data_managers/data_manager_vsnp_genbank/test-data/vsnp_genbank.loc
+++ b/data_managers/data_manager_vsnp_genbank/test-data/vsnp_genbank.loc
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>	<description>

--- a/tools/bioext/bealign_selection.loc.sample
+++ b/tools/bioext/bealign_selection.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<label>	<path>

--- a/tools/bracken/tool-data/bracken_databases.loc.sample
+++ b/tools/bracken/tool-data/bracken_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/tools/kraken_taxonomy_report/kraken_databases.loc.sample
+++ b/tools/kraken_taxonomy_report/kraken_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/tools/krocus/tool-data/krocus_mlst_databases.loc.sample
+++ b/tools/krocus/tool-data/krocus_mlst_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/tools/metasbt/tool-data/metasbt_databases.loc.sample
+++ b/tools/metasbt/tool-data/metasbt_databases.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<version>	<name>	<path>

--- a/tools/mirnature/tool-data/mirnature_selection.loc.sample
+++ b/tools/mirnature/tool-data/mirnature_selection.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<label>	<path>

--- a/tools/sina/tool-data/sina_references.loc.sample
+++ b/tools/sina/tool-data/sina_references.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<name>	<path>

--- a/tools/ucsc_blat/tool-data/all_fasta.loc.sample
+++ b/tools/ucsc_blat/tool-data/all_fasta.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<dbkey>	<name>	<path>


### PR DESCRIPTION
Add a one-line `#<col>\t<col>...` comment (tab-separated, columns from each table's tool_data_table_conf <columns>) to 32 previously-empty .loc / .loc.sample files so they describe their expected format. Found via the repository data-table linter (galaxyproject/planemo#1672, EmptyLocFile).

I don't know what we want to do with this - I assume CI will fail for all of this because we didn't bump the versions but also I don't think any of this is worth a version bump. Should we merge the red CI, wait until the repos are updated and fix them at that time, or bump the versions. 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [x] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
