### PR TITLE
CI: only run slash-command dispatch job for real slash commands

### DIFF
--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -4,12 +4,19 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
+    if: >-
+      ${{ github.repository_owner == 'galaxyproject'
+      && contains(github.event.comment.body, '/run-all-tool-tests') }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      PAT: ${{ secrets.PAT }}
     steps:
       - name: Slash Command Dispatch
-        if: github.repository_owner == 'galaxyproject'
+        if: ${{ env.PAT != '' }}
         uses: peter-evans/slash-command-dispatch@v5
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ env.PAT }}
           commands: |
             run-all-tool-tests


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [x] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

---

CI-only change. Refs bgruening/galaxytools#1944 (item 1). Split from #8281 at @bernt-matthias' request.

**Main effect: stop allocating a runner for every issue comment.** `on: issue_comment` fires on every comment on every issue and PR in this repo, and each one previously started a runner to execute an action that immediately exits. The job is now gated on the command name appearing in the comment body. That is a strict superset of what `slash-command-dispatch` acts on (it requires the command at the start of the first line), so dispatch behaviour, the reaction, and the permission-denied path are all unchanged.

Also in this PR:

- The `repository_owner` check moves from the step to the job, so forks stop allocating a runner for a job that can never dispatch.
- The dispatch step is guarded on a non-empty PAT, so `Missing required input 'token'` cannot fail the run. `secrets` is not available in an `if` condition, but `env` is, and `secrets` *is* available in a job-level `env` — that mapping is the bridge, so no shell step is needed.
- The job now declares `permissions: issues: write`. Only the 👀 reaction uses `GITHUB_TOKEN` (via `reaction-token` → `reactions.createForIssueComment`); the permission check, pull lookup and dispatch all authenticate with the PAT. Note that the tempting `permissions: {}` would silently drop the reaction.

**Scope correction from the earlier revision of this PR:** the PAT guard does *not* fix the copy-of-this-CI case in bgruening/galaxytools. A copy of this file carries an owner check that skips the whole job before the guard is ever reached. What the guard actually covers is PAT loss or rotation within galaxyproject-owned repos. Note it only tests for a non-empty value, so an expired or revoked PAT still reaches the action and still fails.

Where a PAT is set and someone types the command, nothing changes.

`.github/**` is in `pr.yaml`'s `paths-ignore`, so this PR does not trigger the tool CI. `actionlint` is clean. `zizmor` now reports only the pre-existing `unpinned-uses` on the `@v5` tag, which is the convention in this repo (cf. b0bb5703b); the `excessive-permissions` finding it previously reported on this file is resolved by the `permissions` block.
