### PR TITLE
CI: resolve PR labels without the unmaintained associated-PR actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,6 +109,12 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.repository-list != '' || needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
+    # The label lookup below needs pull-requests:read. Declared explicitly so
+    # the job does not depend on the repository's default workflow permissions,
+    # which may be restricted to contents:read.
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -445,6 +451,13 @@ jobs:
     needs: [deploy]
     if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
+    # pull-requests:read for the PR lookup, issues:write because commenting by
+    # issue number goes through the issues API. Needed when secrets.PAT is
+    # unset and the step falls back to github.token.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
     # report to the PR if deployment failed
     # Same lookup as the lint job. This job only runs on push, so the number has
@@ -454,7 +467,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
-        SHA: ${{ github.event.after }}
+        SHA: ${{ github.sha }}
       run: |
         # Assign first so a failing `gh api` fails the step rather than being
         # masked by `echo` inside a command substitution.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -447,13 +447,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # report to the PR if deployment failed
-    - name: Get PR object
-      uses: 8BitJonny/gh-get-current-pr@4.0.0
+    # Same lookup as the lint job. This job only runs on push, so the number has
+    # to come from the commit. No PR found means there is nothing to comment on.
+    - name: Get PR number
       id: getpr
-      with:
-        sha: ${{ github.event.after }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.event.after }}
+      run: |
+        # Assign first so a failing `gh api` fails the step rather than being
+        # masked by `echo` inside a command substitution.
+        number=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty')
+        echo "number=$number" >> "$GITHUB_OUTPUT"
     - name: Create comment
-      if: steps.getpr.outputs.pr_found == 'true'
+      if: steps.getpr.outputs.number != ''
       uses: peter-evans/create-or-update-comment@v5
       with:
         # An explicitly empty token overrides the action's github.token default,

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -126,29 +126,44 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-    - name: Find Pull Request
-      id: find-pr
-      uses: sharesight/find-github-pull-request@v1.3.0
-      with:
-        allowClosed: true
-        failIfNotFound: true
-    - name: Get labels of the PR
-      uses: snnaplab/get-labels-action@v1
-      with:
-        number: ${{ steps.find-pr.outputs.number }}
-    - name: Print PR and label info
+    # On pull_request the number is in the payload, so look the labels up
+    # directly. On push there is no number, so fall back to the PR the commit
+    # came from -- the merged PR's labels must still be honoured here, or a tool
+    # merged with skip-url-check fails lint on main and blocks the ToolShed
+    # deploy. A push with no associated PR yields no labels, i.e. full checks,
+    # rather than failing the job as the previous action did.
+    # Fetching at run time (not from the event payload) means a label added after
+    # a failed run is picked up when that run is retried.
+    - name: Get PR labels
+      id: pr-labels
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        SHA: ${{ github.sha }}
       run: |
-        echo number: ${{ steps.find-pr.outputs.number }}
-        echo labels: ${{ env.LABELS }}
+        # Assign first so a failing `gh api` fails the step: inside a command
+        # substitution its exit status would be masked by `echo`, leaving an
+        # empty output that silently reads as "no labels".
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          labels=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '[.labels[].name] | @json')
+        else
+          # A direct push with no associated PR yields [], i.e. full checks.
+          labels=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '[.[0].labels[]?.name] | @json')
+        fi
+        echo "json=$labels" >> "$GITHUB_OUTPUT"
     - name: Conditionally skip URL/version linter
+      env:
+        PR_LABELS: ${{ steps.pr-labels.outputs.json }}
       run: |
           set -x
 
           to_skip=()
-          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-url-check" 'index($s)' > /dev/null; then
+          if echo "$PR_LABELS" | jq -e --arg s "skip-url-check" 'index($s)' > /dev/null; then
             to_skip+=("tool_urls")
           fi
-          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-version-check" 'index($s)' > /dev/null; then
+          if echo "$PR_LABELS" | jq -e --arg s "skip-version-check" 'index($s)' > /dev/null; then
             to_skip+=("version_bumped")
           fi
 
@@ -438,9 +453,12 @@ jobs:
       with:
         sha: ${{ github.event.after }}
     - name: Create comment
+      if: steps.getpr.outputs.pr_found == 'true'
       uses: peter-evans/create-or-update-comment@v5
       with:
-        token: ${{ secrets.PAT }}
+        # An explicitly empty token overrides the action's github.token default,
+        # so fall back rather than passing secrets.PAT straight through.
+        token: ${{ secrets.PAT || github.token }}
         issue-number: ${{ steps.getpr.outputs.number }}
         body: |
           Deployment status: **${{ needs.deploy.result }}**


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [x] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

---

CI-only change. Refs bgruening/galaxytools#1944 (items 2 and 3). Split from #8280 at @bernt-matthias' request.

**Correction to my earlier description.** I claimed the old lookup silently dropped the skip labels. That was wrong and is withdrawn. `sharesight/find-github-pull-request@v1.3.0` picks the method by event ([source](https://github.com/sharesight/find-github-pull-request/blob/v1.3.0/src/getPullRequest.ts)) and already looks up by number on `pull_request`. The bug I measured is in `8BitJonny/gh-get-current-pr`, which only runs on `push` here, where by-SHA is the only choice. No labels are being lost today.

## What this fixes

1. **A push with no PR kills the lint job** (item 2). The lookup ran with `failIfNotFound: true`. `deploy-report` had the same problem with an empty PR number.
2. **All three Node 20 actions are gone** (item 3), replaced by `gh api` calls. This is the "implement it ourselves" @bernt-matthias suggested, since none of them has a Node 24 release. It also leaves **one way to find a PR**, as asked. One caveat so that is not oversold: `lint` still looks up by number on `pull_request` and by commit on `push`, because a push event has no PR number. What is gone is two different actions behaving differently at the same job.
3. **Four `template-injection` findings**, because `${{ env.LABELS }}` no longer goes into a `run:` block.

`secrets.PAT` was also passed straight to `create-or-update-comment`. An empty token overrides that action's own `github.token` default, so repos without a PAT failed there. It falls back now.

## Why the push branch is kept

It is not about direct pushes. Those now give no labels and run full checks instead of failing. It is there because a push to `main` after a merge *does* have a PR, and its labels still matter: `deploy` needs `lint`, so a tool merged with `skip-url-check` would fail lint on `main` and block the ToolShed upload. The old `allowClosed: true` did the same.

## Why labels are fetched, not read from the payload

`github.event.pull_request.labels` would be cheaper, but `pull_request` does not fire on `labeled`, and a re-run replays the old payload. Labels would be stale in the exact case they exist for: check fails, add `skip-url-check`, hit re-run.

## Verification

`.github/**` is in this workflow's own `paths-ignore`, so **this PR cannot run the workflow it edits.** I ran the changed steps under [`act`](https://github.com/nektos/act) instead, with a script that reads the steps out of `pr.yaml` so the test cannot drift from the merged version.

| case | labels | `EXTRA_SKIP` |
|---|---|---|
| `pull_request` #8279 | `["skip-version-check","skip-url-check"]` | `--skip tool_urls,version_bumped` |
| `pull_request` #8265 | `[]` | *(empty, full checks)* |
| `push` @ `b7943487` | `["skip-version-check"]` | `--skip version_bumped` |
| `pull_request`, bad token | | **job fails** (HTTP 401) |

The last row is on purpose. The `gh api` result is assigned to a variable before being written to `$GITHUB_OUTPUT`, because inside `$(...)` a failure would be hidden by `echo` and read as "no labels".

The `deploy-report` lookup is checked against live commits: `b7943487` resolves to #8244, and a commit with no PR gives an empty number, so the comment step is skipped just like the old `pr_found` gate.

zizmor on `pr.yaml`: 70 findings on `main`, 63 here, none added. actionlint: same single pre-existing finding on both (`github.head_ref` at line 51, not touched here).

For a real end-to-end check someone would need a scratch PR touching a tool directory with `skip-url-check` on it, and confirm `EXTRA_SKIP=--skip tool_urls` in the lint log.

Not included: least-privilege `permissions:` blocks. Nothing in the issue asks for them, but happy to add.
