### PR TITLE
Sort ASV read counts test output for strict async resolution

### DIFF
--- a/tools/mgnify_pipelines_toolkit/make_asv_count_table.xml
+++ b/tools/mgnify_pipelines_toolkit/make_asv_count_table.xml
@@ -26,7 +26,7 @@
             <param name="headers" value="headers.txt"/>
             <param name="map_file" value="test_1_map.txt"/>
             <output name="asv_krona_counts" file="asv_krona_counts.txt" count="1"/>
-            <output name="asv_read_counts" file="asv_read_counts.tsv"/>
+            <output name="asv_read_counts" file="asv_read_counts.tsv" sort="true"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
The tool sorts rows by count but does not break ties, so rows with the same count can come out in any order. The test compared the file exactly, so it only passed when that order happened to match. `sort="true"` compares the rows regardless of order, so the test checks the actual content instead of an order the tool never guarantees. Async just happened to expose this, sync could hit it too.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
