### PR TITLE
Add newick datatype to cactus tree input

### DIFF
--- a/tools/cactus/cactus_cactus.xml
+++ b/tools/cactus/cactus_cactus.xml
@@ -54,7 +54,7 @@
                 <option value="intraspecies">Within-species</option>
             </param>
             <when value="interspecies">
-                <param name="in_tree" type="data" format="nhx" label="Guide tree" help="Phylogenetic tree in Newick format. Required by Cactus to achieve linear scaling with number of input genomes"/>
+                <param name="in_tree" type="data" format="nhx,newick" label="Guide tree" help="Phylogenetic tree in Newick format. Required by Cactus to achieve linear scaling with number of input genomes"/>
             </when>
             <when value="intraspecies">
                 <param name="ref_level" type="text" value="" label="Reference genome" help="Pangenomes from Minigraph-Cactus depend on a predetermined reference genome. Specify one of the Input Genomes as the reference genome. This must match the label used in 'Genome Label'.">

--- a/tools/cactus/cactus_cactus.xml
+++ b/tools/cactus/cactus_cactus.xml
@@ -54,7 +54,7 @@
                 <option value="intraspecies">Within-species</option>
             </param>
             <when value="interspecies">
-                <param name="in_tree" type="data" format="nhx,newick" label="Guide tree" help="Phylogenetic tree in Newick format. Required by Cactus to achieve linear scaling with number of input genomes"/>
+                <param name="in_tree" type="data" format="newick" label="Guide tree" help="Phylogenetic tree in Newick format. Required by Cactus to achieve linear scaling with number of input genomes"/>
             </when>
             <when value="intraspecies">
                 <param name="ref_level" type="text" value="" label="Reference genome" help="Pangenomes from Minigraph-Cactus depend on a predetermined reference genome. Specify one of the Input Genomes as the reference genome. This must match the label used in 'Genome Label'.">

--- a/tools/cactus/macros.xml
+++ b/tools/cactus/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.7.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">20.09</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Cactus accepts Newick tree format as an input, but currently the Galaxy wrapper only allows `nhx` (extended Newick). It's only intuitive to accept `newick` datatype too. Tested with `planemo serve` and seems to work fine with a regular Newick file.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)