### PR TITLE
hap.py: add rtg-tools as a new dependency

### DIFF
--- a/tools/happy/hap.py.xml
+++ b/tools/happy/hap.py.xml
@@ -3,13 +3,14 @@
     <macros>
         <token name="@TOOL_VERSION@">0.3.15</token>
         <token name="@PROFILE@">25.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">hap.py</xref>
     </xrefs>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">hap.py</requirement>
+        <requirement type="package" version="3.13">rtg-tools</requirement>
     </requirements>
     <version_command>som.py -h</version_command>
     <command detect_errors="exit_code"><![CDATA[


### PR DESCRIPTION
Closes: https://github.com/galaxyproject/tools-iuc/issues/8302

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
