### PR TITLE
Update pgxrpi by Enhancing .shed.yml with suite and repository details as I can't find it on toolshed

### DIFF
--- a/tools/pgxRpi/.shed.yml
+++ b/tools/pgxRpi/.shed.yml
@@ -5,6 +5,13 @@ homepage_url: https://github.com/progenetix/pgxRpi
 long_description: |
     pgxRpi is an R wrapper package for the Progenetix REST API that leverages the capabilities of the Beacon v2 specification. It also provides functions to enhance the visualisation of the retrieved genomic variation data.
 remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/main/tools/pgxRpi
+suite:
+  name: suite_pgxrpi
+  description: pgxLoader and pgxFreqplot functions from pgxRpi
+  long_description: A suite of Galaxy wrappers for pgxrpi tools.
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "Wrapper for {{ tool_name }}."
 type: unrestricted
 categories:
 - Variant Analysis


### PR DESCRIPTION
Added suite and auto_tool_repositories sections to .shed.yml. As I can't find the tools in the toolshed

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [ ] License permits unrestricted use (educational + commercial)
* [x] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
