### PR TITLE
Add DotMatch CRISPR count tool

### DIFF
--- a/tools/dotmatch/.shed.yml
+++ b/tools/dotmatch/.shed.yml
@@ -1,0 +1,12 @@
+name: dotmatch
+owner: iuc
+description: Deterministic short-DNA known-target assignment
+long_description: |
+  DotMatch assigns short DNA reads to known targets such as CRISPR guides,
+  barcodes, primers, panels, and whitelist-style target sets. It is not a
+  genome aligner and does not emit SAM/BAM or CIGAR output.
+homepage_url: https://github.com/dnncha/dotmatch
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/main/tools/dotmatch
+type: unrestricted
+categories:
+- Sequence Analysis

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -14,11 +14,12 @@
 	  --out '$counts' --summary '$summary' --sample-qc '$sample_qc' --ambiguous '$ambiguous'
     ]]></command>
     <configfiles>
-        <configfile name="samples_tsv"><![CDATA[
+        <configfile name="samples_tsv"><![CDATA[#set $sample1_line = '\t'.join([$sample1_label, str($sample1_fastq)])
+#set $sample2_line = '\t'.join([$sample2_label, str($sample2_fastq)])
 sample_id	fastq
-$sample1_label	$sample1_fastq
-$sample2_label	$sample2_fastq
-        ]]></configfile>
+$sample1_line
+$sample2_line
+]]></configfile>
     </configfiles>
     <inputs>
         <param name="library" type="data" format="csv,tabular" label="Guide library" help="MAGeCK-style CSV or target TSV accepted by DotMatch."/>

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -14,8 +14,8 @@
 	  --out '$counts' --summary '$summary' --sample-qc '$sample_qc' --ambiguous '$ambiguous'
     ]]></command>
     <configfiles>
-        <configfile name="samples_tsv"><![CDATA[#set $sample1_line = '\t'.join([$sample1_label, str($sample1_fastq)])
-#set $sample2_line = '\t'.join([$sample2_label, str($sample2_fastq)])
+        <configfile name="samples_tsv"><![CDATA[#set $sample1_line = '\t'.join([str($sample1_label), str($sample1_fastq)])
+#set $sample2_line = '\t'.join([str($sample2_label), str($sample2_fastq)])
 sample_id	fastq
 $sample1_line
 $sample2_line

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -29,7 +29,10 @@ $sample2_line
         <param name="sample2_label" type="text" value="sample_2" label="Sample 2 label"/>
         <param name="guide_start" type="integer" value="23" min="0" label="Guide start" help="Zero-based start position of the guide window in each read."/>
         <param name="guide_length" type="integer" value="19" min="1" label="Guide length"/>
-        <param name="k" type="integer" value="1" min="0" max="1" label="Maximum edit count (integer)" help="Number of substitutions allowed when assigning a read; use 0 for exact matching or 1 for one-edit correction."/>
+        <param name="k" type="select" label="Matching mode" help="Exact matching disables edit correction. One-edit correction allows a single substitution within the guide window.">
+            <option value="0">Exact matching</option>
+            <option value="1" selected="true">One-edit correction</option>
+        </param>
         <param name="metric" type="select" label="Metric">
             <option value="levenshtein" selected="true">Levenshtein</option>
             <option value="hamming">Hamming</option>
@@ -60,17 +63,62 @@ $sample2_line
             <output name="counts" file="expected_counts.mageck.tsv"/>
             <output name="sample_qc">
                 <assert_contents>
+                    <has_n_lines n="3"/>
                     <has_text text="assignment_rate"/>
                     <has_text text="ambiguous_rate"/>
                     <has_text text="sample_a"/>
                     <has_text text="sample_b"/>
+                    <has_text text="0.33333333"/>
+                    <has_text text="0.50000000"/>
                 </assert_contents>
             </output>
             <output name="summary">
                 <assert_contents>
-                    <has_text text="&quot;samples&quot;"/>
+                    <has_text text="&quot;k&quot;: 1"/>
+                    <has_text text="&quot;metric&quot;: &quot;hamming&quot;"/>
+                    <has_text text="&quot;assigned_unique&quot;: 1"/>
+                    <has_text text="&quot;ambiguous&quot;: 1"/>
                     <has_text text="sample_a"/>
                     <has_text text="sample_b"/>
+                    <has_text text="guide_a"/>
+                    <has_text text="guide_c"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="3">
+            <param name="library" value="crispr_library.csv"/>
+            <param name="sample1_fastq" value="sample_a.fastq"/>
+            <param name="sample1_label" value="sample_a"/>
+            <param name="sample2_fastq" value="sample_b.fastq"/>
+            <param name="sample2_label" value="sample_b"/>
+            <param name="guide_start" value="0"/>
+            <param name="guide_length" value="4"/>
+            <param name="k" value="0"/>
+            <param name="metric" value="hamming"/>
+            <param name="ambiguous" value="discard"/>
+            <output name="counts" file="expected_counts.mageck.tsv"/>
+            <output name="sample_qc">
+                <assert_contents>
+                    <has_n_lines n="3"/>
+                    <has_text text="assignment_rate"/>
+                    <has_text text="no_match_rate"/>
+                    <has_text text="sample_a"/>
+                    <has_text text="sample_b"/>
+                    <has_text text="0.66666667"/>
+                    <has_text text="0.50000000"/>
+                    <has_text text="0.00000000"/>
+                </assert_contents>
+            </output>
+            <output name="summary">
+                <assert_contents>
+                    <has_text text="&quot;k&quot;: 0"/>
+                    <has_text text="&quot;metric&quot;: &quot;hamming&quot;"/>
+                    <has_text text="&quot;assigned_unique&quot;: 1"/>
+                    <has_text text="&quot;ambiguous&quot;: 0"/>
+                    <has_text text="sample_a"/>
+                    <has_text text="sample_b"/>
+                    <has_text text="guide_a"/>
+                    <has_text text="guide_c"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -1,0 +1,80 @@
+<tool id="dotmatch_crispr_count" name="DotMatch CRISPR count" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@" license="Apache-2.0">
+    <description>assign CRISPR guide reads to a known guide library</description>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <requirements>
+        <requirement type="package" version="@TOOL_VERSION@">dotmatch</requirement>
+    </requirements>
+    <command detect_errors="exit_code"><![CDATA[
+	printf 'sample_id\tfastq\n%s\t%s\n%s\t%s\n' '$sample1_label' '$sample1_fastq' '$sample2_label' '$sample2_fastq' > samples.tsv &&
+	dotmatch crispr-count --library '$library' --samples samples.tsv --guide-start '$guide_start' --guide-length '$guide_length' --k '$k' --metric '$metric' --ambiguity-policy radius
+#if str($metric) == 'levenshtein' and int($indel_window) > 0
+	  --indel-window '$indel_window'
+#end if
+	  --out '$counts' --summary '$summary' --sample-qc '$sample_qc' --ambiguous '$ambiguous'
+    ]]></command>
+    <inputs>
+        <param name="library" type="data" format="csv,tabular,txt" label="Guide library" help="MAGeCK-style CSV or target TSV accepted by DotMatch."/>
+        <param name="sample1_fastq" type="data" format="fastq,fastqsanger,fastq.gz,fastqsanger.gz" label="Sample 1 FASTQ"/>
+        <param name="sample1_label" type="text" value="sample_1" label="Sample 1 label"/>
+        <param name="sample2_fastq" type="data" format="fastq,fastqsanger,fastq.gz,fastqsanger.gz" label="Sample 2 FASTQ"/>
+        <param name="sample2_label" type="text" value="sample_2" label="Sample 2 label"/>
+        <param name="guide_start" type="integer" value="23" min="0" label="Guide start" help="Zero-based start position of the guide window in each read."/>
+        <param name="guide_length" type="integer" value="19" min="1" label="Guide length"/>
+        <param name="k" type="integer" value="1" min="0" max="1" label="Edit-distance threshold"/>
+        <param name="metric" type="select" label="Metric">
+            <option value="levenshtein" selected="true">Levenshtein</option>
+            <option value="hamming">Hamming</option>
+        </param>
+        <param name="indel_window" type="integer" value="1" min="0" max="1" label="Levenshtein indel window" help="Used only when metric is Levenshtein."/>
+        <param name="ambiguous" type="select" label="Ambiguous read handling">
+            <option value="discard" selected="true">Discard from counts</option>
+            <option value="report">Report diagnostics</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="counts" format="tabular" label="${tool.name} on ${on_string}: counts"/>
+        <data name="summary" format="json" label="${tool.name} on ${on_string}: summary"/>
+        <data name="sample_qc" format="tabular" label="${tool.name} on ${on_string}: sample QC"/>
+    </outputs>
+    <tests>
+        <test expect_num_outputs="3">
+            <param name="library" value="crispr_library.csv"/>
+            <param name="sample1_fastq" value="sample_a.fastq"/>
+            <param name="sample1_label" value="sample_a"/>
+            <param name="sample2_fastq" value="sample_b.fastq"/>
+            <param name="sample2_label" value="sample_b"/>
+            <param name="guide_start" value="0"/>
+            <param name="guide_length" value="4"/>
+            <param name="k" value="1"/>
+            <param name="metric" value="hamming"/>
+            <param name="ambiguous" value="discard"/>
+            <output name="counts" file="expected_counts.mageck.tsv"/>
+            <output name="sample_qc">
+                <assert_contents>
+                    <has_text text="assignment_rate"/>
+                    <has_text text="ambiguous_rate"/>
+                    <has_text text="sample_a"/>
+                    <has_text text="sample_b"/>
+                </assert_contents>
+            </output>
+            <output name="summary">
+                <assert_contents>
+                    <has_text text="&quot;samples&quot;"/>
+                    <has_text text="sample_a"/>
+                    <has_text text="sample_b"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+DotMatch assigns short reads to a known CRISPR guide library and writes a
+MAGeCK-compatible count table. Assignments are deterministic: ambiguous reads
+are not silently counted for a target.
+
+DotMatch is a known-target short-DNA assignment engine, not a genome aligner. It
+does not produce SAM/BAM, CIGAR strings, or reference mapping output.
+    ]]></help>
+    <expand macro="citations" />
+</tool>

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -6,23 +6,29 @@
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">dotmatch</requirement>
     </requirements>
+    <configfiles>
+        <configfile name="samples_tsv"><![CDATA[
+sample_id	fastq
+$sample1_label	$sample1_fastq
+$sample2_label	$sample2_fastq
+        ]]></configfile>
+    </configfiles>
     <command detect_errors="exit_code"><![CDATA[
-	printf 'sample_id\tfastq\n%s\t%s\n%s\t%s\n' '$sample1_label' '$sample1_fastq' '$sample2_label' '$sample2_fastq' > samples.tsv &&
-	dotmatch crispr-count --library '$library' --samples samples.tsv --guide-start '$guide_start' --guide-length '$guide_length' --k '$k' --metric '$metric' --ambiguity-policy radius
+	dotmatch crispr-count --library '$library' --samples '$samples_tsv' --guide-start '$guide_start' --guide-length '$guide_length' --k '$k' --metric '$metric' --ambiguity-policy radius
 #if str($metric) == 'levenshtein' and int($indel_window) > 0
 	  --indel-window '$indel_window'
 #end if
 	  --out '$counts' --summary '$summary' --sample-qc '$sample_qc' --ambiguous '$ambiguous'
     ]]></command>
     <inputs>
-        <param name="library" type="data" format="csv,tabular,txt" label="Guide library" help="MAGeCK-style CSV or target TSV accepted by DotMatch."/>
-        <param name="sample1_fastq" type="data" format="fastq,fastqsanger,fastq.gz,fastqsanger.gz" label="Sample 1 FASTQ"/>
+        <param name="library" type="data" format="csv,tabular" label="Guide library" help="MAGeCK-style CSV or target TSV accepted by DotMatch."/>
+        <param name="sample1_fastq" type="data" format="fastqsanger,fastqsanger.gz" label="Sample 1 FASTQ"/>
         <param name="sample1_label" type="text" value="sample_1" label="Sample 1 label"/>
-        <param name="sample2_fastq" type="data" format="fastq,fastqsanger,fastq.gz,fastqsanger.gz" label="Sample 2 FASTQ"/>
+        <param name="sample2_fastq" type="data" format="fastqsanger,fastqsanger.gz" label="Sample 2 FASTQ"/>
         <param name="sample2_label" type="text" value="sample_2" label="Sample 2 label"/>
         <param name="guide_start" type="integer" value="23" min="0" label="Guide start" help="Zero-based start position of the guide window in each read."/>
         <param name="guide_length" type="integer" value="19" min="1" label="Guide length"/>
-        <param name="k" type="integer" value="1" min="0" max="1" label="Edit-distance threshold"/>
+        <param name="k" type="integer" value="1" min="0" max="1" label="Maximum edit count (integer)" help="Number of substitutions allowed when assigning a read; use 0 for exact matching or 1 for one-edit correction."/>
         <param name="metric" type="select" label="Metric">
             <option value="levenshtein" selected="true">Levenshtein</option>
             <option value="hamming">Hamming</option>
@@ -76,5 +82,6 @@ are not silently counted for a target.
 DotMatch is a known-target short-DNA assignment engine, not a genome aligner. It
 does not produce SAM/BAM, CIGAR strings, or reference mapping output.
     ]]></help>
+    <expand macro="creators" />
     <expand macro="citations" />
 </tool>

--- a/tools/dotmatch/dotmatch_crispr_count.xml
+++ b/tools/dotmatch/dotmatch_crispr_count.xml
@@ -6,13 +6,6 @@
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">dotmatch</requirement>
     </requirements>
-    <configfiles>
-        <configfile name="samples_tsv"><![CDATA[
-sample_id	fastq
-$sample1_label	$sample1_fastq
-$sample2_label	$sample2_fastq
-        ]]></configfile>
-    </configfiles>
     <command detect_errors="exit_code"><![CDATA[
 	dotmatch crispr-count --library '$library' --samples '$samples_tsv' --guide-start '$guide_start' --guide-length '$guide_length' --k '$k' --metric '$metric' --ambiguity-policy radius
 #if str($metric) == 'levenshtein' and int($indel_window) > 0
@@ -20,6 +13,13 @@ $sample2_label	$sample2_fastq
 #end if
 	  --out '$counts' --summary '$summary' --sample-qc '$sample_qc' --ambiguous '$ambiguous'
     ]]></command>
+    <configfiles>
+        <configfile name="samples_tsv"><![CDATA[
+sample_id	fastq
+$sample1_label	$sample1_fastq
+$sample2_label	$sample2_fastq
+        ]]></configfile>
+    </configfiles>
     <inputs>
         <param name="library" type="data" format="csv,tabular" label="Guide library" help="MAGeCK-style CSV or target TSV accepted by DotMatch."/>
         <param name="sample1_fastq" type="data" format="fastqsanger,fastqsanger.gz" label="Sample 1 FASTQ"/>

--- a/tools/dotmatch/macros.xml
+++ b/tools/dotmatch/macros.xml
@@ -1,0 +1,10 @@
+<macros>
+    <token name="@TOOL_VERSION@">0.2.2</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">23.1</token>
+    <xml name="citations">
+        <citations>
+            <citation type="doi">10.5281/zenodo.21511337</citation>
+        </citations>
+    </xml>
+</macros>

--- a/tools/dotmatch/macros.xml
+++ b/tools/dotmatch/macros.xml
@@ -2,6 +2,11 @@
     <token name="@TOOL_VERSION@">0.2.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">23.1</token>
+    <xml name="creators">
+        <creator>
+            <person givenName="Donncha" familyName="O'Toole" url="https://github.com/dnncha"/>
+        </creator>
+    </xml>
     <xml name="citations">
         <citations>
             <citation type="doi">10.5281/zenodo.21511337</citation>

--- a/tools/dotmatch/macros.xml
+++ b/tools/dotmatch/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">0.2.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
-    <token name="@PROFILE@">23.1</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@PROFILE@">25.0</token>
     <xml name="creators">
         <creator>
             <person givenName="Donncha" familyName="O'Toole" url="https://github.com/dnncha"/>

--- a/tools/dotmatch/test-data/crispr_library.csv
+++ b/tools/dotmatch/test-data/crispr_library.csv
@@ -1,0 +1,4 @@
+id,gRNA.sequence,Gene
+guide_a,ACGT,GENEA
+guide_b,ACGA,GENEB
+guide_c,TTTT,GENEC

--- a/tools/dotmatch/test-data/expected_counts.mageck.tsv
+++ b/tools/dotmatch/test-data/expected_counts.mageck.tsv
@@ -1,0 +1,4 @@
+sgRNA	Gene	sample_a	sample_b
+guide_a	GENEA	1	0
+guide_b	GENEB	0	0
+guide_c	GENEC	0	1

--- a/tools/dotmatch/test-data/sample_a.fastq
+++ b/tools/dotmatch/test-data/sample_a.fastq
@@ -1,0 +1,16 @@
+@unique
+ACGT
++
+IIII
+@ambiguous
+ACGG
++
+IIII
+@unmatched
+CCCC
++
+IIII
+@invalid
+AC
++
+II

--- a/tools/dotmatch/test-data/sample_b.fastq
+++ b/tools/dotmatch/test-data/sample_b.fastq
@@ -1,0 +1,8 @@
+@unique_b
+TTTT
++
+IIII
+@unmatched_b
+GGGG
++
+IIII


### PR DESCRIPTION
## Tool

Add a Galaxy wrapper for DotMatch `crispr-count` using the published 0.2.2 Bioconda package.

The wrapper accepts a guide library and two FASTQs, writes a MAGeCK-compatible count table, and exposes the native summary and per-sample QC outputs. The test uses tiny deterministic fixtures and checks all three outputs.

## Validation

- `planemo lint tools/dotmatch/dotmatch_crispr_count.xml`
- `planemo test --install_galaxy --no_docker --conda_dependency_resolution ... tools/dotmatch/dotmatch_crispr_count.xml`
- Galaxy 26.1 disposable instance
- Conda dependency: `dotmatch=0.2.2`

The command uses an explicit shell separator because Galaxy normalizes command XML whitespace when rendering jobs.
