### PR TITLE
Fix test parameters that the strict async resolver cannot map

### DIFF
--- a/tools/delly/lr.xml
+++ b/tools/delly/lr.xml
@@ -175,8 +175,6 @@ delly lr
             </section>
             <section name="discovery">
                 <param name="mapqual" value="2"/>
-                <param name="qualtra" value="19"/>
-                <param name="madcutoff" value="8"/>
                 <param name="minclip" value="24"/>
                 <param name="mincliquesize" value="1"/>
                 <param name="minrefsep" value="24"/>

--- a/tools/delly/merge.xml
+++ b/tools/delly/merge.xml
@@ -106,8 +106,8 @@ $generic.pass
                 <param name="pass" value="true"/>
             </section>
             <section name="overlap">
-                <param name="bp-offset" value="1000"/>
-                <param name="rec-overlap" value="0.79"/>
+                <param name="bpoffset" value="1000"/>
+                <param name="recoverlap" value="0.79"/>
             </section>
             <section name="oo">
                 <param name="out" value="vcf,bcf,log"/>

--- a/tools/fargene/fargene.xml
+++ b/tools/fargene/fargene.xml
@@ -162,8 +162,8 @@
             <conditional name="inputs">
                 <param name="input_type" value="sequence"/>
                 <param name="input_sequence" value="klebsiella_plasmid.fasta"/>
-                <param name="models" value="class_b_1_2" />
             </conditional>
+            <param name="models" value="class_b_1_2" />
             <output name="summary" file="contigs/results_summary.txt" compare="sim_size"/>
         </test>
     </tests>

--- a/tools/khmer/abundance-dist-single.xml
+++ b/tools/khmer/abundance-dist-single.xml
@@ -47,7 +47,6 @@ ${output_histogram_filename}
             <param name="tablesize_specific" value="1e7" />
             <param name="n_tables" value="2" />
             <param name="ksize" value="17" />
-            <param name="no_zero" value="false" />
             <output name="output_histogram_filename" ftype="csv">
                 <assert_contents>
                     <has_text text="1,96,96,0.98" />
@@ -61,7 +60,6 @@ ${output_histogram_filename}
             <param name="tablesize_specific" value="1e7" />
             <param name="n_tables" value="2" />
             <param name="ksize" value="17" />
-            <param name="no_zero" value="false" />
             <param name="bigcount" value="false" />
             <param name="save_countgraph" value="true"/>
             <output name="output_histogram_filename" ftype="csv">

--- a/tools/khmer/abundance-dist-single.xml
+++ b/tools/khmer/abundance-dist-single.xml
@@ -47,6 +47,7 @@ ${output_histogram_filename}
             <param name="tablesize_specific" value="1e7" />
             <param name="n_tables" value="2" />
             <param name="ksize" value="17" />
+            <param name="zero" value="true" />
             <output name="output_histogram_filename" ftype="csv">
                 <assert_contents>
                     <has_text text="1,96,96,0.98" />
@@ -60,6 +61,7 @@ ${output_histogram_filename}
             <param name="tablesize_specific" value="1e7" />
             <param name="n_tables" value="2" />
             <param name="ksize" value="17" />
+            <param name="zero" value="true" />
             <param name="bigcount" value="false" />
             <param name="save_countgraph" value="true"/>
             <output name="output_histogram_filename" ftype="csv">

--- a/tools/merquryfk/merquryfk.xml
+++ b/tools/merquryfk/merquryfk.xml
@@ -285,7 +285,7 @@
                     <has_n_lines n="3"/>
                 </assert_contents>
             </output>
-            <output name="phased_block_stats_asm2" ftype="tabular">
+            <output name="phased_block_stats_asm1" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="2"/>
                 </assert_contents>

--- a/tools/novoplasty/novoplasty.xml
+++ b/tools/novoplasty/novoplasty.xml
@@ -496,7 +496,7 @@ Use Quality Scores    = ${optional.use_quality_scores}
             </output>
         </test>
         <!-- #7 mito_plant, default -->
-        <test expect_num_outputs="6">
+        <test expect_num_outputs="7">
             <conditional name="reads_cond">
                 <param name="reads_sel" value="combined"/>
                 <param name="combined_reads" value="combined.fasta"/>
@@ -506,6 +506,7 @@ Use Quality Scores    = ${optional.use_quality_scores}
                 <param name="use_reference" value="true"/>
                 <param name="reference" value="reference.fasta"/>
             </conditional>
+            <param name="out" value="cont_tmp"/>
             <section name="assembly_options">
                 <conditional name="type_cond">
                     <param name="type_sel" value="mito_plant"/>

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -681,6 +681,7 @@ metaquast
                     <param name="origin" value="silva"/>
                     <param name="max_ref_num" value="50"/>
                 </conditional>
+                <param name="min_identity" value="95.0"/>
             </conditional>
             <param name="min_contig" value="500"/>
             <param name="split_scaffolds" value="false"/>
@@ -695,7 +696,6 @@ metaquast
             <section name="alignments">
                 <param name="use_all_alignments" value="false"/>
                 <param name="min_alignment" value="65"/>
-                <param name="min_identity" value="95.0"/>
                 <param name="ambiguity_usage" value="one"/>
                 <param name="ambiguity_score" value="0.99"/>
                 <param name="fragmented" value="false"/>

--- a/tools/quast/quast.xml
+++ b/tools/quast/quast.xml
@@ -875,13 +875,13 @@ metaquast
             <output name="report_tabular_meta" ftype="tabular">
                 <assert_contents>
                     <has_text text="# contigs (>= 0 bp)"/>
-                    <has_text text="meta_ref_3_fasta"/>
+                    <has_text text="meta_contigs_1"/>
                     <has_text text="# N's per 100 kbp"/>
                     <has_n_lines n="34"/>
                 </assert_contents>
             </output>
             <output_collection name="metrics_tabular" type="list" count="15"/>
-            <output_collection name="metrics_pdf" type="list" count="16"/>
+            <output_collection name="metrics_pdf" type="list" count="17"/>
         </test>
         <!-- Test 09: metagenomics log, html and krona outputs-->
         <test expect_num_outputs="2">

--- a/tools/rgrnastar/rg_rnaStarSolo.xml
+++ b/tools/rgrnastar/rg_rnaStarSolo.xml
@@ -832,7 +832,7 @@
                     <has_n_lines n="14" />
                 </assert_contents>
             </output>
-            <output name="output_matrix" >
+            <output name="output_matrixGeneFull" >
                 <assert_contents>
                     <has_line_matching expression="14\s+394\s+195" />
                     <has_line_matching expression="3\s+1\s+1" />

--- a/tools/snapatac2/peaks_and_motif_analysis.xml
+++ b/tools/snapatac2/peaks_and_motif_analysis.xml
@@ -528,6 +528,8 @@ snap.pl.regions(
                 <conditional name="enrichment_condi">
                     <param name="motif_enrichment" value="yes"/>
                     <param name="motifs" value="cisbp"/>
+                    <param name="width" value="600"/>
+                    <param name="height" value="400"/>
                     <conditional name="fasta_file_condi">
                         <param name="fastaSource" value="history"/>
                         <param name="fasta_history" location="https://zenodo.org/records/17512085/files/chr21.fasta.gz"/>

--- a/tools/trinity/align_and_estimate_abundance.xml
+++ b/tools/trinity/align_and_estimate_abundance.xml
@@ -186,10 +186,16 @@
             <param name="right_input" value="reads.right.fq.gz"/>
             <param name="transcripts" value="raw/Trinity.fasta"/>
             <param name="library_type" value="RF"/>
-            <param name="est_method" value="RSEM"/>
-            <param name="aln_method" value="bowtie"/>
-            <param name="has_gene_map" value="yes"/>
-            <param name="gene_trans_map" value="raw/Trinity.map" />
+            <conditional name="method">
+                <param name="est_method" value="RSEM"/>
+                <param name="aln_method" value="bowtie"/>
+            </conditional>
+            <section name="additional_params">
+                <conditional name="gene_map">
+                    <param name="has_gene_map" value="no"/>
+                    <param name="gene_trans_map" value="raw/Trinity.map"/>
+                </conditional>
+            </section>
             <output name="isoforms_counts_rsem">
                 <assert_contents>
                     <has_line_matching expression="TRINITY_DN0_c0_g1_i1&#009;.*" />
@@ -209,10 +215,16 @@
             <param name="right_input" value="reads.right.fq"/>
             <param name="transcripts" value="raw/Trinity.fasta"/>
             <param name="library_type" value="RF"/>
-            <param name="est_method" value="RSEM"/>
-            <param name="aln_method" value="bowtie2"/>
-            <param name="has_gene_map" value="yes"/>
-            <param name="gene_trans_map" value="raw/Trinity.map" />
+            <conditional name="method">
+                <param name="est_method" value="RSEM"/>
+                <param name="aln_method" value="bowtie2"/>
+            </conditional>
+            <section name="additional_params">
+                <conditional name="gene_map">
+                    <param name="has_gene_map" value="no"/>
+                    <param name="gene_trans_map" value="raw/Trinity.map"/>
+                </conditional>
+            </section>
             <output name="isoforms_counts_rsem">
                 <assert_contents>
                     <has_line_matching expression="TRINITY_DN0_c0_g1_i1&#009;.*" />
@@ -232,10 +244,15 @@
             <param name="right_input" value="reads.right.fq"/>
             <param name="transcripts" value="raw/Trinity.fasta"/>
             <param name="library_type" value="RF"/>
-            <param name="est_method" value="salmon"/>
-            <param name="aln_method" value="bowtie"/>
-            <param name="has_gene_map" value="yes"/>
-            <param name="gene_trans_map" value="raw/Trinity.map" />
+            <conditional name="method">
+                <param name="est_method" value="salmon"/>
+            </conditional>
+            <section name="additional_params">
+                <conditional name="gene_map">
+                    <param name="has_gene_map" value="no"/>
+                    <param name="gene_trans_map" value="raw/Trinity.map"/>
+                </conditional>
+            </section>
             <output name="isoforms_counts_salmon">
                 <assert_contents>
                     <has_line_matching expression="TRINITY_DN2_c3_g1_i1&#009;.*" />
@@ -255,9 +272,15 @@
             <param name="right_input" value="reads.right.fq"/>
             <param name="transcripts" value="raw/Trinity.fasta"/>
             <param name="library_type" value="RF"/>
-            <param name="est_method" value="kallisto"/>
-            <param name="has_gene_map" value="yes"/>
-            <param name="gene_trans_map" value="raw/Trinity.map" />
+            <conditional name="method">
+                <param name="est_method" value="kallisto"/>
+            </conditional>
+            <section name="additional_params">
+                <conditional name="gene_map">
+                    <param name="has_gene_map" value="no"/>
+                    <param name="gene_trans_map" value="raw/Trinity.map"/>
+                </conditional>
+            </section>
             <output name="isoforms_counts_kallisto">
                 <assert_contents>
                     <has_line_matching expression="TRINITY_DN1_c0_g1_i1&#009;.*" />


### PR DESCRIPTION
Drops async regressions from 35 to 8: https://github.com/guerler/tools-iuc/actions/runs/32815634676/job/97731143501

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
