### PR TITLE
samestr DB builder: read mOTUs markers from motus_db_versioned.path directly

### DIFF
--- a/data_managers/data_manager_samestr_db/data_manager/macros.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.2025.111</token>
-    <token name="@VERSION_SUFFIX@">3</token>
+    <token name="@VERSION_SUFFIX@">4</token>
     <token name="@PROFILE@">25.0</token>
 
 

--- a/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
+++ b/data_managers/data_manager_samestr_db/data_manager/samestr_db.xml
@@ -55,13 +55,14 @@
             #set $samestr_db_dir = $out_file.extra_files_path + '/samestr_db/' + $db_value
             mkdir -p '$samestr_db_dir' &&
 
-            #set $markers_info1 = $db_path + '/db_mOTU/db_mOTU_taxonomy_ref-mOTUs.tsv'
-            #set $markers_info2 = $db_path + '/db_mOTU/db_mOTU_taxonomy_meta-mOTUs.tsv'
-            #set $markers_fasta = $db_path + '/db_mOTU/db_mOTU_DB_CEN.fasta'
+            ## motus_db_versioned 'path' is the db_mOTU directory itself, as
+            ## written by the mOTUs data manager, so the markers sit next to it.
+            #set $markers_info1 = $db_path + '/db_mOTU_taxonomy_ref-mOTUs.tsv'
+            #set $markers_info2 = $db_path + '/db_mOTU_taxonomy_meta-mOTUs.tsv'
+            #set $markers_fasta = $db_path + '/db_mOTU_DB_CEN.fasta'
 
             #set $db_version_file = $samestr_db_dir + '/' + $version_file_name
-            cp '$db_path'/db_mOTU/db_mOTU_versions '$db_version_file' &&
-
+            cp '$db_path/db_mOTU_versions' '$db_version_file' &&
 
             samestr db
             --markers-info '$markers_info1' '$markers_info2'

--- a/data_managers/data_manager_samestr_db/test-data/motus_db_versioned.loc
+++ b/data_managers/data_manager_samestr_db/test-data/motus_db_versioned.loc
@@ -1,2 +1,2 @@
 #value	version	name	path
-motus_test	mOTUs_3.1.0	mOTUs Test Database	${__HERE__}/
+motus_test	mOTUs_3.1.0	mOTUs Test Database	${__HERE__}/db_mOTU


### PR DESCRIPTION
### What

The SameStr mOTUs data manager hard-codes `$path/db_mOTU/...` when reading the mOTUs marker files, i.e. it treats `motus_db_versioned.fields.path` as the **parent** of `db_mOTU`. That is the wrong end of the convention.

`path` **is** the `db_mOTU` directory:

* The [mOTUs data manager](https://github.com/bgruening/galaxytools/tree/master/data_managers/data_manager_motus_db_downloader) moves the database to `motus_database/${value}/db_mOTU`, and its `value_translation` writes `path = ${GALAXY_DATA_MANAGER_DATA_PATH}/motus_database/${value}/db_mOTU`. Running that DM against a real Galaxy produces exactly such a row (`.../motus_database/db_from_<stamp>/db_mOTU`).
* mOTUs itself requires it. `motus/motus.py` takes the **basename** of the `-db` argument as the file prefix and opens `<db>/<basename>_versions`, `<db>/<basename>_DB_CEN.fasta`, etc. So only the `db_mOTU` directory is a usable mOTUs database path — the parent never is.

The existing `$path/db_mOTU/...` therefore fails (`cp: can't stat .../db_mOTU/db_mOTU_versions`) on every install that ran the mOTUs data manager as shipped. It happens to work on usegalaxy.eu only because that instance's `motus_db_versioned` row was hand-edited to point at the parent directory (its `name` text was never produced by the fetcher either); that row is being corrected to the DM location, at which point the current code breaks there too.

### Fix

Read the markers directly from `path`:

```
--markers-info '$db_path/db_mOTU_taxonomy_ref-mOTUs.tsv' '$db_path/db_mOTU_taxonomy_meta-mOTUs.tsv'
--markers-fasta '$db_path/db_mOTU_DB_CEN.fasta'
```

**No probe and no fallback for the parent layout.** An earlier revision of this PR normalized either layout by probing for a nested `db_mOTU/`. That is deliberately dropped: there should be exactly one way to run this data manager, and silently accepting both layouts papers over misconfigured `.loc` entries instead of surfacing them. Bumped to `+galaxy4`.

The test fixture now points at `${__HERE__}/db_mOTU` (the files were already there, nothing moved).

Only this data manager reads `motus_db_versioned`; the SameStr tools under `tools/samestr/` read `samestr_db` and are unaffected.

### Testing

* `planemo lint` clean.
* `planemo test` — both tests (mOTUs and MetaPhlAn) pass.
* Negative check: with the test loc pointed back at the parent (`${__HERE__}/`), the mOTUs test fails and the MetaPhlAn one still passes, confirming no fallback remains.

### Context / discussion

https://github.com/bgruening/galaxytools/pull/1869

Found while building an mOTUs-derived SameStr database as a reference-data bundle for idc. cc @SaimMomin12 @Minamehr @bernt-matthias
