### PR TITLE
kmindex_query: expose json_vec output format

### DIFF
--- a/tools/kmindex/kmindex_query.xml
+++ b/tools/kmindex/kmindex_query.xml
@@ -1,4 +1,4 @@
-<tool id="kmindex_query" name="kmindex query" version="@TOOL_VERSION@+galaxy4" profile="@PROFILE@">
+<tool id="kmindex_query" name="kmindex query" version="@TOOL_VERSION@+galaxy5" profile="@PROFILE@">
     <description>query k-mer index with sequencing data</description>
     <macros>
         <import>macros.xml</import>
@@ -58,7 +58,7 @@
                 <option value="db" selected="true">Locally installed kmindex indexes</option>
             </param>
             <when value="histdb">
-                <param name="histdb" type="data" format="kmindex" multiple="true" label="Kmindex index(es)" />
+                <param name="histdb" type="data" format="kmindex" multiple="true" label="Kmindex index(es)"/>
             </when>
             <when value="db">
                 <param name="kmindex" type="select" multiple="true" label="kmindex index(es)">
@@ -71,6 +71,7 @@
         <param argument="--threshold" type="float" min="0.0" max="1.0" optional="false" label="Shared k-mers threshold" help="Minimum proportion of matching k-mers required to report a sample. Higher values are stricter (fewer matches reported), lower values are more permissive. Use 0.0 to report all. Suggested starting point: 0.5."/>
         <param argument="--format" type="select" label="Output format" help="Format of the output file">
             <option value="json" selected="true">JSON</option>
+            <option value="json_vec">JSON with positions (json_vec)</option>
             <option value="matrix">Matrix</option>
         </param>
         <param argument="--fast" type="boolean" truevalue="--fast" falsevalue="" checked="false" label="Fast mode" help="Keep more pages in cache for faster queries"/>
@@ -81,7 +82,7 @@
             <filter>format == 'matrix'</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.tsv$" directory="query_output" format="tabular"/>
         </collection>
-        <collection name="output" type="list" label="${tool.name} on ${on_string}: results (json)">
+        <collection name="output_json" type="list" label="${tool.name} on ${on_string}: results (json)">
             <filter>format != 'matrix'</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.*)\.json$" directory="query_output" format="json"/>
         </collection>
@@ -91,115 +92,137 @@
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="histdb"/>
-                <param name="histdb" ftype="kmindex" class="Directory" value="index1" />
+                <param name="histdb" ftype="kmindex" class="Directory" value="index1"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
-            <output_collection name="output" type="list" count="1">
-                <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
+            <output_collection name="output_json" type="list" count="1">
+                <element name="abundance_test" ftype="json" value="expected_query_t1.json"/>
             </output_collection>
         </test>
         <!-- Test 2: Matrix output format -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="histdb"/>
-                <param name="histdb" ftype="kmindex" class="Directory" value="index1" />
+                <param name="histdb" ftype="kmindex" class="Directory" value="index1"/>
             </conditional>
             <param name="fastx" value="query1.fasta.gz"/>
             <param name="format" value="matrix"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
             <output_collection name="output_matrix" type="list" count="1">
-                <element name="abundance_test" ftype="tabular" value="expected_query2_index1.tsv" />
+                <element name="abundance_test" ftype="tabular" value="expected_query2_index1.tsv"/>
             </output_collection>
         </test>
         <!-- Test 3: Query with threshold and z-value -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="histdb"/>
-                <param name="histdb" ftype="kmindex" class="Directory" value="index1" />
+                <param name="histdb" ftype="kmindex" class="Directory" value="index1"/>
             </conditional>
             <param name="fastx" value="query2.fastq.gz"/>
             <param name="threshold" value="0.5"/>
             <param name="zvalue" value="5"/>
             <param name="format" value="json"/>
-            <output_collection name="output" type="list" count="1">
-                <element name="abundance_test" ftype="json" value="expected_query_t4.json" />
+            <output_collection name="output_json" type="list" count="1">
+                <element name="abundance_test" ftype="json" value="expected_query_t4.json"/>
             </output_collection>
         </test>
         <!-- Test 4: query pre-built configured index1 -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="db"/>
-                <param name="kmindex" value="index1" />
+                <param name="kmindex" value="index1"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
-            <output_collection name="output" type="list" count="1">
-                <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
+            <output_collection name="output_json" type="list" count="1">
+                <element name="abundance_test" ftype="json" value="expected_query_t1.json"/>
             </output_collection>
         </test>
         <!-- Test 5: query pre-built configured index2 -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="db"/>
-                <param name="kmindex" value="index2" />
+                <param name="kmindex" value="index2"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
-            <output_collection name="output" type="list" count="1">
-                <element name="test_index" ftype="json" value="expected_query_t6.json" />
+            <output_collection name="output_json" type="list" count="1">
+                <element name="test_index" ftype="json" value="expected_query_t6.json"/>
             </output_collection>
         </test>
         <!-- Test 6: using register index, JSON output -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="db"/>
-                <param name="kmindex" ftype="kmindex" value="register" />
+                <param name="kmindex" ftype="kmindex" value="register"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
-            <output_collection name="output" type="list" count="2">
-                <element name="index1" ftype="json" value="expected_query2_index1.json" />
-                <element name="index2" ftype="json" value="expected_query2_index2.json" />
+            <output_collection name="output_json" type="list" count="2">
+                <element name="index1" ftype="json" value="expected_query2_index1.json"/>
+                <element name="index2" ftype="json" value="expected_query2_index2.json"/>
             </output_collection>
         </test>
         <!-- Test 7: using register index, matrix output -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="db"/>
-                <param name="kmindex" ftype="kmindex" value="register" />
+                <param name="kmindex" ftype="kmindex" value="register"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="matrix"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
             <output_collection name="output_matrix" type="list" count="2">
-                <element name="index1" ftype="tabular" value="expected_query2_index1_register.tsv" />
-                <element name="index2" ftype="tabular" value="expected_query2_index2_register.tsv" />
+                <element name="index1" ftype="tabular" value="expected_query2_index1_register.tsv"/>
+                <element name="index2" ftype="tabular" value="expected_query2_index2_register.tsv"/>
             </output_collection>
         </test>
         <!-- Test 8: query multiple selected indices simultaneously, JSON output -->
         <test expect_num_outputs="1">
             <conditional name="db_opts">
                 <param name="db_opts_selector" value="db"/>
-                <param name="kmindex" value="index1,index2" />
+                <param name="kmindex" value="index1,index2"/>
             </conditional>
             <param name="fastx" value="query1.fasta"/>
             <param name="format" value="json"/>
             <param name="threshold" value="0.0"/>
             <param name="zvalue" value="0"/>
-            <output_collection name="output" type="list" count="2">
-                <element name="abundance_test" ftype="json" value="expected_query_t1.json" />
-                <element name="test_index" ftype="json" value="expected_query_t6.json" />
+            <output_collection name="output_json" type="list" count="2">
+                <element name="abundance_test" ftype="json" value="expected_query_t1.json"/>
+                <element name="test_index" ftype="json" value="expected_query_t6.json"/>
+            </output_collection>
+        </test>
+        <!-- Test 9: json_vec output format -->
+        <test expect_num_outputs="1">
+            <conditional name="db_opts">
+                <param name="db_opts_selector" value="histdb"/>
+                <param name="histdb" ftype="kmindex" class="Directory" value="index1"/>
+            </conditional>
+            <param name="fastx" value="query1.fasta"/>
+            <param name="format" value="json_vec"/>
+            <param name="threshold" value="0.0"/>
+            <param name="zvalue" value="0"/>
+            <output_collection name="output_json" type="list" count="1">
+                <element name="abundance_test" ftype="json">
+                    <assert_contents>
+                        <has_text text="&quot;R&quot;"/>
+                        <has_text text="&quot;P&quot;"/>
+                        <has_text text="abundance_test"/>
+                        <has_text text="query_seq1"/>
+                        <has_text text="MySuperIndex"/>
+                    </assert_contents>
+                </element>
             </output_collection>
         </test>
     </tests>
@@ -217,7 +240,8 @@ kmindex query2 searches one or more pre-built k-mer indices to find the percenta
 
 The output format depends on your selection:
 
-- **JSON**: Detailed results in JSON format
+- **JSON**: Detailed results in JSON format (per-sample k-mer ratios)
+- **JSON with positions (json_vec)**: JSON with per-k-mer position vectors, enabling base-level coverage analysis
 - **Matrix**: Tab-separated matrix of query-sample similarities
 
 **Parameters**


### PR DESCRIPTION
Add json_vec as an output format option in the kmindex query wrapper. This format includes per-k-mer position vectors (R + P fields), enabling base-level coverage analysis. Already supported by kmindex query2 CLI but not previously exposed to Galaxy users.

- Renamed output collection from 'output' to 'output_json' for clarity
- Bumped galaxy version to +galaxy5
- Added test 9 for json_vec format with assert_contents
- Updated help text with description of json_vec format

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
