### PR TITLE
Update OptiType to version 1.5.0

### DIFF
--- a/tools/optitype/optitype.xml
+++ b/tools/optitype/optitype.xml
@@ -29,7 +29,7 @@ export MPLCONFIGDIR=\$TEMP &&
 #set $input_fq = ' '.join($fastqs)
 && optitype run $read_type
 #for $fastq in $fastqs
- --input $fastq
+ --input '$fastq'
 #end for
 #if str($beta) != '': 
  --beta $beta

--- a/tools/optitype/optitype.xml
+++ b/tools/optitype/optitype.xml
@@ -1,8 +1,9 @@
-<tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="26.0">
+<tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>HLA genotyping predictions from NGS data</description>
     <macros>
         <token name="@TOOL_VERSION@">1.5.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@PROFILE@">25.0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">optitype</requirement>

--- a/tools/optitype/optitype.xml
+++ b/tools/optitype/optitype.xml
@@ -1,4 +1,4 @@
-<tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="26.0">
     <description>HLA genotyping predictions from NGS data</description>
     <macros>
         <token name="@TOOL_VERSION@">1.5.0</token>
@@ -151,7 +151,7 @@ plots as unpaired reads, regardless of this setting. ]]>
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <conditional name="fastq_input">
                 <param name="fastq_input_selector" value="paired"/>
                 <param name="fastq_input1" ftype="fastqsanger" value="rna/CRC_81_N_1_fished.fastq"/>
@@ -165,7 +165,7 @@ plots as unpaired reads, regardless of this setting. ]]>
                 </assert_contents>
             </output>
         </test>
-        <test>
+        <test expect_num_outputs="2">
             <conditional name="fastq_input">
                 <param name="fastq_input_selector" value="paired"/>
                 <param name="fastq_input1" ftype="fastqsanger" value="exome/NA11995_SRR766010_1_fished.fastq"/>

--- a/tools/optitype/optitype.xml
+++ b/tools/optitype/optitype.xml
@@ -1,7 +1,7 @@
 <tool id="optitype" name="OptiType" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>HLA genotyping predictions from NGS data</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.3.5</token>
+        <token name="@TOOL_VERSION@">1.5.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
@@ -26,8 +26,10 @@ export MPLCONFIGDIR=\$TEMP &&
 && RAZERS3=`which razers3`
 && sed "s#path_to_razers3#\$RAZERS3#" '$optitype_config' | sed "s/threads=16/threads=\${GALAXY_SLOTS}/" > config.ini
 #set $input_fq = ' '.join($fastqs)
-&& OptiTypePipeline.py 
-$read_type --input ${' '.join($fastqs)}
+&& optitype run $read_type
+#for $fastq in $fastqs
+ --input $fastq
+#end for
 #if str($beta) != '': 
  --beta $beta
 #end if


### PR DESCRIPTION
Updates the OptiType tool to use the latest 1.5.0 release.

The only necessary changes are using `optitype run` instead of `OptiTypePipeline.py` , and using a separate `--input` flag for each input file.

This PR also adds a tool profile and the `expect_num_outputs` attribute for tests.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
