### PR TITLE
Another batch of async regression fixes

### DIFF
--- a/tools/allegro/allegro.xml
+++ b/tools/allegro/allegro.xml
@@ -2,7 +2,7 @@
     <description>Linkage and Haplotype analysis</description>
     <macros>
         <token name="@TOOL_VERSION@">3</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">25.0</token>
         <xml name="macro_inputs" >
             <param name="inp_ped" value="pedin.21" />
@@ -43,8 +43,11 @@ MODEL $cond_haplotypes.section_linkage.extra_linkage_mptspt.value par $opt_xlink
 MODEL $cond_haplotypes.section_linkage.extra_linkage_mptspt.value $cond_haplotypes.section_linkage.cond_linktype.extra_linkage_linexp.value $cond_haplotypes.section_linkage.cond_linktype.extra_linkage_scoring.value $cond_haplotypes.section_linkage.cond_linktype.extra_weighting.value param.mpt ${out_linexp}
  
     #elif $cond_haplotypes.section_linkage.cond_linktype.extra_linkage_type.value == 'classical'
+        #set $het = str($cond_haplotypes.section_linkage.cond_linktype.extra_linkage_par_het) or 'het'
         #if $cond_haplotypes.section_linkage.cond_linktype.cond_customfreqs.opt_custom_freqs.value == 'yes'
-MODEL $cond_haplotypes.section_linkage.extra_linkage_mptspt.value par $opt_xlinked} freq:$cond_haplotypes.section_linkage.cond_linktype.cond_customfreqs.extra_linkage_par_freq pen:$cond_haplotypes.section_linkage.cond_linktype.cond_customfreqs.extra_linkage_par_pen $cond_haplotypes.section_linkage.cond_linktype.extra_linkage_par_het param.mpt ${out_fparam}
+MODEL $cond_haplotypes.section_linkage.extra_linkage_mptspt.value par $opt_xlinked freq:$cond_haplotypes.section_linkage.cond_linktype.cond_customfreqs.extra_linkage_par_freq pen:$cond_haplotypes.section_linkage.cond_linktype.cond_customfreqs.extra_linkage_par_pen $het param.mpt ${out_fparam}
+        #else
+MODEL $cond_haplotypes.section_linkage.extra_linkage_mptspt.value par $opt_xlinked $het param.mpt ${out_fparam}
         #end if
     #end if
 
@@ -272,9 +275,9 @@ UNINFORMATIVE
                     </conditional>
                 </section>
             </conditional>
-            <output name="out_fparam" >
+            <output name="out_linexp" >
                 <assert_contents>
-                    <has_text_matching expression='(\-\d+\.\d+\s+)+rs2822696' />
+                    <has_text_matching expression='(\s+[-\d.]+){4}\s+\S+\s+rs2822696' />
                 </assert_contents>
             </output>
         </test>

--- a/tools/khmer/normalize-by-median.xml
+++ b/tools/khmer/normalize-by-median.xml
@@ -94,7 +94,6 @@ $gzip
             <param name="type" value="specific" />
             <param name="cutoff" value="1" />
             <param name="ksize" value="17" />
-            <param name="paired" value="true" />
             <param name="save_countgraph" value="true"/>
             <output name="report" file="normalize-by-median.paired.report.txt" />
             <output_collection name="sequences" type="list">

--- a/tools/lexicmap/lexicmap.xml
+++ b/tools/lexicmap/lexicmap.xml
@@ -151,7 +151,7 @@
                 <param name="top_n_chains" value="0" />
                 <param name="load_whole_seeds" value="true" />
             </section>
-            <output name="out_file" value="lexicmap_query_result2.tsv" />
+            <output name="out_file" value="lexicmap_query_result2.tsv" sort="true" />
         </test>
         <!-- Test 3 - query two local index with one query file -->
         <test expect_num_outputs="1">
@@ -177,7 +177,7 @@
                 <param name="top_n_chains" value="0" />
                 <param name="load_whole_seeds" value="true" />
             </section>
-            <output name="out_file" value="lexicmap_query_result4.tsv" />
+            <output name="out_file" value="lexicmap_query_result4.tsv" sort="true" />
         </test>
         <!-- Test 5 - query one local index with multiple query files, where only one query will get hits -->
         <test expect_num_outputs="1">
@@ -204,7 +204,7 @@
                 <param name="top_n_chains" value="0" />
                 <param name="load_whole_seeds" value="true" />
             </section>
-            <output name="out_file" value="lexicmap_query_result6.tsv" />
+            <output name="out_file" value="lexicmap_query_result6.tsv" sort="true" />
         </test>
         <!-- Test 7 - query one index found in the history with one query -->
         <test expect_num_outputs="1">
@@ -232,7 +232,7 @@
                 <param name="top_n_chains" value="0" />
                 <param name="load_whole_seeds" value="true" />
             </section>
-            <output name="out_file" value="lexicmap_query_result5.tsv" />
+            <output name="out_file" value="lexicmap_query_result5.tsv" sort="true" />
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/maker/maker.xml
+++ b/tools/maker/maker.xml
@@ -558,7 +558,7 @@ TMP= # specify a directory other than the system default temporary directory for
             <param name="est_evidences|est" value="est.fasta"/>
             <param name="est_evidences|est2genome" value="1"/>
             <param name="repeat_masking|repeat_source|source_type" value="dfam"/>
-            <param name="repeat_masking|repeat_source|species_list" value="drosophila" />
+            <param name="repeat_masking|repeat_source|species_source|species_list" value="human" />
             <output name="output_gff" file="annot_dfam.gff3"/>
             <output name="output_evidences" file="evidences_norm.gff3" compare="sim_size"/>
         </test>

--- a/tools/miniprot/miniprot.xml
+++ b/tools/miniprot/miniprot.xml
@@ -235,7 +235,6 @@
             <param name="output_format" value="gff" />
             <conditional name="adv">
                 <param name="options" value="yes" />
-                <param name="second_round_kmer_size" value="32"/>
             </conditional>
             <output name="output_alignment" ftype="gff3">
                 <assert_contents>
@@ -252,7 +251,6 @@
             <param name="output_format" value="gtf"></param>
             <conditional name="adv">
                 <param name="options" value="yes"></param>
-                <param name="second_round_kmer_size" value="32"></param>
             </conditional>
             <output name="output_alignment" ftype="gtf">
                 <assert_contents>

--- a/tools/spapros/macros.xml
+++ b/tools/spapros/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">0.1.5</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@profile@">22.05</token>
     <xml name="xrefs">
         <xrefs>

--- a/tools/spapros/selection.xml
+++ b/tools/spapros/selection.xml
@@ -74,7 +74,7 @@ m_penalties_adata_celltypes = '$m_penalties_adata_celltypes'.split(','),
 m_penalties_list_celltypes = '$m_penalties_list_celltypes'.split(','),
 #end if
 #if $advanced_options.cond_DE_selection_hparams.select_DE_selection_hparams == 'True':
-DE_selection_hparams={"n": $advanced_options.cond_DE_selection_hparams.n_DE_selection_hparams, "per_group": $advanced_options.cond_DE_selection_hparams.per_group}
+DE_selection_hparams={"n": $advanced_options.cond_DE_selection_hparams.n_DE_selection_hparams, "per_group": $advanced_options.cond_DE_selection_hparams.per_group},
 #end if
 #if $advanced_options.cond_forest_hparams.select_forest_hparams == 'True':
 forest_hparams={"n_trees": $advanced_options.cond_forest_hparams.n_trees, "subsample": $advanced_options.cond_forest_hparams.subsample, "test_subsample": $advanced_options.cond_forest_hparams.test_subsample},

--- a/tools/spapros/selection.xml
+++ b/tools/spapros/selection.xml
@@ -415,6 +415,9 @@ df.to_csv('marker.tsv', sep='\t', index=True)
             <param name="format" value="png"/>
             <param name="genes_key" value="highly_variable"/>
             <param name="celltypes" value="CD34+,CD56+ NK"/>
+            <section name="figure_options_masked_dotplot">
+                <param name="celltypes" value=""/>
+            </section>
             <section name="general_figure_options">
                 <param name="dpi" value="100"/>
             </section>


### PR DESCRIPTION
These are tests where the async resolver binds a parameter that sync silently drops, usually because the test declares it one level above where the tool defines it. Correcting the paths exposed two real tool bugs that had never been exercised: spapros generated invalid Python when the DE selection hyperparameters were enabled, and allegro emitted no MODEL line for classical linkage without custom frequencies, causing it to segfault. Those two carry version bumps and require deployment. The rest are test-only changes. The lexicmap change is the one exception: that test is order-sensitive rather than async-sensitive, and is included because the fix is small and unambiguous.

Two things remain unfixed. The spapros dotplot tests still fail because the tool does not select the same marker genes across runs, even with identical inputs and a fixed seed, so the committed images and marker tables cannot be reproduced in CI. Khmer normalize-by-median also still fails on both sync and async because its count graph size assertion is incorrect; that is out of scope here.

| test(s)                    | R1           | R2        | R3         | reading                 |
|----------------------------|--------------|-----------|------------|-------------------------|
| maker;6, lexicmap_search;1 | REG          | —         | —          | fixed by fixes.011      |
| allegro;2, quast;7         | pass-only    | pass-only | pass-only  | async-only wins, stable |
| spapros_selection;0,1,3    | pass-only    | REG       | agree fail | tool non-reproducible   |
| spapros_selection;4        | agree fail   | REG       | REG        | width 4055±2 too tight  |
| sopa_aggregate;0           | pass-only    | REG       | pass-only  | flips sides             |
| gwtc_analysis;0,1,3        | ;2 pass-only | —         | REG        | remote data fetch       |
| ncbi_eutils_efetch/elink;0 | —            | REG       | —          | network                 |
| delly_call;0, seaborn;1    | —            | —         | REG        | infra / image tolerance |

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
