### PR TITLE
Stabilize GTDB-Tk, HUMAnN, Kaiju, and MAPseq Data Manager identities

### DIFF
--- a/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.py
+++ b/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.py
@@ -184,9 +184,7 @@ def url_download(url, target_directory, meta):
 def create_data_manager_entry(database_name, release, file_path):
     time = date.today().strftime("%Y-%m-%d")
     data_manager_entry = {}
-    data_manager_entry["value"] = (
-        f"{database_name.replace(' ', '_').lower()}_release_{release}_downloaded_{time}"
-    )
+    data_manager_entry["value"] = f"{database_name.replace(' ', '_').lower()}_release_{release}"
     if release == "mocked_232":
         data_manager_entry["name"] = "Mocked GTBD DB (232)"
     else:

--- a/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
+++ b/data_managers/data_manager_gtdbtk_database_installer/data_manager/gtdbtk_database_installer.xml
@@ -2,7 +2,7 @@
     <description></description>
     <macros>
         <token name="@TOOL_VERSION@">232</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">24.0</token>
     </macros>
     <creator>
@@ -53,7 +53,8 @@
             <output name="out_file">
                 <assert_contents>
                     <has_text text="Full Database - release 202 "/>
-                    <has_text text="full_database_release_202_downloaded"/>
+                    <has_text text="full_database_release_202"/>
+                    <has_text negate="true" text="full_database_release_202_downloaded"/>
                 </assert_contents>
             </output>
         </test>
@@ -65,7 +66,7 @@
             <output name="out_file">
                 <assert_contents>
                     <has_text text="Metadata Tables - release 220"/>
-                    <has_text text="metadata_tables_release_220_downloaded_"/>
+                    <has_text text="metadata_tables_release_220"/>
                 </assert_contents>
             </output>
         </test> -->
@@ -76,7 +77,8 @@
             <output name="out_file">
                 <assert_contents>
                     <has_text text="Metadata Tables - release 207"/>
-                    <has_text text="metadata_tables_release_207_downloaded_"/>
+                    <has_text text="metadata_tables_release_207"/>
+                    <has_text negate="true" text="metadata_tables_release_207_downloaded"/>
                 </assert_contents>
             </output>
         </test>

--- a/data_managers/data_manager_humann_database_downloader/data_manager/data_manager_humann_download.py
+++ b/data_managers/data_manager_humann_database_downloader/data_manager/data_manager_humann_download.py
@@ -4,8 +4,8 @@
 import argparse
 import json
 import subprocess
-from datetime import date
 from pathlib import Path
+from urllib.parse import urlparse
 
 HUMANN_REFERENCE_DATA = {
     "chocophlan": {
@@ -113,6 +113,22 @@ def add_data_table_entry(d, table, entry):
         raise Exception("add_data_table_entry: no table '%s'" % table)
 
 
+def get_database_source_id(database, build):
+    """Return the versioned artifact name advertised by HUMAnN."""
+    available = subprocess.check_output(
+        ["humann_databases", "--available"], text=True
+    )
+    prefix = f"{database} : {build} = "
+    for line in available.splitlines():
+        if line.startswith(prefix):
+            filename = Path(urlparse(line[len(prefix):]).path).name
+            for suffix in (".tar.gz", ".tar.bz2", ".tgz", ".zip"):
+                if filename.endswith(suffix):
+                    return filename[:-len(suffix)]
+            return filename
+    raise RuntimeError(f"Unable to determine source for {database} {build}")
+
+
 def download_humann_db(data_tables, table_name, database, build, version, target_dp):
     """Download HUMAnN database
 
@@ -134,12 +150,18 @@ def download_humann_db(data_tables, table_name, database, build, version, target
     db_target_dp = target_dp / Path(database)
     db_dp = db_target_dp / Path(database)
     build_target_dp = db_target_dp / Path(build)
+    source_id = get_database_source_id(database, build)
     # launch tool to get db
-    cmd = "humann_databases --download %s %s %s --update-config no" % (
+    cmd = [
+        "humann_databases",
+        "--download",
         database,
         build,
-        db_target_dp)
-    subprocess.check_call(cmd, shell=True)
+        str(db_target_dp),
+        "--update-config",
+        "no",
+    ]
+    subprocess.check_call(cmd)
     # move db
     db_dp.rename(build_target_dp)
     # add details to data table
@@ -148,7 +170,7 @@ def download_humann_db(data_tables, table_name, database, build, version, target
             data_tables,
             table_name,
             dict(
-                value="%s-%s-%s-%s" % (database, build, version, date.today().strftime("%d%m%Y")),
+                value=f"{database}-{build}-{source_id}",
                 name=HUMANN_REFERENCE_DATA[database][build],
                 dbkey=version,
                 path=str(build_target_dp)))
@@ -159,7 +181,7 @@ def download_humann_db(data_tables, table_name, database, build, version, target
                 data_tables,
                 table_name,
                 dict(
-                    value="%s-%s-%s-%s-%s%s" % (database, build, name, version, date.today().strftime("%d%m%Y"), x.suffix),
+                    value=f"{database}-{build}-{name}-{source_id}{x.suffix}",
                     name=HUMANN_REFERENCE_DATA["utility_mapping"][build][name],
                     dbkey=version,
                     path=str(x)))

--- a/data_managers/data_manager_humann_database_downloader/data_manager/data_manager_humann_download.xml
+++ b/data_managers/data_manager_humann_database_downloader/data_manager/data_manager_humann_download.xml
@@ -2,7 +2,7 @@
     <description>Download HUMAnN database</description>
     <macros>
         <token name="@TOOL_VERSION@">3.9</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">22.01</token>
     </macros>
     <requirements>
@@ -58,7 +58,7 @@ python '$__tool_directory__/data_manager_humann_download.py'
                     <has_text text="humann_nucleotide_database"/>
                     <has_text text="Demo ChocoPhlAn for HUManN"/>
                     <has_text text="chocophlan/DEMO"/>
-                    <has_text text="chocophlan-DEMO-"/>
+                    <has_text text="chocophlan-DEMO-DEMO_chocophlan.v201901_v31"/>
                 </assert_contents>
             </output>
         </test>
@@ -69,10 +69,9 @@ python '$__tool_directory__/data_manager_humann_download.py'
             </conditional>
             <output name="out_file">
                 <assert_contents>
-                    <has_text text="DEMO_diamond"/>
                     <has_text text="Demo UniRef for HUManN"/>
                     <has_text text="uniref/DEMO_diamond"/>
-                    <has_text text="uniref-DEMO_diamond-"/>
+                    <has_text text="uniref-DEMO_diamond-uniref90_DEMO_diamond_v201901b"/>
                 </assert_contents>
             </output>
         </test>
@@ -83,7 +82,6 @@ python '$__tool_directory__/data_manager_humann_download.py'
             </conditional>
             <output name="out_file">
                 <assert_contents>
-                    <has_text text="utility_mapping"/>
                     <has_text text="Mapping (full)"/>
                     <has_text text="utility_mapping/full"/>
                     <has_text text="map_uniref50_uniref90"/>
@@ -106,6 +104,7 @@ python '$__tool_directory__/data_manager_humann_download.py'
                     <has_text text="map_uniref50_name"/>
                     <has_text text="map_ec_name"/>
                     <has_text text="map_pfam_name"/>
+                    <has_text text="full_mapping_v201901b"/>
                     <has_text text=".gz"/>
                     <has_text text=".bz2"/>
                 </assert_contents>

--- a/data_managers/data_manager_humann_database_downloader/test-data/humann_nucleotide_database.loc
+++ b/data_managers/data_manager_humann_database_downloader/test-data/humann_nucleotide_database.loc
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_humann_database_downloader/test-data/humann_protein_database.loc
+++ b/data_managers/data_manager_humann_database_downloader/test-data/humann_protein_database.loc
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_humann_database_downloader/test-data/humann_utility_mapping.loc
+++ b/data_managers/data_manager_humann_database_downloader/test-data/humann_utility_mapping.loc
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_humann_database_downloader/tool-data/humann_nucleotide_database.loc.sample
+++ b/data_managers/data_manager_humann_database_downloader/tool-data/humann_nucleotide_database.loc.sample
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_humann_database_downloader/tool-data/humann_protein_database.loc.sample
+++ b/data_managers/data_manager_humann_database_downloader/tool-data/humann_protein_database.loc.sample
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_humann_database_downloader/tool-data/humann_utility_mapping.loc.sample
+++ b/data_managers/data_manager_humann_database_downloader/tool-data/humann_utility_mapping.loc.sample
@@ -1,4 +1,4 @@
 #This is a sample file distributed with Galaxy that enables tools
 #to use a directory of metagenomics files.  
 #file has this format (white space characters are TAB characters)
-#db-build-version-date	db-name	build	/path/to/data
+#db-build-source	db-name	build	/path/to/data

--- a/data_managers/data_manager_kaiju/data_manager/kaiju_data_manager.xml
+++ b/data_managers/data_manager_kaiju/data_manager/kaiju_data_manager.xml
@@ -2,7 +2,7 @@
     <description>builder</description>
     <macros>
         <token name="@TOOL_VERSION@">1.10.1</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">kaiju</requirement>
@@ -20,49 +20,38 @@
         mv \$(find . -name "*nodes.dmp") '${out_file.extra_files_path}'/nodes.dmp &&
         mv \$(find . -name "*names.dmp") '${out_file.extra_files_path}'/names.dmp &&
         mv \$(find . -name "*.fmi") '${out_file.extra_files_path}'/database.fmi &&
-        cp '$dmjson' '$out_file'
+        #if str($type.date) == "today"
+            database_digest=\$(
+                for database_file in database.fmi names.dmp nodes.dmp; do
+                    printf '%s\0' "\$database_file";
+                    cat '${out_file.extra_files_path}'/"\$database_file";
+                    printf '\0';
+                done | sha256sum | cut -d ' ' -f 1
+            ) &&
+            download_date=\$(date -u +%F) &&
+            sed
+                -e "s/__DATABASE_DIGEST__/\$database_digest/g"
+                -e "s/__DOWNLOAD_DATE__/\$download_date/g"
+                '$dmjson' > '$out_file'
+        #else
+            cp '$dmjson' '$out_file'
+        #end if
     ]]></command>
     <configfiles>
         <configfile name="dmjson"><![CDATA[#slurp
-#import datetime
-#if $type.date == "today"
-    #set date = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+#import json
+#set $database_names = {"refseq": "(refseq) bacterial, archaeal and viral genomes in the NCBI RefSeq database with assembly status Complete", "refseq_nr": "(refseq_nr) proteins from bacteria, Archaea, viruses, fungi and microbial eukaryotes from the NCBI RefSeq non-redundant proteins collection", "refseq_ref": "(refseq_ref) proteins from bacteria, Archaea from the NCBI RefSeq representative assemblies + viral proteins from NCBI RefSeq", "progenomes": "(progenomes) proteins in the set of representative genomes from the proGenomes v3 database and viral proteins from NCBI RefSeq", "nr": "(nr) NCBI BLAST non-redundant protein database 'nr', only Archaea, bacteria, and viruses", "nr_euk": "(nr_euk) nr and additionally including fungi and microbial eukaryotes", "fungi": "(fungi) all fungi genomes from NCBI RefSeq (any assembly status)", "viruses": "(viruses) viral genomes from NCBI RefSeq", "plasmids": "(plasmids) plasmid genomes from NCBI RefSeq", "rvdb": "(rvdb) viral proteins from RVDB-prot"}
+#set $database = str($type.select)
+#set $source_date = str($type.date)
+#if $source_date == "today"
+    #set $display_date = "__DOWNLOAD_DATE__"
+    #set $value = $database + "_sha256___DATABASE_DIGEST__"
 #else
-    #set date = $type.date
+    #set $display_date = $source_date
+    #set $value = $source_date + "_" + $database
 #end if
-#if $type.select == "refseq"
-    #set name = "(refseq) bacterial, archaeal and viral genomes in the NCBI RefSeq database with assembly status Complete"
-#elif $type.select == "refseq_nr"
-    #set name = "(refseq_nr) proteins from bacteria, Archaea, viruses, fungi and microbial eukaryotes from the NCBI RefSeq non-redundant proteins collection"
-#elif $type.select == "refseq_ref"
-    #set name = "(refseq_ref) proteins from bacteria, Archaea from the NCBI RefSeq representative assemblies + viral proteins from NCBI RefSeq"
-#elif $type.select == "progenomes"
-    #set name = "(progenomes) proteins in the set of representative genomes from the proGenomes v3 database and viral proteins from NCBI RefSeq"
-#elif $type.select == "nr"
-    #set name = "(nr) NCBI BLAST non-redundant protein database 'nr', only Archaea, bacteria, and viruses"
-#elif $type.select == "nr_euk"
-    #set name = "(nr_euk) nr and additionally including fungi and microbial eukaryotes"
-#elif $type.select == "fungi"
-    #set name = "(fungi) all fungi genomes from NCBI RefSeq (any assembly status)"
-#elif $type.select == "viruses"
-    #set name = "(viruses) viral genomes from NCBI RefSeq"
-#elif $type.select == "plasmids"
-    #set name = "(plasmids) plasmid genomes from NCBI RefSeq"
-#elif $type.select == "rvdb"
-    #set name = "(tvdb) viral proteins from RVDB-prot"
-#end if
-{
-  "data_tables":{
-    "kaiju":[
-      {
-        "value": "${date}_${$type.select}",
-        "name": "${date} $name",
-        "path": "output/",
-        "version": "@TOOL_VERSION@"
-      }
-    ]
-  }
-}
+#set $entry = {"value": $value, "name": $display_date + " " + $database_names[$database], "path": "output/", "version": "@TOOL_VERSION@"}
+${json.dumps({"data_tables": {"kaiju": [$entry]}}, sort_keys=True)}
 ]]></configfile>
     </configfiles>
     <inputs>
@@ -150,14 +139,7 @@
                 <param name="select" value="viruses"/>
                 <param name="date" value="2024-08-15"/>
             </conditional>
-            <output name="out_file">
-                <assert_contents>
-                    <has_text text="kaiju"/>
-                    <has_text text="(viruses)"/>
-                    <has_text text="2024-08-15"/>
-                    <has_text text="@TOOL_VERSION@"/>
-                </assert_contents>
-            </output>
+            <output name="out_file" file="kaiju-viruses-2024-08-15.json"/>
         </test>
         <test>
             <conditional name="type">
@@ -168,6 +150,9 @@
                 <assert_contents>
                     <has_text text="kaiju"/>
                     <has_text text="(viruses)"/>
+                    <has_text text="viruses_sha256_"/>
+                    <has_text negate="true" text="__DATABASE_DIGEST__"/>
+                    <has_text negate="true" text="__DOWNLOAD_DATE__"/>
                     <has_text negate="true" text="2024-05-10"/>
                     <has_text text="@TOOL_VERSION@"/>
                 </assert_contents>

--- a/data_managers/data_manager_kaiju/test-data/kaiju-viruses-2024-08-15.json
+++ b/data_managers/data_manager_kaiju/test-data/kaiju-viruses-2024-08-15.json
@@ -1,0 +1,1 @@
+{"data_tables": {"kaiju": [{"name": "2024-08-15 (viruses) viral genomes from NCBI RefSeq", "path": "output/", "value": "2024-08-15_viruses", "version": "1.10.1"}]}}

--- a/data_managers/data_manager_kaiju/tool-data/kaiju.loc.sample
+++ b/data_managers/data_manager_kaiju/tool-data/kaiju.loc.sample
@@ -1,4 +1,4 @@
-# id: db name + date
+# id: source snapshot + db name, or db name + content digest for current builds
 # name: what is shown to the user in the select
 # path: of the reference data must contain database.fmi, names.dmp and nodes.dmp
 # version: version used for constructing the DB (or just the current version at the time when pre-computed indices were downloaded)

--- a/data_managers/data_manager_mapseq/data_manager/data_manager_fetch_mapseq_db.py
+++ b/data_managers/data_manager_mapseq/data_manager/data_manager_fetch_mapseq_db.py
@@ -5,7 +5,8 @@ import json
 import os
 import shutil
 import tarfile
-from datetime import datetime
+from datetime import date
+from pathlib import Path
 
 import wget
 
@@ -34,6 +35,14 @@ DB_names = {
     "mgnify_v6_pr2": "MGnify PR2 (v6.0) - PR2-20240702",
     "test_lsu": "Trimmed LSU Test DB",
 }
+
+
+def source_id(url):
+    filename = Path(url).name
+    for suffix in (".tar.gz", ".tar.bz2", ".tgz", ".zip"):
+        if filename.endswith(suffix):
+            return filename.removesuffix(suffix)
+    return filename
 
 
 def download_untar_store(url, tmp_path, dest_path):
@@ -104,8 +113,8 @@ def main():
     workdir = params["output_data"][0]["extra_files_path"]
     os.mkdir(workdir)
 
-    time = datetime.utcnow().strftime("%Y-%m-%d")
-    db_value = f"{args.db_type}_from_{time}"
+    download_date = date.today().isoformat()
+    db_value = f"{args.db_type}_{source_id(DB_paths[args.db_type])}"
 
     # output paths
     db_path = os.path.join(workdir, db_value)
@@ -126,7 +135,7 @@ def main():
         "data_tables": {
             "mapseq_db": {
                 "value": db_value,
-                "name": f"{db_name} downloaded at {time}",
+                "name": f"{db_name} downloaded at {download_date}",
                 "version": args.version,
                 "path": db_path,
             }

--- a/data_managers/data_manager_mapseq/data_manager/macros.xml
+++ b/data_managers/data_manager_mapseq/data_manager/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">1.1</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
         <requirements>

--- a/data_managers/data_manager_mapseq/data_manager/mapseq_db_fetcher.xml
+++ b/data_managers/data_manager_mapseq/data_manager/mapseq_db_fetcher.xml
@@ -53,7 +53,7 @@
         </conditional>
         <output name="out_file">
             <assert_contents>
-                <has_text text="mgnify_v5_lsu"/>
+                <has_text text="mgnify_v5_lsu_silva_lsu-20200130"/>
                 <has_text text="5.0.7"/>
             </assert_contents>
         </output>


### PR DESCRIPTION
Galaxy workflows serialize Data Manager table selector values, so local installation dates make identical reference data incompatible across Galaxy instances. Runtime dates now remain only in human-readable names; workflow-facing values and derived paths use immutable source or content identity.

GTDB-Tk

Changed full and metadata database values and tests, and bumped the wrapper from 232+galaxy0 to 232+galaxy1. Values combine the database kind with the immutable GTDB release, distinguishing full and metadata data and every release. For release 202 on 2026-08-28, value changes from full_database_release_202_downloaded_2026-08-28 to full_database_release_202; name remains Full Database - release 202 (2026-08-28), and the managed path uses the stable value.

HUMAnN

Changed value generation, tests, and loc documentation, and bumped the wrapper from 3.9+galaxy0 to 3.9+galaxy1. The manager resolves the versioned artifact advertised by humann_databases --available and combines its complete basename with database and build; utility mappings also include the individual mapping filename. Upstream artifact versions are stable, and these namespaces prevent database, build, and mapping-file collisions. For DEMO ChocoPhlAn on 2026-08-28, value changes from chocophlan-DEMO-3.9-28082026 to chocophlan-DEMO-DEMO_chocophlan.v201901_v31; name remains Demo ChocoPhlAn for HUManN, dbkey remains 3.9, and the managed path uses the stable value. Tests retain the complete stable identity assertion uniref-DEMO_diamond-uniref90_DEMO_diamond_v201901b while removing the redundant DEMO_diamond substring assertion.

Kaiju

Render Data Manager JSON directly in a Cheetah configfile with no metadata-only Python helper or required_files entry, and bump the wrapper from 1.10.1+galaxy0 to 1.10.1+galaxy1. Dated prebuilt values retain their immutable upstream snapshot date and are checked against a deterministic whole-file JSON fixture; 2024-08-15_viruses remains unchanged. For mutable current builds, the runtime shell hashes database.fmi, names.dmp, and nodes.dmp in fixed filename/NUL/content/NUL order with sha256sum, then substitutes only the digest and download-date sentinels into the rendered JSON. Checksums never run during Cheetah rendering. For the regression content on 2025-04-14, value changes from 2025-04-14_viruses to viruses_sha256_575a726f33d7545789891f08ed770d17e472c2623dc0b9e6b171cd581374688e; name remains 2025-04-14 (viruses) viral genomes from NCBI RefSeq, and the managed path uses the digest value.

MAPseq

Changed value generation and tests, and bumped the wrapper from 1.1+galaxy4 to 1.1+galaxy5. Values combine the database type with the complete versioned source-archive basename, so source snapshots remain stable while the database-type namespace prevents collisions between MGnify pipeline versions and database classes. For MGnify v5 LSU on 2026-08-28, value changes from mgnify_v5_lsu_from_2026-08-28 to mgnify_v5_lsu_silva_lsu-20200130; name remains MGnify LSU (v5.0.7) - silva_lsu-20200130 downloaded at 2026-08-28, version remains 5.0, and the managed path uses the stable value. Tests retain the complete stable identity assertion mgnify_v5_lsu_silva_lsu-20200130 while removing the redundant mgnify_v5_lsu substring assertion.

Discussion: https://github.com/galaxyproject/tools-iuc/issues/8360

Proposed standard: https://github.com/galaxy-iuc/standards/pull/93

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
