### PR TITLE
multiqc: `| true` should be `|| true` when copying plot files

### DIFF
--- a/tools/multiqc/macros.xml
+++ b/tools/multiqc/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.35</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="bio_tools">
         <xrefs>

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -274,11 +274,11 @@ $export
 mkdir -p ./plots &&
 ls -l ./report_data/ &&
 ##cat ./report_data/multiqc_busco.txt &&
-cp ./report_data/*plot*.txt ./plots/ | true ## don't fail if no plot files are generated
+{ cp ./report_data/*plot*.txt ./plots/ 2>/dev/null || true; } ## don't fail if no plot files are generated
 
 #if $png_plots == "true"
     && mkdir -p ./png_plots
-    && cp ./report_plots/png/*.png ./png_plots/ | true ## don't fail if no png plots are generated
+    && { cp ./report_plots/png/*.png ./png_plots/ 2>/dev/null || true; } ## don't fail if no png plots are generated
 #end if
 
     ]]></command>


### PR DESCRIPTION
Both plot-copying lines end in `| true`, with a comment stating the intent:

  cp ./report_data/*plot*.txt ./plots/ | true ## don't fail if no plot files are generated
  && cp ./report_plots/png/*.png ./png_plots/ | true ## don't fail if no png plots are generated

`| true` pipes cp's stdout into `true` rather than running `true` when cp fails. It happens to yield exit 0 today, so the intent is met by accident -- but only while pipefail is off. With `set -o pipefail` the same line exits 1, so the tool is one shell-option change away from failing every run that produces no plot files.

A table-only report is exactly such a run. Reproduced on usegalaxy.org with a custom-content table: MultiQC itself completes and writes report.html, then the wrapper leaves

  cp: cannot stat './report_data/*plot*.txt': No such file or directory

in the stderr of a SUCCESSFUL job. With detect_errors="aggressive" that text is worth not emitting at all, and it is misleading to anyone reading the log.

⚠ A bare `|| true` would be a regression, not a fix. Both lines sit inside `&&` chains, and `a && b || true` groups as `(a && b) || true` -- so an earlier failure in the chain would be masked too. Verified:

  false && ls && cp missing dest || true                 -> exit 0  (masks it)
  false && ls && { cp missing dest 2>/dev/null || true; } -> exit 1  (preserved)

Hence the brace group. `2>/dev/null` additionally keeps the expected "no such file" out of a successful job's stderr.

Verified for all four cases: intent preserved when cp fails, earlier failures still propagate, and the line is now immune to pipefail rather than broken by it.

VERSION_SUFFIX 2 -> 3.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] Use of AI
  - [ ] The contribution is mostly AI generated
  - [X] The contribution has been assisted by AI
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
