### PR TITLE
Update Anndata suite to version 0.12.10

### DIFF
--- a/tools/anndata/export.xml
+++ b/tools/anndata/export.xml
@@ -15,7 +15,7 @@
 adata = ad.read_h5ad('$input', backed='r')
 adata.write_csvs('.', sep="\t", skip_data = False)
     ]]></configfile>
-</configfiles>
+    </configfiles>
     <inputs>
         <param name="input" type="data" format="h5ad" label="Annotated data matrix to export" help="Create individual tabular files for matrix, obs, obsm, var and varm annotations"/>
     </inputs>

--- a/tools/anndata/export.xml
+++ b/tools/anndata/export.xml
@@ -40,7 +40,7 @@ adata.write_csvs('.', sep="\t", skip_data = False)
         </test>
     </tests>
     <help><![CDATA[
-This tool exports an AnnData dataset to a tabular files (`write_csvs method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.write_csvs.html>`__)
+This tool exports an AnnData dataset to a tabular files (`write_csvs method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.write_csvs.html>`__)
 
 @HELP@
     ]]></help>

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -130,7 +130,7 @@ print(adata)
                 <param name="input" type="data" format="tabular,csv,tsv" label="Annotated data matrix"/>
                 <param name="first_column_names" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Does the first column store the row names?"/>
             </when>
-            <when value="10x_h5" >
+            <when value="10x_h5">
                 <param name="input" type="data" format="h5" label="Data matrix"/>
             </when>
             <when value="mtx">
@@ -169,11 +169,11 @@ print(adata)
         <test expect_num_outputs="1">
             <conditional name="in">
                 <param name="adata_format" value="loom"/>
-                <param name="input" ftype="loom" value="krumsiek11.loom" />
+                <param name="input" ftype="loom" value="krumsiek11.loom"/>
                 <param name="sparse" value="True"/>
                 <param name="cleanup" value="False"/>
-                <param name="x_name"  value="spliced"/>
-                <param name="obs_names" value="CellID" />
+                <param name="x_name" value="spliced"/>
+                <param name="obs_names" value="CellID"/>
                 <param name="var_names" value="Gene"/>
             </conditional>
             <assert_stdout>
@@ -284,7 +284,8 @@ print(adata)
                 <has_text_matching expression="2 × 13"/>
             </assert_stdout>
         </test>
-        <test expect_num_outputs="1"><!-- 10x h5 test -->
+        <test expect_num_outputs="1">
+            <!-- 10x h5 test -->
             <conditional name="in">
                 <param name="adata_format" value="10x_h5"/>
                 <param name="input" value="dropletutils_input.h5"/>
@@ -292,8 +293,8 @@ print(adata)
             <output name="anndata">
                 <assert_contents>
                     <has_text text="HDF"/>
-                    <has_text text="ENSG00000258728" />
-                    <has_text text="GCGAGAAAGTTGTAGA" />
+                    <has_text text="ENSG00000258728"/>
+                    <has_text text="GCGAGAAAGTTGTAGA"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -321,10 +321,10 @@ print(adata)
 
 This tool creates an AnnData from several input types:
 
-- Loom (`read_loom method <https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_loom.html>`__)
-- Tabular (`read_csv method <https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_csv.html>`__)
-- Matrix Market (mtx), from Cell ranger or not (`read_mtx method <https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_mtx.html>`__)
-- UMI tools (`read_umi_tools method <https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_umi_tools.html>`__)
+- Loom (`read_loom method <https://anndata.scverse.org/en/stable/generated/anndata.io.read_loom.html>`__)
+- Tabular (`read_csv method <https://anndata.scverse.org/en/stable/generated/anndata.io.read_csv.html>`__)
+- Matrix Market (mtx), from Cell ranger or not (`read_mtx method <https://anndata.scverse.org/en/stable/generated/anndata.io.read_mtx.html>`__)
+- UMI tools (`read_umi_tools method <https://anndata.scverse.org/en/stable/generated/anndata.io.read_umi_tools.html>`__)
 
 @HELP@
     ]]></help>

--- a/tools/anndata/import.xml
+++ b/tools/anndata/import.xml
@@ -104,7 +104,7 @@ adata.obs = obs
 adata.var = var
 
 #end if
-adata.write('anndata.h5ad', compression='gzip')
+adata.write_h5ad('anndata.h5ad', compression='gzip')
 print(adata)
 ]]></configfile>
     </configfiles>

--- a/tools/anndata/inspect.xml
+++ b/tools/anndata/inspect.xml
@@ -204,10 +204,10 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="general">
                 <assert_contents>
-                    <has_text_matching expression="AnnData object with n_obs .* n_vars = 500 .* 11" />
-                    <has_text_matching expression="obs: 'cell_type'" />
-                    <has_text_matching expression="uns: 'highlights', 'iroot'" />
-                </assert_contents>            
+                    <has_text_matching expression="AnnData object with n_obs .* n_vars = 500 .* 11"/>
+                    <has_text_matching expression="obs: 'cell_type'"/>
+                    <has_text_matching expression="uns: 'highlights', 'iroot'"/>
+                </assert_contents>
             </output>
         </test>
         <test expect_num_outputs="1">
@@ -289,15 +289,15 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="uns_neighbors_connectivities" ftype="mtx">
                 <assert_contents>
-                    <has_text_matching expression="100	100	2496" />
-                    <has_text_matching expression="4.880" />
+                    <has_text_matching expression="100 100 2496"/>
+                    <has_text_matching expression="4.880"/>
                 </assert_contents>
             </output>
             <output name="uns_neighbors_distances" ftype="mtx">
                 <assert_contents>
-                    <has_text_matching expression="100	100	1400" />
-                    <has_text_matching expression="4.973" />
-                    <has_text_matching expression="4.877" />
+                    <has_text_matching expression="100 100 1400"/>
+                    <has_text_matching expression="4.973"/>
+                    <has_text_matching expression="4.877"/>
                 </assert_contents>
             </output>
         </test>
@@ -310,15 +310,15 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="uns_paga_connectivities" ftype="mtx">
                 <assert_contents>
-                    <has_text_matching expression="16	16	97" />
-                    <has_text_matching expression="2 1 1" />
-                    <has_text_matching expression="8.839" />
+                    <has_text_matching expression="16 16 97"/>
+                    <has_text_matching expression="2 1 1"/>
+                    <has_text_matching expression="8.839"/>
                 </assert_contents>
             </output>
             <output name="uns_paga_connectivities_tree" ftype="mtx">
                 <assert_contents>
-                    <has_text_matching expression="16	16	15" />
-                    <has_text_matching expression="1 2 1" />
+                    <has_text_matching expression="16 16 15"/>
+                    <has_text_matching expression="1 2 1"/>
                 </assert_contents>
             </output>
         </test>
@@ -331,16 +331,16 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="uns_pca_variance">
                 <assert_contents>
-                    <has_text_matching expression="0.75409\d{2}" />
-                    <has_text_matching expression="3.28186\d{2}e-05" />
-                    <has_n_columns n="1" />
+                    <has_text_matching expression="0.75409\d{2}"/>
+                    <has_text_matching expression="3.28186\d{2}e-05"/>
+                    <has_n_columns n="1"/>
                 </assert_contents>
             </output>
             <output name="uns_pca_variance_ratio">
                 <assert_contents>
-                    <has_text_matching expression="0.039053\d{2}" />
-                    <has_text_matching expression="0.00013167" />
-                    <has_n_columns n="1" />
+                    <has_text_matching expression="0.039053\d{2}"/>
+                    <has_text_matching expression="0.00013167"/>
+                    <has_n_columns n="1"/>
                 </assert_contents>
             </output>
         </test>
@@ -353,7 +353,7 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="uns_rank_genes_groups_names">
                 <assert_contents>
-                    <has_n_columns n="5" />
+                    <has_n_columns n="5"/>
                     <has_text_matching expression="Ery\tMk\tMo\tNeu\tprogenitor"/>
                     <has_text_matching expression="Gata1\tFog1\tPu.1\tCebpa\tEgrNab"/>
                     <has_text_matching expression="EgrNab\tEgrNab\tSCL\tSCL\tGfi1"/>
@@ -361,30 +361,30 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </output>
             <output name="uns_rank_genes_groups_scores">
                 <assert_contents>
-                    <has_n_columns n="5" />
+                    <has_n_columns n="5"/>
                     <has_text_matching expression="Ery\tMk\tMo\tNeu\tprogenitor"/>
-<!--                    <has_text_matching expression="18.8\d{4}"/>-->
+                    <!--                    <has_text_matching expression="18.8\d{4}"/>-->
                     <has_text_matching expression="17.85673"/>
-<!--                    <has_text_matching expression="-2.637\d{4}"/>-->
-<!--                    <has_text_matching expression="-2.980\d{4}"/>-->
+                    <!--                    <has_text_matching expression="-2.637\d{4}"/>-->
+                    <!--                    <has_text_matching expression="-2.980\d{4}"/>-->
                     <has_text_matching expression="-6.46\d{4}"/>
                 </assert_contents>
             </output>
             <output name="uns_rank_genes_groups_logfoldchanges">
                 <assert_contents>
-                    <has_n_columns n="5" />
+                    <has_n_columns n="5"/>
                 </assert_contents>
             </output>
             <output name="uns_rank_genes_groups_pvals">
                 <assert_contents>
-                    <has_n_columns n="5" />
-<!--                    <has_text_matching expression="1.8009"/>-->
+                    <has_n_columns n="5"/>
+                    <!--                    <has_text_matching expression="1.8009"/>-->
                 </assert_contents>
             </output>
             <output name="uns_rank_genes_groups_pvals_adj">
                 <assert_contents>
-                    <has_n_columns n="5" />
-<!--                    <has_text_matching expression="1.97952"/>-->
+                    <has_n_columns n="5"/>
+                    <!--                    <has_text_matching expression="1.97952"/>-->
                 </assert_contents>
             </output>
         </test>
@@ -397,10 +397,10 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="obsm_X_pca">
                 <assert_contents>
-                    <has_text_matching expression="0.0045348783" />
-                    <has_text_matching expression="3.4109413" />
-                    <has_text_matching expression="-0.6401007" />
-                    <has_n_columns n="10" />
+                    <has_text_matching expression="0.0045348783"/>
+                    <has_text_matching expression="3.4109413"/>
+                    <has_text_matching expression="-0.6401007"/>
+                    <has_n_columns n="10"/>
                 </assert_contents>
             </output>
         </test>
@@ -413,11 +413,11 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="obsm_X_umap">
                 <assert_contents>
-                    <has_text text="1.664" />
-                    <has_text text="5.425" />
-                    <has_text text="-1.748" />
-                    <has_text text="-9.714" />
-                    <has_n_columns n="2" />
+                    <has_text text="1.664"/>
+                    <has_text text="5.425"/>
+                    <has_text text="-1.748"/>
+                    <has_text text="-9.714"/>
+                    <has_n_columns n="2"/>
                 </assert_contents>
             </output>
         </test>
@@ -430,9 +430,9 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="obsm_X_tsne">
                 <assert_contents>
-                    <has_text text="14.301989" />
-                    <has_text text="-19.447426" />
-                    <has_n_columns n="2" />
+                    <has_text text="14.301989"/>
+                    <has_text text="-19.447426"/>
+                    <has_n_columns n="2"/>
                 </assert_contents>
             </output>
         </test>
@@ -446,11 +446,11 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             <output_collection name="obsm_X_draw_graph">
                 <element name="fr">
                     <assert_contents>
-                        <has_text text="-39.77" />
-                        <has_text text="-24.83" />
-                        <has_text text="-34.34" />
-                        <has_text text="-22.34" />
-                        <has_n_columns n="2" />
+                        <has_text text="-39.77"/>
+                        <has_text text="-24.83"/>
+                        <has_text text="-34.34"/>
+                        <has_text text="-22.34"/>
+                        <has_n_columns n="2"/>
                     </assert_contents>
                 </element>
             </output_collection>
@@ -464,9 +464,9 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="obsm_X_diffmap">
                 <assert_contents>
-                    <has_text text="0.1006" />
-                    <has_text text="-0.0619" />
-                    <has_n_columns n="15" />
+                    <has_text text="0.1006"/>
+                    <has_text text="-0.0619"/>
+                    <has_n_columns n="15"/>
                 </assert_contents>
             </output>
         </test>
@@ -479,9 +479,9 @@ pd.DataFrame(adata.varm['PCs']).to_csv("$varm_PCs", sep="\t", index = False)
             </conditional>
             <output name="varm_PCs">
                 <assert_contents>
-                    <has_text_matching expression="0.2352" />
-                    <has_text_matching expression="-0.0492" />
-                    <has_n_columns n="10" />
+                    <has_text_matching expression="0.2352"/>
+                    <has_text_matching expression="-0.0492"/>
+                    <has_n_columns n="10"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/anndata/inspect.xml
+++ b/tools/anndata/inspect.xml
@@ -493,7 +493,7 @@ This tool inspects a AnnData dataset and returns:
 
 - General information about the object as text
 - The full data matrix (`X`) as a Tabular
-- A chunk of the data matrix as a Tabular, using the `chunk_X method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.chunk_X.html>`__
+- A chunk of the data matrix as a Tabular, using the `chunk_X method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.chunk_X.html>`__
 - Key-indexed observations annotation (`obs`) as a Tabular
 - Key-indexed annotation of variables/features (`var`) as a Tabular
 

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -14,6 +14,7 @@
     <xml name="citations">
         <citations>
             <citation type="doi">10.1186/s13059-017-1382-0</citation>
+            <yield/>
         </citations>
     </xml>
     <xml name="version_command">

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -43,7 +43,7 @@ of statistics (Hastie et al., 2009)  and machine learning (Murphy, 2012), the co
 and machine learning packages in Python (statsmodels, scikit-learn).
 
 More details on the `AnnData documentation
-<https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.html>`__
+<https://anndata.scverse.org/en/stable/index.html>`__
 
 
 **Loom data**

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -1,11 +1,11 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.11.4</token>
-    <token name="@VERSION_SUFFIX@">3</token>
-    <token name="@PROFILE@">21.09</token>
+    <token name="@TOOL_VERSION@">0.12.10</token>
+    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">anndata</requirement>
-            <requirement type="package" version="1.11.5">scanpy</requirement>
+            <requirement type="package" version="1.12.4">scanpy</requirement>
             <requirement type="package" version="3.0.8">loompy</requirement>
             <requirement type="package" version="2.3.3">pandas</requirement>
             <yield />

--- a/tools/anndata/macros.xml
+++ b/tools/anndata/macros.xml
@@ -8,7 +8,7 @@
             <requirement type="package" version="1.12.4">scanpy</requirement>
             <requirement type="package" version="3.0.8">loompy</requirement>
             <requirement type="package" version="2.3.3">pandas</requirement>
-            <yield />
+            <yield/>
         </requirements>
     </xml>
     <xml name="citations">
@@ -76,9 +76,9 @@ and cells, such as Name, Chromosome, Position (for genes), and Strain, Sex, Age 
     <xml name="sanitize_query" token_validinitial="string.printable">
         <sanitizer>
             <valid initial="@VALIDINITIAL@">
-                <remove value="&apos;" />
+                <remove value="'"/>
             </valid>
-       </sanitizer>
+        </sanitizer>
     </xml>
     <xml name="bio_tools">
         <xrefs>

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -115,9 +115,6 @@ adata.var['${to_var}'] = adata.var['${from_var}']
 del adata.var['${from_var}']
 #end if
 
-#else if $manipulate.function == 'strings_to_categoricals'
-adata.strings_to_categoricals()
-
 #else if $manipulate.function == 'transpose'
 adata = adata.to_memory()
 adata = adata.transpose()
@@ -144,7 +141,7 @@ res_dir = "output_split"
 os.makedirs(res_dir, exist_ok=True)
 for s,field_value in enumerate(adata.obs["${manipulate.key}"].unique()):
     ad_s = adata[adata.obs.${manipulate.key} == field_value].copy()
-    ad_s.write(f"{res_dir}/${manipulate.key}_{s}.h5ad", compression='gzip')
+    ad_s.write_h5ad(f"{res_dir}/${manipulate.key}_{s}.h5ad", compression='gzip')
 
 #else if $manipulate.function == 'copy_obs'
 source_adata = ad.read_h5ad('$source_adata', backed='r')
@@ -213,7 +210,7 @@ adata.raw = adata
 #end if
 
 #if $manipulate.function != 'split_on_obs'
-adata.write('anndata.h5ad', compression='gzip')
+adata.write_h5ad('anndata.h5ad', compression='gzip')
 print(adata)
 #end if
 
@@ -231,7 +228,6 @@ print(adata)
                 <option value="flag_genes">Flag genes start with a pattern</option><!--adapted from EBI anndata operations tool -->
                 <option value="rename_obs">Rename fileds in AnnData observations</option><!--adapted from EBI anndata operations tool -->
                 <option value="rename_var">Rename fileds in AnnData variables</option><!--adapted from EBI anndata operations tool -->
-                <option value="strings_to_categoricals">Transform string annotations to categoricals</option>
                 <option value="transpose">Transpose the data matrix, leaving observations and variables interchanged</option>
                 <option value="add_annotation">Add new annotation(s) for observations or variables</option>
                 <option value="split_on_obs">Split the AnnData object into multiple AnnData objects based on the values of a given obs key</option><!--adapted from EBI anndata operations tool-->
@@ -328,7 +324,6 @@ print(adata)
                 </param>
                 <param name="keep_original" type="boolean" checked="false" label="Keep original" help="If activated, it will also keep the original column"/>
             </when>
-            <when value="strings_to_categoricals" ></when>
             <when value="transpose" ></when>
             <when value="add_annotation">
                 <param name="var_obs" type="select" label="What to annotate?">
@@ -487,24 +482,6 @@ print(adata)
                 <has_text_matching expression="adata.rename_categories"/>
                 <has_text_matching expression="key='cell_type'"/>
                 <has_text_matching expression="categories=\['ery', 'mk', 'mo', 'progenitor'\]"/>
-                <has_text_matching expression="500 × 11"/>
-            </assert_stdout>
-            <output name="anndata" ftype="h5ad">
-                <assert_contents>
-                    <has_h5_keys keys="obs/cell_type"/>
-                    <has_h5_keys keys="uns/highlights"/>
-                    <has_h5_keys keys="uns/iroot"/>
-                </assert_contents>
-            </output>
-        </test>
-        <test expect_num_outputs="1">
-            <!-- test 5 -->
-            <param name="input" value="krumsiek11.h5ad"/>
-            <conditional name="manipulate">
-                <param name="function" value="strings_to_categoricals"/>
-            </conditional>
-            <assert_stdout>
-                <has_text_matching expression="adata.strings_to_categoricals"/>
                 <has_text_matching expression="500 × 11"/>
             </assert_stdout>
             <output name="anndata" ftype="h5ad">
@@ -821,7 +798,7 @@ print(adata)
                     <has_h5_keys keys="obsm/X_pca"/>
                     <has_h5_keys keys="obsm/X_umap"/>
                     <has_h5_keys keys="layers/count"/>
-                    <has_h5_keys keys="layers/new_count"/>                    
+                    <has_h5_keys keys="layers/new_count"/>
                     <has_h5_keys keys="obsp/connectivities"/>
                     <has_h5_keys keys="obsp/distances"/>
                 </assert_contents>
@@ -847,7 +824,7 @@ print(adata)
                     <has_h5_keys keys="obsm/X_pca"/>
                     <has_h5_keys keys="obsm/X_umap"/>
                     <has_h5_keys keys="layers/count"/>
-                    <has_h5_keys keys="layers/new_X"/>                    
+                    <has_h5_keys keys="layers/new_X"/>
                     <has_h5_keys keys="obsp/connectivities"/>
                     <has_h5_keys keys="obsp/distances"/>
                 </assert_contents>
@@ -870,7 +847,7 @@ print(adata)
                     <has_h5_keys keys="uns/iroot"/>
                     <has_h5_keys keys="obsm/X_pca"/>
                     <has_h5_keys keys="obsm/X_umap"/>
-                    <has_h5_keys keys="layers/count"/>                    
+                    <has_h5_keys keys="layers/count"/>
                     <has_h5_keys keys="obsp/connectivities"/>
                     <has_h5_keys keys="obsp/distances"/>
                 </assert_contents>
@@ -953,10 +930,6 @@ The possible manipulations are:
 - Flag genes start with a pattern
 
     Useful for flagging the mitochondrial or ribosomal protein genes
-
-- Transform string annotations to categoricals (`strings_to_categoricals method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.strings_to_categoricals.html>`__)
-
-    Only affects string annotations that lead to less categories than the total number of observations.
 
 - Transpose the data matrix, leaving observations and variables interchanged (`transpose method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.transpose.html>`__)
 

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -922,15 +922,15 @@ The possible manipulations are:
 
     If you use `join='outer'` this fills 0s for sparse data when variables are absent in a batch. Use this with care. Dense data is filled with `NaN`
 
-- Makes the obs index unique by appending '1', '2', etc (`obs_names_make_unique method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.obs_names_make_unique.html>`__)
+- Makes the obs index unique by appending '1', '2', etc (`obs_names_make_unique method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.obs_names_make_unique.html>`__)
 
     The first occurrence of a non-unique value is ignored.
 
-- Makes the var index unique by appending '1', '2', etc (`var_names_make_unique method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.var_names_make_unique.html>`__)
+- Makes the var index unique by appending '1', '2', etc (`var_names_make_unique method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.var_names_make_unique.html>`__)
 
     The first occurrence of a non-unique value is ignored.
 
-- Rename categories of annotation `key` in `obs`, `var` and `uns` (`rename_categories method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.rename_categories.html>`__)
+- Rename categories of annotation `key` in `obs`, `var` and `uns` (`rename_categories method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.rename_categories.html>`__)
 
     Besides calling `self.obs[key].cat.categories = categories` - similar for `var` - this also renames categories in unstructured annotation that uses the categorical annotation `key`
 
@@ -942,7 +942,7 @@ The possible manipulations are:
 
     Useful for flagging the mitochondrial or ribosomal protein genes
 
-- Transpose the data matrix, leaving observations and variables interchanged (`transpose method <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.transpose.html>`__)
+- Transpose the data matrix, leaving observations and variables interchanged (`transpose method <https://anndata.scverse.org/en/stable/generated/anndata.AnnData.transpose.html>`__)
 
     Data matrix is transposed, observations and variables are interchanged.
 

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -23,27 +23,31 @@
 
 adata = ad.read_h5ad('$input', backed='r')
 
-#if $manipulate.function == 'concatenate'
+#if $manipulate.function == 'concat'
 adata = adata.to_memory()
     #for i, filepath in enumerate($manipulate.other_adatas)
 adata_$i = ad.read_h5ad('$filepath', backed='r').to_memory()
     #end for
-adata = adata.concatenate(
+adata = adata.concat(
     #for i, filepath in enumerate($manipulate.other_adatas)
     adata_$i,
     #end for
+    axis='$manipulate.axis',
     join='$manipulate.join',
     #if str($manipulate.index_unique) != ''
     index_unique='$manipulate.index_unique',
     #else
     index_unique=None,
     #end if
-    #if str($manipulate.uns_merge) != 'None'
-    uns_merge='$manipulate.uns_merge',
+    #if str($manipulate.merge) != 'None'
+    merge='$manipulate.merge',
+    uns_merge='$manipulate.merge',
     #else
-    uns_merge=None,
+    merge=None,
     #end if
-    batch_key='$manipulate.batch_key')
+    #if str($manipulate.label) != '':
+    label='$manipulate.label')
+    #end if
 
 #else if $manipulate.function == 'var_names_make_unique'
 adata.var_names_make_unique(join='$manipulate.join')
@@ -220,7 +224,7 @@ print(adata)
         <param name="input" type="data" format="h5ad" label="Annotated data matrix"/>
         <conditional name="manipulate">
             <param name="function" type="select" label="Function to manipulate the object">
-                <option value="concatenate">Concatenate along the observations axis</option>
+                <option value="concat">Concatenate along the observations axis</option>
                 <option value="obs_names_make_unique">Makes the obs index unique by appending '1', '2', etc</option>
                 <option value="var_names_make_unique">Makes the var index unique by appending '1', '2', etc</option>
                 <option value="rename_categories">Rename categories of annotation</option>
@@ -238,21 +242,25 @@ print(adata)
                 <option value="copy_X">Copy data matrix (.X) from a different anndata object</option>
                 <option value="save_raw">Freeze the current state into the 'raw' attribute</option>
             </param>
-            <when value="concatenate">
+            <when value="concat">
                 <param name="other_adatas" type="data" format="h5ad" multiple="true" label="Annotated data matrix to add"/>
-                <param name="join" type="select" label="Join method">
+                <param argument="axis" type="select" label="JWhich axis to concatenate along">
+                    <option value="obs">Obs</option>
+                    <option value="var">Vars</option>
+                </param>
+                <param argument="join" type="select" label="Join method">
                     <option value="inner">Intersection of variables</option>
                     <option value="outer">Union of variables</option>
                 </param>
-                <param name="batch_key" type="text" value="batch" label="Key to add the batch annotation to obs"/>
-                <param name="uns_merge" type="select" label="Strategy to use for merging entries of uns" help="These strategies are applied recusivley.">
-                    <option value="None" selected="true">The default. The concatenated object will just have an empty dict for uns</option>
+                <param argument="label" type="text" value="" optional="true" label="Key to add the batch annotation to obs/var. If not set, no column will be added"/>
+                <param argument="merge" type="select" label="How elements not aligned to the axis being concatenated along are selected" help="The same will be applied on uns entries, except it is applied recusivley.">
+                    <option value="None" selected="true">No elements are kept</option>
                     <option value="same">Only entries which have the same value in all AnnData objects are kept</option>
-                    <option value="unique">Only entries which have one unique value in all AnnData objects are kept</option>
+                    <option value="unique">Elements for which there is only one possible value are kept</option>
                     <option value="first">The first non-missing value is used</option>
-                    <option value="only">A value is included if only one of the AnnData objects has a value at this path</option>
+                    <option value="only">Elements that show up in only one of the objects are kept</option>
                 </param>
-                <param name="index_unique" type="select" label="Separator to join the existing index names with the batch category" help="Leave it empty to keep existing indices">
+                <param argument="index_unique" type="select" optional="true" label="Separator to join the existing index names with the batch category" help="Leave it empty to keep existing indices">
                     <option value="-">-</option>
                     <option value="_">_</option>
                     <option value=" "> </option>
@@ -409,18 +417,18 @@ print(adata)
             <!-- test 1 -->
             <param name="input" value="import.csv.h5ad"/>
             <conditional name="manipulate">
-                <param name="function" value="concatenate"/>
+                <param name="function" value="concat"/>
                 <param name="other_adatas" value="import.csv.h5ad"/>
                 <param name="join" value="inner"/>
-                <param name="batch_key" value="batch"/>
+                <param name="label" value="batch"/>
                 <param name="index_unique" value="-"/>
             </conditional>
             <assert_stdout>
                 <has_text_matching expression="adata_0"/>
-                <has_text_matching expression="adata.concatenate"/>
+                <has_text_matching expression="adata.concat"/>
                 <has_text_matching expression="join='inner'"/>
                 <has_text_matching expression="index_unique='-'"/>
-                <has_text_matching expression="batch_key='batch'"/>
+                <has_text_matching expression="label='batch'"/>
                 <has_text_matching expression="6 × 2"/>
             </assert_stdout>
             <output name="anndata" ftype="h5ad">
@@ -905,7 +913,7 @@ This tool takes an AnnData dataset, manipulates it and returns it.
 
 The possible manipulations are:
 
-- Concatenate along the observations axis (`concatenate method <https://anndata.readthedocs.io/en/stable/generated/anndata.AnnData.concatenate.html>`__)
+- Concatenate along the observations axis (`concatenate method <https://anndata.scverse.org/en/stable/generated/anndata.concat.html>`__)
 
     The `uns`, `varm` and `obsm` attributes are ignored.
 

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -150,8 +150,8 @@ adata = adata.to_memory()
 res_dir = "output_split"
 os.makedirs(res_dir, exist_ok=True)
 for s,field_value in enumerate(adata.obs["${manipulate.key}"].unique()):
-    ad_s = adata[adata.obs.${"manipulate.key"} == field_value].copy()
-    ad_s.write_h5ad(f"{res_dir}/${'manipulate.key'}_{s}.h5ad", compression='gzip')
+    ad_s = adata[adata.obs["${manipulate.key}"] == field_value].copy()
+    ad_s.write_h5ad(f"{res_dir}/${manipulate.key}_{s}.h5ad", compression='gzip')
 
 #else if $manipulate.function == 'copy_obs'
 source_adata = ad.read_h5ad('$source_adata', backed='r')
@@ -183,7 +183,7 @@ else:
 source_adata = ad.read_h5ad('$source_adata', backed='r')
     #for $key in $manipulate.keys
 if '$key.source_key' in source_adata.obsm:
-        #if $key.target_key is None
+        #if str($key.target_key) == ''
     adata.obsm['$key.source_key'] = source_adata.obsm['$key.source_key']
         #else
     adata.obsm['$key.target_key'] = source_adata.obsm['$key.source_key']
@@ -196,7 +196,7 @@ else:
 source_adata = ad.read_h5ad('$source_adata', backed='r')
     #for $key in $manipulate.keys
 if '$key.source_key' in source_adata.layers:
-        #if $key.target_key is None
+        #if str($key.target_key) == ''
     adata.layers['$key.source_key'] = source_adata.layers['$key.source_key']
         #else
     adata.layers['$key.target_key'] = source_adata.layers['$key.source_key']
@@ -207,7 +207,7 @@ else:
 
 #else if $manipulate.function == 'copy_X'
 source_adata = ad.read_h5ad('$source_adata', backed='r')
-    #if $target_key is None
+    #if str($target_key) == ''
 adata.X = source_adata.X
     #else
 adata.layers['$target_key'] = source_adata.X
@@ -254,7 +254,7 @@ print(adata)
             </param>
             <when value="concat">
                 <param name="other_adatas" type="data" format="h5ad" multiple="true" label="Annotated data matrix to add"/>
-                <param argument="axis" type="select" label="JWhich axis to concatenate along">
+                <param argument="axis" type="select" label="Which axis to concatenate along">
                     <option value="obs">Obs</option>
                     <option value="var">Vars</option>
                 </param>

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -28,10 +28,12 @@ adata = adata.to_memory()
     #for i, filepath in enumerate($manipulate.other_adatas)
 adata_$i = ad.read_h5ad('$filepath', backed='r').to_memory()
     #end for
-adata = adata.concat(
+adata = ad.concat(
+    [adata,
     #for i, filepath in enumerate($manipulate.other_adatas)
     adata_$i,
     #end for
+    ],
     axis='$manipulate.axis',
     join='$manipulate.join',
     #if str($manipulate.index_unique) != ''
@@ -45,9 +47,12 @@ adata = adata.concat(
     #else
     merge=None,
     #end if
-    #if str($manipulate.label) != '':
-    label='$manipulate.label')
+    #if str($manipulate.label) != ''
+    label='$manipulate.label',
+    #else
+    label=None,
     #end if
+)
 
 #else if $manipulate.function == 'var_names_make_unique'
 adata.var_names_make_unique(join='$manipulate.join')
@@ -428,7 +433,7 @@ print(adata)
             </conditional>
             <assert_stdout>
                 <has_text_matching expression="adata_0"/>
-                <has_text_matching expression="adata.concat"/>
+                <has_text_matching expression="ad.concat"/>
                 <has_text_matching expression="join='inner'"/>
                 <has_text_matching expression="index_unique='-'"/>
                 <has_text_matching expression="label='batch'"/>

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -229,12 +229,16 @@ print(adata)
                 <option value="var_names_make_unique">Makes the var index unique by appending '1', '2', etc</option>
                 <option value="rename_categories">Rename categories of annotation</option>
                 <option value="remove_keys">Remove keys from obs or var annotations</option>
-                <option value="flag_genes">Flag genes start with a pattern</option><!--adapted from EBI anndata operations tool -->
-                <option value="rename_obs">Rename fileds in AnnData observations</option><!--adapted from EBI anndata operations tool -->
-                <option value="rename_var">Rename fileds in AnnData variables</option><!--adapted from EBI anndata operations tool -->
+                <option value="flag_genes">Flag genes start with a pattern</option>
+                <!--adapted from EBI anndata operations tool -->
+                <option value="rename_obs">Rename fileds in AnnData observations</option>
+                <!--adapted from EBI anndata operations tool -->
+                <option value="rename_var">Rename fileds in AnnData variables</option>
+                <!--adapted from EBI anndata operations tool -->
                 <option value="transpose">Transpose the data matrix, leaving observations and variables interchanged</option>
                 <option value="add_annotation">Add new annotation(s) for observations or variables</option>
-                <option value="split_on_obs">Split the AnnData object into multiple AnnData objects based on the values of a given obs key</option><!--adapted from EBI anndata operations tool-->
+                <option value="split_on_obs">Split the AnnData object into multiple AnnData objects based on the values of a given obs key</option>
+                <!--adapted from EBI anndata operations tool-->
                 <option value="copy_obs">Copy observation keys from a different anndata object</option>
                 <option value="copy_uns">Copy uns keys from a different anndata object</option>
                 <option value="copy_embed">Copy embeddings from a different anndata object</option>
@@ -286,7 +290,7 @@ print(adata)
                             <expand macro="sanitize_query"/>
                         </param>
                     </when>
-                    <when value="no"></when>
+                    <when value="no"/>
                 </conditional>
             </when>
             <when value="remove_keys">
@@ -302,11 +306,11 @@ print(adata)
                     <param name="startswith" type="text" label="Text that you expect the genes to be flagged to start with" help="For example, 'MT-' for mito genes">
                         <sanitizer invalid_char="">
                             <valid initial="string.ascii_letters,string.digits,string.punctuation">
-                                <remove value="&apos;" />
+                                <remove value="'"/>
                             </valid>
                         </sanitizer>
                     </param>
-                    <param name="col_in" value='' optional="true" type="text" label="Column in .var to use" help="By default it uses the var_names (normally gene symbols)">
+                    <param name="col_in" value="" optional="true" type="text" label="Column in .var to use" help="By default it uses the var_names (normally gene symbols)">
                         <expand macro="sanitize_query"/>
                     </param>
                     <param name="col_out" type="text" label="Name of the column in var.names where this boolean flag is stored" help="For example, name this column as 'mito' for mitochondrial genes.">
@@ -332,25 +336,24 @@ print(adata)
                 </param>
                 <param name="keep_original" type="boolean" checked="false" label="Keep original" help="If activated, it will also keep the original column"/>
             </when>
-            <when value="transpose" ></when>
+            <when value="transpose"/>
             <when value="add_annotation">
                 <param name="var_obs" type="select" label="What to annotate?">
                     <option value="var">Variables (var)</option>
                     <option value="obs">Observations (obs)</option>
                 </param>
-                <param name="new_annot" type="data" format="tabular" label="Table with new annotations"
-                    help="The new table should have the same number of rows and the same order as obs or var. The key names should be in the header (1st line)"/>
+                <param name="new_annot" type="data" format="tabular" label="Table with new annotations" help="The new table should have the same number of rows and the same order as obs or var. The key names should be in the header (1st line)"/>
             </when>
             <when value="split_on_obs">
                 <param name="key" type="text" label="The obs key to split on" help="For example, if you want to split on cluster annotation, you can use the key 'louvain'. The output will be a collection of anndata objects">
                     <sanitizer invalid_char="">
                         <valid initial="string.ascii_letters,string.digits,string.punctuation">
-                            <remove value="&apos;" />
+                            <remove value="'"/>
                         </valid>
                     </sanitizer>
                 </param>
             </when>
-            <when value="save_raw"></when>
+            <when value="save_raw"/>
             <when value="copy_obs">
                 <param name="source_adata" type="data" format="h5ad" label="Source anndata object" help="Ideally the source AnnData object should contain the same set of genes and cells."/>
                 <repeat name="keys" title="Keys from obs to copy" min="1">

--- a/tools/anndata/manipulate.xml
+++ b/tools/anndata/manipulate.xml
@@ -46,6 +46,7 @@ adata = ad.concat(
     uns_merge='$manipulate.merge',
     #else
     merge=None,
+    uns_merge=None,
     #end if
     #if str($manipulate.label) != ''
     label='$manipulate.label',
@@ -109,7 +110,7 @@ k_cat = adata.var_names.str.startswith('${flag.startswith}')
 if k_cat.sum() > 0:
     adata.var['${flag.col_out}'] = k_cat
 else:
-    print(f'No genes starting with {'${flag.startswith}'} found.')
+    print(f"No genes starting with '${flag.startswith}' found.")
 #end for
 
 #else if $manipulate.function == 'rename_obs':
@@ -149,8 +150,8 @@ adata = adata.to_memory()
 res_dir = "output_split"
 os.makedirs(res_dir, exist_ok=True)
 for s,field_value in enumerate(adata.obs["${manipulate.key}"].unique()):
-    ad_s = adata[adata.obs.${manipulate.key} == field_value].copy()
-    ad_s.write_h5ad(f"{res_dir}/${manipulate.key}_{s}.h5ad", compression='gzip')
+    ad_s = adata[adata.obs.${"manipulate.key"} == field_value].copy()
+    ad_s.write_h5ad(f"{res_dir}/${'manipulate.key'}_{s}.h5ad", compression='gzip')
 
 #else if $manipulate.function == 'copy_obs'
 source_adata = ad.read_h5ad('$source_adata', backed='r')
@@ -416,7 +417,7 @@ print(adata)
             <filter>manipulate['function'] != 'split_on_obs'</filter>
         </data>
         <collection name="output_h5ad_split" type="list" label="${tool.name} (${manipulate.function}) on ${on_string} Collection">
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.h5" directory="output_split" format="h5ad" visible="true"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.h5ad" directory="output_split" format="h5ad" visible="true"/>
             <filter>manipulate['function'] == 'split_on_obs'</filter>
         </collection>
     </outputs>

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -38,7 +38,7 @@ python '$__tool_directory__/tsv_to_loompy.py'
 #end if
       ]]></command>
     <configfiles>
-    <configfile name="script_file"><![CDATA[
+        <configfile name="script_file"><![CDATA[
 @CMD_imports@
 #if $operation.to_perform == 'import'
     #if $operation.from.file_type == 'ad'
@@ -93,21 +93,20 @@ adata.write_loom('converted.loom')
                         <param name="rowdata" type="data" format="tabular" label="Tsv of row data." help="First row is row attributes, subsequent are values."/>
                     </when>
                 </conditional>
-
             </when>
         </conditional>
     </inputs>
     <outputs>
-        <data name="loomout" format="loom" from_work_dir='converted.loom' label="${tool.name} (${operation.to_perform}) on ${on_string} Loom file">
+        <data name="loomout" format="loom" from_work_dir="converted.loom" label="${tool.name} (${operation.to_perform}) on ${on_string} Loom file">
             <filter>operation['to_perform'] == 'manipulate' or operation['to_perform'] == 'import'</filter>
         </data>
-        <collection name="layer_tsvs" type="list" label="Layer matrices" >
+        <collection name="layer_tsvs" type="list" label="Layer matrices">
             <filter>operation['to_perform'] == 'export'</filter>
-            <discover_datasets pattern="__designation__" format="tabular" directory="output" visible="false" />
+            <discover_datasets pattern="__designation__" format="tabular" directory="output" visible="false"/>
         </collection>
-        <collection name="attribute_tsvs" type="list" label="Attribute matrices" >
+        <collection name="attribute_tsvs" type="list" label="Attribute matrices">
             <filter>operation['to_perform'] == 'export'</filter>
-            <discover_datasets pattern="__designation__" format="tabular" directory="attributes" visible="false" />
+            <discover_datasets pattern="__designation__" format="tabular" directory="attributes" visible="false"/>
         </collection>
     </outputs>
     <tests>

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -188,12 +188,12 @@ adata.write_loom('converted.loom')
     <help><![CDATA[
 This tool allows the user to modify an existing loom data file by adding column attributes, row attributes or additional layers via tsv files.
     ]]></help>
-    <citations>
-        <citation type="bibtex">@UNPUBLISHED{Linnarsson2016,
-            author = "Linnarsson lab"
-            title = "Loompy"
-            year = "2013"
-            note = "https://github.com/linnarsson-lab/loompy"}
-        </citation>
-    </citations>
+        <expand macro="citations">
+            <citation type="bibtex">@UNPUBLISHED{Linnarsson2016,
+                author = "Linnarsson lab"
+                title = "Loompy"
+                year = "2013"
+                note = "https://github.com/linnarsson-lab/loompy"}
+            </citation>
+        </expand>
 </tool>

--- a/tools/anndata/modify_loom.xml
+++ b/tools/anndata/modify_loom.xml
@@ -190,9 +190,9 @@ This tool allows the user to modify an existing loom data file by adding column 
     ]]></help>
         <expand macro="citations">
             <citation type="bibtex">@UNPUBLISHED{Linnarsson2016,
-                author = "Linnarsson lab"
-                title = "Loompy"
-                year = "2013"
+                author = "Linnarsson lab",
+                title = "Loompy",
+                year = "2013",
                 note = "https://github.com/linnarsson-lab/loompy"}
             </citation>
         </expand>


### PR DESCRIPTION
It updates the suite to version 0.12.10, the same anndata version as the spatialdata tool suite. After this PR is merged, I will update the tool to the latest version. The reason is that I want to have a compatible anndata version with what spatialdata is using.




FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] Use of AI
  - [ ] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
