### PR TITLE
CI: deploy-report needs pull-requests: write for the github.token fallback

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -451,12 +451,13 @@ jobs:
     needs: [deploy]
     if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
-    # pull-requests:read for the PR lookup, issues:write because commenting by
-    # issue number goes through the issues API. Needed when secrets.PAT is
-    # unset and the step falls back to github.token.
+    # pull-requests:write because the comment target is always a pull request
+    # -- the number comes from /commits/{sha}/pulls -- and create-or-update-comment
+    # documents GITHUB_TOKEN as needing (issues: write, pull-requests: write).
+    # Needed when secrets.PAT is unset and the step falls back to github.token.
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
     # report to the PR if deployment failed


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [x] The contribution is mostly AI generated
  - [ ] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

---

Follow-up to #8281. CI-only change.

That PR added a `github.token` fallback so `deploy-report` no longer dies when `secrets.PAT` is unset:

```yaml
token: ${{ secrets.PAT || github.token }}
```

but the accompanying `permissions:` block grants `pull-requests: read`. The comment target is always a pull request, since the number is resolved from `/commits/{sha}/pulls`, and [create-or-update-comment documents](https://github.com/peter-evans/create-or-update-comment#action-inputs) `GITHUB_TOKEN` as needing (`issues: write`, `pull-requests: write`). So on the fallback path the POST returns `403 Resource not accessible by integration`, and the deploy status comment the job exists to send never arrives.

This repository never hits it, because `PAT` is set here and the fallback is dead code. It is the only path in `bgruening/galaxytools`, which runs a copy of this CI with no PAT. Found while porting #8280 and #8281 across in bgruening/galaxytools#1980.

One line: `pull-requests: read` to `write`.

`.github/**` is in `pr.yaml`'s `paths-ignore`, so this does not trigger the tool CI. `actionlint` is unchanged (the one pre-existing `github.head_ref` finding).
