### PR TITLE
LexicMap: make --all flag default-on and more prominent

### DIFF
--- a/tools/lexicmap/lexicmap.xml
+++ b/tools/lexicmap/lexicmap.xml
@@ -1,4 +1,4 @@
-<tool id="lexicmap_search" name="LexicMap Search" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE_VERSION@">
+<tool id="lexicmap_search" name="LexicMap Search" version="@TOOL_VERSION@+galaxy3" profile="@PROFILE_VERSION@">
     <description>nucleotide sequence tool for querying genomes</description>
     <macros>
         <import>macros.xml</import>
@@ -92,13 +92,13 @@
             </when>
         </conditional>
         <param argument="--top-n-genomes" type="integer" value="0" label="Keep top N genome matches for a query (0 for all)"/>
+        <param argument="--all" type="boolean" truevalue="--all" falsevalue="" checked="true" label="Output all columns" help="Output more columns, e.g., matched sequences. Use this if you want to output blast-style format with 'lexicmap utils 2blast'."/>
         <section name="advanced_settings" title="Advanced settings" expanded="false">
             <param argument="--align-band" value="100" type="integer" label="Align band" help="Band size in backtracking the score matrix (pseudo alignment"/>
             <param argument="-align-ext-len" min="0" value="1000" type="integer" label="Align extend length" help="Extend length of upstream and downstream of seed regions, for extracting query and target sequences for alignment. It should be &lt;= contig interval length in database."/>
             <param argument="-align-max-gap" value="20" type="integer" label="Align max gap" help="Maximum gap in a HSP segment."/>
             <param argument="--align-min-match-len" value="50" type="integer" label="Align min match length" help="Minimum aligned length in a HSP segment."/>
             <param argument="--align-min-match-pident" min="60" value="70" max="100" type="float" label="Align min match pident" help="Minimum base identity (percentage) in a HSP segment. Should be between 60 and 100."/>
-            <param argument="--all" type="boolean" truevalue="--all" falsevalue="" checked="false" label="All all columns" help="Output more columns, e.g., matched sequences. Use this if you want to output blast-style format with 'lexicmap utils 2blast'."/>
             <param argument="--load-whole-seeds" type="boolean" truevalue="--load-whole-seeds" falsevalue="" checked="false" label="Load whole seeds" help="Load the whole seed data into memory for faster search"/>
             <param argument="--max-evalue" value="10" type="float" label="Max evalue" help="Maximum evalue of a HSP segment."/>
             <param argument="--max-query-conc" value="12" type="integer" label="Max query conc" help="Maximum number of concurrent queries. Bigger values do not improve the batch searching speed and consume much memory."/>
@@ -114,7 +114,7 @@
     <outputs>
         <data name="out_file" format="tabular">
             <actions>
-                <conditional name="advanced_settings.all">
+                <conditional name="all">
                     <when value="true">
                         <action name="column_names" type="metadata" default="Qquery,qlen,hits,sgenome,sseqid,qcovGnm,cls,hsp,qcovHSP,alenHSP,pident,gaps,qstart,qend,sstart,send,sstr,slen,evalue,bitscore,cigar,qseq,sseq,align"/>
                     </when>
@@ -133,6 +133,7 @@
                 <param name="lexicmap_index" value="LexicMapIndex1"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -146,6 +147,7 @@
                 <param name="lexicmap_index" value="LexicMapIndex1"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz,lexicmap_query2.fasta.gz"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -159,6 +161,7 @@
                 <param name="lexicmap_index" value="LexicMapIndexCombined"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -172,6 +175,7 @@
                 <param name="lexicmap_index" value="LexicMapIndexCombined"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz,lexicmap_query2.fasta.gz,lexicmap_query3.fasta"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -185,6 +189,7 @@
                 <param name="lexicmap_index" value="LexicMapIndexCombined"/>
             </conditional>
             <param name="query" value="lexicmap_query_multi.fasta.gz"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -198,6 +203,7 @@
                 <param name="lexicmap_index" value="LexicMapIndex2"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz,lexicmap_query2.fasta.gz,lexicmap_query3.fasta"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -211,6 +217,7 @@
                 <param name="lexicmap_index" value="LexicMapIndex1,LexicMapIndex2,LexicMapIndexCombined"/>
             </conditional>
             <param name="query" value="lexicmap_query.fasta.gz,lexicmap_query2.fasta.gz,lexicmap_query3.fasta"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -225,6 +232,7 @@
             </conditional>
             <param name="top_n_genomes" value="0"/>
             <param name="query" value="lexicmap_query.fasta.gz"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>
@@ -239,6 +247,7 @@
             </conditional>
             <param name="top_n_genomes" value="0"/>
             <param name="query" value="lexicmap_query.fasta.gz,lexicmap_query3.fasta"/>
+            <param name="all" value="false"/>
             <section name="advanced_settings">
                 <param name="top_n_chains" value="0"/>
                 <param name="load_whole_seeds" value="true"/>


### PR DESCRIPTION
a request from the logan folks to move the lexicmap -all flag to more prominent place and default on

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] Use of AI
  - [ ] The contribution is mostly AI generated
  - [x] The contribution has been assisted by AI
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.

To request a review once your PR is ready, comment "please review" on the PR. This will
automatically apply the `ready-for-review` label if the PR is not a draft, all review
threads are resolved, and all CI checks have passed.
